### PR TITLE
Fix edit profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -75,6 +75,7 @@ class UsersController < ApplicationController
     if @user.is_student?(current_course)
       @user.teams.set_for_course(current_course.id, params[:user][:course_team_ids])
     end
+
     @user.update_attributes(params[:user])
     if @user.save && @user.is_student?(current_course)
       redirect_to students_path, :notice => "#{term_for :student} #{@user.name} was successfully updated!"
@@ -127,8 +128,13 @@ class UsersController < ApplicationController
 
   def update_profile
     @user = current_user
-    @user.update_attributes(params[:user])
-    if @user.save
+
+    if params[:user][:password].blank? && params[:user][:password_confirmation].blank?
+      params[:user].delete(:password)
+      params[:user].delete(:password_confirmation)
+    end
+
+    if @user.update_attributes(params[:user])
       redirect_to dashboard_path, :notice => "Your profile was successfully updated!"
     else
       redirect_to edit_profile_users_path(@user), :alert => "I'm sorry, something went wrong. Your profile was not successfully updated."

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -104,13 +104,12 @@ describe UsersController do
       end
     end
 
-    describe "GET update_profile" do
+    describe "POST update_profile" do
       it "successfully updates the users profile" do
         params = { display_name: "gandalf" }
         post :update_profile, id: @professor.id, :user => params
-        @professor.reload
         response.should redirect_to(dashboard_path)
-        @professor.display_name.should eq("gandalf")
+        @professor.reload.display_name.should eq("gandalf")
       end
     end
 
@@ -269,13 +268,19 @@ describe UsersController do
       end
     end
 
-    describe "GET update_profile" do
+    describe "POST update_profile" do
       it "successfully updates the users profile" do
-        params = { display_name: "frodo" }
+        params = { display_name: "frodo", password: "", password_confirmation: "" }
         post :update_profile, id: @student.id, :user => params
-        @student.reload
-        response.should redirect_to(dashboard_path)
-        @student.display_name.should eq("frodo")
+        expect(response).to redirect_to(dashboard_path)
+        expect(@student.reload.display_name).to eq("frodo")
+      end
+
+      it "successfully updates the user's password" do
+        params = { password: "test", password_confirmation: "test" }
+        post :update_profile, id: @student.id, :user => params
+        expect(response).to redirect_to(dashboard_path)
+        expect(User.authenticate(@student.email, "test")).to eq @student
       end
     end
 


### PR DESCRIPTION
The ability to update a profile (via `/users/edit_profile`) was broken due to the fact that a password was not required.

In order to update a profile without specifying a password each time, the `password` and `password_confirmation` fields were removed from the parameters if they were not blanked.