### PR TITLE
1168 reimport of identical scores

### DIFF
--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -72,10 +72,9 @@ class GradeImporter
   end
 
   def find_student(row, students)
-    if row.identifier =~ /@/
-      students.find { |student| student.email.downcase == row.identifier }
-    else
-      students.find { |student| student.username.downcase == row.identifier }
+    message = row.identifier =~ /@/ ? :email : :username
+    students.find do |student|
+      student.public_send(message).downcase == row.identifier
     end
   end
 

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -87,18 +87,20 @@ class GradeImporter
   end
 
   class GradeRow
+    include QuoteHelper
+
     attr_reader :data
 
     def identifier
-      data[2].downcase if data[2]
+      remove_smart_quotes(data[2]).downcase if data[2]
     end
 
     def feedback
-      data[4]
+      remove_smart_quotes data[4]
     end
 
     def grade
-      data[3].to_i if data[3]
+      remove_smart_quotes(data[3]).to_i if data[3]
     end
 
     def has_grade?

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -15,7 +15,7 @@ class GradeImporter
     if file
       if course && assignment
         students = course.students
-        CSV.foreach(file, headers: true, encoding: 'ISO-8859-1') do |csv|
+        CSV.foreach(file, headers: true) do |csv|
           row = GradeRow.new csv
 
           student = find_student(row, students)

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -55,7 +55,7 @@ class GradeImporter
 
   def assign_grade(row, grade)
     grade.raw_score = grade_column(row)
-    grade.feedback = row[4]
+    grade.feedback = feedback_column(row)
     grade.status = "Graded" if grade.status.nil?
     grade.instructor_modified = true
   end
@@ -67,12 +67,18 @@ class GradeImporter
     end
   end
 
+  def feedback_column(row)
+    row[4]
+  end
+
   def grade_column(row)
     row[3].to_i if row[3]
   end
 
   def update_grade?(row, grade)
-    grade.present? && grade.raw_score != grade_column(row)
+    grade.present? &&
+      (grade.raw_score != grade_column(row) ||
+       grade.feedback != feedback_column(row))
   end
 
   def update_grade(row, grade)

--- a/app/views/grades/_import_results_table.html.haml
+++ b/app/views/grades/_import_results_table.html.haml
@@ -1,0 +1,16 @@
+%table.responsive.nofeatures_default_last_name_dynatable
+  %thead
+    %tr
+      %th First Name
+      %th Last Name
+      %th Email
+      %th Score
+      %th Feedback
+  %tbody
+    - grades.each do |grade|
+      %tr
+        %td= link_to grade.student.first_name, student_path(grade.student)
+        %td= link_to grade.student.last_name, student_path(grade.student)
+        %td= link_to grade.student.email, student_path(grade.student)
+        %td= grade.raw_score
+        %td= grade.feedback

--- a/app/views/grades/import_results.html.haml
+++ b/app/views/grades/import_results.html.haml
@@ -19,6 +19,26 @@
             %td= row[:data]
             %td= row[:errors]
 
+  - unless @result.unchanged.empty?
+    %h4.subtitle
+      = "#{@result.unchanged.count} #{"Grade".pluralize(@result.unchanged.count)} Not Imported (already existed)"
+    %table.responsive.nofeatures_default_last_name_dynatable
+      %thead
+        %tr
+          %th First Name
+          %th Last Name
+          %th Email
+          %th Score
+          %th Feedback
+      %tbody
+        - @result.unchanged.each do |grade|
+          %tr
+            %td= link_to grade.student.first_name, student_path(grade.student)
+            %td= link_to grade.student.last_name, student_path(grade.student)
+            %td= link_to grade.student.email, student_path(grade.student)
+            %td= grade.raw_score
+            %td= grade.feedback
+
   %h4.subtitle
     = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
   %table.responsive.nofeatures_default_last_name_dynatable

--- a/app/views/grades/import_results.html.haml
+++ b/app/views/grades/import_results.html.haml
@@ -22,38 +22,8 @@
   - unless @result.unchanged.empty?
     %h4.subtitle
       = "#{@result.unchanged.count} #{"Grade".pluralize(@result.unchanged.count)} Not Imported (already existed)"
-    %table.responsive.nofeatures_default_last_name_dynatable
-      %thead
-        %tr
-          %th First Name
-          %th Last Name
-          %th Email
-          %th Score
-          %th Feedback
-      %tbody
-        - @result.unchanged.each do |grade|
-          %tr
-            %td= link_to grade.student.first_name, student_path(grade.student)
-            %td= link_to grade.student.last_name, student_path(grade.student)
-            %td= link_to grade.student.email, student_path(grade.student)
-            %td= grade.raw_score
-            %td= grade.feedback
+    = render partial: "grades/import_results_table", locals: { grades: @result.unchanged }
 
   %h4.subtitle
     = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
-  %table.responsive.nofeatures_default_last_name_dynatable
-    %thead
-      %tr
-        %th First Name
-        %th Last Name
-        %th Email
-        %th Score
-        %th Feedback
-    %tbody
-      - @result.successful.each do |grade|
-        %tr
-          %td= link_to grade.student.first_name, student_path(grade.student)
-          %td= link_to grade.student.last_name, student_path(grade.student)
-          %td= link_to grade.student.email, student_path(grade.student)
-          %td= grade.raw_score
-          %td= grade.feedback
+  = render partial: "grades/import_results_table", locals: { grades: @result.successful }

--- a/app/views/grades/import_results.html.haml
+++ b/app/views/grades/import_results.html.haml
@@ -19,11 +19,11 @@
             %td= row[:data]
             %td= row[:errors]
 
+  %h4.subtitle
+    = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
+  = render partial: "grades/import_results_table", locals: { grades: @result.successful }
+
   - unless @result.unchanged.empty?
     %h4.subtitle
       = "#{@result.unchanged.count} #{"Grade".pluralize(@result.unchanged.count)} Not Imported (already existed)"
     = render partial: "grades/import_results_table", locals: { grades: @result.unchanged }
-
-  %h4.subtitle
-    = "#{@result.successful.count} #{"Grade".pluralize(@result.successful.count)} Imported Successfully"
-  = render partial: "grades/import_results_table", locals: { grades: @result.successful }

--- a/lib/quote_helper.rb
+++ b/lib/quote_helper.rb
@@ -1,0 +1,18 @@
+module QuoteHelper
+  def remove_smart_quotes(string)
+    regex = Regexp.new smart_quote_characters.join("|")
+    string.gsub(regex, "")
+  end
+
+  def smart_quote_characters
+    double_smart_quote_characters + single_smart_quote_characters
+  end
+
+  def double_smart_quote_characters
+    ["\u201C", "\u201D"].freeze
+  end
+
+  def single_smart_quote_characters
+    ["\u2018", "\u2019"].freeze
+  end
+end

--- a/lib/quote_helper.rb
+++ b/lib/quote_helper.rb
@@ -1,5 +1,6 @@
 module QuoteHelper
   def remove_smart_quotes(string)
+    return "" unless string
     regex = Regexp.new smart_quote_characters.join("|")
     string.gsub(regex, "")
   end

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -68,6 +68,13 @@ describe GradeImporter do
           }.to_not change grade, :updated_at
         end
 
+        it "updates the grade if the grade is the same but the feedback is different" do
+          grade = create :grade, assignment: assignment, student: student, raw_score: 4000, feedback: "You need some work"
+          result = subject.import(course, assignment)
+          expect(result.successful.count).to eq 1
+          expect(result.successful.first).to eq grade
+        end
+
         it "contains an unsuccessful row if the grade is not valid" do
           allow_any_instance_of(Grade).to receive(:valid?).and_return false
           allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -58,6 +58,14 @@ describe GradeImporter do
           expect(grade.feedback).to eq "You did great!"
         end
 
+        it "does not update the grade if the grade is the same as the one being imported" do
+          grade = create :grade, assignment: assignment, student: student, raw_score: 4000, feedback: "You did great!"
+          expect {
+            result = subject.import(course, assignment)
+            expect(result.successful).to be_empty
+          }.to_not change grade, :updated_at
+        end
+
         it "contains an unsuccessful row if the grade is not valid" do
           allow_any_instance_of(Grade).to receive(:valid?).and_return false
           allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])

--- a/spec/importers/grade_importer_spec.rb
+++ b/spec/importers/grade_importer_spec.rb
@@ -58,11 +58,13 @@ describe GradeImporter do
           expect(grade.feedback).to eq "You did great!"
         end
 
-        it "does not update the grade if the grade is the same as the one being imported" do
+        it "does not update the grade if the grade and the feedback are the same as the one being imported" do
           grade = create :grade, assignment: assignment, student: student, raw_score: 4000, feedback: "You did great!"
           expect {
             result = subject.import(course, assignment)
             expect(result.successful).to be_empty
+            expect(result.unchanged.count).to eq 1
+            expect(result.unchanged.first).to eq grade
           }.to_not change grade, :updated_at
         end
 

--- a/spec/lib/quote_helper_spec.rb
+++ b/spec/lib/quote_helper_spec.rb
@@ -1,0 +1,22 @@
+require "rspec/core"
+require "./lib/quote_helper"
+
+describe QuoteHelper do
+  class Container
+    include QuoteHelper
+  end
+
+  subject { Container.new }
+
+  describe "#remove_smart_quotes" do
+    it "removes single smart quotes" do
+      with_smart_quotes = "\u2018this is a thing\u2019"
+      expect(subject.remove_smart_quotes(with_smart_quotes)).to eq "this is a thing"
+    end
+
+    it "removes double smart quotes" do
+      with_smart_quotes = "\u201Cthis is a thing\u201D"
+      expect(subject.remove_smart_quotes(with_smart_quotes)).to eq "this is a thing"
+    end
+  end
+end

--- a/spec/lib/quote_helper_spec.rb
+++ b/spec/lib/quote_helper_spec.rb
@@ -18,5 +18,9 @@ describe QuoteHelper do
       with_smart_quotes = "\u201Cthis is a thing\u201D"
       expect(subject.remove_smart_quotes(with_smart_quotes)).to eq "this is a thing"
     end
+
+    it "handles nil string" do
+      expect(subject.remove_smart_quotes(nil)).to eq ""
+    end
   end
 end


### PR DESCRIPTION
Does not re-import (change a score) for a grade if the grade's score and feedback are the same.

If the `GradeImporter` detects a score that is the same, it does not change it and it puts the grade into an `unchanged` bucket. This bucket is now displayed on the grade import results view:

<img width="1655" alt="screen shot 2015-10-06 at 1 25 30 pm" src="https://cloud.githubusercontent.com/assets/35017/10316549/c5a53a84-6c2d-11e5-9ab6-08e837c76f02.png">

The `GradeImporter` now handles smart quotes as well.

Closes #1168 