### PR TITLE
Self grading with levels

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -241,7 +241,15 @@ class GradesController < ApplicationController
     @assignment = current_course.assignments.find(params[:id])
     if @assignment.open?
       @grade = current_student.grade_for_assignment(@assignment)
-      @grade.raw_score = params[:present] == 'true' ? @assignment.point_total : 0
+      if params[:present] == "true"
+        if params[:raw_score].present?
+          @grade.raw_score = params[:raw_score]
+        else
+          @grade.raw_score = @assignment.point_total
+        end
+      else
+        @grade.raw_score = 0
+      end
       @grade.status = "Graded"
       respond_to do |format|
         if @grade.save

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -242,8 +242,8 @@ class GradesController < ApplicationController
     if @assignment.open?
       @grade = current_student.grade_for_assignment(@assignment)
       if params[:present] == "true"
-        if params[:raw_score].present?
-          @grade.raw_score = params[:raw_score]
+        if params[:grade].present? && params[:grade][:raw_score].present?
+          @grade.raw_score = params[:grade][:raw_score]
         else
           @grade.raw_score = @assignment.point_total
         end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3,9 +3,9 @@ class Assignment < ActiveRecord::Base
   attr_accessible :name, :description, :point_total, :open_at, :due_at, :grade_scope, :visible, :required,
     :accepts_submissions, :accepts_links, :accepts_text, :accepts_attachments, :release_necessary, :media, :thumbnail, :media_credit, :media_caption,
     :accepts_submissions_until, :points_predictor_display, :notify_released, :mass_grade_type, :assignment_type_id, :assignment_type,
-    :include_in_timeline, :include_in_predictor, :include_in_to_do, :grades_attributes, :assignment_file_ids, :student_logged,
-    :assignment_files_attributes, :assignment_file, :assignment_score_levels_attributes, :assignment_score_level, :score_levels_attributes,
-    :remove_media, :remove_thumbnail, :use_rubric, :resubmissions_allowed, :pass_fail, :hide_analytics, 
+    :include_in_timeline, :include_in_predictor, :include_in_to_do, :grades_attributes, :assignment_file_ids, :student_logged, :student_logged_button_text,
+    :student_logged_revert_button_text, :assignment_files_attributes, :assignment_file, :assignment_score_levels_attributes, :assignment_score_level,
+    :score_levels_attributes, :remove_media, :remove_thumbnail, :use_rubric, :resubmissions_allowed, :pass_fail, :hide_analytics,
     :unlock_conditions, :unlock_conditions_attributes, :visible_when_locked
 
 
@@ -34,11 +34,11 @@ class Assignment < ActiveRecord::Base
   has_many :tasks, :as => :assignment, :dependent => :destroy
 
   # Unlocks
-  has_many :unlock_conditions, :as => :unlockable, :dependent => :destroy 
+  has_many :unlock_conditions, :as => :unlockable, :dependent => :destroy
   has_many :unlock_keys, :class_name => 'UnlockCondition', :foreign_key => :condition_id, :dependent => :destroy
 
   accepts_nested_attributes_for :unlock_conditions, allow_destroy: true, :reject_if => proc { |a| a['condition_type'].blank? || a['condition_id'].blank? }
-  
+
   has_many :unlock_states, :as => :unlockable, :dependent => :destroy
 
   # Student created submissions to be graded
@@ -247,15 +247,15 @@ class Assignment < ActiveRecord::Base
   def check_unlock_status(student)
     if ! is_unlocked_for_student?(student)
       goal = unlock_conditions.count
-      count = 0 
+      count = 0
       unlock_conditions.each do |condition|
         if condition.is_complete?(student)
           count += 1
-        end 
+        end
       end
-      if goal == count 
+      if goal == count
         if unlock_states.where(:student_id => student.id).present?
-          unlock_states.where(:student_id => student.id).first.unlocked = true 
+          unlock_states.where(:student_id => student.id).first.unlocked = true
         else
           self.unlock_states.create(:student_id => student.id, :unlocked => true, :unlockable_id => self.id, :unlockable_type => "Assignment")
         end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -68,6 +68,9 @@ class Assignment < ActiveRecord::Base
 
   validates_presence_of :assignment_type_id
 
+  validates :student_logged_button_text, presence: { message: "can't be blank if student logged", if: :student_logged? }
+  validates :student_logged_revert_button_text, presence: { message: "can't be blank if student logged", if: :student_logged? }
+
   validate :open_before_close, :submissions_after_due, :submissions_after_open
 
   # Filtering Assignments by Team Work, Group Work, and Individual Work

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -5,7 +5,6 @@ class AssignmentType < ActiveRecord::Base
     :percentage_course, :point_setting, :points_predictor_display,
     :predictor_description, :resubmission, :universal_point_value,
     :student_weightable, :mass_grade, :score_level, :mass_grade_type,
-    :student_logged_revert_button_text, :student_logged_button_text,
     :position
 
   belongs_to :course, touch: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -587,9 +587,9 @@ class User < ActiveRecord::Base
   end
 
   #Used to allow students to self-log a grade, currently only a boolean (complete or not)
-  #TODO Should allow them to use a select list or slider to determine their grade from a range of options
   def self_reported_done?(assignment)
-    (grade_for_assignment(assignment).try(:score) ) && (grade_for_assignment(assignment).try(:score)== grade_for_assignment(assignment).try(:point_total))
+    grade = grade_for_assignment(assignment)
+    grade.present? && grade.is_student_visible?
   end
 
 

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -1,5 +1,5 @@
 / Using Simple Form to create an assignment type
-- if @assignment_type.errors.any? 
+- if @assignment_type.errors.any?
   .alert-box.alert.radius
     .italic= "#{pluralize(@assignment_type.errors.count, "error")} prohibited this #{(term_for :assignment_type).downcase} from being saved:"
     %ul
@@ -35,18 +35,6 @@
         .sr-only Description
         = f.text_area :predictor_description, :label => "Description"
       .form_label How would you like to describe this #{term_for :assignment} type on the student dashboard? Are there hints that you can give students that will help them understand how to succeed?
-
-  %section
-    %h4.uppercase Self-Grading
-    .form-item
-      = f.label :student_logged_button_text, "Button Text"
-      = f.text_field :student_logged_button_text, {"aria-describedby" => "txtButtonText"}
-      .form_label{:id => "txtButtonText"} If you would like students to be able to log their own grades, what would you like the button that does this to say?
-
-    .form-item
-      = f.label :student_logged_revert_button_text, "Revert Button Text"
-      = f.text_field :student_logged_revert_button_text, {"aria-describedby" => "txtRevertButtonText"}
-      .form_label{:id => "txtRevertButtonText"} If a student unchecks this button, what should it say?
 
   .submit-buttons
     %ul

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -40,7 +40,6 @@
     .form-item
       = f.input :accepts_submissions_until, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker', :value => @assignment.try(:accepts_submissions_until) }, :label => "Accept until"
 
-
     .form-item
       = f.label :grade_scope, "Individual or Group?"
       = f.select :grade_scope, [["Individual"], ["Group"]]
@@ -77,7 +76,6 @@
       = f.check_box :required
       .form_label Are ALL #{term_for :students} expected to complete this #{term_for :assignment} to pass the course?
 
-
     - if current_course.accepts_submissions?
       .form-item
         .assignment_options
@@ -105,11 +103,6 @@
         = f.label :resubmissions_allowed #{term_for :assignment} Resubmissions
         = f.check_box :resubmissions_allowed
         .form_label Can #{term_for :students} resubmit this #{term_for :assignment}?
-
-    .form-item
-      = f.label :student_logged
-      = f.check_box :student_logged
-      .form_label Do #{term_for :students} self-report their grade for this #{term_for :assignment}?
 
     .form-item
       = f.label :release_necessary
@@ -141,6 +134,23 @@
         = f.label :hide_analytics, "Hide Analytics?"
         = f.check_box :hide_analytics, {"aria-describedby" => "hideAnalytics"}
         .form_label{:id => "hideAnalytics"}  Do you want to hide assignment analytics from students?
+
+  %section
+    %h4.uppercase Self-Grading
+    .form-item
+      = f.label :student_logged
+      = f.check_box :student_logged
+      .form_label Do #{term_for :students} self-report their grade for this #{term_for :assignment}?
+
+    .form-item
+      = f.label :student_logged_button_text, "Button Text"
+      = f.text_field :student_logged_button_text, {"aria-describedby" => "txtButtonText"}
+      .form_label{:id => "txtButtonText"} If you would like students to be able to log their own grades, what would you like the button that does this to say?
+
+    .form-item
+      = f.label :student_logged_revert_button_text, "Revert Button Text"
+      = f.text_field :student_logged_revert_button_text, {"aria-describedby" => "txtRevertButtonText"}
+      .form_label{:id => "txtRevertButtonText"} If a student unchecks this button, what should it say?
 
   %section
     %h4 Timeline

--- a/app/views/assignments/_guidelines.haml
+++ b/app/views/assignments/_guidelines.haml
@@ -7,12 +7,7 @@
 .italic= "Due: #{@assignment.due_at}" if @assignment.due_at?
 
 - if @assignment.student_logged? && @assignment.open? && current_user_is_student?
-
-  = simple_form_for current_student.grade_for_assignment(@assignment), :url => self_log_grades_assignment_path(@assignment), :method => :post do |f|
-    - present = current_student.self_reported_done?(@assignment)
-    = hidden_field_tag :present, !present
-    - if ! current_student.self_reported_done?(@assignment)
-      = f.submit (@assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
+  = render partial: "assignments/self_log_form", locals: { student: current_student, assignment: @assignment }
 
 - if @assignment.assignment_files.present?
   %hr

--- a/app/views/assignments/_guidelines.haml
+++ b/app/views/assignments/_guidelines.haml
@@ -12,7 +12,7 @@
     - present = current_student.self_reported_done?(@assignment)
     = hidden_field_tag :present, !present
     - if ! current_student.self_reported_done?(@assignment)
-      = f.submit (@assignment_type.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
+      = f.submit (@assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
 
 - if @assignment.assignment_files.present?
   %hr

--- a/app/views/assignments/_self_log_form.html.haml
+++ b/app/views/assignments/_self_log_form.html.haml
@@ -1,0 +1,7 @@
+= simple_form_for current_student.grade_for_assignment(assignment), :url => self_log_grades_assignment_path(assignment), :method => :post do |f|
+  - present = student.self_reported_done?(assignment)
+  = hidden_field_tag :present, !present
+  - if !present
+    - if assignment.has_levels?
+      = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }
+    = f.submit (assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -96,7 +96,7 @@
                           = hidden_field_tag :present, !present
                           - if !present
                             - if assignment.has_levels?
-                              = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }, :include_blank => true
+                              = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }
                             = f.submit (assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
                       - else
                         %span

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -86,7 +86,7 @@
                             .italic.bold= "Your Goal: #{points grade.predicted_score}" if grade && grade.predicted_score > 0 && current_user_is_student?
                     %td
                       - if assignment.future?
-                        %span= "#{assignment.due_at.strftime("%A, %b %d, %l:%M%p")}" 
+                        %span= "#{assignment.due_at.strftime("%A, %b %d, %l:%M%p")}"
                       - else
                         %span
                     %td
@@ -95,7 +95,7 @@
                           - present = @student.self_reported_done?(assignment)
                           = hidden_field_tag :present, !present
                           - if ! @student.self_reported_done?(assignment)
-                            = f.submit (assignment_type.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
+                            = f.submit (assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
                       - else
                         %span
                     %td
@@ -125,7 +125,7 @@
                           - if assignment.is_unlockable? && ! assignment.is_unlocked_for_student?(current_student)
                             %li= link_to "Unlock", manually_unlock_unlock_state_path(:student_id => current_student.id, :assignment_id => assignment.id), :method => :post, :class => "button"
                           - if assignment.is_individual?
-                            - if grade_released_for_assignment    
+                            - if grade_released_for_assignment
                               %li= link_to "Edit Grade", edit_assignment_grade_path(assignment.id, :student_id => @student.id), :class => 'button'
                             - else
                               %li= link_to 'Grade', edit_assignment_grade_path(:assignment_id =>assignment.id, :student_id => @student.id), :class => 'button'

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -94,7 +94,9 @@
                         = simple_form_for current_student.grade_for_assignment(assignment), :url => self_log_grades_assignment_path(assignment), :method => :post do |f|
                           - present = @student.self_reported_done?(assignment)
                           = hidden_field_tag :present, !present
-                          - if ! @student.self_reported_done?(assignment)
+                          - if !present
+                            - if assignment.has_levels?
+                              = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }, :include_blank => true
                             = f.submit (assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
                       - else
                         %span

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -91,13 +91,7 @@
                         %span
                     %td
                       - if assignment.student_logged? && assignment.open? && current_user_is_student?
-                        = simple_form_for current_student.grade_for_assignment(assignment), :url => self_log_grades_assignment_path(assignment), :method => :post do |f|
-                          - present = @student.self_reported_done?(assignment)
-                          = hidden_field_tag :present, !present
-                          - if !present
-                            - if assignment.has_levels?
-                              = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }
-                            = f.submit (assignment.student_logged_button_text), :class => "button #{present ? 'alert' : 'success'} tiny radius"
+                        = render partial: "assignments/self_log_form", locals: { student: @student, assignment: assignment }
                       - else
                         %span
                     %td

--- a/db/migrate/20150819142043_remove_student_logged_fields_from_assignment_types.rb
+++ b/db/migrate/20150819142043_remove_student_logged_fields_from_assignment_types.rb
@@ -1,0 +1,16 @@
+class RemoveStudentLoggedFieldsFromAssignmentTypes < ActiveRecord::Migration
+  def change
+    # Move the data from assignment types to assignments
+    AssignmentType.includes(:assignments).find_each do |type|
+      type.assignments.each do |assignment|
+        assignment.student_logged_button_text = type.student_logged_button_text
+        assignment.student_logged_revert_button_text =
+          type.student_logged_revert_button_text
+        assignment.save validate: false
+      end
+    end
+
+    remove_column :assignment_types, :student_logged_button_text
+    remove_column :assignment_types, :student_logged_revert_button_text
+  end
+end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -401,8 +401,6 @@ assignment_types[:polsci_attendance] = AssignmentType.create! do |at|
   at.due_date_present = true
   at.order_placement = 1
   at.mass_grade_type = "Checkbox"
-  at.student_logged_button_text = "I'm in class!"
-  at.student_logged_revert_button_text = "I couldn't make it"
 end
 puts "Check yourself in - and be sure to pay attention to the lecture!"
 
@@ -596,6 +594,8 @@ end
     a.release_necessary = false
     a.grade_scope = "Individual"
     a.student_logged = true
+    a.student_logged_button_text = "I'm in class!"
+    a.student_logged_revert_button_text = "I couldn't make it"
     if n < 15
       a.due_at = ((15-n)/2).weeks.ago
     else

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150814215710) do
+ActiveRecord::Schema.define(version: 20150819142043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,32 +82,30 @@ ActiveRecord::Schema.define(version: 20150814215710) do
   end
 
   create_table "assignment_types", force: :cascade do |t|
-    t.string   "name",                              limit: 255
-    t.string   "point_setting",                     limit: 255
+    t.string   "name",                     limit: 255
+    t.string   "point_setting",            limit: 255
     t.boolean  "levels"
-    t.string   "points_predictor_display",          limit: 255
+    t.string   "points_predictor_display", limit: 255
     t.integer  "resubmission"
     t.integer  "max_value"
     t.integer  "percentage_course"
     t.text     "predictor_description"
-    t.datetime "created_at",                                                   null: false
-    t.datetime "updated_at",                                                   null: false
+    t.datetime "created_at",                                          null: false
+    t.datetime "updated_at",                                          null: false
     t.integer  "course_id"
     t.integer  "universal_point_value"
     t.integer  "minimum_score"
-    t.integer  "step_value",                                    default: 1
+    t.integer  "step_value",                           default: 1
     t.integer  "grade_scheme_id"
     t.boolean  "due_date_present"
     t.integer  "order_placement"
     t.boolean  "mass_grade"
-    t.string   "mass_grade_type",                   limit: 255
+    t.string   "mass_grade_type",          limit: 255
     t.boolean  "student_weightable"
-    t.string   "student_logged_button_text",        limit: 255
-    t.string   "student_logged_revert_button_text", limit: 255
-    t.boolean  "notify_released",                               default: true
-    t.boolean  "include_in_timeline",                           default: true
-    t.boolean  "include_in_predictor",                          default: true
-    t.boolean  "include_in_to_do",                              default: true
+    t.boolean  "notify_released",                      default: true
+    t.boolean  "include_in_timeline",                  default: true
+    t.boolean  "include_in_predictor",                 default: true
+    t.boolean  "include_in_to_do",                     default: true
     t.boolean  "is_attendance"
     t.boolean  "has_winners"
     t.integer  "num_winner_levels"

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -156,7 +156,15 @@ describe GradesController do
       it "creates a maximum score by the student" do
         post :self_log, id: @assignment.id, present: "true"
         grade = @assignment.grades.last
-        expect(grade.reload.raw_score).to eq @assignment.point_total
+        expect(grade.raw_score).to eq @assignment.point_total
+      end
+
+      context "with assignment levels" do
+        it "creates a score for the student at the specified level" do
+          post :self_log, id: @assignment.id, present: "true", raw_score: "10000"
+          grade = @assignment.grades.last
+          expect(grade.raw_score).to eq 10000
+        end
       end
     end
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -153,10 +153,10 @@ describe GradesController do
     end
 
     describe "POST self_log" do
-      it "posts a self-logged score" do
-        pending
-        get :edit, {:grade_id => @grade.id, :assignment_id => @assignment.id}
-        (expect(response.status).to eq(200))
+      it "creates a maximum score by the student" do
+        post :self_log, id: @assignment.id, present: "true"
+        grade = @assignment.grades.last
+        expect(grade.reload.raw_score).to eq @assignment.point_total
       end
     end
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -161,7 +161,7 @@ describe GradesController do
 
       context "with assignment levels" do
         it "creates a score for the student at the specified level" do
-          post :self_log, id: @assignment.id, present: "true", raw_score: "10000"
+          post :self_log, id: @assignment.id, present: "true", grade: { raw_score: "10000" }
           grade = @assignment.grades.last
           expect(grade.raw_score).to eq 10000
         end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -59,17 +59,30 @@ describe Assignment do
 
   it { should be_valid }
 
-  #validations
-  it "is valid with a name and assignment type" do
-    expect(build(:assignment)).to be_valid
-  end
+  context "validations" do
+    it "is valid with a name and assignment type" do
+      expect(build(:assignment)).to be_valid
+    end
 
-  it "is invalid without a name" do
-    expect(build(:assignment, name: nil)).to have(1).errors_on(:name)
-  end
+    it "is invalid without a name" do
+      expect(build(:assignment, name: nil)).to have(1).errors_on(:name)
+    end
 
-  it "is invalid without an assignment type" do
-    expect(build(:assignment, assignment_type: nil)).to have(1).errors_on(:assignment_type_id)
+    it "is invalid without an assignment type" do
+      expect(build(:assignment, assignment_type: nil)).to have(1).errors_on(:assignment_type_id)
+    end
+
+    it "requires logged button text if it is student logged" do
+      subject = build :assignment, student_logged: true
+      expect(subject).to_not be_valid
+      expect(subject.errors[:student_logged_button_text]).to include "can't be blank if student logged"
+    end
+
+    it "requires logged revert button text if it is student logged" do
+      subject = build :assignment, student_logged: true
+      expect(subject).to_not be_valid
+      expect(subject.errors[:student_logged_revert_button_text]).to include "can't be blank if student logged"
+    end
   end
 
   it "has optional dates associated with it" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,6 +93,17 @@ describe User do
     end
   end
 
+  describe "#self_reported_done?" do
+    it "is not self reported if there are no grades" do
+      expect(@student).to_not be_self_reported_done(@assignment)
+    end
+
+    it "is self reported if there is at least one graded grade" do
+      @grade.update_attribute :status, "Graded"
+      expect(@student).to be_self_reported_done(@assignment)
+    end
+  end
+
   context "validations" do
     it "requires the password confirmation to match" do
       user = User.new password: "test", password_confirmation: "blah"


### PR DESCRIPTION
Allows a student to choose from levels to self score if the assignment has levels. This is the experience from the syllabus:

![self-grade](https://cloud.githubusercontent.com/assets/35017/9367146/9cea8992-4689-11e5-90a3-22bd0f477db1.gif)

Once the student assigns a score, they no longer are allowed to score again.

This removes the `student_logged_button_text` and the `student_logged_revert_button_text` were removed from the `AssignmentType` and moved to the `Assignment`.

The `Assignment` form now contains a self logging section:

<img width="981" alt="screen shot 2015-08-19 at 3 53 01 pm" src="https://cloud.githubusercontent.com/assets/35017/9367279/68675d66-468a-11e5-97d5-2a58d948ea8e.png">

Validation rules were added to an `Assignment` so that it ensures the buttons for students to score a grade were not blank. The button texts are required if the assignment is `student_logged?`.

Closes #18