### PR TITLE
Instructors of record

### DIFF
--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -60,8 +60,8 @@ $("#team_student_ids").select2({
   allowClear: true
 });
 
-// Select2 Search forms for course creation
-$("#course_instructors_of_record_ids").select2({
+// Select2 Search forms for anything that has a data-behavior of multi-select
+$(document).find("[data-behavior~=multi-select]").select2({
   allowClear: true
 });
 

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -60,5 +60,10 @@ $("#team_student_ids").select2({
   allowClear: true
 });
 
+// Select2 Search forms for course creation
+$("#course_instructors_of_record_ids").select2({
+  allowClear: true
+});
+
 // Initializing highcharts table data, currently used to display team charts
 $('table.highchart').highchartTable();

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -115,7 +115,7 @@ class CoursesController < ApplicationController
 
     respond_to do |format|
       if @course.save
-        @course.course_memberships.create(:user_id => current_user.id, :role => current_user.course_memberships.where(:course_id => current_course.id).first.role)
+        @course.course_memberships.create(:user_id => current_user.id, :role => current_user.course_memberships.where(:course_id => current_course.id).first.role, instructor_of_record: true)
         session[:course_id] = @course.id
         format.html { redirect_to course_path(@course), notice: "Course #{@course.name} successfully created" }
         format.json { render json: @course, status: :created, location: @course }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -42,9 +42,15 @@ class GroupsController < ApplicationController
     else
       @group.approved = "Approved"
     end
-    respond_to do |format|
+    respond_to do |format|- unless current_course.instructors_of_record.empty?
+    .small-12
+      %p
+      %p= raw current_course.grading_philosophy
+      %h6= "-- #{"Prof".pluralize(current_course.instructors_of_record.count)}. #{current_course.instructors_of_record.map(&:last_name).join(", ") }"
       if @group.save
-        #NotificationMailer.group_created(@group.id).deliver
+        #current_course.instructors_of_record.each do |professor|
+          #NotificationMailer.group_created(@group.id, professor).deliver
+        #end
         #NotificationMailer.group_notify(@group.id).deliver
         format.html { respond_with @group }
       else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -42,11 +42,7 @@ class GroupsController < ApplicationController
     else
       @group.approved = "Approved"
     end
-    respond_to do |format|- unless current_course.instructors_of_record.empty?
-    .small-12
-      %p
-      %p= raw current_course.grading_philosophy
-      %h6= "-- #{"Prof".pluralize(current_course.instructors_of_record.count)}. #{current_course.instructors_of_record.map(&:last_name).join(", ") }"
+    respond_to do |format|
       if @group.save
         #current_course.instructors_of_record.each do |professor|
           #NotificationMailer.group_created(@group.id, professor).deliver

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -15,7 +15,7 @@ class NotificationMailer < ActionMailer::Base
       format.text
     end
   end
-  
+
   def grade_export(course,user,csv_data)
     @user = user
     @course = course
@@ -40,7 +40,7 @@ class NotificationMailer < ActionMailer::Base
     @user = @submission.student
     @course = @submission.course
     @assignment = @submission.assignment
-    mail(:to => @user.email, 
+    mail(:to => @user.email,
       :subject => "#{@course.courseno} - #{@assignment.name} Submitted") do |format|
       format.text
       format.html
@@ -52,7 +52,7 @@ class NotificationMailer < ActionMailer::Base
     @user = @submission.student
     @course = @submission.course
     @assignment = @submission.assignment
-    mail(:to => @user.email, 
+    mail(:to => @user.email,
       :subject => "#{@course.courseno} - #{@assignment.name} Submission Updated") do |format|
       format.text
       format.html
@@ -88,17 +88,17 @@ class NotificationMailer < ActionMailer::Base
     @user = @grade.student
     @course = @grade.course
     @assignment = @grade.assignment
-    mail(:to => @user.email, 
+    mail(:to => @user.email,
       :subject => "#{@course.courseno} - #{@assignment.name} Graded") do |format|
       format.text
       format.html
     end
   end
 
-  def group_created(group_id)
+  def group_created(group_id, professor)
     @group = Group.find group_id
     @course = @group.course
-    @professor = @group.course.professor
+    @professor = professor
     mail(:to => @professor.email, :subject => "#{@course.courseno} - New Group to Review") do |format|
       format.text
       format.html
@@ -135,7 +135,7 @@ class NotificationMailer < ActionMailer::Base
     @earned_badge = EarnedBadge.find earned_badge_id
     @user = @earned_badge.student
     @course = @earned_badge.course
-    mail(:to => @user.email, 
+    mail(:to => @user.email,
       :subject => "#{@course.courseno} - You've earned a new #{@course.badge_term}!") do |format|
       format.text
       format.html

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -59,24 +59,24 @@ class NotificationMailer < ActionMailer::Base
     end
   end
 
-  def new_submission(submission_id)
+  def new_submission(submission_id, professor)
     @submission = Submission.find submission_id
     @user = @submission.student
     @course = @submission.course
     @assignment = @submission.assignment
-    @professor = @course.professor
+    @professor = professor
     mail(:to => @professor.email, :subject => "#{@course[:courseno]} - New Submission to Grade") do |format|
       format.text
       format.html
     end
   end
 
-  def revised_submission(submission_id)
+  def revised_submission(submission_id, professor)
     @submission = Submission.find submission_id
     @user = @submission.student
     @course = @submission.course
     @assignment = @submission.assignment
-    @professor = @course.professor
+    @professor = professor
     mail(:to => @professor.email, :subject => "#{@course[:courseno]} - Updated Submission to Grade") do |format|
       format.text
       format.html

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,6 +11,10 @@ class Course < ActiveRecord::Base
     end
   end
 
+  def instructors_of_record
+    User.instructors_of_record(self)
+  end
+
   # Staff returns all professors and GSI for the course.
   # Note that this is different from is_staff? which currently
   # includes Admin users

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,16 +20,22 @@ class Course < ActiveRecord::Base
   end
 
   def instructors_of_record_ids=(value)
-    excluded = course_memberships.reject { |membership| value.include? membership.user_id }
-    excluded.each do |remove|
-      remove.instructor_of_record = false
-      remove.save
+    user_ids = value.map(&:to_i)
+
+    # Remove instructors of record that are not in the array of ids
+    course_memberships.select do |membership|
+      membership.instructor_of_record && !user_ids.include?(membership.user_id)
+    end.each do |membership|
+      membership.instructor_of_record = false
+      membership.save
     end
 
-    current = course_memberships.select { |membership| value.include? membership.user_id }
-    current.each do |current|
-      current.instructor_of_record = true
-      current.save
+    # Add instructors of record that are in the array of ids
+    course_memberships.select do |membership|
+      !membership.instructor_of_record && user_ids.include?(membership.user_id)
+    end.each do |membership|
+      membership.instructor_of_record = true
+      membership.save
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -287,10 +287,6 @@ class Course < ActiveRecord::Base
     students_being_graded.count
   end
 
-  def professor
-    course_memberships.where(:role => "professor").first.user if course_memberships.where(:role => "professor").first.present?
-  end
-
   def point_total_for_challenges
     challenges.pluck('point_total').sum
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -19,6 +19,20 @@ class Course < ActiveRecord::Base
     instructors_of_record.map(&:id)
   end
 
+  def instructors_of_record_ids=(value)
+    excluded = course_memberships.reject { |membership| value.include? membership.user_id }
+    excluded.each do |remove|
+      remove.instructor_of_record = false
+      remove.save
+    end
+
+    current = course_memberships.select { |membership| value.include? membership.user_id }
+    current.each do |current|
+      current.instructor_of_record = true
+      current.save
+    end
+  end
+
   # Staff returns all professors and GSI for the course.
   # Note that this is different from is_staff? which currently
   # includes Admin users
@@ -62,7 +76,8 @@ class Course < ActiveRecord::Base
     :team_challenges, :team_leader_term, :max_assignment_types_weighted,
     :point_total, :in_team_leaderboard, :grade_scheme_elements_attributes,
     :add_team_score_to_student, :status, :assignments_attributes, :character_profiles,
-    :start_date, :end_date, :pass_term, :fail_term, :syllabus, :hide_analytics
+    :start_date, :end_date, :pass_term, :fail_term, :syllabus, :hide_analytics,
+    :instructors_of_record_ids
 
   with_options :dependent => :destroy do |c|
     c.has_many :assignment_types

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,6 +15,10 @@ class Course < ActiveRecord::Base
     User.instructors_of_record(self)
   end
 
+  def instructors_of_record_ids
+    instructors_of_record.map(&:id)
+  end
+
   # Staff returns all professors and GSI for the course.
   # Note that this is different from is_staff? which currently
   # includes Admin users

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -27,10 +27,13 @@ class CourseMembership < ActiveRecord::Base
       case extra['roles'].downcase
       when /instructor/
         self.update_attribute(:role, 'professor')
+        self.update_attribute(:instructor_of_record, true)
       when /teachingassistant/
         self.update_attribute(:role, 'gsi')
+        self.update_attribute(:instructor_of_record, true)
       else
         self.update_attribute(:role, 'student')
+        self.update_attribute(:instructor_of_record, false)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,12 @@ class User < ActiveRecord::Base
       User.where(id: user_ids).students_in_team(team.id, user_ids)
     end
 
+    def instructors_of_record(course)
+      user_ids = CourseMembership
+        .where(course: course, instructor_of_record: true)
+        .pluck(:user_id)
+      User.where(id: user_ids)
+    end
   end
 
   attr_accessor :password, :password_confirmation, :cached_last_login_at, :course_team_ids, :score, :team

--- a/app/validators/instructor_of_record_validator.rb
+++ b/app/validators/instructor_of_record_validator.rb
@@ -1,0 +1,8 @@
+class InstructorOfRecordValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if !record.staff? && value
+      role_name = record.role.blank? ? "anyone" : record.role.pluralize
+      record.errors[attribute] << "is not valid for #{role_name}"
+    end
+  end
+end

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -94,13 +94,14 @@
       = f.input :media_credit
       = f.input :media_caption
 
-  %section
-    %h4.uppercase Professors
-    .form-item
-      = f.label :professors
-      = f.input :instructors_of_record_ids, collection: f.object.staff,
-        label: false, wrapper: false, input_html: { multiple: true }
-      .form_label Enter a professor's name to add them to this course
+  - unless @course.new_record?
+    %section
+      %h4.uppercase Professors
+      .form-item
+        = f.label :professors
+        = f.input :instructors_of_record_ids, collection: f.object.staff,
+          label: false, wrapper: false, input_html: { multiple: true }
+        .form_label Enter a professor's name to add them to this course
 
   %section
     %h4.uppercase GradeCraft Settings

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -81,7 +81,7 @@
     .form-item
       = f.label :meeting_times, "Class Meeting Times"
       = f.text_field :meeting_times
-      
+
     .form-item
       = f.label :syllabus
       = f.file_field :syllabus
@@ -93,6 +93,14 @@
       = f.file_field :media_file
       = f.input :media_credit
       = f.input :media_caption
+
+  %section
+    %h4.uppercase Professors
+    .form-item
+      = f.label :professors
+      = f.input :instructors_of_record_ids, collection: f.object.staff,
+        label: false, wrapper: false, input_html: { multiple: true }
+      .form_label Enter a professor's name to add them to this course
 
   %section
     %h4.uppercase GradeCraft Settings
@@ -154,7 +162,7 @@
     .form-item
       = f.label :hide_analytics, "Hide Analytics?"
       = f.check_box :hide_analytics, {"aria-describedby" => "hideAnalytics"}
-      .form_label{:id => "hideAnalytics"}  Do you want to hide assignment and course analytics from students? 
+      .form_label{:id => "hideAnalytics"}  Do you want to hide assignment and course analytics from students?
 
 
     - if current_user_is_admin?

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -100,7 +100,7 @@
       .form-item
         = f.label :professors
         = f.input :instructors_of_record_ids, collection: f.object.staff,
-          label: false, wrapper: false, input_html: { multiple: true }
+          label: false, wrapper: false, input_html: { multiple: true, data: { behavior: "multi-select" } }
         .form_label Enter a professor's name to add them to this course
 
   %section

--- a/app/views/courses/_grading_philosophy.html.haml
+++ b/app/views/courses/_grading_philosophy.html.haml
@@ -1,0 +1,5 @@
+- if !course.instructors_of_record.empty? && course.grading_philosophy.present?
+  .small-12
+    %p
+    %p= raw course.grading_philosophy
+    %h6= "-- #{"Prof".pluralize(course.instructors_of_record.count)}. #{course.instructors_of_record.map(&:last_name).join(", ") }"

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -11,7 +11,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   .panel
     %h4 THE BASICS
     %p.clear
@@ -76,7 +76,6 @@
       %b Meeting Time:
       = @course.meeting_times
 
-
   .panel
     %h4 BADGES
     %p.clear
@@ -106,6 +105,11 @@
         %b Section Leaders will be called:
         = @course.team_leader_term
 
+  .panel
+    %h4 PROFESSORS
+    %p.clear
+      - @course.instructors_of_record.each do |user|
+        %p= user.name
 
   .panel
     %h4 GROUPS

--- a/app/views/grade_scheme_elements/index.html.haml
+++ b/app/views/grade_scheme_elements/index.html.haml
@@ -11,7 +11,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   / Grade Scheme Elements Table Display
   %table.nofeatures_dynatable{"aria-describedby" => "tableCaption"}
     %thead
@@ -28,8 +28,4 @@
           %td{:data => { :"sort-value" => "#{element.low_range }" }}= points element.low_range
           %td{:data => { :"sort-value" => "#{element.high_range }" }}= points element.high_range
 
-  - if current_course.professor.present?
-    .small-12
-      %p
-      %p= raw current_course.grading_philosophy
-      %h6= "-- Prof. #{current_course.professor.try(:last_name) }"
+  = render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,6 +1,6 @@
 = simple_form_for @group do |f|
 
-  - if @group.errors.any? 
+  - if @group.errors.any?
     .alert-box.alert
       .italic= "#{pluralize(@group.errors.count, "error")} prohibited this group from being saved:"
       %ul
@@ -47,7 +47,7 @@
             .form_label If your #{term_for :group} knows what it will be working on, you can submit that here.
             = f.text_area :proposal, :class => "froala"
             = f.hidden_field :id
-         
+
       - if @group.persisted?
         = link_to 'Add a Proposal', '#', class: 'add-proposal button'
 

--- a/app/views/layouts/navigation/_class_info.haml
+++ b/app/views/layouts/navigation/_class_info.haml
@@ -1,7 +1,8 @@
 %li
-  %a{:href => "#"} 
+  %a{:href => "#"}
     %i.fa.fa-flash.fa-fw
-    Professor #{ current_course.professor.try(:name) }
+    = "Professor".pluralize(current_course.instructors_of_record.count)
+    = current_course.instructors_of_record.map(&:name).join(", ")
 - if current_course.office.present?
   %li
     %a{:href => "#"}

--- a/app/views/students/course_progress.html.haml
+++ b/app/views/students/course_progress.html.haml
@@ -2,7 +2,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   - @grade_scheme_elements.each do |element|
     - if current_student.cached_score_for_course(current_course) < element.low_range
       .progress.bar_magic.transparent.center
@@ -22,7 +22,7 @@
     - else
       .progress.bar_magic.striped.center
         .meter
-          %span Your rank: 
+          %span Your rank:
           %span= element.level
           %span= element.letter
           %span with
@@ -30,7 +30,5 @@
           %span points.
           %span=points element.points_to_next_level(current_student, current_course)
           %span= " points to the next level!"
-          
-  - if current_course.professor.present? && current_course.grading_philosophy.present?
-    %p= raw current_course.grading_philosophy
-    %h3= "– Prof. #{current_course.professor.try(:last_name) }"
+
+  = render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/db/migrate/20150825152037_add_instructor_of_record_to_course_memberships.rb
+++ b/db/migrate/20150825152037_add_instructor_of_record_to_course_memberships.rb
@@ -1,0 +1,5 @@
+class AddInstructorOfRecordToCourseMemberships < ActiveRecord::Migration
+  def change
+    add_column :course_memberships, :instructor_of_record, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150821033921) do
+ActiveRecord::Schema.define(version: 20150825152037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,12 +313,13 @@ ActiveRecord::Schema.define(version: 20150821033921) do
   create_table "course_memberships", force: :cascade do |t|
     t.integer  "course_id"
     t.integer  "user_id"
-    t.integer  "score",                         default: 0,         null: false
+    t.integer  "score",                            default: 0,         null: false
     t.boolean  "shared_badges"
     t.text     "character_profile"
     t.datetime "last_login_at"
-    t.boolean  "auditing",                      default: false,     null: false
-    t.string   "role",              limit: 255, default: "student", null: false
+    t.boolean  "auditing",                         default: false,     null: false
+    t.string   "role",                 limit: 255, default: "student", null: false
+    t.boolean  "instructor_of_record",             default: false
   end
 
   add_index "course_memberships", ["course_id", "user_id"], name: "index_course_memberships_on_course_id_and_user_id", unique: true, using: :btree
@@ -527,9 +528,9 @@ ActiveRecord::Schema.define(version: 20150821033921) do
     t.string   "pass_fail_status"
     t.boolean  "feedback_read",                    default: false
     t.datetime "feedback_read_at"
-    t.boolean  "is_custom_value",                  default: false
     t.boolean  "feedback_reviewed",                default: false
     t.datetime "feedback_reviewed_at"
+    t.boolean  "is_custom_value",                  default: false
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -1,0 +1,20 @@
+namespace :courses do
+  desc "Initializes the instructors of record for all existing courses"
+  task :update_instructors_of_record => :environment do
+    all = []
+    CourseMembership.find_each do |membership|
+      membership.update_attribute :instructor_of_record, false
+    end
+
+    Course.find_each do |course|
+      course_membership = course.course_memberships.where(role: "professor").first
+      if course_membership
+        course_membership.instructor_of_record = true
+        course_membership.save
+        all << course_membership
+      end
+    end
+
+    puts "\nSuccessfully updates all #{all.count} #{"course".pluralize(all.count)}."
+  end
+end

--- a/spec/models/course_membership_spec.rb
+++ b/spec/models/course_membership_spec.rb
@@ -1,7 +1,64 @@
-# spec/models/course_membership_spec.rb
-
 require 'spec_helper'
 
 describe CourseMembership do
+  context "validations" do
+    subject { build :course_membership }
 
+    it "requires that the role is a staff role for instructors of record" do
+      subject.role = "student"
+      subject.instructor_of_record = true
+      expect(subject).to_not be_valid
+      expect(subject.errors[:instructor_of_record]).to include "is not valid for students"
+    end
+
+    it "requires that a role is specified if the instructor of record is set" do
+      subject.role = nil
+      subject.instructor_of_record = true
+      expect(subject).to_not be_valid
+      expect(subject.errors[:instructor_of_record]).to include "is not valid for anyone"
+    end
+  end
+
+  describe "#student?" do
+    it "is a student if the role is student" do
+      subject.role = "student"
+      expect(subject).to be_student
+    end
+  end
+
+  describe "#professor?" do
+    it "is a professor if the role is professor" do
+      subject.role = "professor"
+      expect(subject).to be_professor
+    end
+  end
+
+  describe "#gsi?" do
+    it "is a gsi if the role is gsi" do
+      subject.role = "gsi"
+      expect(subject).to be_gsi
+    end
+  end
+
+  describe "#admin?" do
+    it "is an admin if the role is admin" do
+      subject.role = "admin"
+      expect(subject).to be_admin
+    end
+  end
+
+  describe "#staff?" do
+    it "is staff if it has a professor, gsi, or admin role" do
+      roles = ["professor", "gsi", "admin"]
+      roles.each do |role|
+        subject.role = role
+        expect(subject).to be_staff
+      end
+    end
+
+    it "is not staff if it has a student role" do
+      subject.role = "student"
+      expect(subject).to_not be_staff
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -97,4 +97,18 @@ describe Course do
       expect(subject.instructors_of_record).to eq [membership.user]
     end
   end
+
+  describe "#instructors_of_record_ids=" do
+    it "adds the instructors of record if they were not there before" do
+      membership = create :staff_course_membership, course: subject
+      subject.instructors_of_record_ids = [membership.user_id]
+      expect(subject.instructors_of_record).to eq [membership.user]
+    end
+
+    it "removes the instructors of record that are not present" do
+      membership = create :staff_course_membership, course: subject, instructor_of_record: true
+      subject.instructors_of_record_ids = []
+      expect(subject.instructors_of_record).to be_empty
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -90,4 +90,11 @@ describe Course do
     @course.pass_term.should eq("Pass")
     @course.fail_term.should eq("Fail")
   end
+
+  describe "#instructors_of_record" do
+    it "returns all the staff who are instructors of record for the course" do
+      membership = create :staff_course_membership, course: subject, instructor_of_record: true
+      expect(subject.instructors_of_record).to eq [membership.user]
+    end
+  end
 end


### PR DESCRIPTION
This PR allows for multiple staff members to be added as instructors of record for a `Course`. These instructors are displayed within the course information. 

The `Course#professor` method was removed and it was replaced with `Course#instructors_of_record` instead.

A `boolean` column `instructor_of_record` was added to the `CourseMembership` table. I added a validation in order to ensure that only staff can be added as an instructor of record. To accomplish this, I needed to add "role methods" to the `CourseMembership` object including `course_membership#staff?`. This contains the "same logic" as `User.is_staff?(course)` but there was no way to share this logic. Any ideas would be helpful if you feel it's a big deal.

Here is an example of updating a course and adding additional instructors of record.

![instructors-of-record](https://cloud.githubusercontent.com/assets/35017/9479078/aba3afda-4b49-11e5-9d8e-f196f42be11b.gif)

In order to deploy this, the following tasks need to be run:

- [ ] `bundle exec rake db:migrate`
- [ ] `bundle exec rake courses:update_instructors_of_record`

Closes #5