### PR TITLE
add tooltip for uploads

### DIFF
--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -109,7 +109,7 @@ h4.subtitle.success
 h5.section-title
   font-size: 1.3rem
   background-color: $primary-color
-  padding: .5rem 1rem 
+  padding: .5rem 1rem
   margin: 1px 2px 0 1px
   z-index: 10 !important
   overflow: hidden
@@ -117,16 +117,16 @@ h5.section-title
   border-top-right-radius: $global-radius
   border-top-left-radius: $global-radius
 
-  a 
+  a
     color: #FFF
-  a.button 
+  a.button
     color: #FFF
 
-.label.radius 
+.label.radius
   font-size: 70%
 
 .label.radius a
-  color: #FFF 
+  color: #FFF
 
 .label.radius a:hover
   color: $primary-color-4
@@ -139,14 +139,17 @@ h5.section-title
   color: #000
 
 .label.right.radius.success, .label.right.radius.alert, .label.right.radius
-
-  span.has-tip  
+  span.has-tip
     font-size: 120%
     color: #FFF
     font-weight: normal
 
+.uploaded-files
+  span.has-tip
+    font-weight: normal
+
 /* Used for screen reader only items */
-.sr-only 
+.sr-only
   position: absolute
   width: 1px
   height: 1px

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -192,12 +192,14 @@
         = af.file_field :file, :multiple => true
       - if @assignment.assignment_files.exists?
         %h5.bold Uploaded files
-        %ul#uploaded_files
+        %ul.uploaded-files
           - @assignment.assignment_files.each do |af|
             - next if af.new_record?
             %li
               - if af.file_processing
-                = "#{af.filename} (upload in progress...)"
+                = "#{af.filename}"
+                %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                  = "(upload in progress)"
               - else
                 = link_to af.filename, af.url, :target => "_blank"
                 = link_to "(Remove)", remove_uploads_path({ :model => "AssignmentFile", :assignment_id => @assignment.id, :upload_id => af.id } )

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -51,12 +51,14 @@
           = bf.file_field :file, :multiple => true
         - if @badge.badge_files.exists?
           %h5.bold Uploaded files
-          %ul#uploaded_files
+          %ul.uploaded-files
             - @badge.badge_files.each do |bf|
               - next if bf.new_record?
               %li
                 - if bf.file_processing
-                  = "#{bf.filename} (upload in progress...)"
+                  = "#{bf.filename}"
+                  %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                    = "(upload in progress)"
                 - else
                   = link_to bf.filename, bf.url, :target => "_blank"
                   = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", :badge_id => @badge.id, :upload_id => bf.id } )

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -73,12 +73,14 @@
         = cf.file_field :file, :multiple => true
       - if @challenge.challenge_files.exists?
         %h5.bold Uploaded files
-        %ul#uploaded_files
+        %ul.uploaded-files
           - @challenge.challenge_files.each do |cf|
             - next if cf.new_record?
             %li
               - if cf.file_processing
-                = "#{cf.filename} (upload in progress...)"
+                = "#{cf.filename}"
+                %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                  = "(upload in progress)"
               - else
                 = link_to cf.filename, cf.url, :target => "_blank"
                 = link_to "(Remove)", remove_uploads_path({ :model => "ChallengeFile", :challenge_id => @challenge.id, :upload_id => cf.id } )

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -37,12 +37,14 @@
           = gf.file_field :file, :multiple => true
         - if @grade.grade_files.exists?
           %h5.bold Uploaded files
-          %ul#uploaded_files
+          %ul.uploaded-files
             - @grade.grade_files.each do |gf|
               - next if gf.new_record?
               %li
-                - if gf.file_processing
-                  = "#{gf.filename} (upload in progress...)"
+                - if ! gf.file_processing
+                  = "#{gf.filename}"
+                  %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                    = "(upload in progress)"
                 - else
                   = link_to gf.filename, gf.url, :target => "_blank"
                   = link_to "(Remove)", remove_uploads_path({ :model => "GradeFile", :grade_id => @grade.id, :upload_id => gf.id } )

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -18,11 +18,13 @@
         = sf.file_field :file, :multiple => true
       - if @submission.submission_files.exists?
         %h5.bold Uploaded files
-        %ul#uploaded_files
+        %ul.uploaded-files
           - current_student.submission_for_assignment(@assignment).submission_files.each do |sf|
             %li
               - if sf.file_processing
-                = "#{sf.filename} (upload in progress...)"
+                = "#{sf.filename}"
+                %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                  = "(upload in progress)"
               - else
                 = link_to sf.filename, sf.url, :target => "_blank"
                 = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", :assignment_id => @assignment.id, :upload_id => sf.id } )

--- a/app/views/submissions/_student_show.haml
+++ b/app/views/submissions/_student_show.haml
@@ -31,11 +31,13 @@
     - if current_student.submission_for_assignment(@assignment).submission_files.present?
       %p
         %span.smallcaps Attachments:
-        %ul
+        %ul.uploaded-files
           - current_student.submission_for_assignment(@assignment).submission_files.each do |sf|
             %li
               - if sf.file_processing
-                = "#{sf.filename} (upload in progress...)"
+                = "#{sf.filename}"
+                %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                  = "(upload in progress)"
               - else
                 = link_to sf.filename, sf.url
 
@@ -74,11 +76,13 @@
     - if @group.submission_for_assignment(@assignment).submission_files.present?
       %p
         %span.smallcaps Attachments:
-        %ul
+        %ul.uploaded-files
           - @group.submission_for_assignment(@assignment).submission_files.each do |sf|
             %li
               - if sf.file_processing
-                = "#{sf.filename} (upload in progress...)"
+                = "#{sf.filename}"
+                %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
+                  = "(upload in progress)"
               - else
                 = link_to sf.filename, sf.url
 


### PR DESCRIPTION
Improves messaging when a file is uploading so students don't think they have to remain on the page.
Changes affect views for the following uploads:

  * assignments
  * badges
  * challenges
  * grades
  * submissions