### PR TITLE
Fix student queries

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -286,8 +286,8 @@ class GradesController < ApplicationController
     @assignment_score_levels = @assignment.assignment_score_levels.order_by_value
 
     if params[:team_id].present?
-      @team = current_course.teams.find_by(team_params)
-      @students = current_course.students_by_team.joins(:teams).where(:teams => team_params)
+      @team = current_course.teams.find_by(id: params[:team_id])
+      @students = current_course.students_by_team(@team)
     else
       @students = current_course.students
     end
@@ -300,10 +300,6 @@ class GradesController < ApplicationController
   end
 
   private
-
-    def team_params
-      @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
-    end
 
     def mass_edit_student_ids
       @mass_edit_student_ids ||= @students.pluck(:id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,11 +23,11 @@ class User < ActiveRecord::Base
 
     def students_being_graded(course, team=nil)
       user_ids = CourseMembership.where(course: course, role: "student", auditing: false).pluck(:user_id)
+      query = User.where(id: user_ids)
       if team
-        User.where(id: user_ids).select { |student| team.student_ids.include? student.id }
-      else
-        User.where(id: user_ids)
+        query = query.includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
       end
+      query
     end
 
     def students_auditing(course, team=nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,25 +24,20 @@ class User < ActiveRecord::Base
     def students_being_graded(course, team=nil)
       user_ids = CourseMembership.where(course: course, role: "student", auditing: false).pluck(:user_id)
       query = User.where(id: user_ids)
-      if team
-        query = query.includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
-      end
+      query = query.students_in_team(team.id, user_ids) if team
       query
     end
 
     def students_auditing(course, team=nil)
       user_ids = CourseMembership.where(course: course, role: "student", auditing: true).pluck(:user_id)
       query = User.where(id: user_ids)
-      if team
-        query = query.includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
-      end
+      query = query.students_in_team(team.id, user_ids) if team
       query
     end
 
     def students_by_team(course, team)
       user_ids = CourseMembership.where(course: course, role: "student").pluck(:user_id)
-      User.where(id: user_ids).
-        includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
+      User.where(id: user_ids).students_in_team(team.id, user_ids)
     end
 
   end
@@ -62,6 +57,8 @@ class User < ActiveRecord::Base
 
   scope :order_by_high_score, -> { includes(:course_memberships).order 'course_memberships.score DESC' }
   scope :order_by_low_score, -> { includes(:course_memberships).order 'course_memberships.score ASC' }
+  scope :students_in_team, -> (team_id, student_ids) \
+    { includes(:team_memberships).where(team_memberships: { team_id: team_id, student_id: student_ids }) }
 
   mount_uploader :avatar_file_name, AvatarUploader
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,13 +35,10 @@ class User < ActiveRecord::Base
       User.where(id: user_ids)
     end
 
-    def students_by_team(course, team=nil)
+    def students_by_team(course, team)
       user_ids = CourseMembership.where(course: course, role: "student").pluck(:user_id)
-      if team
-        User.where(id: user_ids).select { |student| team.student_ids.include? student.id }
-      else
-        User.where(id: user_ids)
-      end
+      User.where(id: user_ids).
+        includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
     end
 
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,11 @@ class User < ActiveRecord::Base
 
     def students_auditing(course, team=nil)
       user_ids = CourseMembership.where(course: course, role: "student", auditing: true).pluck(:user_id)
-      User.where(id: user_ids)
+      query = User.where(id: user_ids)
+      if team
+        query = query.includes(:team_memberships).where(team_memberships: { team_id: team.id, student_id: user_ids })
+      end
+      query
     end
 
     def students_by_team(course, team)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,18 @@ describe User do
     end
   end
 
+  describe ".students_auditing" do
+    let(:student_being_audited) { create(:user) }
+    before do
+      create(:course_membership, course: @course, user: student_being_audited, auditing: true)
+    end
+
+    it "returns all the students that are being audited" do
+      result = User.students_auditing(@course)
+      expect(result.pluck(:id)).to eq [student_being_audited.id]
+    end
+  end
+
   describe ".students_being_graded" do
     let(:student_not_being_graded) { create(:user) }
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,32 @@ describe User do
     end
   end
 
+  describe ".students_being_graded" do
+    let(:student_not_being_graded) { create(:user) }
+    before do
+      create(:course_membership, course: @course, user: student_not_being_graded, auditing: true)
+    end
+
+    it "returns all the students that are being graded" do
+      result = User.students_being_graded(@course)
+      expect(result.pluck(:id)).to eq [@student.id]
+    end
+
+    context "with a team" do
+      let(:student_in_team) { create :user }
+      let(:team) { create :team, course: @course }
+      before do
+        create(:course_membership, course: @course, user: student_in_team)
+        team.students << student_in_team
+      end
+
+      it "returns only students in the team that are being graded" do
+        result = User.students_being_graded(@course, team)
+        expect(result.pluck(:id)).to eq [student_in_team.id]
+      end
+    end
+  end
+
   describe "#activated?" do
     it "is activated when the activation state is active" do
       user = build :user, activation_state: "active"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,20 @@ describe User do
       result = User.students_auditing(@course)
       expect(result.pluck(:id)).to eq [student_being_audited.id]
     end
+
+    context "with a team" do
+      let(:student_in_team) { create :user }
+      let(:team) { create :team, course: @course }
+      before do
+        create(:course_membership, course: @course, user: student_in_team, auditing: true)
+        team.students << student_in_team
+      end
+
+      it "returns only students in the team that are being audited" do
+        result = User.students_auditing(@course, team)
+        expect(result.pluck(:id)).to eq [student_in_team.id]
+      end
+    end
   end
 
   describe ".students_being_graded" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,6 +55,18 @@ describe User do
     end
   end
 
+  describe ".students_by_team" do
+    let(:team) { create :team, course: @course }
+    before do
+      team.students << @student
+    end
+
+    it "returns only students in the team" do
+      result = User.students_by_team(@course, team)
+      expect(result.pluck(:id)).to eq [@student.id]
+    end
+  end
+
   describe "#activated?" do
     it "is activated when the activation state is active" do
       user = build :user, activation_state: "active"


### PR DESCRIPTION
This fixes an issue where several class methods off of `User` where returning an `Array` when a `Team` was passed in and an `ActiveRecord::Relation` when a team was not passed in.

This caused an issue with the client code that was using it was assuming a relation being returned.

These changes return an `ActiveRecord::Relation` on the following `User` queries whether a team was passed in or not.

* `User.students_being_graded`
* `User.students_auditing`
* `User.students_by_team`