### PR TITLE
Flag students

### DIFF
--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -98,6 +98,12 @@ tbody
   text-align: center
   float: right
 
+.flagged-user-icon > .fa-flag
+  color: $color-grey-6
+
+  &.flagged
+    color: $color-orange-1
+
 @media (max-width: 1000px)
   .hide-for-small
     display: none

--- a/app/assets/stylesheets/color.sass
+++ b/app/assets/stylesheets/color.sass
@@ -36,6 +36,7 @@ $color-grey-2: #666666
 $color-grey-3: #CCCCCC
 $color-grey-4: #EEEEEE
 $color-grey-5: #FFFFFF
+$color-grey-6: #999999
 
 $color-black: $color-grey-00 // alias
 $color-white: $color-grey-5 // alias

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -19,6 +19,11 @@ class StudentsController < ApplicationController
     end
   end
 
+  def flagged
+    @title = "Flagged #{(current_course.user_term).pluralize}"
+    @students = FlaggedUser.flagged current_course, current_user
+  end
+
   #Course wide leaderboard - excludes auditors from view
   def leaderboard
     # before_filter :ensure_staff?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -95,7 +95,6 @@ class UsersController < ApplicationController
       format.html { redirect_to users_url, :notice => "#{@name} was successfully deleted" }
       format.json { head :ok }
     end
-
   end
 
   def activate
@@ -116,6 +115,11 @@ class UsersController < ApplicationController
       redirect_to dashboard_path, notice: "Welcome to GradeCraft!" and return
     end
     render :activate, alert: @user.errors.full_messages.first
+  end
+
+  def flag
+    @user = User.find(params[:id])
+    FlaggedUser.toggle! current_course, current_user, @user.id
   end
 
   # We don't allow students to edit their info directly - this is a mediated view

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -5,8 +5,6 @@ module UsersHelper
 
   def flagged_user_icon(course, flagger, flagged_id)
     flagged = FlaggedUser.flagged? course, flagger, flagged_id
-    style = flagged ? "fa-star" : "fa-star-o"
-    text = flagged ? "Unflag" : "Flag"
-    raw("<i class=\"fa #{style} fa-fw\"></i> #{text}")
+    raw("<i class=\"fa fa-flag fa-fw #{"flagged" if flagged}\"></i>")
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,4 +2,11 @@ module UsersHelper
   def generate_random_password
     Sorcery::Model::TemporaryToken.generate_random_token
   end
+
+  def flagged_user_icon(course, flagger, flagged_id)
+    flagged = FlaggedUser.flagged? course, flagger, flagged_id
+    style = flagged ? "fa-star" : "fa-star-o"
+    text = flagged ? "Unflag" : "Flag"
+    raw("<i class=\"fa #{style} fa-fw\"></i> #{text}")
+  end
 end

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -11,12 +11,16 @@ class FlaggedUser < ActiveRecord::Base
     create course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id
   end
 
+  def self.flagged?(course, flagger, flagged_id)
+    where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).exists?
+  end
+
   def self.unflag!(course, flagger, flagged_id)
     where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).destroy_all
   end
 
   def self.toggle!(course, flagger, flagged_id)
-    if where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).exists?
+    if flagged? course, flagger, flagged_id
       unflag! course, flagger, flagged_id
     else
       flag! course, flagger, flagged_id

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -19,6 +19,10 @@ class FlaggedUser < ActiveRecord::Base
     where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).destroy_all
   end
 
+  def self.flagged(course, flagger)
+    where(course_id: course.id, flagger_id: flagger.id).map(&:flagged)
+  end
+
   def self.toggle!(course, flagger, flagged_id)
     if flagged? course, flagger, flagged_id
       unflag! course, flagger, flagged_id

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -4,7 +4,7 @@ class FlaggedUser < ActiveRecord::Base
   belongs_to :flagged, class_name: "User"
 
   validates :course, presence: true
-  validates :flagger, presence: true, course_membership: true
+  validates :flagger, presence: true, course_membership: true, staff_flagger: true
   validates :flagged, presence: true, course_membership: true
 
   def self.flag!(course, flagger, flagged_id)

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -1,0 +1,7 @@
+class FlaggedUser < ActiveRecord::Base
+  belongs_to :course
+
+  def self.flag!(course, flagger, flagged_id)
+    self.create course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id
+  end
+end

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -8,6 +8,18 @@ class FlaggedUser < ActiveRecord::Base
   validates :flagged, presence: true, course_membership: true
 
   def self.flag!(course, flagger, flagged_id)
-    self.create course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id
+    create course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id
+  end
+
+  def self.unflag!(course, flagger, flagged_id)
+    where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).destroy_all
+  end
+
+  def self.toggle!(course, flagger, flagged_id)
+    if where(course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id).exists?
+      unflag! course, flagger, flagged_id
+    else
+      flag! course, flagger, flagged_id
+    end
   end
 end

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -1,5 +1,11 @@
 class FlaggedUser < ActiveRecord::Base
   belongs_to :course
+  belongs_to :flagger, class_name: "User"
+  belongs_to :flagged, class_name: "User"
+
+  validates :course, presence: true
+  validates :flagger, presence: true, course_membership: true
+  validates :flagged, presence: true, course_membership: true
 
   def self.flag!(course, flagger, flagged_id)
     self.create course_id: course.id, flagger_id: flagger.id, flagged_id: flagged_id

--- a/app/validators/course_membership_validator.rb
+++ b/app/validators/course_membership_validator.rb
@@ -1,0 +1,10 @@
+class CourseMembershipValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if record.course.present? && value.present?
+      user = value
+      unless CourseMembership.where(course_id: record.course.id, user_id: user.id).exists?
+        record.errors[attribute] << "must belong to the course"
+      end
+    end
+  end
+end

--- a/app/validators/staff_flagger_validator.rb
+++ b/app/validators/staff_flagger_validator.rb
@@ -1,0 +1,10 @@
+class StaffFlaggerValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if record.course.present? && value.present?
+      flagger = value
+      unless flagger.is_staff?(record.course)
+        record.errors[attribute] << "must be a staff member"
+      end
+    end
+  end
+end

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -65,7 +65,7 @@
 
 %h5 Users
 %li= link_to_unless_current raw("<i class='fa fa-user fa-fw'></i> #{term_for :students}"), students_path
-%li= link_to_unless_current raw("<i class='fa fa-star fa-fw'></i> Flagged #{term_for :students}"), flagged_students_path
+%li= link_to_unless_current raw("<i class='fa fa-flag fa-fw'></i> Flagged #{term_for :students}"), flagged_students_path
 - if current_course.has_teams?
   %li= link_to_unless_current raw("<i class='fa fa-users fa-fw'></i> #{term_for :teams}"), teams_path
 %li= link_to_unless_current raw("<i class='fa fa-user-plus fa-fw'></i> #{term_for :groups}"), groups_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -65,6 +65,7 @@
 
 %h5 Users
 %li= link_to_unless_current raw("<i class='fa fa-user fa-fw'></i> #{term_for :students}"), students_path
+%li= link_to_unless_current raw("<i class='fa fa-star fa-fw'></i> Flagged #{term_for :students}"), flagged_students_path
 - if current_course.has_teams?
   %li= link_to_unless_current raw("<i class='fa fa-users fa-fw'></i> #{term_for :teams}"), teams_path
 %li= link_to_unless_current raw("<i class='fa fa-user-plus fa-fw'></i> #{term_for :groups}"), groups_path

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -16,7 +16,7 @@
   %tbody
     - students.each do |student|
       %tr
-        %td 
+        %td
           - if student.avatar_file_name.present?
             %img.img-rounded{:src => student.avatar_file_name, :width => 30}
         %td= link_to student.first_name, student_path(student)
@@ -37,7 +37,8 @@
           - if student.grade_for_course(current_course).present?
             = student.grade_for_course(current_course).name
         %td
-          .right
+          = div_for student, class: "right" do
             %ul.button-bar
+              %li= link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "button flagged-user-icon"
               %li= link_to raw("<i class='fa fa-edit fa-fw'> </i> Edit"), edit_user_path(student), :class => "button"
               %li= link_to raw("<i class='fa fa-trash fa-fw'> </i> Delete"), student.course_memberships.where(:course_id => current_course.id).first, :class => 'button', :data => { confirm: 'This will delete the student from your course - Are you sure?' }, :method => :delete

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -2,6 +2,7 @@
   %thead
     %tr
       %th
+      %th
       %th First Name
       %th Last Name
       - if current_course.in_team_leaderboard? || current_course.character_names?
@@ -16,6 +17,9 @@
   %tbody
     - students.each do |student|
       %tr
+        %td
+          = div_for student do
+            = link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "flagged-user-icon"
         %td
           - if student.avatar_file_name.present?
             %img.img-rounded{:src => student.avatar_file_name, :width => 30}
@@ -37,8 +41,7 @@
           - if student.grade_for_course(current_course).present?
             = student.grade_for_course(current_course).name
         %td
-          = div_for student, class: "right" do
+          .right
             %ul.button-bar
-              %li= link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "button flagged-user-icon"
               %li= link_to raw("<i class='fa fa-edit fa-fw'> </i> Edit"), edit_user_path(student), :class => "button"
               %li= link_to raw("<i class='fa fa-trash fa-fw'> </i> Delete"), student.course_memberships.where(:course_id => current_course.id).first, :class => 'button', :data => { confirm: 'This will delete the student from your course - Are you sure?' }, :method => :delete

--- a/app/views/students/flagged.html.haml
+++ b/app/views/students/flagged.html.haml
@@ -1,0 +1,7 @@
+= content_nav_for User, "Flagged #{term_for :students}"
+
+%h3.pagetitle= @title
+
+.pageContent
+  = render 'layouts/alerts'
+  = render 'students_table', :course => current_course, :students => @students

--- a/app/views/students/leaderboard.html.haml
+++ b/app/views/students/leaderboard.html.haml
@@ -16,6 +16,7 @@
   %table.nofeatures_default_rank_dynatable
     %thead
       %tr
+        %th
         %th{:scope => "col", "data-dynatable-sorts" => "rank"} Rank
         %th{:scope => "col"} First Name
         %th{:scope => "col"} Last Name
@@ -33,6 +34,9 @@
       %tbody
         - @students.each_with_index do |student, index|
           %tr
+            %td
+              = div_for student do
+                = link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "flagged-user-icon"
             %td{"data-title" => "Rank"}= index + 1
             %td{"data-title" => "First Name"}= link_to student.first_name, student_path(student)
             %td{"data-title" => "Last Name"}= link_to student.last_name, student_path(student)
@@ -53,8 +57,7 @@
                     %img{:src => badge.icon, :alt => badge.name, :width => "20", :title => badge.name}
               %td{:style => "display: none"}= student.earned_badges_for_course(current_course).count
             %td{"data-title" => "Options"}
-              = div_for student, class: "right", style: "min-width: 160px;" do
+              .right
                 %ul.button-bar
-                  %li= link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "button flagged-user-icon"
                   %li= mail_to student.email, raw('<i class="fa fa-envelope fa-fw"></i> Email'), :class => "button"
                   %li= link_to raw('<i class="fa fa-edit fa-fw"></i> Edit'), edit_user_path(student), :class => "button"

--- a/app/views/students/leaderboard.html.haml
+++ b/app/views/students/leaderboard.html.haml
@@ -53,7 +53,8 @@
                     %img{:src => badge.icon, :alt => badge.name, :width => "20", :title => badge.name}
               %td{:style => "display: none"}= student.earned_badges_for_course(current_course).count
             %td{"data-title" => "Options"}
-              .right
+              .right{style: "min-width: 160px;"}
                 %ul.button-bar
+                  %li= link_to raw('<i class="fa fa-star fa-fw"></i> Flag'), flag_user_path(student), method: :post, remote: true, class: "button"
                   %li= mail_to student.email, raw('<i class="fa fa-envelope fa-fw"></i> Email'), :class => "button"
                   %li= link_to raw('<i class="fa fa-edit fa-fw"></i> Edit'), edit_user_path(student), :class => "button"

--- a/app/views/students/leaderboard.html.haml
+++ b/app/views/students/leaderboard.html.haml
@@ -53,8 +53,8 @@
                     %img{:src => badge.icon, :alt => badge.name, :width => "20", :title => badge.name}
               %td{:style => "display: none"}= student.earned_badges_for_course(current_course).count
             %td{"data-title" => "Options"}
-              .right{style: "min-width: 160px;"}
+              = div_for student, class: "right", style: "min-width: 160px;" do
                 %ul.button-bar
-                  %li= link_to raw('<i class="fa fa-star fa-fw"></i> Flag'), flag_user_path(student), method: :post, remote: true, class: "button"
+                  %li= link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "button flagged-user-icon"
                   %li= mail_to student.email, raw('<i class="fa fa-envelope fa-fw"></i> Email'), :class => "button"
                   %li= link_to raw('<i class="fa fa-edit fa-fw"></i> Edit'), edit_user_path(student), :class => "button"

--- a/app/views/students/sidebar/_sidebar_avatar.haml
+++ b/app/views/students/sidebar/_sidebar_avatar.haml
@@ -1,13 +1,16 @@
-.avatar.text-center
+= div_for current_student, class: "avatar text-center" do
   %h3= current_student.name
   %hr
   - if current_student.avatar_file_name.present?
-    %img.img-rounded{:src => current_student.avatar_file_name, :width => 150} 
+    %img.img-rounded{:src => current_student.avatar_file_name, :width => 150}
     %br
   .italic= "#{current_student.team_for_course(current_course).name}" if current_student.team_for_course(current_course).present?
   .italic= "Last activity: #{current_student.try(:last_activity_at) || "(never)"} "
   %ul
+    - if current_user_is_staff?
+      %li= link_to flagged_user_icon(current_course, current_user, current_student.id), flag_user_path(current_student), method: :post, remote: true, class: "button flagged-user-icon"
     %li= link_to raw('<i class="fa fa-edit fa-fw"></i> Edit'), edit_user_path(current_student), :class => "button"
     %li= link_to raw('<i class="fa fa-envelope fa-fw"></i> Email'), 'mailto:#{current_student.email}"', :class => "button"
-    - if current_user_is_admin?
+  - if current_user_is_admin?
+    %ul
       %li= link_to "Recalculate Score", student_recalculate_path(:student_id => current_student.id), :class => "button"

--- a/app/views/students/sidebar/_sidebar_avatar.haml
+++ b/app/views/students/sidebar/_sidebar_avatar.haml
@@ -1,5 +1,8 @@
 = div_for current_student, class: "avatar text-center" do
-  %h3= current_student.name
+  %h3
+    - if current_user_is_staff?
+      = link_to flagged_user_icon(current_course, current_user, current_student.id), flag_user_path(current_student), method: :post, remote: true, class: "flagged-user-icon"
+    = current_student.name
   %hr
   - if current_student.avatar_file_name.present?
     %img.img-rounded{:src => current_student.avatar_file_name, :width => 150}
@@ -7,10 +10,7 @@
   .italic= "#{current_student.team_for_course(current_course).name}" if current_student.team_for_course(current_course).present?
   .italic= "Last activity: #{current_student.try(:last_activity_at) || "(never)"} "
   %ul
-    - if current_user_is_staff?
-      %li= link_to flagged_user_icon(current_course, current_user, current_student.id), flag_user_path(current_student), method: :post, remote: true, class: "button flagged-user-icon"
     %li= link_to raw('<i class="fa fa-edit fa-fw"></i> Edit'), edit_user_path(current_student), :class => "button"
     %li= link_to raw('<i class="fa fa-envelope fa-fw"></i> Email'), 'mailto:#{current_student.email}"', :class => "button"
-  - if current_user_is_admin?
-    %ul
+    - if current_user_is_admin?
       %li= link_to "Recalculate Score", student_recalculate_path(:student_id => current_student.id), :class => "button"

--- a/app/views/users/flag.js.haml
+++ b/app/views/users/flag.js.haml
@@ -1,0 +1,1 @@
+alert("It works");

--- a/app/views/users/flag.js.haml
+++ b/app/views/users/flag.js.haml
@@ -1,1 +1,1 @@
-alert("It works");
+$("##{dom_id @user} .flagged-user-icon").html("#{escape_javascript flagged_user_icon(current_course, current_user, @user.id)}");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,7 @@ GradeCraft::Application.routes.draw do
       get :scores_for_single_assignment
       get :final_grades
       get :class_badges
+      get :flagged
     end
   end
   resources :staff, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,7 +234,7 @@ GradeCraft::Application.routes.draw do
   get 'using_gradecraft' => 'pages#using_gradecraft'
   get 'contact' => 'pages#contact'
   get 'features' => 'pages#features'
-  
+
   #11. Rubrics & Grade Schemes
   resources :rubrics
 
@@ -268,6 +268,7 @@ GradeCraft::Application.routes.draw do
   resources :users do
     get :activate, on: :member
     post :activate, on: :member, action: :activated
+    post :flag, on: :member
     collection do
       get :edit_profile
       put :update_profile

--- a/db/migrate/20150906162657_create_flagged_users.rb
+++ b/db/migrate/20150906162657_create_flagged_users.rb
@@ -1,0 +1,13 @@
+class CreateFlaggedUsers < ActiveRecord::Migration
+  def change
+    create_table :flagged_users do |t|
+      t.references :course, index: true, foreign_key: true
+      t.integer :flagger_id, index: true
+      t.integer :flagged_id, index: true
+
+      t.timestamps null: false
+    end
+    add_foreign_key :flagged_users, :users, column: :flagger_id
+    add_foreign_key :flagged_users, :users, column: :flagged_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -467,6 +467,18 @@ ActiveRecord::Schema.define(version: 20150907224335) do
     t.datetime "updated_at",             null: false
   end
 
+  create_table "flagged_users", force: :cascade do |t|
+    t.integer  "course_id"
+    t.integer  "flagger_id"
+    t.integer  "flagged_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "flagged_users", ["course_id"], name: "index_flagged_users_on_course_id", using: :btree
+  add_index "flagged_users", ["flagged_id"], name: "index_flagged_users_on_flagged_id", using: :btree
+  add_index "flagged_users", ["flagger_id"], name: "index_flagged_users_on_flagger_id", using: :btree
+
   create_table "grade_files", force: :cascade do |t|
     t.integer  "grade_id"
     t.string   "filename",        limit: 255
@@ -894,4 +906,7 @@ ActiveRecord::Schema.define(version: 20150907224335) do
   add_foreign_key "announcement_states", "users"
   add_foreign_key "announcements", "courses"
   add_foreign_key "announcements", "users", column: "author_id"
+  add_foreign_key "flagged_users", "courses"
+  add_foreign_key "flagged_users", "users", column: "flagged_id"
+  add_foreign_key "flagged_users", "users", column: "flagger_id"
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -95,6 +95,22 @@ describe UsersController do
       end
     end
 
+    describe "POST flag" do
+      it "flags the student by the user if the student is not flagged" do
+        post :flag, id: @student.id, format: :js
+        flagged_user = FlaggedUser.last
+        expect(flagged_user.flagged_id).to eq @student.id
+        expect(flagged_user.flagger_id).to eq @professor.id
+        expect(flagged_user.course_id).to eq @course.id
+      end
+
+      it "unflags the student if the student is already flagged" do
+        FlaggedUser.flag! @course, @professor, @student.id
+        post :flag, id: @student.id, format: :js
+        expect(FlaggedUser.count).to be_zero
+      end
+    end
+
     describe "GET edit_profile" do
       it "renders the edit profile user form" do
         get :edit_profile
@@ -153,7 +169,6 @@ describe UsersController do
         expect(response.body).to include "The team is not cool"
       end
     end
-
   end
 
   context "as a student" do

--- a/spec/models/flagged_student_spec.rb
+++ b/spec/models/flagged_student_spec.rb
@@ -1,0 +1,17 @@
+require "active_record_spec_helper"
+
+describe FlaggedUser do
+  let(:course) { create :course }
+  let(:professor) { create :user }
+  let(:student) { create :user }
+
+  it "creates a relationship between staff and a student" do
+    FlaggedUser.flag!(course, professor, student.id)
+    result = FlaggedUser.last
+    expect(result.course_id).to eq course.id
+    expect(result.flagger_id).to eq professor.id
+    expect(result.flagged_id).to eq student.id
+  end
+
+  xit "does not allow a student to be flagged by another student"
+end

--- a/spec/models/flagged_student_spec.rb
+++ b/spec/models/flagged_student_spec.rb
@@ -5,6 +5,51 @@ describe FlaggedUser do
   let(:professor) { create :user }
   let(:student) { create :user }
 
+  before do
+    create :course_membership, course: course, user: professor, role: "professor"
+    create :course_membership, course: course, user: student, role: "student"
+  end
+
+  context "validations" do
+    subject do
+      FlaggedUser.new course_id: course.id,
+        flagger_id: professor.id,
+        flagged_id: student.id
+    end
+
+    it "a course is required" do
+      subject.course_id = 123
+      expect(subject).to_not be_valid
+      expect(subject.errors[:course]).to include "can't be blank"
+    end
+
+    it "a flagger is required" do
+      subject.flagger_id = 123
+      expect(subject).to_not be_valid
+      expect(subject.errors[:flagger]).to include "can't be blank"
+    end
+
+    it "a flagged user is required" do
+      subject.flagged_id = 123
+      expect(subject).to_not be_valid
+      expect(subject.errors[:flagged]).to include "can't be blank"
+    end
+
+    it "the flagger must belong to the course" do
+      CourseMembership.where(course_id: course.id, user_id: professor.id).destroy_all
+      expect(subject).to_not be_valid
+      expect(subject.errors[:flagger]).to include "must belong to the course"
+    end
+
+    it "the flagged must belong to the course" do
+      CourseMembership.where(course_id: course.id, user_id: student.id).destroy_all
+      expect(subject).to_not be_valid
+      expect(subject.errors[:flagged]).to include "must belong to the course"
+    end
+
+    xit "does not allow a student to be flagged by another student"
+  end
+
   it "creates a relationship between staff and a student" do
     FlaggedUser.flag!(course, professor, student.id)
     result = FlaggedUser.last
@@ -12,6 +57,4 @@ describe FlaggedUser do
     expect(result.flagger_id).to eq professor.id
     expect(result.flagged_id).to eq student.id
   end
-
-  xit "does not allow a student to be flagged by another student"
 end

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -58,11 +58,13 @@ describe FlaggedUser do
     end
   end
 
-  it "creates a relationship between staff and a student" do
-    FlaggedUser.flag!(course, professor, student.id)
-    result = FlaggedUser.last
-    expect(result.course_id).to eq course.id
-    expect(result.flagger_id).to eq professor.id
-    expect(result.flagged_id).to eq student.id
+  describe ".flag!" do
+    it "creates a relationship between staff and a student" do
+      FlaggedUser.flag!(course, professor, student.id)
+      result = FlaggedUser.last
+      expect(result.course_id).to eq course.id
+      expect(result.flagger_id).to eq professor.id
+      expect(result.flagged_id).to eq student.id
+    end
   end
 end

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -1,4 +1,4 @@
-require "active_record_spec_helper"
+require "spec_helper"
 
 describe FlaggedUser do
   let(:course) { create :course }
@@ -47,7 +47,15 @@ describe FlaggedUser do
       expect(subject.errors[:flagged]).to include "must belong to the course"
     end
 
-    xit "does not allow a student to be flagged by another student"
+    it "does not allow a student to be flagged by another student" do
+      another_student = create :user
+      create :course_membership, course: course, user: another_student, role: "student"
+      subject = FlaggedUser.new course_id: course.id,
+        flagger_id: another_student.id,
+        flagged_id: student.id
+      expect(subject).to_not be_valid
+      expect(subject.errors[:flagger]).to include "must be a staff member"
+    end
   end
 
   it "creates a relationship between staff and a student" do

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -77,6 +77,17 @@ describe FlaggedUser do
     end
   end
 
+  describe ".flagged?" do
+    it "returns true if the user is flagged by the flagger for the course" do
+      FlaggedUser.flag!(course, professor, student.id)
+      expect(FlaggedUser.flagged? course, professor, student.id).to eq true
+    end
+
+    it "returns false if the user is not flagged by the flagger for the course" do
+      expect(FlaggedUser.flagged? course, professor, student.id).to eq false
+    end
+  end
+
   describe ".toggle!" do
     it "creates a relationship between staff and a student if it doesn't exist" do
       FlaggedUser.toggle!(course, professor, student.id)

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -88,6 +88,13 @@ describe FlaggedUser do
     end
   end
 
+  describe ".flagged" do
+    it "returns the users who were flagged by a user for a course" do
+      FlaggedUser.flag!(course, professor, student.id)
+      expect(FlaggedUser.flagged(course, professor)).to eq [student]
+    end
+  end
+
   describe ".toggle!" do
     it "creates a relationship between staff and a student if it doesn't exist" do
       FlaggedUser.toggle!(course, professor, student.id)

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -67,4 +67,26 @@ describe FlaggedUser do
       expect(result.flagged_id).to eq student.id
     end
   end
+
+  describe ".unflag!" do
+    before { FlaggedUser.flag!(course, professor, student.id) }
+
+    it "deletes the relationship between staff and student" do
+      FlaggedUser.unflag!(course, professor, student.id)
+      expect(FlaggedUser.count).to be_zero
+    end
+  end
+
+  describe ".toggle!" do
+    it "creates a relationship between staff and a student if it doesn't exist" do
+      FlaggedUser.toggle!(course, professor, student.id)
+      expect(FlaggedUser.count).to eq 1
+    end
+
+    it "deletes the relationship between staff and student if it does exist" do
+      FlaggedUser.flag!(course, professor, student.id)
+      FlaggedUser.toggle!(course, professor, student.id)
+      expect(FlaggedUser.count).to eq 0
+    end
+  end
 end

--- a/spec/views/students/index_spec.rb
+++ b/spec/views/students/index_spec.rb
@@ -16,6 +16,7 @@ describe "students/index" do
   before(:each) do
     assign(:title, "Student Roster")
     allow(view).to receive(:current_course).and_return(@course)
+    allow(view).to receive(:current_user).and_return(@student_1)
   end
 
   it "renders successfully" do


### PR DESCRIPTION
Allows staff members to flag various students. A staff member can flag a student from the leaderboard, student profile, and the student index views. A new menu item was added so that the staff member can view a list of the flagged students.

![flagged-users](https://cloud.githubusercontent.com/assets/35017/9800159/693e43ac-57d9-11e5-9d17-f37484817d62.gif)

![screen shot 2015-09-10 at 4 31 53 pm](https://cloud.githubusercontent.com/assets/35017/9800175/8163a12a-57d9-11e5-96d4-4b5517b1844e.png)

![screen shot 2015-09-10 at 4 32 34 pm](https://cloud.githubusercontent.com/assets/35017/9800186/91482bb0-57d9-11e5-8256-f0b2c9899b3d.png)

* Only allows staff members to flag students
* Only can assign a flagged to student to a course if they belong to a course
* NOTE: I am using the unobtrusive js method for flagging students. I don't believe this has been used before in the app (responding with view.js.haml) so let me know if you don't want me to use this and I will change it
* NOTE: There could be a possible "loop hole" where the student is flagged to a specific course but then they are removed from this course. They would still be contained within this courses' flagged users. I can create an `before_destroy` callback on a `CourseMembership` to remove this flagged student but I did not know how often that happens. (I try to avoid callbacks as much as possible).