### PR TITLE
Do not fragment cache the assignment within the student todo list

### DIFF
--- a/app/views/students/sidebar/_sidebar_to_do_list.haml
+++ b/app/views/students/sidebar/_sidebar_to_do_list.haml
@@ -3,23 +3,22 @@
   %hr
   - cache multi_cache_key :student_sidebar_todo_list, current_student, current_course do
     - current_course.assignments.chronological.includes(:assignment_type, :unlock_conditions).each do |assignment|
-      - cache ["v1", assignment] do
-        - if assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(current_student)
-          .assignment-item
-            - if assignment.accepts_submissions? && assignment.is_unlocked_for_student?(current_student)
-              - if assignment.is_individual?
-                .right= render "students/submissions", assignment: assignment
-              - else
-                .right= render "students/group_submissions", assignment: assignment, group: current_student.group_for_assignment(assignment)
-            - if assignment.is_predicted_by_student?(current_student)
-              %a
-                %i.fa.fa-star.fa-fw.yellow
-              .display_on_hover.hover-style
-                You have included this #{term_for :assignment} in your grade prediction
-            - if current_student.submission_for_assignment(assignment).present?
-              %span.bold.strikethrough= link_to "#{assignment.try(:name)}", assignment
-              .small.uppercase= "#{assignment.assignment_type.name}"
+      - if assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(current_student)
+        .assignment-item
+          - if assignment.accepts_submissions? && assignment.is_unlocked_for_student?(current_student)
+            - if assignment.is_individual?
+              .right= render "students/submissions", assignment: assignment
             - else
-              %span.bold= link_to assignment.name, assignment_grade_path(assignment, :student_id => current_student)
-              .small.uppercase= "#{assignment.assignment_type.name}"
-              .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
+              .right= render "students/group_submissions", assignment: assignment, group: current_student.group_for_assignment(assignment)
+          - if assignment.is_predicted_by_student?(current_student)
+            %a
+              %i.fa.fa-star.fa-fw.yellow
+            .display_on_hover.hover-style
+              You have included this #{term_for :assignment} in your grade prediction
+          - if current_student.submission_for_assignment(assignment).present?
+            %span.bold.strikethrough= link_to "#{assignment.try(:name)}", assignment
+            .small.uppercase= "#{assignment.assignment_type.name}"
+          - else
+            %span.bold= link_to assignment.name, assignment_grade_path(assignment, :student_id => current_student)
+            .small.uppercase= "#{assignment.assignment_type.name}"
+            .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"


### PR DESCRIPTION
Fixes an issue with caching so that assignment submissions are not cached for all users.

We verified this on staging to ensure that the submission todo list was valid for 2 users after one user submitted for an assignment. It was marked as done for that student but still marked as needing completing for the other.

Fixes https://www.myworkboard.com/wb/index.php/activity/ActionItemDetails?id=831569&