### PR TITLE
Fix course list navigation caching

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,4 +1,5 @@
 class CoursesController < ApplicationController
+  include CoursesHelper
 
   before_filter :ensure_staff?, :except => [:timeline]
 
@@ -124,6 +125,7 @@ class CoursesController < ApplicationController
       if @course.save
         @course.course_memberships.create(:user_id => current_user.id, :role => current_user.role(current_course), instructor_of_record: true)
         session[:course_id] = @course.id
+        bust_course_list_cache current_user
         format.html { redirect_to course_path(@course), notice: "Course #{@course.name} successfully created" }
         format.json { render json: @course, status: :created, location: @course }
       else
@@ -139,6 +141,7 @@ class CoursesController < ApplicationController
 
     respond_to do |format|
       if @course.update_attributes(params[:course])
+        bust_course_list_cache current_user
         format.html { redirect_to @course, notice: "Course #{@course.name} successfully updated" }
       else
         redirect_to edit_course_path

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -1,0 +1,14 @@
+module CoursesHelper
+  def current_courses_cache_key(user)
+    multi_cache_key :current_user_current_courses, user
+  end
+
+  def archived_courses_cache_key(user)
+    multi_cache_key :current_user_archived_courses, user
+  end
+
+  def bust_course_list_cache(user)
+    Rails.cache.delete_matched "#{:current_user_current_courses}*"
+    Rails.cache.delete_matched "#{:current_user_archived_courses}*"
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -125,6 +125,8 @@ class Course < ActiveRecord::Base
   validate :max_more_than_min
 
   scope :alphabetical, -> { order('courseno ASC') }
+  scope :active, -> { where(status: true) }
+  scope :inactive, -> { where.not(status: true) }
 
   def self.find_or_create_by_lti_auth_hash(auth_hash)
     criteria = { lti_uid: auth_hash['extra']['raw_info']['context_id'] }
@@ -223,7 +225,7 @@ class Course < ActiveRecord::Base
   def formatted_short_name
     if semester.present? && year.present?
       "#{self.courseno} #{(self.semester).capitalize.first[0]}#{self.year}"
-    else 
+    else
       "#{courseno}"
     end
   end

--- a/app/views/layouts/navigation/_course_list.haml
+++ b/app/views/layouts/navigation/_course_list.haml
@@ -1,16 +1,14 @@
-- cache multi_cache_key :current_user_current_courses, current_user do
-  - current_user.courses.alphabetical.each do |c|
+- cache current_courses_cache_key(current_user) do
+  - current_user.courses.active.alphabetical.each do |c|
     - cache ["v1", c] do
-      - if c.active?
-        %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
+      %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
 - if current_user_is_staff?
   %li= link_to raw("Create a New Course <i class='fa fa-angle-double-right fa-fw'></i>"), new_course_path
 
-- cache multi_cache_key :current_user_archived_courses, current_user do
+- cache archived_courses_cache_key(current_user) do
   - if current_user.archived_courses.present?
     %hr.dotted.top-margin
     %h4.past-label Past Courses
-    - current_user.courses.alphabetical.each do |c|
+    - current_user.courses.inactive.alphabetical.each do |c|
       - cache ["v1", c] do
-        - if ! c.active?
-          %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'
+        %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -89,6 +89,24 @@ describe Course do
     expect(@course.fail_term).to eq("Fail")
   end
 
+  describe ".active" do
+    it "returns courses that have a status" do
+      Course.destroy_all
+      active = create :course, status: true
+      inactive = create :course, status: false
+      expect(Course.active.to_a).to eq [active]
+    end
+  end
+
+  describe ".inactive" do
+    it "returns courses that do not have a status" do
+      Course.destroy_all
+      active = create :course, status: true
+      inactive = create :course, status: false
+      expect(Course.inactive.to_a).to eq [inactive]
+    end
+  end
+
   describe "#instructors_of_record" do
     it "returns all the staff who are instructors of record for the course" do
       membership = create :staff_course_membership, course: subject, instructor_of_record: true


### PR DESCRIPTION
This PR fixes an issue with repeating courses in the active / past course dropdown navigation menu. It also busts the cache when a course is updated or created so the menu updates.