### PR TITLE
Fix the caching of the course list

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -8,7 +8,7 @@ module CoursesHelper
   end
 
   def bust_course_list_cache(user)
-    #Rails.cache.delete_matched "#{:current_user_current_courses}*"
-    #Rails.cache.delete_matched "#{:current_user_archived_courses}*"
+    expire_fragment current_courses_cache_key(user)
+    expire_fragment archived_courses_cache_key(user)
   end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -8,7 +8,7 @@ module CoursesHelper
   end
 
   def bust_course_list_cache(user)
-    Rails.cache.delete_matched "#{:current_user_current_courses}*"
-    Rails.cache.delete_matched "#{:current_user_archived_courses}*"
+    #Rails.cache.delete_matched "#{:current_user_current_courses}*"
+    #Rails.cache.delete_matched "#{:current_user_archived_courses}*"
   end
 end

--- a/app/views/layouts/navigation/_course_list.haml
+++ b/app/views/layouts/navigation/_course_list.haml
@@ -1,14 +1,14 @@
-- cache current_courses_cache_key(current_user) do
-  - current_user.courses.active.alphabetical.each do |c|
-    - cache ["v1", c] do
-      %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
+/ cache current_courses_cache_key(current_user) do
+- current_user.courses.active.alphabetical.each do |c|
+  - cache ["v1", c] do
+    %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
 - if current_user_is_staff?
   %li= link_to raw("Create a New Course <i class='fa fa-angle-double-right fa-fw'></i>"), new_course_path
 
-- cache archived_courses_cache_key(current_user) do
-  - if current_user.archived_courses.present?
-    %hr.dotted.top-margin
-    %h4.past-label Past Courses
-    - current_user.courses.inactive.alphabetical.each do |c|
-      - cache ["v1", c] do
-        %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'
+/ cache archived_courses_cache_key(current_user) do
+- if current_user.archived_courses.present?
+  %hr.dotted.top-margin
+  %h4.past-label Past Courses
+  - current_user.courses.inactive.alphabetical.each do |c|
+    - cache ["v1", c] do
+      %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'

--- a/app/views/layouts/navigation/_course_list.haml
+++ b/app/views/layouts/navigation/_course_list.haml
@@ -1,14 +1,14 @@
-/ cache current_courses_cache_key(current_user) do
-- current_user.courses.active.alphabetical.each do |c|
-  - cache ["v1", c] do
-    %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
+- cache current_courses_cache_key(current_user), skip_digest: true do
+  - current_user.courses.active.alphabetical.each do |c|
+    - cache ["v1", c] do
+      %li= link_to raw("<i class ='fa fa-home fa-fw'></i> #{c.formatted_short_name} "), change_current_course_path(:course_id => c.id), :method => 'post'
 - if current_user_is_staff?
   %li= link_to raw("Create a New Course <i class='fa fa-angle-double-right fa-fw'></i>"), new_course_path
 
-/ cache archived_courses_cache_key(current_user) do
-- if current_user.archived_courses.present?
-  %hr.dotted.top-margin
-  %h4.past-label Past Courses
-  - current_user.courses.inactive.alphabetical.each do |c|
-    - cache ["v1", c] do
-      %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'
+- cache archived_courses_cache_key(current_user), skip_digest: true do
+  - if current_user.archived_courses.present?
+    %hr.dotted.top-margin
+    %h4.past-label Past Courses
+    - current_user.courses.inactive.alphabetical.each do |c|
+      - cache ["v1", c] do
+        %li.archived= link_to raw("<i class ='fa fa-home fa-fw'></i>  #{c.formatted_short_name}"), change_current_course_path(:course_id => c.id), :method => 'post'


### PR DESCRIPTION
Since Dalli does not support `delete_matched` we need to find an alternative way of deleting the caches for the course list.

Since we cannot find the cache key by a fragment of the cache key, we need to come up with an alternative.

When using fragment caching, Rails adds a `views` namespace to the beginning of the cache key and a digest (of the fragment contents) to the end of the cache key. The fragment cache key for the course list ends up looking like `views/current_user_current_courses/147-20150923110988/jafdgfdkdfhfrjr`. This is the `views` namespace, followed by the cache key (`current_user_current_courses`), followed by the cache key for the `user` (147-20150923110988), followed by a digest.

There is a controller method called `expire_fragment` which is better to use when deleting fragment caches because it adds the `views` fragment at the beginning. Since `expire_fragment` does not add the digest, we need to turn the digest off on the view caching. You can do this with the `skip_digest` option on the view `cache` method.

I turned off the digest for the course list which makes the expiration of the fragment caching possible but it does have a negative side affect. If we ever change the content of the course info partial, no one will see it unless we clear the cache when deploying. I found this negative to outweigh the positives of caching the course list, which is run on *every* request.