### PR TITLE
Remove user roles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,17 +198,9 @@ class User < ActiveRecord::Base
     end
   end
 
-  # During the migration where roles are transferred from the user to the
-  # course membership, we need to account for role being a column on users (before)
-  # and a method (after). Once this migration is complete, course should not be an
-  # optional parameter, and we should remove the if...else check and always go with else
-  def role(course=nil)
-    if self.attributes.include? "role"
-      self.attributes["role"]
-    else
-      return nil if self.course_memberships.where(course_id: course).empty?
-      self.course_memberships.where(course: course).first.role
-    end
+  def role(course)
+    return nil if self.course_memberships.where(course_id: course).empty?
+    self.course_memberships.where(course: course).first.role
   end
 
   # TODO redefine staff as professors and gsi only.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
 
   attr_accessor :remember_me, :password, :password_confirmation, :cached_last_login_at, :course_team_ids, :score
   attr_accessible :username, :email, :password, :password_confirmation,
-    :avatar_file_name, :role, :first_name, :last_name, :rank, :user_id,
+    :avatar_file_name, :first_name, :last_name, :rank, :user_id,
     :display_name, :private_display, :default_course_id, :last_activity_at,
     :last_login_at, :last_logout_at, :team_ids, :courses, :course_ids,
     :shared_badges, :earned_badges, :earned_badges_attributes,

--- a/db/migrate/20150114214652_remove_role_from_user.rb
+++ b/db/migrate/20150114214652_remove_role_from_user.rb
@@ -1,0 +1,7 @@
+class RemoveRoleFromUser < ActiveRecord::Migration
+  def change
+    if column_exists? :users, :role
+      remove_column :users, :role, :string
+    end
+  end
+end

--- a/db/migrate/20150114214652_remove_role_from_user.rb
+++ b/db/migrate/20150114214652_remove_role_from_user.rb
@@ -1,7 +1,0 @@
-class RemoveRoleFromUser < ActiveRecord::Migration
-  def change
-    if column_exists? :users, :role
-      remove_column :users, :role, :string
-    end
-  end
-end


### PR DESCRIPTION
Hi Cait,

The first two commits should be sufficient to manage all uses of role to the CourseMemberships (and throw an error if there is anywhere user.role is still called without passing in a course). 

The third commit contains the migration -- take a look at it if you would as I've never written a migration that takes into account multiple schemas. I ran it locally and it went fine on my dev environment where role was not a column on user -- I'm hoping it is still a column on staging and you can test that it works there first. One other thing to make sure of is that when new students were registered for this semester, their roles were added not on the User model but on CourseMemberships.