### PR TITLE
add limit to submission files

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -66,6 +66,9 @@ class SubmissionsController < ApplicationController
     @submission.student = current_student if current_user_is_student?
     if @submission_files
       @submission_files.each do |sf|
+        if sf.size > GradeCraft::Application.config.max_upload_file_size
+          return redirect_to new_assignment_submission_path(@assignment, @submission), alert: "#{@assignment.name} not saved! #{sf.original_filename} was larger than the maximum 40 MB file size."
+        end
         @submission.submission_files.new(file: sf, filename: sf.original_filename[0..49])
       end
     end
@@ -118,6 +121,9 @@ class SubmissionsController < ApplicationController
 
     if @submission_files
       @submission_files.each do |sf|
+        if sf.size > GradeCraft::Application.config.max_upload_file_size
+          return redirect_to new_assignment_submission_path(@assignment, @submission), alert: "#{@assignment.name} not saved! #{sf.original_filename} was larger than the maximum 40 MB file size."
+        end
         @submission.submission_files.new(file: sf, filename: sf.original_filename[0..49])
       end
     end

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -21,11 +21,6 @@
         %ul.uploaded-files
           - current_student.submission_for_assignment(@assignment).submission_files.each do |sf|
             %li
-              / - if sf.file_processing
-              /   = "#{sf.filename}"
-              /   %span.has-tip{:title => "Refresh page to confirm upload has completed", :data => {'tooltip' => true}}
-              /     = "(upload in progress)"
-              / - else
               = link_to sf.filename, sf.url, :target => "_blank"
               = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", :assignment_id => @assignment.id, :upload_id => sf.id } )
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module GradeCraft
     config.assets.paths << Rails.root.join("app", "assets", "fonts")
     config.filter_parameters += [:password]
     config.i18n.enforce_available_locales = true
+    config.max_upload_file_size = 40000000 # 40 MB
     config.generators do |g|
       g.integration_tool :mini_test
       g.orm :active_record


### PR DESCRIPTION
This will check on the back end for files exceeding the max file size.  We may also want to look into adding javascript warnings as soon as the file is added to the form.