### PR TITLE
Activate users fixes

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -25,6 +25,7 @@ class PasswordsController < ApplicationController
 
     @user.password_confirmation = params[:user][:password_confirmation]
     if @user.change_password!(params[:user][:password])
+      @user.activate! unless @user.activated?
       auto_login @user
       redirect_to dashboard_path, notice: "Password was successfully updated" and return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,6 +162,10 @@ class User < ActiveRecord::Base
     end
   end
 
+  def activated?
+    activation_state == "active"
+  end
+
   def default_course
     super || courses.first
   end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -208,7 +208,7 @@ puts "LARP Day is going to happen. Watch out for the Dungeon Master's sword!"
 students = user_names.map do |name|
   first_name, last_name = name.split(' ')
   username = name.parameterize.sub('-','.')
-  User.create! do |u|
+  user = User.create! do |u|
     u.username = username
     u.first_name = first_name
     u.last_name = last_name
@@ -216,7 +216,9 @@ students = user_names.map do |name|
     u.password = 'uptonogood'
     u.courses << [ educ_course, polsci_course, information_course ]
     u.teams << [ educ_teams.sample, polsci_teams.sample, info_teams.sample ]
-  end.activate!
+  end
+  user.activate!
+  user
 end
 puts "Generated #{students.count} unruly students"
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,4 +1,11 @@
 namespace :users do
+  desc "Activates all existing users"
+  task :activate => :environment do
+    all = User.all
+    all.each(&:activate!)
+    puts "\nSuccessfully activated all #{all.count} #{"user".pluralize(all.count)}."
+  end
+
   namespace :set do
     desc "Set all user passwords to a common one for testing purposes"
     task :master_password => :environment do

--- a/spec/controllers/passwords_controller_spec.rb
+++ b/spec/controllers/passwords_controller_spec.rb
@@ -47,17 +47,25 @@ describe PasswordsController do
     let(:user) { create :user, reset_password_token: "blah" }
 
     context "with matching passwords" do
-      before do
+      it "changes the user's password" do
         put :update, id: user.reset_password_token,
           token: user.reset_password_token,
           user: { password: "blah", password_confirmation: "blah" }
-      end
-
-      it "changes the user's password" do
         expect(User.authenticate(user.email, "blah")).to eq user
       end
 
+      it "activates the user if they are not activated" do
+        user.update_attribute(:activation_state, "pending")
+        put :update, id: user.reset_password_token,
+          token: user.reset_password_token,
+          user: { password: "blah", password_confirmation: "blah" }
+        expect(user.reload).to be_activated
+      end
+
       it "logs the user in" do
+        put :update, id: user.reset_password_token,
+          token: user.reset_password_token,
+          user: { password: "blah", password_confirmation: "blah" }
         expect(response).to redirect_to dashboard_path
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,18 @@ describe User do
     end
   end
 
+  describe "#activated?" do
+    it "is activated when the activation state is active" do
+      user = build :user, activation_state: "active"
+      expect(user).to be_activated
+    end
+
+    it "is not activated when the activation state is pending" do
+      user = build :user, activation_state: "pending"
+      expect(user).to_not be_activated
+    end
+  end
+
   context "validations" do
     it "requires the password confirmation to match" do
       user = User.new password: "test", password_confirmation: "blah"


### PR DESCRIPTION
Fixes several issues with activating users.

* User is activated if they are not activated but updated their password
* Rake task to activate all users (which can be run when deployed) `rake users:activate`
* `db/samples.rb` is fixed thanks to a catch from Mav!