### PR TITLE
fix error when submission is empty

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -57,7 +57,7 @@ class SubmissionsController < ApplicationController
 
   def create
     @assignment = current_course.assignments.find(params[:assignment_id])
-    if params[:submission][:submission_files_attributes].present?
+    if params[:submission] && params[:submission][:submission_files_attributes].present?
       @submission_files = params[:submission][:submission_files_attributes]["0"]["file"]
       params[:submission].delete :submission_files_attributes
     end
@@ -109,7 +109,7 @@ class SubmissionsController < ApplicationController
 
   def update
     @assignment = current_course.assignments.find(params[:assignment_id])
-    if params[:submission][:submission_files_attributes].present?
+    if params[:submission] && params[:submission][:submission_files_attributes].present?
       @submission_files = params[:submission][:submission_files_attributes]["0"]["file"]
       params[:submission].delete :submission_files_attributes
     end


### PR DESCRIPTION
  This will check for an empty submission before attempting to pull the
  upload file attributes out. Note that we may still want to disable the
  submission button until a valid submission has been created (a link,
  text, or a uploaded file must be present.)