### PR TITLE
Import grades error reporting

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -334,7 +334,7 @@ class AssignmentsController < ApplicationController
   def grade_import
     @assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
-      format.csv { send_data @assignment.grade_import }
+      format.csv { send_data @assignment.grade_import(current_course.students) }
     end
   end
 
@@ -368,7 +368,7 @@ class AssignmentsController < ApplicationController
           error_log = ""
 
           open( "#{export_dir}/_grade_import_template.csv",'w' ) do |f|
-            f.puts @assignment.grade_import(students: @students)
+            f.puts @assignment.grade_import(@students)
           end
 
           @students.each do |student|

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -339,14 +339,6 @@ class AssignmentsController < ApplicationController
     end
   end
 
-  def username_based_grade_import
-    @assignment = current_course.assignments.find(params[:id])
-    respond_to do |format|
-      format.csv { send_data @assignment.username_based_grade_import }
-    end
-  end
-
-  # Exporting the grades for a single assignment
   def export_grades
     @assignment = current_course.assignments.find(params[:id])
     respond_to do |format|

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -331,11 +331,10 @@ class AssignmentsController < ApplicationController
     redirect_to assignments_url, notice: "#{(term_for :assignment).titleize} #{@name} successfully deleted"
   end
 
-  # Export .csv file example for grade imports
-  def email_based_grade_import
+  def grade_import
     @assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
-      format.csv { send_data @assignment.email_based_grade_import }
+      format.csv { send_data @assignment.grade_import }
     end
   end
 
@@ -369,7 +368,7 @@ class AssignmentsController < ApplicationController
           error_log = ""
 
           open( "#{export_dir}/_grade_import_template.csv",'w' ) do |f|
-            f.puts @assignment.username_based_grade_import(students: @students)
+            f.puts @assignment.grade_import(students: @students)
           end
 
           @students.each do |student|

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -596,7 +596,7 @@ class GradesController < ApplicationController
     @title = "Import Grades for #{@assignment.name}"
   end
 
-  def email_import
+  def upload
     if params[:file].blank?
       flash[:notice] = "File missing"
       redirect_to assignment_path(@assignment)

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -596,52 +596,6 @@ class GradesController < ApplicationController
     @title = "Import Grades for #{@assignment.name}"
   end
 
-  #upload based on username
-  def username_import
-    @assignment = current_course.assignments.find(params[:id])
-    @students = current_course.students
-    grade_ids = []
-    require 'csv'
-
-    if params[:file].blank?
-      flash[:notice] = "File missing"
-      redirect_to assignment_path(@assignment)
-    else
-      CSV.foreach(params[:file].tempfile, :headers => true, :encoding => 'ISO-8859-1') do |row|
-        @students.each do |student|
-          if student.username.downcase == row[2].downcase && row[3].present?
-            if student.grades.where(:assignment_id => @assignment).present?
-              @assignment.all_grade_statuses_grade_for_student(student).tap do |grade|
-                grade.raw_score = row[3].to_i
-                grade.feedback = row[4]
-                if grade.status == nil
-                  grade.status = "Graded"
-                end
-                grade.instructor_modified = true
-                grade.save!
-                grade_ids << grade.id
-              end
-            else
-              @assignment.grades.create! do |grade|
-                grade.assignment_id = @assignment.id
-                grade.student_id = student.id
-                grade.raw_score = row[3].to_i
-                grade.feedback = row[4]
-                grade.status = "Graded"
-                grade.instructor_modified = true
-                grade.save!
-                grade_ids << grade.id
-              end
-            end
-          end
-        end
-      end
-    Resque.enqueue(MultipleGradeUpdater, grade_ids)
-
-    redirect_to assignment_path(@assignment), :notice => "Upload successful"
-    end
-  end
-
   def email_import
     if params[:file].blank?
       flash[:notice] = "File missing"

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -44,7 +44,7 @@ class GradesController < ApplicationController
     session[:return_to] = request.referer
 
     @student = current_student
- 
+
     # TODO: what is this needed for?
     redirect_to @assignment and return unless current_student.present?
 
@@ -268,7 +268,7 @@ class GradesController < ApplicationController
       @grade_files = params[:grade][:grade_files_attributes]["0"]["file"]
       params[:grade].delete :grade_files_attributes
     end
-  end 
+  end
 
   public
 
@@ -642,50 +642,17 @@ class GradesController < ApplicationController
     end
   end
 
-  #upload based on "email"
   def email_import
-    @assignment = current_course.assignments.find(params[:id])
-    @students = current_course.students
-    grade_ids = []
-
-    require 'csv'
-
     if params[:file].blank?
       flash[:notice] = "File missing"
       redirect_to assignment_path(@assignment)
     else
-      CSV.foreach(params[:file].tempfile, :headers => true, :encoding => 'ISO-8859-1') do |row|
-        @students.each do |student|
-          if student.email.downcase == row[2].downcase && row[3].present?
-            if student.grades.where(:assignment_id => @assignment).present?
-              @assignment.all_grade_statuses_grade_for_student(student).tap do |grade|
-                grade.raw_score = row[3].to_i
-                grade.feedback = row[4]
-                if grade.status == nil
-                  grade.status = "Graded"
-                end
-                grade.instructor_modified = true
-                grade.save!
-                grade_ids << grade.id
-              end
-            else
-              @assignment.grades.create! do |grade|
-                grade.assignment_id = @assignment.id
-                grade.student_id = student.id
-                grade.raw_score = row[3].to_i
-                grade.feedback = row[4]
-                grade.status = "Graded"
-                grade.instructor_modified = true
-                grade.save!
-                grade_ids << grade.id
-              end
-            end
-          end
-        end
-      end
-      Resque.enqueue(MultipleGradeUpdater, grade_ids)
+      @assignment = current_course.assignments.find(params[:id])
+      @students = current_course.students
 
-      redirect_to assignment_path(@assignment), :notice => "Upload successful"
+      @result = GradeImporter.new(params[:file].tempfile).import(current_course, @assignment)
+      Resque.enqueue(MultipleGradeUpdater, @result.successful.map(&:id))
+      render :import_results
     end
   end
 

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -1,12 +1,50 @@
+require 'csv'
+
 class GradeImporter
   attr_reader :successful, :unsuccessful
+  attr_accessor :file
 
   def initialize(file)
+    @file = file
     @successful = []
     @unsuccessful = []
   end
 
-  def import
+  def import(course=nil, assignment=nil)
+    if file
+      if course && assignment
+        students = course.students
+        CSV.foreach(file, headers: true, encoding: 'ISO-8859-1') do |row|
+          student = find_student(row, students)
+          if student
+            if has_grade?(row)
+              grade = create_grade row, assignment, student
+            end
+          end
+        end
+      end
+    end
+
     self
+  end
+
+  private
+
+  def has_grade?(row)
+    row[3].present?
+  end
+
+  def create_grade(row, assignment, student)
+    assignment.grades.create do |grade|
+      grade.student_id = student.id
+      grade.raw_score = row[3].to_i
+      grade.feedback = row[4]
+      grade.status = "Graded"
+      grade.instructor_modified = true
+    end
+  end
+
+  def find_student(row, students)
+    students.find { |student| student.email.downcase == row[2].downcase }
   end
 end

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -29,7 +29,11 @@ class GradeImporter
           update_grade row, grade if grade
           grade ||= create_grade row, assignment, student
 
-          successful << grade
+          if grade.valid?
+            successful << grade
+          else
+            append_unsuccessful row, grade.errors.full_messages.join(", ")
+          end
         end
       end
     end

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -16,11 +16,17 @@ class GradeImporter
         students = course.students
         CSV.foreach(file, headers: true, encoding: 'ISO-8859-1') do |row|
           student = find_student(row, students)
-          if student
-            if has_grade?(row)
-              grade = create_grade row, assignment, student
-            end
+          if student.nil?
+            append_unsuccessful row, "Student not found in course"
+            next
           end
+          if !has_grade?(row)
+            append_unsuccessful row, "Grade not specified"
+            next
+          end
+
+          grade = create_grade row, assignment, student
+          successful << grade
         end
       end
     end
@@ -29,6 +35,10 @@ class GradeImporter
   end
 
   private
+
+  def append_unsuccessful(row, errors)
+    unsuccessful << { data: row.to_s, errors: errors }
+  end
 
   def has_grade?(row)
     row[3].present?

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -26,7 +26,7 @@ class GradeImporter
           end
 
           grade = assignment.all_grade_statuses_grade_for_student(student)
-          update_grade row, grade if grade
+          grade = update_grade row, grade if grade
           grade ||= create_grade row, assignment, student
 
           if grade.valid?
@@ -68,6 +68,7 @@ class GradeImporter
   def update_grade(row, grade)
     assign_grade row, grade
     grade.save
+    grade
   end
 
   def find_student(row, students)

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -72,6 +72,11 @@ class GradeImporter
   end
 
   def find_student(row, students)
-    students.find { |student| student.email.downcase == row[2].downcase }
+    identifier = row[2].downcase
+    if identifier =~ /@/
+      students.find { |student| student.email.downcase == identifier }
+    else
+      students.find { |student| student.username.downcase == identifier }
+    end
   end
 end

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -1,0 +1,12 @@
+class GradeImporter
+  attr_reader :successful, :unsuccessful
+
+  def initialize(file)
+    @successful = []
+    @unsuccessful = []
+  end
+
+  def import
+    self
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -468,22 +468,6 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  def username_based_grade_import(options = {})
-    students = options.fetch(:students, course.students)
-    csv_options = options.fetch(:csv, {})
-    CSV.generate(csv_options) do |csv|
-      csv << ["First Name", "Last Name", "Username", "Score", "Feedback"]
-      students.each do |student|
-        grade = student.grade_for_assignment(self)
-        if grade and (grade.instructor_modified? || grade.graded_or_released?)
-          csv << [student.first_name, student.last_name, student.username, student.grade_for_assignment(self).score, student.grade_for_assignment(self).try(:feedback) ]
-        else
-          csv << [student.first_name, student.last_name, student.username, "", "" ]
-        end
-      end
-    end
-  end
-
   # Calculating how many of each score exists
   def score_count
     Hash[grades.graded_or_released.group_by{ |g| g.score }.map{ |k, v| [k, v.size] }]

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -454,7 +454,7 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  def email_based_grade_import(options = {})
+  def grade_import(options = {})
     CSV.generate(options) do |csv|
       csv << ["First Name", "Last Name", "Email", "Score", "Feedback"]
       course.students.each do |student|

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -454,10 +454,10 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  def grade_import(options = {})
+  def grade_import(students, options = {})
     CSV.generate(options) do |csv|
       csv << ["First Name", "Last Name", "Email", "Score", "Feedback"]
-      course.students.each do |student|
+      students.each do |student|
         grade = student.grade_for_assignment(self)
         if grade and (grade.instructor_modified? || grade.graded_or_released?)
           csv << [student.first_name, student.last_name, student.email, student.grade_for_assignment(self).score, student.grade_for_assignment(self).try(:feedback) ]

--- a/app/views/grades/import.html.haml
+++ b/app/views/grades/import.html.haml
@@ -17,6 +17,6 @@
       Columns should be in the following order:
       %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", grade_import_assignment_path(format: 'csv'), :class => "bold"}
 
-    = form_tag({:action => :email_import}, :multipart => true) do
+    = form_tag({:action => :upload}, :multipart => true) do
       = file_field_tag 'file'
       = submit_tag("Import", :class => "button")

--- a/app/views/grades/import.html.haml
+++ b/app/views/grades/import.html.haml
@@ -15,7 +15,7 @@
 
     %p
       Columns should be in the following order:
-      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", email_based_grade_import_assignment_path(format: 'csv'), :class => "bold"}
+      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", grade_import_assignment_path(format: 'csv'), :class => "bold"}
 
     = form_tag({:action => :email_import}, :multipart => true) do
       = file_field_tag 'file'

--- a/app/views/grades/import.html.haml
+++ b/app/views/grades/import.html.haml
@@ -4,32 +4,19 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   %p
-    To import grades, upload a .csv file with either of the two following formats. These fields <b> MUST </b> be in the specified order. Two important keys:
-    %ul 
+    To import grades, upload a .csv file with the following format. These fields <b> MUST </b> be in the specified order. Two important keys:
+    %ul
       %li You may include additional information in the extra columns, but that content will be ignored.
       %li If a student already has a grade for this assignment in GradeCraft, and there is a new grade present in the upload, <b> the old grade will be replaced. </b>
 
   %hr
 
     %p
-      %b By Email<br/>
       Columns should be in the following order:
-      %br #{term_for :student}'s first name, #{term_for :student}'s last name, email, score, and any text feedback you'd like to include. #{link_to "Download Sample File", email_based_grade_import_assignment_path(format: 'csv'), :class => "bold"}
+      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", email_based_grade_import_assignment_path(format: 'csv'), :class => "bold"}
 
     = form_tag({:action => :email_import}, :multipart => true) do
-      = file_field_tag 'file'
-      = submit_tag("Import", :class => "button")
-      %br
-      %br
-      %br
-
-    %p
-      %b By Uniqname<br/>
-      Columns should be in the following order: 
-      %br #{term_for :student}'s first name, #{term_for :student}'s last name, uniqname, score, and any text feedback you'd like to include. #{link_to "Download Sample File", username_based_grade_import_assignment_path(format: 'csv'), :class => "bold"}
-
-    = form_tag({:action => :username_import}, :multipart => true) do
       = file_field_tag 'file'
       = submit_tag("Import", :class => "button")

--- a/app/views/grades/import_results.html.haml
+++ b/app/views/grades/import_results.html.haml
@@ -1,0 +1,41 @@
+= content_nav_for @assignment, "Import Results"
+
+%h3.pagetitle Import Results
+
+.pageContent
+  = render 'layouts/alerts'
+
+  - unless @result.unsuccessful.empty?
+    %h4.subtitle
+      = "#{@result.unsuccessful.count} #{"Grade".pluralize(@result.unsuccessful.count)} Not Imported"
+    .columns
+      %table.responsive
+        %thead
+          %tr
+            %th Data
+            %th Error(s)
+        %tbody
+          - @result.unsuccessful.each do |row|
+            %tr
+              %td= row[:data]
+              %td= row[:errors]
+
+  %h4.subtitle
+    = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
+  .columns
+    %table.responsive.nofeatures_default_last_name_dynatable
+      %thead
+        %tr
+          %th First Name
+          %th Last Name
+          %th Email
+          %th Score
+          %th Feedback
+      %tbody
+        - @result.successful.each do |grade|
+          %tr
+            %td= link_to grade.student.first_name, student_path(grade.student)
+            %td= link_to grade.student.last_name, student_path(grade.student)
+            %td= link_to grade.student.email, student_path(grade.student)
+            %td= grade.raw_score
+            %td= grade.feedback

--- a/app/views/grades/import_results.html.haml
+++ b/app/views/grades/import_results.html.haml
@@ -8,34 +8,32 @@
   - unless @result.unsuccessful.empty?
     %h4.subtitle
       = "#{@result.unsuccessful.count} #{"Grade".pluralize(@result.unsuccessful.count)} Not Imported"
-    .columns
-      %table.responsive
-        %thead
+    %table.responsive.nofeatures_dynatable
+      %thead
+        %tr
+          %th Data
+          %th Error(s)
+      %tbody
+        - @result.unsuccessful.each do |row|
           %tr
-            %th Data
-            %th Error(s)
-        %tbody
-          - @result.unsuccessful.each do |row|
-            %tr
-              %td= row[:data]
-              %td= row[:errors]
+            %td= row[:data]
+            %td= row[:errors]
 
   %h4.subtitle
     = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
-  .columns
-    %table.responsive.nofeatures_default_last_name_dynatable
-      %thead
+  %table.responsive.nofeatures_default_last_name_dynatable
+    %thead
+      %tr
+        %th First Name
+        %th Last Name
+        %th Email
+        %th Score
+        %th Feedback
+    %tbody
+      - @result.successful.each do |grade|
         %tr
-          %th First Name
-          %th Last Name
-          %th Email
-          %th Score
-          %th Feedback
-      %tbody
-        - @result.successful.each do |grade|
-          %tr
-            %td= link_to grade.student.first_name, student_path(grade.student)
-            %td= link_to grade.student.last_name, student_path(grade.student)
-            %td= link_to grade.student.email, student_path(grade.student)
-            %td= grade.raw_score
-            %td= grade.feedback
+          %td= link_to grade.student.first_name, student_path(grade.student)
+          %td= link_to grade.student.last_name, student_path(grade.student)
+          %td= link_to grade.student.email, student_path(grade.student)
+          %td= grade.raw_score
+          %td= grade.feedback

--- a/app/views/users/import_results.html.haml
+++ b/app/views/users/import_results.html.haml
@@ -4,36 +4,34 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   - unless @result.unsuccessful.empty?
     %h4.subtitle
       = "#{@result.unsuccessful.count} #{"Student".pluralize(@result.unsuccessful.count)} Not Imported"
-    .columns
-      %table.responsive
-        %thead
+    %table.responsive.nofeatures_dynatable
+      %thead
+        %tr
+          %th Data
+          %th Error(s)
+      %tbody
+        - @result.unsuccessful.each do |row|
           %tr
-            %th Data
-            %th Error(s)
-        %tbody
-          - @result.unsuccessful.each do |row|
-            %tr
-              %td= row[:data]
-              %td= row[:errors]
+            %td= row[:data]
+            %td= row[:errors]
 
   %h4.subtitle
     = "#{@result.successful.count} #{"Student".pluralize(@result.successful.count)} Imported Successfully"
-  .columns
-    %table.responsive.nofeatures_default_last_name_dynatable
-      %thead
+  %table.responsive.nofeatures_default_last_name_dynatable
+    %thead
+      %tr
+        %th First Name
+        %th Last Name
+        %th Username
+        %th Email
+    %tbody
+      - @result.successful.each do |user|
         %tr
-          %th First Name
-          %th Last Name
-          %th Username
-          %th Email
-      %tbody
-        - @result.successful.each do |user|
-          %tr
-            %td= link_to user.first_name, student_path(user)
-            %td= link_to user.last_name, student_path(user)
-            %td= link_to user.username, student_path(user)
-            %td= link_to user.email, student_path(user)
+          %td= link_to user.first_name, student_path(user)
+          %td= link_to user.last_name, student_path(user)
+          %td= link_to user.username, student_path(user)
+          %td= link_to user.email, student_path(user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ GradeCraft::Application.routes.draw do
         post :edit_status
         put :update_status
         get :import
-        post :email_import
+        post :upload
         post :self_log
         post :predict_score
         post :feedback_read

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,8 +70,6 @@ GradeCraft::Application.routes.draw do
       get 'export_grades'
       get 'export_submissions'
       get 'email_based_grade_import' => 'assignments#email_based_grade_import'
-      get 'username_based_grade_import' => 'assignments#username_based_grade_import'
-      get 'name_based_grade_import' => 'assignments#name_based_grade_import'
       get 'rubric_grades_review'
       put :update_rubrics
       scope 'grades', as: :grades, controller: :grades do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,8 +77,6 @@ GradeCraft::Application.routes.draw do
         put :update_status
         get :import
         post :email_import
-        post :username_import
-        post :name_import
         post :self_log
         post :predict_score
         post :feedback_read

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ GradeCraft::Application.routes.draw do
       put 'group_grade' => 'grades#group_update'
       get 'export_grades'
       get 'export_submissions'
-      get 'email_based_grade_import' => 'assignments#email_based_grade_import'
+      get 'grade_import' => 'assignments#grade_import'
       get 'rubric_grades_review'
       put :update_rubrics
       scope 'grades', as: :grades, controller: :grades do

--- a/spec/active_record_spec_helper.rb
+++ b/spec/active_record_spec_helper.rb
@@ -1,0 +1,57 @@
+ENV['RAILS_ENV'] ||= 'test'
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))
+
+require 'active_record'
+require 'acts_as_list'
+require 'canable'
+require 'carrierwave'
+require 'carrierwave/orm/activerecord'
+require 'carrierwave_backgrounder'
+require 'backgrounder/orm/activemodel'
+require 'factory_girl'
+require 'faker'
+require 'protected_attributes'
+require 'sanitize'
+require 'sorcery'
+require 'yaml'
+
+::ActiveRecord::Base.raise_in_transactional_callbacks = true
+::ActiveRecord::Base.extend CarrierWave::Backgrounder::ORM::ActiveModel
+
+require './lib/display_helpers'
+require './lib/s3_file'
+Dir['./app/validators/*.rb'].each { |f| require f }
+Dir['./app/uploaders/*.rb'].each { |f| require f }
+Dir['./app/models/*.rb'].each { |f| require f }
+
+def fixture_file(file, filetype='image/jpg')
+  require 'rack/test'
+  Rack::Test::UploadedFile.new File.join('spec', 'fixtures', 'files', file), filetype
+end
+
+connection_info = YAML.load_file("config/database.yml")["test"]
+ActiveRecord::Base.establish_connection(connection_info)
+
+ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
+
+FactoryGirl.factories.clear
+FactoryGirl.find_definitions
+
+RSpec.configure do |config|
+  # Base Spec Helper
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+  config.mock_with :rspec
+  config.order = "random"
+  config.tty = true
+  # End Base Spec Helper
+
+  config.include FactoryGirl::Syntax::Methods
+
+  config.around do |example|
+    ActiveRecord::Base.transaction do
+      example.run
+    raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/spec/active_record_spec_helper.rb
+++ b/spec/active_record_spec_helper.rb
@@ -18,6 +18,12 @@ require 'yaml'
 ::ActiveRecord::Base.raise_in_transactional_callbacks = true
 ::ActiveRecord::Base.extend CarrierWave::Backgrounder::ORM::ActiveModel
 
+::Sorcery::Controller::Config.submodules = [:user_activation]
+::Sorcery::Controller::Config.user_config do |user|
+  user.activation_mailer_disabled = true
+  user.user_activation_mailer = nil
+end
+
 require './lib/display_helpers'
 require './lib/s3_file'
 Dir['./app/validators/*.rb'].each { |f| require f }

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -311,21 +311,11 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET email_based_grade_import" do
+    describe "GET grade_import" do
       context "with CSV format" do
         it "returns sample csv data" do
-          get :email_based_grade_import, :id => @assignment, :format => :csv
+          get :grade_import, :id => @assignment, :format => :csv
           response.body.should include("First Name,Last Name,Email,Score,Feedback")
-        end
-      end
-    end
-
-    describe "GET username_based_grade_import" do
-      context "with CSV format" do
-        it "returns sample csv data" do
-          grade = create(:grade, assignment: @assignment, student: @student, feedback: "good jorb!")
-          get :username_based_grade_import, :id => @assignment, :format => :csv
-          response.body.should include("First Name,Last Name,Username,Score,Feedback")
         end
       end
     end
@@ -521,8 +511,7 @@ describe AssignmentsController do
         :update,
         :destroy,
         :export_grades,
-        :email_based_grade_import,
-        :username_based_grade_import,
+        :grade_import,
         :update_rubrics,
         :rubric_grades_review
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -120,7 +120,7 @@ describe GradesController do
       end
     end
 
-    describe "POST email_import" do
+    describe "POST upload" do
       render_views
 
       let(:file) { fixture_file "grades.csv", "text/csv" }
@@ -129,13 +129,13 @@ describe GradesController do
         @student.update_attribute :email, "robert@example.com"
         @second_student.update_attribute :username, "jimmy"
 
-        post :email_import, id: @assignment.id, file: file
+        post :upload, id: @assignment.id, file: file
         expect(response).to render_template :import_results
         expect(response.body).to include "2 Grades Imported Successfully"
       end
 
       it "renders any errors that have occured" do
-        post :email_import, id: @assignment.id, file: file
+        post :upload, id: @assignment.id, file: file
         expect(response.body).to include "2 Grades Not Imported"
         expect(response.body).to include "Student not found in course"
       end
@@ -283,9 +283,9 @@ describe GradesController do
         end
       end
 
-      describe "POST email_import" do
+      describe "POST upload" do
         it "redirects to root path" do
-          post :email_import, { :id => @assignment.id}
+          post :upload, { :id => @assignment.id}
           response.should redirect_to(:root)
         end
       end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -119,6 +119,27 @@ describe GradesController do
         response.should render_template(:import)
       end
     end
+
+    describe "POST email_import" do
+      render_views
+
+      let(:file) { fixture_file "grades.csv", "text/csv" }
+
+      it "renders the results from the import" do
+        @student.update_attribute :email, "robert@example.com"
+        @second_student.update_attribute :username, "jimmy"
+
+        post :email_import, id: @assignment.id, file: file
+        expect(response).to render_template :import_results
+        expect(response.body).to include "2 Grades Imported Successfully"
+      end
+
+      it "renders any errors that have occured" do
+        post :email_import, id: @assignment.id, file: file
+        expect(response.body).to include "2 Grades Not Imported"
+        expect(response.body).to include "Student not found in course"
+      end
+    end
   end
 
   context "as student" do

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -283,14 +283,7 @@ describe GradesController do
         end
       end
 
-      describe "GET username_import" do
-        it "redirects to root path" do
-          get :username_import, { :id => @assignment.id}
-          response.should redirect_to(:root)
-        end
-      end
-
-      describe "GET email_import" do
+      describe "POST email_import" do
         it "redirects to root path" do
           post :email_import, { :id => @assignment.id}
           response.should redirect_to(:root)

--- a/spec/fixtures/files/grades.csv
+++ b/spec/fixtures/files/grades.csv
@@ -1,0 +1,2 @@
+First Name,Last Name,Email,Score,Feedback
+Robert,Plant,robert@example.com,4000,"You did great!"

--- a/spec/fixtures/files/grades.csv
+++ b/spec/fixtures/files/grades.csv
@@ -1,2 +1,3 @@
 First Name,Last Name,Email,Score,Feedback
 Robert,Plant,robert@example.com,4000,"You did great!"
+Jimmy,Page,jimmy,3000,

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -1,5 +1,4 @@
-require 'active_record_spec_helper'
-require './app/importers/grade_importer'
+require 'spec_helper'
 
 describe GradeImporter do
   describe "#import" do

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -11,14 +11,35 @@ describe GradeImporter do
 
     context "with a file" do
       let(:file) { fixture_file "grades.csv", "text/csv" }
+      let(:course) { create :course }
+      let(:assignment) { create :assignment, course: course }
       subject { GradeImporter.new(file.tempfile) }
 
       it "does not create a grade if the student does not exist" do
-        expect { subject.import }.to_not change { User.count }
+        student = create :user
+        create :course_membership, user_id: student.id, course_id: course.id,
+            role: "student"
+        expect { subject.import(course, assignment) }.to_not change { User.count }
       end
 
-      context "with a student" do
-        xit "creates the grade if it is not there"
+      xit "is unsuccessful if the student does not exist"
+
+      context "with a student in the file" do
+        let(:student) { create :user, email: "robert@example.com" }
+        before do
+          create :course_membership, user_id: student.id, course_id: course.id,
+            role: "student"
+        end
+
+        it "creates the grade if it is not there" do
+          subject.import(course, assignment)
+          grade = Grade.last
+          expect(grade.raw_score).to eq 4000
+          expect(grade.feedback).to eq "You did great!"
+          expect(grade.status).to eq "Graded"
+          expect(grade.instructor_modified).to eq true
+        end
+
         xit "updates the grade if it is already there"
         xit "creates a grade for a student by unique name"
       end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -10,10 +10,18 @@ describe GradeImporter do
     end
 
     context "with a file" do
-      xit "does not create a grade if the student does not exist"
-      xit "creates the grade if it is not there"
-      xit "updates the grade if it is already there"
-      xit "creates a grade for a student by unique name"
+      let(:file) { fixture_file "grades.csv", "text/csv" }
+      subject { GradeImporter.new(file.tempfile) }
+
+      it "does not create a grade if the student does not exist" do
+        expect { subject.import }.to_not change { User.count }
+      end
+
+      context "with a student" do
+        xit "creates the grade if it is not there"
+        xit "updates the grade if it is already there"
+        xit "creates a grade for a student by unique name"
+      end
     end
   end
 end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -1,0 +1,19 @@
+require 'active_record_spec_helper'
+require './app/importers/grade_importer'
+
+describe GradeImporter do
+  describe "#import" do
+    it "returns empty results when there is no file" do
+      result = GradeImporter.new(nil).import
+      expect(result.successful).to be_empty
+      expect(result.unsuccessful).to be_empty
+    end
+
+    context "with a file" do
+      xit "does not create a grade if the student does not exist"
+      xit "creates the grade if it is not there"
+      xit "updates the grade if it is already there"
+      xit "creates a grade for a student by unique name"
+    end
+  end
+end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -59,6 +59,14 @@ describe GradeImporter do
           expect(grade.feedback).to eq "You did great!"
         end
 
+        it "contains an unsuccessful row if the grade is not valid" do
+          allow_any_instance_of(Grade).to receive(:valid?).and_return false
+          allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])
+          result = subject.import(course, assignment)
+          expect(result.unsuccessful.count).to eq 1
+          expect(result.unsuccessful.first[:errors]).to eq "The grade is not cool"
+        end
+
         xit "creates a grade for a student by unique name"
       end
     end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -51,7 +51,14 @@ describe GradeImporter do
           expect(result.successful.last).to eq grade
         end
 
-        xit "updates the grade if it is already there"
+        it "updates the grade if it is already there" do
+          create :grade, assignment: assignment, student: student, raw_score: 1000
+          subject.import(course, assignment)
+          grade = Grade.last
+          expect(grade.raw_score).to eq 4000
+          expect(grade.feedback).to eq "You did great!"
+        end
+
         xit "creates a grade for a student by unique name"
       end
     end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -28,7 +28,7 @@ describe GradeImporter do
 
         it "is unsuccessful if the student does not exist" do
           result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 1
+          expect(result.unsuccessful.count).to eq 2
           expect(result.unsuccessful.first[:errors]).to eq "Student not found in course"
         end
       end
@@ -63,11 +63,18 @@ describe GradeImporter do
           allow_any_instance_of(Grade).to receive(:valid?).and_return false
           allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])
           result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 1
+          expect(result.unsuccessful.count).to eq 2
           expect(result.unsuccessful.first[:errors]).to eq "The grade is not cool"
         end
 
-        xit "creates a grade for a student by unique name"
+        it "creates a grade for a student by username" do
+          username_student = create :user, username: "jimmy"
+          create :course_membership, user_id: username_student.id, course_id: course.id,
+            role: "student"
+          result = subject.import(course, assignment)
+          grade = assignment.all_grade_statuses_grade_for_student(username_student)
+          expect(grade).to_not be_nil
+        end
       end
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -127,7 +127,7 @@ describe Assignment do
       course.assignments << @assignment
       student = create(:user)
       student.courses << course
-      @assignment.grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},\"\",\"\"\n")
+      @assignment.grade_import(course.students).should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},\"\",\"\"\n")
     end
 
     it "also returns grade fields with instructor modified grade" do
@@ -137,7 +137,7 @@ describe Assignment do
       student.courses << course
       grade = create(:grade, assignment: @assignment, student: student, feedback: "good jorb!", instructor_modified: true)
       submission = create(:submission, grade: grade, student: student, assignment: @assignment)
-      @assignment.grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
+      @assignment.grade_import(course.students).should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
     end
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -140,44 +140,4 @@ describe Assignment do
       @assignment.email_based_grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
     end
   end
-
-  describe "username based grade import" do
-    it "returns sample csv data, including ungraded students" do
-      course = create(:course)
-      course.assignments << @assignment
-      student = create(:user)
-      student.courses << course
-      @assignment.username_based_grade_import.should eq("First Name,Last Name,Username,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.username},\"\",\"\"\n")
-    end
-
-    it "returns grade fields with instructor modified grade" do
-      course = create(:course)
-      course.assignments << @assignment
-      student = create(:user)
-      student.courses << course
-      grade = create(:grade, assignment: @assignment, student: student, feedback: "good jorb!", instructor_modified: true)
-      submission = create(:submission, grade: grade, student: student, assignment: @assignment)
-      @assignment.username_based_grade_import.should eq("First Name,Last Name,Username,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.username},#{grade.score},#{grade.feedback}\n")
-    end
-
-    it "returns students in csv alphabetized by last name" do
-      course = create(:course)
-      course.assignments << @assignment
-      student = create(:user, last_name: 'Zed')
-      student.courses << course
-      student2 = create(:user, last_name: 'Alpha')
-      student2.courses << course
-      @assignment.username_based_grade_import.should match(/Alpha.*\n.*Zed/)
-    end
-
-    it "handles a subset of students when passed in the params" do
-      course = create(:course)
-      course.assignments << @assignment
-      student = create(:user)
-      student.courses << course
-      student2 = create(:user)
-      student2.courses << course
-      @assignment.username_based_grade_import({students: [student]}).should_not match(student2.last_name)
-    end
-  end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -121,13 +121,13 @@ describe Assignment do
     end
   end
 
-  describe "email based grade import" do
+  describe "grade import" do
     it "returns sample csv data, including ungraded students" do
       course = create(:course)
       course.assignments << @assignment
       student = create(:user)
       student.courses << course
-      @assignment.email_based_grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},\"\",\"\"\n")
+      @assignment.grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},\"\",\"\"\n")
     end
 
     it "also returns grade fields with instructor modified grade" do
@@ -137,7 +137,7 @@ describe Assignment do
       student.courses << course
       grade = create(:grade, assignment: @assignment, student: student, feedback: "good jorb!", instructor_modified: true)
       submission = create(:submission, grade: grade, student: student, assignment: @assignment)
-      @assignment.email_based_grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
+      @assignment.grade_import.should eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
     end
   end
 end


### PR DESCRIPTION
Importer to import `Grade`s for students and report the results after the import. This is very similar to the `StudentImporter`.

After an import, results are now displayed which includes both successful and unsuccessful students.

![grade-importer](https://cloud.githubusercontent.com/assets/35017/9510783/b4e69126-4c3d-11e5-8ffa-f67c7e63b609.gif)

Removed the two different options to import grades with students by username or email address. Instead the `GradeImporter` checks to see if the identifier is an email address and if it is, it retrieves the student by email address instead of username.

I started creating an `active_record_spec_helper` and I used it while TDD'ing the `GradeImporter` which increased the feedback loop tremendously. When I ran all of the specs together however, I had to remove the reference in order to save time. I will re-look at this when I upgrade RSpec.