### PR TITLE
Quick grade notifications

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -326,7 +326,8 @@ class GradesController < ApplicationController
     if @assignment.update_attributes(params[:assignment])
       grade_ids = []
       @assignment.grades.each do |grade|
-        if grade.graded_or_released?
+        scored_changed = grade.previous_changes[:raw_score].present?
+        if scored_changed && grade.graded_or_released?
           grade_ids << grade.id
         end
       end

--- a/app/workers/multiple_grade_updater.rb
+++ b/app/workers/multiple_grade_updater.rb
@@ -2,13 +2,13 @@ class MultipleGradeUpdater
   @queue= :multiplegradeupdater
 
   def self.perform(grade_ids)
-    p "Starting MultipleGradeUpdater"
+    puts "Starting MultipleGradeUpdater"
     begin
       grades = Grade.where(id: grade_ids).includes(:assignment).load
       grades.each do |grade|
         grade.save_student_and_team_scores
           if grade.assignment.notify_released?
-            NotificationMailer.grade_released(grade.id).deliver
+            NotificationMailer.grade_released(grade.id).deliver_now
           end
         end
     rescue Exception => e

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -85,6 +85,14 @@ describe GradesController do
             change { ActionMailer::Base.deliveries.count }.by 1
         end
       end
+
+      it "only sends notifications to the students if the grade changed" do
+        @grade.update_attributes({ raw_score: 1000 })
+        run_background_jobs_immediately do
+          expect { put :mass_update, id: @assignment.id, assignment: { grades_attributes: grades_attributes } }.to_not \
+            change { ActionMailer::Base.deliveries.count }
+        end
+      end
     end
 
     describe "GET group_edit" do

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -2,9 +2,8 @@ require 'spec_helper'
 
 describe GradesController do
 
-	context "as professor" do
-
-		before do
+  context "as professor" do
+    before do
       @course = create(:course_accepting_groups)
       @professor = create(:user)
       @professor.courses << @course
@@ -22,71 +21,46 @@ describe GradesController do
       @assignment.groups << @group
       @group.students << [@student, @second_student, @third_student]
 
-			@grade = create(:grade)
-			@assignment.grades << @grade
+      @grade = create(:grade)
+      @assignment.grades << @grade
 
       login_user(@professor)
       session[:course_id] = @course.id
       allow(Resque).to receive(:enqueue).and_return(true)
     end
 
-		describe "GET show" do
+    describe "GET show" do
       it "shows the grade" do
         get :show, { :id => @grade.id, :assignment_id => @assignment.id, :student_id => @student.id }
-      	GradesController.stub(:current_student).and_return(@student)
-      	assigns(:assignment).should eq(@assignment)
+        GradesController.stub(:current_student).and_return(@student)
+        assigns(:assignment).should eq(@assignment)
         assigns(:title).should eq("#{@student.name}'s Grade for #{@assignment.name}")
         response.should render_template(:show)
       end
     end
 
-		describe "GET edit" do
+    describe "GET edit" do
       it "shows the grade edit form" do
         get :edit, { :id => @grade.id, :assignment_id => @assignment.id, :student_id => @student.id }
-  			GradesController.stub(:current_student).and_return(@student)
-      	assigns(:assignment).should eq(@assignment)
+        GradesController.stub(:current_student).and_return(@student)
+        assigns(:assignment).should eq(@assignment)
         assigns(:title).should eq("Grading #{@student.name}'s #{@assignment.name}")
         response.should render_template(:edit)
       end
     end
 
-		describe "POST update" do
-
-			it "updates the grade" do
-				pending
+    describe "POST update" do
+      it "updates the grade" do
+        pending
         params = { raw_score: 1000, assignment_id: @assignment.id }
         post :update, { :id => @grade.id, :assignment_id => @assignment.id, :student_id => @student.id }, :grade => params
         @grade.reload
         response.should redirect_to(assignment_path(@grade.assignment))
         @grade.score.should eq(1000)
       end
-
     end
 
-		describe "POST submit_rubric" do
-      pending
-    end
-
-		describe "GET remove" do
-      pending
-    end
-
-		describe "GET destroy" do
-      it "destroys the grade" do
-      	pending
-        expect{ get :destroy, {:id => @grade, :assignment_id => @assignment.id } }.to change(Grade,:count).by(-1)
-      end
-    end
-
-		describe "GET self_log" do
-      pending
-    end
-
-		describe "POST predict_score" do
-      pending
-    end
-
-		describe "GET mass_edit" do
+    describe "GET mass_edit" do
       it "assigns params" do
         get :mass_edit, :id => @assignment.id
         assigns(:title).should eq("Quick Grade #{@assignment.name}")
@@ -94,55 +68,42 @@ describe GradesController do
       end
     end
 
-		describe "POST mass_update" do
-      pending
+    describe "PUT mass_update" do
+      it "updates the grades for the specific assignment" do
+        grades = { "0" => { graded_by_id: @professor.id, instructor_modified: true,
+                            student_id: @student.id, raw_score: 1000, id: @grade.id }}
+        put :mass_update, id: @assignment.id, assignment: { grades_attributes: grades }
+        expect(@grade.reload.raw_score).to eq 1000
+      end
     end
 
-		describe "GET group_edit" do
+    describe "GET group_edit" do
       it "assigns params" do
-      	get :group_edit, { :id => @assignment.id, :group_id => @group.id}
+        get :group_edit, { :id => @assignment.id, :group_id => @group.id}
         assigns(:title).should eq("Grading #{@group.name}'s #{@assignment.name}")
         response.should render_template(:group_edit)
       end
     end
 
-		describe "POST group_update" do
-      pending
-    end
-
-		describe "GET edit_status" do
+    describe "GET edit_status" do
       it "displays the edit status page" do
         get :edit_status, {:grade_ids => [@grade.id], :id => @assignment.id}
         assigns(:title).should eq("#{@assignment.name} Grade Statuses")
-  			response.should render_template(:edit_status)
+        response.should render_template(:edit_status)
       end
     end
 
-		describe "POST update_status" do
-      pending
-    end
-
-		describe "GET import" do
+    describe "GET import" do
       it "displays the import page" do
-      	get :import, { :id => @assignment.id}
-      	assigns(:title).should eq("Import Grades for #{@assignment.name}")
-      	response.should render_template(:import)
+        get :import, { :id => @assignment.id}
+        assigns(:title).should eq("Import Grades for #{@assignment.name}")
+        response.should render_template(:import)
       end
     end
+  end
 
-		describe "GET username_import" do
-      pending
-    end
-
-		describe "GET email_import" do
-      pending
-    end
-
-	end
-
-	context "as student" do
-
-		before do
+  context "as student" do
+    before do
       @course = create(:course)
       @student = create(:user)
       @student.courses << @course
@@ -152,135 +113,133 @@ describe GradesController do
       @assignment_type = create(:assignment_type, course: @course)
       @assignment = create(:assignment)
       @course.assignments << @assignment
-			@grade = create(:grade)
-			@assignment.grades << @grade
-			@group = create(:group)
-			@assignment.groups << @group
+      @grade = create(:grade)
+      @assignment.grades << @grade
+      @group = create(:group)
+      @assignment.groups << @group
     end
 
-		describe "GET show" do
+    describe "GET show" do
       it "shows the grade display" do
         get :show, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-  			expect(response).to redirect_to(assignment_path(@assignment))
+        expect(response).to redirect_to(assignment_path(@assignment))
       end
     end
 
-		describe "POST predict_score" do
+    describe "POST predict_score" do
       it "posts to the predict score path" do
-      	pending
+        pending
         get :predict_score, {:grade_id => @grade.id, :id => @assignment.id, :student_id => @student.id }
-  			(expect(response.status).to eq(200))
+        (expect(response.status).to eq(200))
       end
     end
 
-		describe "POST self_log" do
+    describe "POST self_log" do
       it "posts a self-logged score" do
-      	pending
+        pending
         get :edit, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-  			(expect(response.status).to eq(200))
+        (expect(response.status).to eq(200))
       end
     end
 
+    describe "protected routes" do
+      describe "GET edit" do
+        it "redirects to root path" do
+          get :edit, {:grade_id => @grade.id, :assignment_id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-		describe "protected routes" do
+      describe "GET update" do
+        it "redirects to root path" do
+          get :update, {:grade_id => @grade.id, :assignment_id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-			describe "GET edit" do
-	      it "redirects to root path" do
-	        get :edit, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET submit_rubric" do
+        it "redirects to root path" do
+          get :submit_rubric, {:grade_id => @grade.id, :assignment_id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET update" do
-	      it "redirects to root path" do
-	        get :update, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET remove" do
+        it "redirects to root path" do
+          get :remove, { :id => @assignment.id, :grade_id => @grade.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET submit_rubric" do
-	      it "redirects to root path" do
-	        get :submit_rubric, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "DELETE destroy" do
+        it "redirects to root path" do
+          delete :destroy, {:grade_id => @grade.id, :assignment_id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET remove" do
-	      it "redirects to root path" do
-	        get :remove, { :id => @assignment.id, :grade_id => @grade.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET mass_edit" do
+        it "redirects to root path" do
+          get :mass_edit, { :id => @assignment.id }
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "DELETE destroy" do
-	      it "redirects to root path" do
-	        delete :destroy, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET mass_update" do
+        it "redirects to root path" do
+          post :mass_update, { :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET mass_edit" do
-	      it "redirects to root path" do
-	        get :mass_edit, { :id => @assignment.id }
-	        response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET group_edit" do
+        it "redirects to root path" do
+          get :group_edit, { :id => @assignment.id, :group_id => @group.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET mass_update" do
-	      it "redirects to root path" do
-	        post :mass_update, { :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET group_update" do
+        it "redirects to root path" do
+          post :group_update, { :id => @assignment.id, :group_id => @group.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET group_edit" do
-	      it "redirects to root path" do
-	        get :group_edit, { :id => @assignment.id, :group_id => @group.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET edit_status" do
+        it "redirects to root path" do
+          get :edit_status, {:grade_ids => [@grade.id], :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET group_update" do
-	      it "redirects to root path" do
-	        post :group_update, { :id => @assignment.id, :group_id => @group.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "POST update_status" do
+        it "redirects to root path" do
+          post :update_status, {:grade_ids => @grade.id, :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET edit_status" do
-	      it "redirects to root path" do
-	        get :edit_status, {:grade_ids => [@grade.id], :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET import" do
+        it "redirects to root path" do
+          get :import, { :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "POST update_status" do
-	      it "redirects to root path" do
-	        post :update_status, {:grade_ids => @grade.id, :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET username_import" do
+        it "redirects to root path" do
+          get :username_import, { :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
 
-	    describe "GET import" do
-	      it "redirects to root path" do
-	      	get :import, { :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
-
-	    describe "GET username_import" do
-	      it "redirects to root path" do
-	      	get :username_import, { :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
-
-	    describe "GET email_import" do
-	      it "redirects to root path" do
-	        post :email_import, { :id => @assignment.id}
-	  			response.should redirect_to(:root)
-	      end
-	    end
+      describe "GET email_import" do
+        it "redirects to root path" do
+          post :email_import, { :id => @assignment.id}
+          response.should redirect_to(:root)
+        end
+      end
     end
-	end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
   config.include Sorcery::TestHelpers::Rails::Integration, type: :feature
 
+  config.include BackgroundJobs
 
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true

--- a/spec/support/background_jobs.rb
+++ b/spec/support/background_jobs.rb
@@ -1,7 +1,10 @@
 module BackgroundJobs
   def run_background_jobs_immediately
-    Resque.inline do
-      yield
-    end
+    allow(Resque).to receive(:enqueue).and_call_original
+    inline = Resque.inline
+    Resque.inline = true
+    yield
+  ensure
+    Resque.inline = inline
   end
 end

--- a/spec/support/background_jobs.rb
+++ b/spec/support/background_jobs.rb
@@ -1,0 +1,7 @@
+module BackgroundJobs
+  def run_background_jobs_immediately
+    Resque.inline do
+      yield
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that only students with grades that were changed during the `mass_update` are notified that they have a new score.

This makes sure that the `raw_score` was changed before adding their grade to be sent to the `MultipleGradeUpdater` which sends out the grade updated notification.

In order to get the `Resque` job to run during the controller test, I added a helper to run the background jobs immediately.

Closes #17