### PR TITLE
Testing login paths for all roles

### DIFF
--- a/app/views/layouts/navigation/_authenticated_nav.haml
+++ b/app/views/layouts/navigation/_authenticated_nav.haml
@@ -16,5 +16,5 @@
       %img.profile-pic{:src => current_user.avatar_file_name, :height => 20}
     = current_user.public_name
     %i.fa.fa-caret-down.hidden-2m
-  %ul.subnav
+  %ul.subnav#account-info
     = render "layouts/navigation/account_info"

--- a/spec/factories/course_membership_factory.rb
+++ b/spec/factories/course_membership_factory.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
       role 'gsi'
     end
 
-    factory :instructor_course_membership do
-      role 'instructor'
+    factory :professor_course_membership do
+      role 'professor'
     end
 
     factory :admin_course_membership do

--- a/spec/features/logging_in_spec.rb
+++ b/spec/features/logging_in_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "logging in" do
+feature "logging in", focus: true do
   let(:password) { "p@ssword" }
 
   context "as a student" do
@@ -22,6 +22,54 @@ feature "logging in" do
       LoginPage.new(user).submit({ password: "blah" })
       expect(current_path).to eq user_sessions_path
       expect(page).to have_error_message "Email or Password were invalid, login failed."
+    end
+  end
+
+  context "as a professor" do
+    let!(:course_membership) { create :professor_course_membership, user: user }
+    let(:user) { create :user, password: password }
+
+    before { visit root_path }
+
+    scenario "with a password successfully" do
+      LoginPage.new(user).submit({ password: password })
+
+      expect(current_path).to eq analytics_top_10_path
+      within("header") do
+        expect(page).to have_content user.display_name
+      end
+    end
+  end
+
+  context "as a gsi" do
+    let!(:course_membership) { create :staff_course_membership, user: user }
+    let(:user) { create :user, password: password }
+
+    before { visit root_path }
+
+    scenario "with a password successfully" do
+      LoginPage.new(user).submit({ password: password })
+
+      expect(current_path).to eq analytics_top_10_path
+      within("header") do
+        expect(page).to have_content user.display_name
+      end
+    end
+  end
+
+  context "as an admin" do
+    let!(:course_membership) { create :admin_course_membership, user: user }
+    let(:user) { create :user, password: password }
+
+    before { visit root_path }
+
+    scenario "with a password successfully" do
+      LoginPage.new(user).submit({ password: password })
+
+      expect(current_path).to eq analytics_top_10_path
+      within(".sidebar-container") do
+        expect(page).to have_content "Search Courses"
+      end
     end
   end
 end

--- a/spec/features/logging_out_spec.rb
+++ b/spec/features/logging_out_spec.rb
@@ -20,7 +20,7 @@ feature "logging out" do
       end
 
       expect(current_path).to eq root_path
-      expect(page).to have_content "You are now logged out."
+      expect(page).to have_notification_message('notice', 'You are now logged out.')
     end
 
   end

--- a/spec/features/logging_out_spec.rb
+++ b/spec/features/logging_out_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "logging in" do
+feature "logging out" do
   let(:password) { "p@ssword" }
 
   context "as a student" do

--- a/spec/features/logging_out_spec.rb
+++ b/spec/features/logging_out_spec.rb
@@ -9,20 +9,20 @@ feature "logging out" do
 
     before { visit root_path }
 
-    scenario "with a password successfully" do
+    before(:each) do
       LoginPage.new(user).submit({ password: password })
+    end
 
-      expect(current_path).to eq syllabus_path
-      within("header") do
-        expect(page).to have_content user.display_name
+    scenario "successfully" do
+
+      within("#account-info") do
+        click_link "Logout"
       end
+
+      expect(current_path).to eq root_path
+      expect(page).to have_content "You are now logged out."
     end
 
-    scenario "with an invalid email and password combination" do
-      LoginPage.new(user).submit({ password: "blah" })
-      expect(current_path).to eq user_sessions_path
-      expect(page).to have_error_message "Email or Password were invalid, login failed."
-    end
   end
   
 end


### PR DESCRIPTION
This PR adds feature tests confirming that all user roles are successfully routed to the correct landing page path under the condition that the timeline is turned off. 