### PR TITLE
Rubrics copy

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -60,7 +60,7 @@ class CoursesController < ApplicationController
               a.rubric.metrics.each do |metric|
                 new_metric = metric.dup
                 new_metric.rubric_id = new_rubric.id
-                new_metric
+                new_metric.save
                 if metric.tiers.present?
                   metric.tiers.each do |tier|
                     new_tier = tier.dup

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -52,6 +52,32 @@ class CoursesController < ApplicationController
               nasl.save
             end
           end
+          if a.rubric.present?
+            new_rubric = a.rubric.dup
+            new_rubric.assignment_id = na.id
+            new_rubric.save
+            if a.rubric.metrics.present?
+              a.rubric.metrics.each do |metric|
+                new_metric = metric.dup
+                new_metric.rubric_id = new_rubric.id
+                new_metric
+                if metric.tiers.present?
+                  metric.tiers.each do |tier|
+                    new_tier = tier.dup
+                    new_tier.metric_id = new_metric.id
+                    new_tier.save
+                    if tier.tier_badges.present?
+                      tier.tier_badges.each do |tier_badge|
+                        new_tier_badge = tier_badge.dup
+                        new_tier_badge.tier_id = new_tier.id
+                        new_tier_badge.save
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -8,9 +8,6 @@ class MetricsController < ApplicationController
     respond_with @metric, layout: false
   end
 
-  def edit
-  end
-
   def create
     @metric = Metric.create params[:metric]
     respond_with @metric, layout: false, serializer: ExistingMetricSerializer
@@ -19,9 +16,6 @@ class MetricsController < ApplicationController
   def destroy
     @metric.destroy
     respond_with @metric, layout: false
-  end
-
-  def show
   end
 
   def update


### PR DESCRIPTION
@zaz Will you review this? I'm stuck on one thing: 

1. Navigate to the courses index: http://localhost:5000/courses
2. Click the course copy button
3. If you look at the new course (it will have automatically moved you into it), it will have successfully copied any assignment rubrics, but because of the metric after_create method (:generate_default_tiers), it will have created two 0 level, and two full credit tiers per metric (copying the original, and creating new ones)
4. So the question is, is there an alt way to trigger the after_create methods to create the tiers? Or should the copy method be written in a different way?

Thanks! 
cait