### PR TITLE
Mongo fix

### DIFF
--- a/app/analytics_aggregates/course_user_pageview.rb
+++ b/app/analytics_aggregates/course_user_pageview.rb
@@ -6,7 +6,7 @@ class CourseUserPageview
   field :user_id, type: Integer
   field :pages, type: Hash
 
-  scope_by :course_id, :user_id, :pages
+  scope_by :course_id, :user_id
 
   increment_keys "pages.%{page}.%{granular_key}" => 1,
                  "pages._all.%{granular_key}" => 1

--- a/app/analytics_exports/course_user_aggregate_export.rb
+++ b/app/analytics_exports/course_user_aggregate_export.rb
@@ -16,7 +16,7 @@ class CourseUserAggregateExport
     end
     @user_pageviews = loaded_data[:user_pageviews].inject(Hash.new(0)) do |hash, pageview|
       # CourseUserPageview must have `scope_by :pages` for this to work w/ mongoid > 4.0.0
-      hash[pageview.user_id] = pageview.pages["_all"]["all_time"]
+      hash[pageview.user_id] = pageview.raw_attributes["pages"]["_all"]["all_time"]
       hash
     end
     @user_logins = loaded_data[:user_logins].inject(Hash.new(0)) do |hash, login|

--- a/app/analytics_exports/course_user_aggregate_export.rb
+++ b/app/analytics_exports/course_user_aggregate_export.rb
@@ -15,7 +15,7 @@ class CourseUserAggregateExport
       hash
     end
     @user_pageviews = loaded_data[:user_pageviews].inject(Hash.new(0)) do |hash, pageview|
-      # CourseUserPageview must have `scope_by :pages` for this to work w/ mongoid > 4.0.0
+      # pageview.pages raises an error w/ mongoid > 4.0.0
       hash[pageview.user_id] = pageview.raw_attributes["pages"]["_all"]["all_time"]
       hash
     end


### PR DESCRIPTION
Cait, here is an alternate query for the export that allows us to use the older syntax for course_user_pageview without raising an error. We should try this on staging to see if this solves our moped error.