### PR TITLE
Replace all forms with errors with common partial

### DIFF
--- a/app/views/announcements/_form.html.haml
+++ b/app/views/announcements/_form.html.haml
@@ -1,9 +1,4 @@
-- if @announcement.errors.any?
-  .alert-box.alert
-    .italic= "#{pluralize(@announcement.errors.count, "error")} prohibited this announcement from being saved:"
-    %ul
-      - @announcement.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @announcement }
 
 = simple_form_for(@announcement) do |f|
   %section

--- a/app/views/announcements/new.html.haml
+++ b/app/views/announcements/new.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render "form"

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -1,10 +1,4 @@
-/ Using Simple Form to create an assignment type
-- if @assignment_type.errors.any?
-  .alert-box.alert
-    .italic= "#{pluralize(@assignment_type.errors.count, "error")} prohibited this #{(term_for :assignment_type).downcase} from being saved:"
-    %ul
-      - @assignment_type.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @assignment_type, term: term_for(:assignment_type) }
 
 = simple_form_for(@assignment_type) do |f|
   / First section should cover the simple stuff we need to know about every assignment type
@@ -34,7 +28,7 @@
       .textarea
         .form_label How would you like to describe this #{term_for :assignment} type on the student dashboard? Are there hints that you can give students that will help them understand how to succeed?
         = f.text_area :predictor_description, :label => "Description", :class => "froala"
-      
+
   .submit-buttons
     %ul
       %li= f.button :submit, "#{@assignment_type.persisted? ? 'Update' : 'Create'} #{term_for :assignment_type}"

--- a/app/views/assignment_types/edit.html.haml
+++ b/app/views/assignment_types/edit.html.haml
@@ -5,7 +5,4 @@
 = render "buttons"
 
 .pageContent
-  = render 'layouts/alerts'
-  
-  / Display Assignment Type form
   = render 'form'

--- a/app/views/assignment_types/new.html.haml
+++ b/app/views/assignment_types/new.html.haml
@@ -5,6 +5,4 @@
 = render 'buttons'
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -1,9 +1,4 @@
-- if @assignment.errors.any?
-  .alert-box.alert
-    .italic= "#{pluralize(@assignment.errors.count, "error")} prohibited this #{term_for :assignment} from being saved:"
-    %ul
-      - @assignment.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @assignment, term: term_for(:assignment) }
 
 = simple_form_for(@assignment, :html => { :novalidate => true }) do |f|
   %section
@@ -136,7 +131,7 @@
     .form-item
       = f.label :student_logged
       = f.check_box :student_logged
-      .form_label Do #{term_for :students} self-report their grade for this #{term_for :assignment}? If you add grade levels below, they'll be able to select their self-assessed score from the list during the open time period. If you don't, they'll be able to select that they did the work and earn full points. 
+      .form_label Do #{term_for :students} self-report their grade for this #{term_for :assignment}? If you add grade levels below, they'll be able to select their self-assessed score from the list during the open time period. If you don't, they'll be able to select that they did the work and earn full points.
 
   %section
     %h4 Timeline

--- a/app/views/assignments/edit.html.haml
+++ b/app/views/assignments/edit.html.haml
@@ -5,6 +5,4 @@
 = render "buttons"
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/assignments/new.html.haml
+++ b/app/views/assignments/new.html.haml
@@ -5,6 +5,4 @@
 = render "buttons"
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -1,9 +1,4 @@
-- if @badge.errors.any?
-  .alert-box.alert
-    .italic= "#{pluralize(@badge.errors.count, "error")} prohibited this #{(term_for :badge).titleize} from being saved:"
-    %ul
-      - @badge.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @badge, term: term_for(:badge) }
 
 = simple_form_for @badge do |f|
   %section
@@ -27,7 +22,7 @@
       = f.label :visible
       = f.check_box :visible
       .form_label Can #{term_for :students} see this #{term_for :badge}?
-    
+
     .form-item
       = f.label :can_earn_multiple_times,"Multi-award"
       = f.check_box :can_earn_multiple_times
@@ -44,7 +39,7 @@
     %h4 Unlocks
     .form-item
       = f.input :visible_when_locked
-    
+
       .unlock-conditions
         %p.hint Unlock description here
         %script(id="unlock-condition-template" type="text/x-template")

--- a/app/views/badges/edit.html.haml
+++ b/app/views/badges/edit.html.haml
@@ -18,6 +18,4 @@
         Quick Award
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/badges/new.html.haml
+++ b/app/views/badges/new.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -1,9 +1,4 @@
-- if @challenge.errors.any?
-  .alert-box.alert.radius
-    .italic= "#{pluralize(@challenge.errors.count, "error")} prohibited this #{term_for :challenge} from being saved:"
-    %ul
-      - @challenge.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @challenge, term: term_for(:challenge) }
 
 = simple_form_for(@challenge) do |f|
   %section
@@ -46,7 +41,7 @@
       = f.check_box :release_necessary
       .form_label Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
 
-  
+
   %section
     %h4 Grade Levels
     .challenge-score-levels

--- a/app/views/challenges/edit.html.haml
+++ b/app/views/challenges/edit.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/challenges/new.html.haml
+++ b/app/views/challenges/new.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -1,9 +1,4 @@
-- if @course.errors.any?
-  .alert-box.alert
-    .italic= "#{pluralize(@course.errors.count, "error")} prohibited this course from being saved:"
-    %ul
-      - @course.errors.full_messages.each do |msg|
-        %li= msg
+= render partial: 'layouts/alerts', locals: { model: @course }
 
 = simple_form_for(@course, :validate => false)  do |f|
   %section

--- a/app/views/courses/edit.html.haml
+++ b/app/views/courses/edit.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/courses/new.html.haml
+++ b/app/views/courses/new.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/courses/predictor_settings.html.haml
+++ b/app/views/courses/predictor_settings.html.haml
@@ -4,15 +4,9 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   #massGrade
-    - if @course.errors.any? 
-      .columns
-        .alert-box.alert
-          .italic= "#{pluralize(@course.errors.count, "error")} prohibited these settings from being saved:"
-          %ul
-            - @course.errors.full_messages.each do |msg|
-              %li= msg
+    = render partial: 'layouts/alerts', locals: { model: @course, term: "settings" }
 
     = simple_form_for @course, method: :put, :url => predictor_settings_course_path(@course) do |f|
 

--- a/app/views/courses/predictor_settings.html.haml
+++ b/app/views/courses/predictor_settings.html.haml
@@ -3,8 +3,6 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-
   #massGrade
     = render partial: 'layouts/alerts', locals: { model: @course, term: "settings" }
 

--- a/app/views/courses/timeline_settings.html.haml
+++ b/app/views/courses/timeline_settings.html.haml
@@ -4,15 +4,10 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   #massGrade
-    - if @course.errors.any? 
-      .alert-box.alert
-        .italic= "#{pluralize(@course.errors.count, "error")} prohibited these settings from being saved:"
-        %ul
-          - @course.errors.full_messages.each do |msg|
-            %li= msg
-            
+    = render partial: 'layouts/alerts', locals: { model: @course, term: "settings" }
+
     = simple_form_for @course, method: :put, :url => timeline_settings_course_path(@course) do |f|
 
       %table

--- a/app/views/courses/timeline_settings.html.haml
+++ b/app/views/courses/timeline_settings.html.haml
@@ -3,8 +3,6 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-
   #massGrade
     = render partial: 'layouts/alerts', locals: { model: @course, term: "settings" }
 

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -1,7 +1,7 @@
 .grade-container(ng-app="gradecraft")
   = csrf_meta_tag
 
-  = render partial: 'layouts/alerts', locals: { model: @grade }
+  = render partial: 'layouts/alerts', locals: { model: @grade, display_flash: false }
 
   - if @assignment.accepts_submissions? && @student.submission_for_assignment(@assignment).present?
     %section

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -1,12 +1,7 @@
 .grade-container(ng-app="gradecraft")
   = csrf_meta_tag
 
-  - if @grade.errors.any?
-    .alert-box.alert
-      .italic= "#{pluralize(@grade.errors.count, "error")} prohibited this grade from being saved:"
-      %ul
-        - @grade.errors.full_messages.each do |msg|
-          %li= msg
+  = render partial: 'layouts/alerts', locals: { model: @grade }
 
   - if @assignment.accepts_submissions? && @student.submission_for_assignment(@assignment).present?
     %section

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,11 +1,6 @@
 = simple_form_for @group do |f|
 
-  - if @group.errors.any?
-    .alert-box.alert
-      .italic= "#{pluralize(@group.errors.count, "error")} prohibited this group from being saved:"
-      %ul
-        - @group.errors.full_messages.each do |msg|
-          %li= msg
+  = render partial: 'layouts/alerts', locals: { model: @group }
 
   %section
     .form-item

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -10,6 +10,4 @@
         See #{term_for :group}
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -6,6 +6,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'

--- a/app/views/layouts/_alerts.haml
+++ b/app/views/layouts/_alerts.haml
@@ -1,12 +1,14 @@
-- flash.each do |name, message|
-  %div{ class: "alert-box #{name}" }
-    = message.html_safe
-    %a{ href: "#", class: "close" }
-      = "&times;".html_safe
+- display_flash = local_assigns.has_key?(:display_flash) ? display_flash : true
+- if display_flash
+  - flash.each do |name, message|
+    %div{ class: "alert-box #{name}" }
+      = message.html_safe
+      %a{ href: "#", class: "close" }
+        = "&times;".html_safe
 
-- if !request.get? && local_assigns[:model].present? && !model.valid?
+- if !request.get? && local_assigns.has_key?(:model) && !model.valid?
   .alert-box.alert
-    - message_term = local_assigns[:term] ? term : model.class.name.humanize.downcase
+    - message_term = local_assigns.has_key?(:term) ? term : model.class.name.humanize.downcase
     .italic= "#{pluralize(model.errors.count, "error")} prohibited this #{message_term} from being saved:"
     %ul
       - model.errors.full_messages.each do |message|

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,10 +1,6 @@
 = simple_form_for @user do |f|
-  - if @user.errors.any?
-    .alert-box.alert
-      .italic= "#{pluralize(@user.errors.count, "error")} prohibited this #{term_for :assignment} from being saved:"
-      %ul
-        - @user.errors.full_messages.each do |msg|
-          %li= msg
+  = render partial: 'layouts/alerts', locals: { model: @user, term: term_for(:assignment) }
+
   %section
     %h4.uppercase= "User Profile"
     .form-item

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -2,7 +2,5 @@
 
 %h3.pagetitle= @title
 
-.pageContent  
-  = render 'layouts/alerts'
-    
+.pageContent
   = render 'form'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render 'layouts/alerts'
-  
   = render 'form'


### PR DESCRIPTION
Uses a common partial (`app/views/layouts/alerts`) to display model errors instead of having each form display a different partial.

This replaces all current views that display model errors without using the common partial.