### PR TITLE
Moved javascript include to header

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
       = current_course.try(:name) || 'GradeCraft'
     = stylesheet_link_tag "application", :media => "all", media: "all"
     = javascript_include_tag "vendor/modernizr"
-    //= javascript_include_tag "application", 'data-turbolinks-track' => true 
+    = javascript_include_tag "application", 'data-turbolinks-track' => true 
     = csrf_meta_tags
     = yield(:head)
 
@@ -69,4 +69,4 @@
             .small-12.columns
               = render 'layouts/footer'
         = render 'layouts/google_analytics'
-        = javascript_include_tag 'application'
+        //= javascript_include_tag 'application'


### PR DESCRIPTION
@josankapo Will you take a look at this? The three charts that are broken are: 

- On the student dashboard, the box plot in the student nav bar is broken
- On the teams page, the chart of the team scores is broken
- On the student grade predictor page, the dropdown arrows don't work to expand the assignment type sections 