### PR TITLE
Activating new accounts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -104,10 +104,15 @@ class UsersController < ApplicationController
   def activated
     @token = params[:token]
     @user = User.load_from_activation_token(@token)
-    @user.update_attributes params[:user]
-    @user.activate!
-    auto_login @user
-    redirect_to dashboard_path, notice: "Welcome to GradeCraft!"
+
+    redirect_to root_path, alert: "Invalid activation token. Please contact support to request a new one." and return unless @user
+
+    if @user.update_attributes params[:user]
+      @user.activate!
+      auto_login @user
+      redirect_to dashboard_path, notice: "Welcome to GradeCraft!" and return
+    end
+    render :activate, alert: @user.errors.full_messages.first
   end
 
   # We don't allow students to edit their info directly - this is a mediated view

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,14 +52,18 @@ class UsersController < ApplicationController
     random_password = Sorcery::Model::TemporaryToken.generate_random_token
     @user = User.create(params[:user].merge({password: random_password}))
 
-    if @user.valid? && @user.is_student?(current_course)
-      redirect_to students_path, :notice => "#{term_for :student} #{@user.name} was successfully created!"
-    elsif @user.valid? && @user.is_staff?(current_course)
-      redirect_to staff_index_path, :notice => "Staff Member #{@user.name} was successfully created!"
-    else
-      render :new
+    if @user.valid?
+      UserMailer.activation_needed_email(@user).deliver_now
+      if @user.is_student?(current_course)
+        redirect_to students_path,
+          :notice => "#{term_for :student} #{@user.name} was successfully created!" and return
+      elsif @user.is_staff?(current_course)
+        redirect_to staff_index_path,
+          :notice => "Staff Member #{@user.name} was successfully created!" and return
+      end
     end
     expire_action :action => :index
+    render :new
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -104,8 +104,10 @@ class UsersController < ApplicationController
   def activated
     @token = params[:token]
     @user = User.load_from_activation_token(@token)
+    @user.update_attributes params[:user]
     @user.activate!
-    render nothing: true
+    auto_login @user
+    redirect_to dashboard_path, notice: "Welcome to GradeCraft!"
   end
 
   # We don't allow students to edit their info directly - this is a mediated view

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,10 +49,12 @@ class UsersController < ApplicationController
 
   def create
     @teams = current_course.teams
-    @user = User.create(params[:user])
-    if @user.save && @user.is_student?(current_course)
+    random_password = Sorcery::Model::TemporaryToken.generate_random_token
+    @user = User.create(params[:user].merge({password: random_password}))
+
+    if @user.valid? && @user.is_student?(current_course)
       redirect_to students_path, :notice => "#{term_for :student} #{@user.name} was successfully created!"
-    elsif @user.save && @user.is_staff?(current_course)
+    elsif @user.valid? && @user.is_staff?(current_course)
       redirect_to staff_index_path, :notice => "Staff Member #{@user.name} was successfully created!"
     else
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   before_filter :ensure_staff?, :except => [:activate, :activated, :edit_profile, :update_profile]
   before_filter :ensure_admin?, :only => [:all]
+  skip_before_filter :require_login, :only => [:activate, :activated]
 
   def index
     @title = "All Users"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   respond_to :html, :json
 
-  before_filter :ensure_staff?, :except => [:activate, :edit_profile, :update_profile]
+  before_filter :ensure_staff?, :except => [:activate, :activated, :edit_profile, :update_profile]
   before_filter :ensure_admin?, :only => [:all]
 
   def index
@@ -99,6 +99,13 @@ class UsersController < ApplicationController
     @user = User.load_from_activation_token(params[:id])
     @token = params[:id]
     redirect_to root_path, alert: "Invalid activation token. Please contact support to request a new one." and return unless @user
+  end
+
+  def activated
+    @token = params[:token]
+    @user = User.load_from_activation_token(@token)
+    @user.activate!
+    render nothing: true
   end
 
   # We don't allow students to edit their info directly - this is a mediated view

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   respond_to :html, :json
 
-  before_filter :ensure_staff?, :except => [:edit_profile, :update_profile]
+  before_filter :ensure_staff?, :except => [:activate, :edit_profile, :update_profile]
   before_filter :ensure_admin?, :only => [:all]
 
   def index
@@ -93,6 +93,12 @@ class UsersController < ApplicationController
       format.json { head :ok }
     end
 
+  end
+
+  def activate
+    @user = User.load_from_activation_token(params[:id])
+    @token = params[:id]
+    redirect_to root_path, alert: "Invalid activation token. Please contact support to request a new one." and return unless @user
   end
 
   # We don't allow students to edit their info directly - this is a mediated view

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,9 @@
 class UserMailer < ActionMailer::Base
   default from: "mailer@gradecraft.com"
 
+  def activation_needed_email(user)
+  end
+
   def reset_password_email(user)
     @user = user
     mail(:to => user.email, :subject => "Your GradeCraft Password Reset Instructions")

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,7 +4,7 @@ class UserMailer < ActionMailer::Base
   def activation_needed_email(user)
     @user = user
     mail to: @user.email,
-         subject: " Welcome to GradeCraft! Please activate your account"
+         subject: "Welcome to GradeCraft! Please activate your account"
   end
 
   def reset_password_email(user)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,6 +2,9 @@ class UserMailer < ActionMailer::Base
   default from: "mailer@gradecraft.com"
 
   def activation_needed_email(user)
+    @user = user
+    mail to: @user.email,
+         subject: " Welcome to GradeCraft! Please activate your account"
   end
 
   def reset_password_email(user)

--- a/app/views/user_mailer/activation_needed_email.text.haml
+++ b/app/views/user_mailer/activation_needed_email.text.haml
@@ -1,0 +1,12 @@
+Hello, #{@user.first_name}
+===============================================
+
+Welcome to GradeCraft!
+
+In order to complete your new account, please follow the link below to validate your email address and specify your password.
+
+#{activate_user_url(@user.activation_token).html_safe}
+
+Thanks,
+
+The GradeCraft team

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -26,16 +26,6 @@
       = f.label :display_name
       = f.text_field :display_name
 
-    - if current_user_is_admin?
-      .clear
-
-      .small-12.medium-4.columns
-        = f.label :password
-        = f.password_field :password, :as => :password
-      .small-12.medium-4.columns
-        = f.label :password_confirmation
-        = f.password_field :password_confirmation, :as => :password
-
     .clear
 
   - if current_user_is_admin?

--- a/app/views/users/activate.html.haml
+++ b/app/views/users/activate.html.haml
@@ -2,7 +2,7 @@
   .columns.panel.radius.callout
     %h5 Welcome to GradeCraft
     %p Enter a password and a confirmation below to complete your account
-    = simple_form_for @user, :url => activate_user_path(@token) do |f|
+    = simple_form_for @user, :url => activate_user_path(@token), :method => :post do |f|
       = hidden_field_tag :token, @token
       = f.label :password
       = f.password_field :password

--- a/app/views/users/activate.html.haml
+++ b/app/views/users/activate.html.haml
@@ -1,0 +1,11 @@
+.row
+  .columns.panel.radius.callout
+    %h5 Welcome to GradeCraft
+    %p Enter a password and a confirmation below to complete your account
+    = simple_form_for @user, :url => activate_user_path(@token) do |f|
+      = hidden_field_tag :token, @token
+      = f.label :password
+      = f.password_field :password
+      = f.label :password_confirmation
+      = f.password_field :password_confirmation
+      = f.submit "Activate Your Account", :class => "button tiny radius"

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -2,7 +2,7 @@
 # The default is nothing which will include only core features (password encryption, login/logout).
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging, :external
-Rails.application.config.sorcery.submodules = [:remember_me, :reset_password, :session_timeout, :save_return_to_url, :activity_logging]
+Rails.application.config.sorcery.submodules = [:remember_me, :reset_password, :session_timeout, :save_return_to_url, :activity_logging, :user_activation]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -121,11 +121,14 @@ Rails.application.config.sorcery.configure do |config|
                                                                                       # activation code expires. nil for
                                                                                       # never expires.
 
+    user.activation_mailer_disabled = true
+    user.user_activation_mailer = UserMailer
     # user.user_activation_mailer = nil                                               # your mailer class. Required.
 
     # user.activation_needed_email_method_name = :activation_needed_email             # activation needed email method
                                                                                       # on your mailer class.
 
+    user.activation_success_email_method_name = nil # do not send a success email
     # user.activation_success_email_method_name = :activation_success_email           # activation success email method
                                                                                       # on your mailer class.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,7 @@ GradeCraft::Application.routes.draw do
 
   resources :users do
     get :activate, on: :member
+    post :activate, on: :member, to: :activated
     collection do
       get :edit_profile
       put :update_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,7 +253,7 @@ GradeCraft::Application.routes.draw do
 
   resources :users do
     get :activate, on: :member
-    post :activate, on: :member, to: :activated
+    post :activate, on: :member, action: :activated
     collection do
       get :edit_profile
       put :update_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ GradeCraft::Application.routes.draw do
   end
 
   resources :users do
+    get :activate, on: :member
     collection do
       get :edit_profile
       put :update_profile

--- a/db/migrate/20150806205557_sorcery_user_activation.rb
+++ b/db/migrate/20150806205557_sorcery_user_activation.rb
@@ -1,0 +1,9 @@
+class SorceryUserActivation < ActiveRecord::Migration
+  def change
+    add_column :users, :activation_state, :string, :default => nil
+    add_column :users, :activation_token, :string, :default => nil
+    add_column :users, :activation_token_expires_at, :datetime, :default => nil
+
+    add_index :users, :activation_token
+  end
+end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -216,7 +216,7 @@ students = user_names.map do |name|
     u.password = 'uptonogood'
     u.courses << [ educ_course, polsci_course, information_course ]
     u.teams << [ educ_teams.sample, polsci_teams.sample, info_teams.sample ]
-  end
+  end.activate!
 end
 puts "Generated #{students.count} unruly students"
 
@@ -234,7 +234,7 @@ User.create! do |u|
       cm.role = "admin"
     end
   end
-end
+end.activate!
 puts "Albus Dumbledore just apparated into Hogwarts"
 
 # Generate sample professor
@@ -249,7 +249,7 @@ User.create! do |u|
     cm.course = information_course
     cm.role = "professor"
   end
-end
+end.activate!
 puts "Severus Snape has been spotted in Slytherin House"
 
 # Generate sample professor
@@ -264,7 +264,7 @@ User.create! do |u|
     cm.course = educ_course
     cm.role = "professor"
   end
-end
+end.activate!
 puts "Headmistress McGonagall is here...shape up!"
 
 # Generate sample professor
@@ -279,7 +279,7 @@ User.create! do |u|
     cm.course = polsci_course
     cm.role = "professor"
   end
-end
+end.activate!
 puts "Shhhh... he hates being called Nearly Headless Nick!"
 
 # Generate sample GSI
@@ -296,7 +296,7 @@ User.create! do |u|
       cm.role = "gsi"
     end
   end
-end
+end.activate!
 puts "Percy Weasley has arrived on campus, on time as usual"
 
 #Create demo academic history content

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150730192800) do
+ActiveRecord::Schema.define(version: 20150806205557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -825,8 +825,12 @@ ActiveRecord::Schema.define(version: 20150730192800) do
     t.string   "lti_uid",                         limit: 255
     t.string   "last_login_from_ip_address",      limit: 255
     t.string   "kerberos_uid",                    limit: 255
+    t.string   "activation_state"
+    t.string   "activation_token"
+    t.datetime "activation_token_expires_at"
   end
 
+  add_index "users", ["activation_token"], name: "index_users_on_activation_token", using: :btree
   add_index "users", ["kerberos_uid"], name: "index_users_on_kerberos_uid", using: :btree
   add_index "users", ["last_logout_at", "last_activity_at"], name: "index_users_on_last_logout_at_and_last_activity_at", using: :btree
   add_index "users", ["remember_me_token"], name: "index_users_on_remember_me_token", using: :btree

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -52,28 +52,40 @@ describe UsersController do
     end
 
     describe "POST create" do
-      before(:each) do
-        post :create, user: { first_name: "Jimmy",
-                              last_name: "Page",
-                              username: "jimmy",
-                              email: "jimmy@example.com" }
-      end
       let(:user) { User.unscoped.last }
 
-      it "creates a new user" do
-        expect(user.email).to eq "jimmy@example.com"
-        expect(user.username).to eq "jimmy"
-        expect(user.first_name).to eq "Jimmy"
-        expect(user.last_name).to eq "Page"
+      context "calling create" do
+        before(:each) do
+          post :create, user: { first_name: "Jimmy",
+                                last_name: "Page",
+                                username: "jimmy",
+                                email: "jimmy@example.com" }
+        end
+
+        it "creates a new user" do
+          expect(user.email).to eq "jimmy@example.com"
+          expect(user.username).to eq "jimmy"
+          expect(user.first_name).to eq "Jimmy"
+          expect(user.last_name).to eq "Page"
+        end
+
+        it "generates a random password for a user" do
+          expect(user.crypted_password).to_not be_blank
+        end
+
+        it "requires the new user to be activated" do
+          expect(user.activation_token).to_not be_blank
+          expect(user.activation_state).to eq "pending"
+        end
       end
 
-      it "generates a random password for a user" do
-        expect(user.crypted_password).to_not be_blank
-      end
-
-      it "requires the new user to be activated" do
-        expect(user.activation_token).to_not be_blank
-        expect(user.activation_state).to eq "pending"
+      it "sends an activation email for the user" do
+        expect {
+          post :create, user: { first_name: "Jimmy",
+                                last_name: "Page",
+                                username: "jimmy",
+                                email: "jimmy@example.com" }
+        }.to change { ActionMailer::Base.deliveries.count }.by 1
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -51,8 +51,20 @@ describe UsersController do
       end
     end
 
-		describe "GET create" do
-      pending
+    describe "POST create" do
+      it "creates a new user" do
+        post :create, user: { first_name: "Jimmy",
+                              last_name: "Page",
+                              username: "jimmy",
+                              email: "jimmy@example.com" }
+        user = User.last
+        expect(user.email).to eq "jimmy@example.com"
+        expect(user.username).to eq "jimmy"
+        expect(user.first_name).to eq "Jimmy"
+        expect(user.last_name).to eq "Page"
+      end
+
+      xit "generates a random password for a user"
     end
 
 		describe "GET update" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -58,9 +58,9 @@ describe UsersController do
                               username: "jimmy",
                               email: "jimmy@example.com" }
       end
+      let(:user) { User.unscoped.last }
 
       it "creates a new user" do
-        user = User.unscoped.last
         expect(user.email).to eq "jimmy@example.com"
         expect(user.username).to eq "jimmy"
         expect(user.first_name).to eq "Jimmy"
@@ -68,8 +68,12 @@ describe UsersController do
       end
 
       it "generates a random password for a user" do
-        user = User.unscoped.last
         expect(user.crypted_password).to_not be_blank
+      end
+
+      it "requires the new user to be activated" do
+        expect(user.activation_token).to_not be_blank
+        expect(user.activation_state).to eq "pending"
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -52,19 +52,25 @@ describe UsersController do
     end
 
     describe "POST create" do
-      it "creates a new user" do
+      before(:each) do
         post :create, user: { first_name: "Jimmy",
                               last_name: "Page",
                               username: "jimmy",
                               email: "jimmy@example.com" }
-        user = User.last
+      end
+
+      it "creates a new user" do
+        user = User.unscoped.last
         expect(user.email).to eq "jimmy@example.com"
         expect(user.username).to eq "jimmy"
         expect(user.first_name).to eq "Jimmy"
         expect(user.last_name).to eq "Page"
       end
 
-      xit "generates a random password for a user"
+      it "generates a random password for a user" do
+        user = User.unscoped.last
+        expect(user.crypted_password).to_not be_blank
+      end
     end
 
 		describe "GET update" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -150,6 +150,41 @@ describe UsersController do
       end
     end
 
+    describe "POST activated" do
+      before do
+        @student.update_attribute :activation_token, "blah"
+        @student.update_attribute :activation_state, "pending"
+        post :activated, id: @student.activation_token,
+          token: @student.activation_token,
+          user: { password: "blah", password_confirmation: "blah" }
+      end
+
+      context "with matching passwords" do
+        it "activates the user" do
+          expect(@student.reload.activation_state).to eq "active"
+        end
+
+        xit "updates the user's password"
+        xit "logs the user in"
+      end
+
+      context "with a tampered activation token" do
+        xit "does not activate the user"
+        xit "does not update the user's password"
+        xit "redirects to the root url"
+      end
+
+      context "with a non-matching password" do
+        xit "does not activate the user"
+        xit "renders the activate template"
+      end
+
+      context "with a blank password" do
+        xit "does not activate the user"
+        xit "renders the activate template"
+      end
+    end
+
     describe "GET edit_profile" do
       it "renders the edit profile user form" do
         get :edit_profile

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -89,10 +89,6 @@ describe UsersController do
       end
     end
 
-		describe "GET update" do
-      pending
-    end
-
     describe "GET destroy" do
       it "destroys the user" do
         expect{ get :destroy, {:id => @student } }.to change(User,:count).by(-1)
@@ -126,13 +122,9 @@ describe UsersController do
       end
     end
 
-		describe "GET upload" do
-      pending
-    end
+  end
 
-	end
-
-	context "as a student" do
+  context "as a student" do
 
     before do
       @course = create(:course)
@@ -144,7 +136,21 @@ describe UsersController do
       allow(Resque).to receive(:enqueue).and_return(true)
     end
 
-		describe "GET edit_profile" do
+    describe "GET activate" do
+      before(:each) { @student.update_attribute :activation_token, "blah" }
+
+      it "exists" do
+        get :activate, id: @student.activation_token
+        expect(response).to be_success
+      end
+
+      it "redirects to the root url if the token is not correct" do
+        get :activate, id: "blech"
+        expect(response).to redirect_to root_path
+      end
+    end
+
+    describe "GET edit_profile" do
       it "renders the edit profile user form" do
         get :edit_profile
         assigns(:title).should eq("Edit My Profile")
@@ -153,7 +159,7 @@ describe UsersController do
       end
     end
 
-		describe "GET update_profile" do
+    describe "GET update_profile" do
       it "successfully updates the users profile" do
         params = { display_name: "frodo" }
         post :update_profile, id: @student.id, :user => params
@@ -164,7 +170,7 @@ describe UsersController do
     end
 
 
-		describe "protected routes" do
+    describe "protected routes" do
       [
         :index,
         :new,
@@ -190,5 +196,5 @@ describe UsersController do
       end
     end
 
-	end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -164,8 +164,13 @@ describe UsersController do
           expect(@student.reload.activation_state).to eq "active"
         end
 
-        xit "updates the user's password"
-        xit "logs the user in"
+        it "updates the user's password" do
+          expect(User.authenticate(@student.email, "blah")).to eq @student
+        end
+
+        it "logs the user in" do
+          expect(response).to redirect_to dashboard_path
+        end
       end
 
       context "with a tampered activation token" do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,7 +4,8 @@ FactoryGirl.define do
     last_name { Faker::Name.last_name }
     username { Faker::Internet.user_name }
     email { Faker::Internet.email }
-    salt "asdasdastr4325234324sdfds"
-    crypted_password { Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) }
+    password { "secret" }
+
+    after(:create) { |user| user.activate! }
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ describe UserMailer do
   let(:email) { ActionMailer::Base.deliveries.last }
   let(:user) { create :user, reset_password_token: "blah" }
 
-  describe "reset_password_email" do
+  describe ".reset_password_email" do
     before(:each) { UserMailer.reset_password_email(user).deliver_now }
 
     it "is sent from a notifications email" do
@@ -21,6 +21,31 @@ describe UserMailer do
 
     it "has the password reset link" do
       expect(email.body).to include edit_password_url("blah")
+    end
+  end
+
+  describe ".activation_needed_email" do
+    let(:user) { create :user }
+
+    before(:each) do
+      user.update_attribute :activation_token, "blah"
+      UserMailer.activation_needed_email(user).deliver_now
+    end
+
+    it "is sent from the a notifications email" do
+      expect(email.from).to eq ["mailer@gradecraft.com"]
+    end
+
+    it "is sent to the user's email" do
+      expect(email.to).to eq [user.email]
+    end
+
+    it "has an appropriate subject" do
+      expect(email.subject).to eq "Welcome to GradeCraft! Please activate your account"
+    end
+
+    it "has the activation link" do
+      expect(email.body).to include activate_user_url("blah")
     end
   end
 end


### PR DESCRIPTION
This pull request allows staff to create new user accounts (with `/users/new`) without specifying a password for the new user. A random password is generated for the new user and an activation email is sent to the user for them to complete their account.

New users are not allowed to sign up without activating their accounts.

There is a [migration](https://github.com/UM-USElab/gradecraft-development/blob/0d3dad27064b6427d557466eba9db606b4147965/db/migrate/20150806205557_sorcery_user_activation.rb) to add the Sorcery user activation submodule fields to the `User`.

All of the users that were created during the setup are also activated now.

This is the new user create view (with the removal of the password fields):

![screen shot 2015-08-07 at 10 24 20 pm](https://cloud.githubusercontent.com/assets/35017/9148673/374e2d94-3d53-11e5-91e4-b38225102c32.png)

This is the email that the new user gets when they get created:

![screen shot 2015-08-07 at 10 24 50 pm](https://cloud.githubusercontent.com/assets/35017/9148675/3e64bb34-3d53-11e5-8981-5cb8ca10bce3.png)

This is the form that the new user goes to in order to activate their account:

![screen shot 2015-08-07 at 10 25 14 pm](https://cloud.githubusercontent.com/assets/35017/9148676/475ac8e6-3d53-11e5-9aac-b0125f9132f0.png)

Closes #33b on on the punch list