### PR TITLE
Fix profile alerts

### DIFF
--- a/app/assets/stylesheets/_alerts.sass
+++ b/app/assets/stylesheets/_alerts.sass
@@ -24,7 +24,7 @@
   &.success, &.notice
 
 .student .alert-box
-  margin: 1.5rem 1rem 0
+  margin: 0 0 1rem
 
 .staff .alert-box
   margin-bottom: 1rem
@@ -43,4 +43,3 @@
 
   ul
     margin-bottom: 0
-    background-color: $secondary-color-3

--- a/app/assets/stylesheets/_alerts.sass
+++ b/app/assets/stylesheets/_alerts.sass
@@ -1,4 +1,4 @@
-.alert-box 
+.alert-box
   padding: .25rem .5rem !important
   background-color: $primary-color-5
   color: #FFF
@@ -21,7 +21,7 @@
       opacity: 0.5
   &.alert
     background-color: $alert-color
-  &.success
+  &.success, &.notice
 
 .student .alert-box
   margin: 1.5rem 1rem 0
@@ -33,7 +33,7 @@
   background-color: lighten($color-red-1, 10%)
   font-size: 110%
 
-.alert-box.success
+.alert-box.success, .alert-box.notice
   background-color: darken($color-green-2, 2%)
   font-size: 110%
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -137,7 +137,10 @@ class UsersController < ApplicationController
     if @user.update_attributes(params[:user])
       redirect_to dashboard_path, :notice => "Your profile was successfully updated!"
     else
-      redirect_to edit_profile_users_path(@user), :alert => "I'm sorry, something went wrong. Your profile was not successfully updated."
+      @title = "Edit My Profile"
+      @course_membership = @user.course_memberships.where(course_id: current_course).first
+      @default_course_options = @user.courses
+      render :edit_profile
     end
   end
 

--- a/app/views/layouts/_alerts.haml
+++ b/app/views/layouts/_alerts.haml
@@ -1,12 +1,5 @@
-- if flash[:notice]
-  .alert-box.success
-    = flash[:notice].html_safe
-    <a href="" class="close">&times;</a>
-- if flash[:error]
-  .alert-box.error
-    = flash[:error].html_safe
-    <a href="" class="close">&times;</a>
-- if flash[:alert]
-  .alert-box.alert
-    = flash[:alert].html_safe
-    <a href="" class="close">&times;</a>
+- flash.each do |name, message|
+  %div{ class: "alert-box #{name}" }
+    = message.html_safe
+    %a{ href: "#", class: "close" }
+      = "&times;".html_safe

--- a/app/views/layouts/_alerts.haml
+++ b/app/views/layouts/_alerts.haml
@@ -3,3 +3,11 @@
     = message.html_safe
     %a{ href: "#", class: "close" }
       = "&times;".html_safe
+
+- if !request.get? && local_assigns[:model].present? && !model.valid?
+  .alert-box.alert
+    - message_term = local_assigns[:term] ? term : model.class.name.humanize.downcase
+    .italic= "#{pluralize(model.errors.count, "error")} prohibited this #{message_term} from being saved:"
+    %ul
+      - model.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -3,9 +3,9 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
-  = simple_form_for(@user, method: :put, :url => update_profile_users_path(@user)) do |f|
+  = render partial: 'layouts/alerts', locals: { model: @user, term: "profile" }
+
+  = simple_form_for(@user, method: :put, :url => update_profile_users_path) do |f|
 
     .form-item
       %label.bold Your Avatar


### PR DESCRIPTION
Displays the validation errors associated with the user's profile instead of just displaying that there were issues.

The following is an example of what is displayed. (Notice the weird validation styles. I did not touch those because that's how they were built. I can fix them if needed).

<img width="1192" alt="screen shot 2015-08-30 at 11 07 29 pm" src="https://cloud.githubusercontent.com/assets/35017/9571509/780d4a38-4f6c-11e5-8a35-8ac794643e65.png">

I updated the `views/layouts/_alerts.html.haml` view to display model errors if there are some. This can be a reusable component that we can use on the other views that display model errors. Please let me know if you'd like me to spread this view to replace the other views that render model errors.

