### PR TITLE
Allow a user to be added to the course if they already exist

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -135,12 +135,13 @@ describe UsersController do
       end
 
       it "renders any errors that have occured" do
-        User.create first_name: "Jimmy", last_name: "Page",
-          email: "jimmy@example.com", username: "jimmy"
+        user = User.create first_name: "Jimmy", last_name: "Page",
+          email: "jimmy@example.com", username: "jimmy", password: "blah"
+        user.update_attribute :username, "1" * 51
         post :upload, file: file
         expect(response.body).to include "1 Student Not Imported"
         expect(response.body).to include "Jimmy,Page,jimmy,jimmy@example.com"
-        expect(response.body).to include "Email has already been taken"
+        expect(response.body).to include "Username is too long"
       end
 
       it "renders any errors that occur with the team creation" do

--- a/spec/importers/student_importer_spec.rb
+++ b/spec/importers/student_importer_spec.rb
@@ -30,6 +30,13 @@ describe StudentImporter do
         expect(team.students.first.email).to eq "jimmy@example.com"
       end
 
+      it "just adds the student to the team if the student already exists" do
+        User.create first_name: "Jimmy", last_name: "Page",
+            email: "jimmy@example.com", username: "jimmy", password: "blah"
+        subject.import course
+        expect(team.students.first.email).to eq "jimmy@example.com"
+      end
+
       it "creates the team and adds the student if the team does not exist" do
         Team.unscoped.last.destroy
         subject.import course
@@ -55,12 +62,13 @@ describe StudentImporter do
       end
 
       it "contains an unsuccessful row if the user is not valid" do
-        User.create first_name: "Jimmy", last_name: "Page",
-            email: "jimmy@example.com", username: "jimmy"
+        user = User.create first_name: "Jimmy", last_name: "Page",
+            email: "jimmy@example.com", username: "jimmy", password: "blah"
+        user.update_attribute :username, ""
         result = subject.import course
         expect(result.successful.count).to eq 1
         expect(result.unsuccessful.count).to eq 1
-        expect(result.unsuccessful.first[:errors]).to eq "Email has already been taken"
+        expect(result.unsuccessful.first[:errors]).to eq "Username can't be blank"
       end
 
       it "contains an unsuccessful row if the team is not valid" do


### PR DESCRIPTION
Adds the ability for the `StudentImport` to just add the user to the course if the user already exists. It used to make the user invalid since the email address already existed.

Closes #6