### PR TITLE
Run coverage seperately

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ end
 group :test do
   # added to development for parallel_tests
   gem 'capybara', '~> 2.5.0'
+  gem 'codeclimate-test-reporter'
   gem 'database_cleaner', "~> 1.0.1"
   gem 'launchy'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     chunky_png (1.3.4)
+    codeclimate-test-reporter (0.4.8)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -626,6 +628,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   carrierwave
   carrierwave_backgrounder
+  codeclimate-test-reporter
   coffee-rails
   compass-rails
   d3-rails
@@ -705,3 +708,6 @@ DEPENDENCIES
   whenever
   wysiwyg-rails
   zeus-parallel_tests
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [ ![Codeship Status for UM-USElab/gradecraft-development](https://codeship.com/projects/a7421010-4e8b-0133-aacd-4e8e1c03c7f2/status?branch=master)](https://codeship.com/projects/106957)
 
+[![Test Coverage](https://codeclimate.com/github/UM-USElab/gradecraft-development/badges/coverage.svg)](https://codeclimate.com/github/UM-USElab/gradecraft-development/coverage)
+
+[![Code Climate](https://codeclimate.com/github/UM-USElab/gradecraft-development/badges/gpa.svg)](https://codeclimate.com/github/UM-USElab/gradecraft-development)
+
 ## Current features:
 * Badges
 * Teams (course-long memberships)

--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@
 1. Run `bundle exec rake db:create`
 1. Optional: run `bundle exec rake db:sample`
 1. Run `foreman start`
+
+## Running specs
+
+To run all of the spec examples, you can run the following (this is also the default rake task):
+
+```
+bundle exec rake spec
+```
+
+To run all of the spec examples with code coverage, you can run the following:
+
+```
+bundle exec rake spec:coverage
+```

--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ To run all of the spec examples with code coverage, you can run the following:
 ```
 bundle exec rake spec:coverage
 ```
+
+## Contributing
+
+1. Clone the repository `git clone https://github.com/UM-USElab/gradecraft-development`
+1. Create a feature branch `git checkout -b my-awesome-feature`
+1. Code!
+1. Commit your changes (small commits please)
+1. Push your new branch `git push origin my-awesome-feature`
+1. Create a pull request `hub pull-request -b um-uselab:master -h um-uselab:my-awesome-feature`

--- a/Rakefile
+++ b/Rakefile
@@ -8,5 +8,5 @@ GradeCraft::Application.load_tasks
 require 'resque/tasks'
 
 task "resque:setup" => :environment do
-    ENV['QUEUE'] = "*"
+  ENV['QUEUE'] = "*"
 end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,0 +1,11 @@
+desc "Run all spec examples"
+begin
+  ENV["RAILS_ENV"] = 'test'
+
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+rescue LoadError
+  # no rspec available
+end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,6 +1,6 @@
 desc "Run all spec examples"
 begin
-  ENV["RAILS_ENV"] = 'test'
+  ENV["RAILS_ENV"] = "test"
 
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
@@ -8,4 +8,12 @@ begin
   task :default => :spec
 rescue LoadError
   # no rspec available
+end
+
+namespace :spec do
+  desc "Run all spec examples with coverage"
+  task :coverage do
+    ENV["COVERAGE"] = "true"
+    Rake::Task["spec"].invoke
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start if ENV["COVERAGE"]
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,10 @@
-require 'simplecov'
-SimpleCov.start if ENV["COVERAGE"]
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start
+
+  require 'codeclimate-test-reporter'
+  CodeClimate::TestReporter.start
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'


### PR DESCRIPTION
This PR adds several new `rake` tasks to run the specs with and without code coverage. To just run all the specs, you can run `rake spec` (or simply `rake`) and to run them with coverage, you can run `rake spec:coverage`.

The README was updated in order to document these new rake tasks.

[CodeClimate](https://codeclimate.com/github/UM-USElab/gradecraft-development) was also added to this project so we can view where our pain points are and we can view the code coverage in CI. It may be removed later if it is too much at this point.