### PR TITLE
User import do not require teams

### DIFF
--- a/app/importers/student_importer.rb
+++ b/app/importers/student_importer.rb
@@ -14,7 +14,7 @@ class StudentImporter
     if file
       CSV.foreach(file, headers: true, skip_blanks: true) do |row|
         team = find_or_create_team row, course
-        if !team.valid?
+        if team && !team.valid?
           append_unsuccessful row, team.errors.full_messages.join(", ")
           next
         end
@@ -22,7 +22,7 @@ class StudentImporter
         user = create_user row, course
 
         if user.valid?
-          team.students << user
+          team.students << user if team
           UserMailer.activation_needed_email(user).deliver_now
           successful << user
         else
@@ -53,6 +53,7 @@ class StudentImporter
 
   def find_or_create_team(row, course)
     name = row[4]
+    return if name.blank?
     team = Team.find_by_course_and_name course.id, name
     team ||= Team.create course_id: course.id, name: name
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -129,8 +129,9 @@ describe UsersController do
       it "renders the results from the import" do
         post :upload, file: file
         expect(response).to render_template :import_results
-        expect(response.body).to include "1 Student Imported Successfully"
+        expect(response.body).to include "2 Students Imported Successfully"
         expect(response.body).to include "jimmy@example.com"
+        expect(response.body).to include "robert@example.com"
       end
 
       it "renders any errors that have occured" do

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,2 +1,3 @@
 First Name,Last Name,Username,Email,Team Name
+Robert,Plant,rober,robert@example.com,
 Jimmy,Page,jimmy,jimmy@example.com,Zeppelin

--- a/spec/importers/student_importer_spec.rb
+++ b/spec/importers/student_importer_spec.rb
@@ -39,20 +39,20 @@ describe StudentImporter do
 
       it "sends the activation email to each student" do
         expect { subject.import course }.to \
-          change { ActionMailer::Base.deliveries.count }.by 1
+          change { ActionMailer::Base.deliveries.count }.by 2
       end
 
       it "contains a successful user if the user and team are valid" do
         result = subject.import course
-        expect(result.successful.count).to eq 1
-        expect(result.successful.first).to eq user
+        expect(result.successful.count).to eq 2
+        expect(result.successful.last).to eq user
       end
 
       it "contains an unsuccessful row if the user is not valid" do
         User.create first_name: "Jimmy", last_name: "Page",
             email: "jimmy@example.com", username: "jimmy"
         result = subject.import course
-        expect(result.successful.count).to be_zero
+        expect(result.successful.count).to eq 1
         expect(result.unsuccessful.count).to eq 1
         expect(result.unsuccessful.first[:errors]).to eq "Email has already been taken"
       end
@@ -61,7 +61,7 @@ describe StudentImporter do
         allow_any_instance_of(Team).to receive(:valid?).and_return false
         allow_any_instance_of(Team).to receive(:errors).and_return double(full_messages: ["The team is not cool"])
         result = subject.import course
-        expect(result.successful.count).to be_zero
+        expect(result.successful.count).to eq 1
         expect(result.unsuccessful.count).to eq 1
         expect(result.unsuccessful.first[:errors]).to eq "The team is not cool"
       end

--- a/spec/importers/student_importer_spec.rb
+++ b/spec/importers/student_importer_spec.rb
@@ -37,6 +37,12 @@ describe StudentImporter do
         expect(team.students.first.email).to eq "jimmy@example.com"
       end
 
+      it "does not add the student to the team if a team is not specified" do
+        subject.import course
+        user = User.unscoped.first
+        expect(team.students).to_not include user
+      end
+
       it "sends the activation email to each student" do
         expect { subject.import course }.to \
           change { ActionMailer::Base.deliveries.count }.by 2


### PR DESCRIPTION
This change to the user import does not require that a team be specified in order to import the user record.

If the team is blank, the team import is skipped.

Closes #5