### PR TITLE
Added specs for predictor, and bugfix for grade display

### DIFF
--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -1,3 +1,11 @@
+# All directives used on the predictor page.
+
+# Article Icon
+# Defines hovertext and font awesome icons for the icon bar in the predictor.
+# Each icon is turned on by by a boolean on the assignment or badge model with the same name.
+# Icons are defined in the predictor service and looped through in the haml:
+# "is_required", "is_late", "has_info", "is_locked", "has_been_unlocked", "is_a_condition", "group"
+
 @gradecraft.directive 'predictorArticleIcon', [ 'PredictorService', (PredictorService)->
 
   return {
@@ -9,6 +17,7 @@
     }
     templateUrl: 'ng_predictor_icons.html'
     link: (scope, el, attr)->
+
       scope.targetTerm = ()->
         if @targetType == "assignment"
           PredictorService.termFor.assignment
@@ -33,27 +42,27 @@
         @target.unlock_keys
 
       scope.iconHtml = {
-        late: {
+        is_late: {
           tooltip: 'This ' + scope.targetTerm() + ' is late!'
           icon: "fa-exclamation-triangle"
         }
-        required: {
+        is_required: {
           tooltip: 'This ' + scope.targetTerm() + ' is required!'
           icon: "fa-star"
         }
-        info: {
+        has_info: {
           tooltip: scope.description()
           icon: "fa-info-circle"
         }
-        locked: {
+        is_locked: {
           tooltip: scope.conditions()
           icon: "fa-lock"
         }
-        unlocked: {
+        is_unlocked: {
           tooltip: scope.conditions()
           icon: "fa-unlock-alt"
         }
-        condition: {
+        is_a_condition: {
           tooltip: scope.keys()
           icon: "fa-key"
         }

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["required", "late", "info", "locked", "unlocked", "condition", "group"]
+    icons = []# ["is_required", "is_late", "has_info", "is_locked", "has_been_unlocked", "is_a_condition", "group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = []# ["is_required", "is_late", "has_info", "is_locked", "has_been_unlocked", "is_a_condition", "group"]
+    icons = ["is_required", "is_late", "has_info", "is_locked", "has_been_unlocked", "is_a_condition", "group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/templates/ng_predictor_icons.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_icons.html.haml
@@ -1,4 +1,4 @@
-.icon.predictor-required-icon{'ng-if' => 'target[iconName]'}
+.icon.predictor-required-icon{'ng-if' => 'target[iconName]', 'ng-class' => 'iconName'}
   %a
     %i.fa.fa-fw{'class'=>'{{iconHtml[iconName].icon}}'}
   .display_on_hover.hover-style

--- a/app/assets/stylesheets/_icons.sass
+++ b/app/assets/stylesheets/_icons.sass
@@ -9,4 +9,3 @@ i.fa-slack
 
 i.fa-group, i.fa-key, i.fa-lock, i.fa-group, i.fa-exclamation-circle
   clear: both
-  padding: .25rem 0 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -251,18 +251,13 @@ class AssignmentsController < ApplicationController
         if grade.nil?
           grade = Grade.create(:assignment => assignment, :student => @student)
         end
-        assignment.current_student_grade = grade
 
-        # Only pass through points if they have been released by the professor
-        unless grade.is_student_visible?
-          assignment.current_student_grade.pass_fail_status = nil
-          assignment.current_student_grade.score = nil
-        end
-
-        # don't allow professors to view predictions
-        unless current_user.is_student?(current_course)
-          assignment.current_student_grade.predicted_score = 0
-        end
+        assignment.current_student_grade = {
+          id: grade.id,
+          pass_fail_status: grade.is_student_visible? ? grade.pass_fail_status : nil,
+          score: grade.is_student_visible? ? grade.score : nil,
+          predicted_score: current_user.is_student?(current_course) ? grade.predicted_score : 0
+        }
       end
     end
   end
@@ -271,12 +266,9 @@ class AssignmentsController < ApplicationController
 
     def predictor_assignments_data
       @assignments = current_course.assignments.select(
-        :accepts_attachments,
-        :accepts_links,
         :accepts_resubmissions_until,
         :accepts_submissions,
         :accepts_submissions_until,
-        :accepts_text,
         :assignment_type_id,
         :course_id,
         :description,
@@ -284,16 +276,12 @@ class AssignmentsController < ApplicationController
         :grade_scope,
         :id,
         :include_in_predictor,
-        :media,
-        :media_caption,
-        :media_credit,
         :name,
         :open_at,
         :pass_fail,
         :point_total,
         :points_predictor_display,
         :position,
-        :updated_at,
         :release_necessary,
         :required,
         :resubmissions_allowed,
@@ -308,16 +296,13 @@ class AssignmentsController < ApplicationController
     def predictor_grades(student)
       @grades = student.grades.where(:course_id => current_course).select(
         :assignment_id,
-        :assignment_type_id,
-        :course_id,
+        :final_score,
         :id,
         :predicted_score,
         :pass_fail_status,
         :status,
         :student_id,
         :raw_score,
-        :final_score,
-        :updated_at,
         :score
       )
     end

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -133,25 +133,32 @@ class BadgesController < ApplicationController
       @student = NullStudent.new
       @update_badges = false
     end
-
     @badges = predictor_badge_data
-    @badges.each do |badge|
-      badge.student_predicted_earned_badge = badge.find_or_create_predicted_earned_badge(@student)
-    end
   end
 
   private
 
   def predictor_badge_data
-    current_course.badges.select( :id,
-                                  :name,
-                                  :description,
-                                  :point_total,
-                                  :visible,
-                                  :visible_when_locked,
-                                  :can_earn_multiple_times,
-                                  :position,
-                                  :updated_at,
-                                  :icon)
+    badges = current_course.badges.select(
+      :id,
+      :name,
+      :description,
+      :point_total,
+      :visible,
+      :visible_when_locked,
+      :can_earn_multiple_times,
+      :position,
+      :updated_at,
+      :icon)
+    badges.each do |badge|
+      prediction = badge.find_or_create_predicted_earned_badge(@student)
+      if current_user.is_student?(current_course)
+        badge.student_predicted_earned_badge = {id: prediction.id, times_earned: prediction.times_earned_including_actual}
+      else
+        badge.student_predicted_earned_badge = {id: prediction.id, times_earned: prediction.actual_times_earned}
+      end
+    end
+    return badges
   end
+
 end

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -60,11 +60,19 @@ class GradeSchemeElementsController < ApplicationController
     end
   end
 
+  # TODO: Here we set the total earnable points as 110% of the low range of the higest earnable grade,
+  # and we default to a (most likely nil value) course.total_points if the professor has not yet created the
+  # grade scheme elements.
+  # We need:
+  # 1. A workflow that allows professors to create a course in a natural progression,
+  #    but does not allow for a course without grade scheme elements
+  # 2. A way to calculate the total points on the course, if it is not set.
+  # 3. Update spec to include all valid scenarios
   def student_predictor_data
     @grade_scheme_elements = current_course.grade_scheme_elements.select(:id, :low_range, :letter, :level)
     if @grade_scheme_elements
       @total_points = (@grade_scheme_elements.first.low_range * 1.1).to_i
-    else #TODO: we need to warn professors to set their GSI
+    else
       @total_points = current_course.total_points
     end
   end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -123,10 +123,12 @@ class StudentsController < ApplicationController
   public
 
   # Display the grade predictor
+  #   students - style blocks to fill entire page, render layout with no sidebar
+  #   staff - render standard laout with sidebar
   def predictor
     if current_user_is_student?
       @fullpage = true
-      render :layout => 'predictor' if current_user_is_student?
+      render :layout => 'predictor'
     end
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -241,6 +241,7 @@ class Assignment < ActiveRecord::Base
     grades.where(:student => student).first.predicted_score > 0 rescue nil
   end
 
+  #if there are unlock conditions, they have been met
   def is_unlocked_for_student?(student)
     if unlock_states.where(:student_id => student.id).present?
       unlock_states.where(:student_id => student.id).first.is_unlocked?

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -11,7 +11,7 @@ class GradeSchemeElement < ActiveRecord::Base
   # Getting the name of the Grade Scheme Element - the Level if it's present, the Letter if not
   def name
     if level? && letter?
-      "#{letter} / #{level} "
+      "#{letter} / #{level}"
     elsif level?
       level
     elsif letter?

--- a/app/models/predicted_earned_badge.rb
+++ b/app/models/predicted_earned_badge.rb
@@ -2,12 +2,23 @@ class PredictedEarnedBadge < ActiveRecord::Base
 
   attr_accessible :student_id, :badge_id, :times_earned
 
-  # `touch: true` is breaking on create and destroy actions
-  belongs_to :badge#, touch: true
-  belongs_to :student#, touch: true
+  belongs_to :badge
+  belongs_to :student, :class_name => 'User'
 
   def total_predicted_points
-    self.badge.total_points * times_earned
+    self.badge.point_total * times_earned
   end
 
+  def actual_times_earned
+    self.badge.earned_badge_count_for_student(self.student)
+  end
+
+  # Returns the higher number: predicted times earned or actually earned and visible to student
+  def times_earned_including_actual
+    if times_earned < actual_times_earned
+      actual_times_earned
+    else
+      times_earned
+    end
+  end
 end

--- a/app/views/assignments/student_predictor_data.json.jbuilder
+++ b/app/views/assignments/student_predictor_data.json.jbuilder
@@ -29,6 +29,8 @@ json.assignments @assignments do |assignment|
     }
   end
 
+  # student's grade info inserted into each assignment
+  # student's prediction info inserted into each grade
   if assignment.current_student_grade
     assignment.current_student_grade.tap do |grade|
       json.grade do

--- a/app/views/assignments/student_predictor_data.json.jbuilder
+++ b/app/views/assignments/student_predictor_data.json.jbuilder
@@ -1,35 +1,43 @@
 json.assignments @assignments do |assignment|
   next unless assignment.point_total > 0 || assignment.pass_fail?
   next unless assignment.visible_for_student?(@student)
+  next unless assignment.include_in_predictor?
   json.merge! assignment.attributes
   json.score_levels assignment.assignment_score_levels.map {|asl| {name: asl.name, value: asl.value}}
+
+  # points earned is all or nothing
   json.fixed assignment.fixed?
-  json.info ! assignment.description.blank?
 
-  if assignment.current_student_grade
-    assignment.current_student_grade.tap do |grade|
-      json.grade do
-        json.id grade.id
-        json.predicted_score grade.predicted_score
-        json.score grade.score
-        json.pass_fail_status grade.pass_fail_status if assignment.pass_fail
-      end
-    end
-  end
+  # boolean states for icons
+  json.is_required assignment.required
+  json.has_info ! assignment.description.blank?
+  json.is_late assignment.past? && assignment.accepts_submissions && ! @student.submission_for_assignment(assignment).present? ? true : false
 
-  json.late assignment.past? && assignment.accepts_submissions && ! @student.submission_for_assignment(assignment).present? ? true : false
-  json.locked ! assignment.is_unlocked_for_student?(@student)
-  json.unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(@student)
+  json.is_locked ! assignment.is_unlocked_for_student?(@student)
+
+  json.has_been_unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(@student)
   if assignment.is_unlockable?
     json.unlock_conditions assignment.unlock_conditions.map{ |condition|
       "#{condition.name} must be #{condition.condition_state}"
     }
   end
-  json.condition assignment.is_a_condition?
+
+  json.is_a_condition assignment.is_a_condition?
   if assignment.is_a_condition?
     json.unlock_keys assignment.unlock_keys.map{ |key|
       "#{key.unlockable.name} is unlocked by #{key.condition_state} #{key.condition.name}"
     }
+  end
+
+  if assignment.current_student_grade
+    assignment.current_student_grade.tap do |grade|
+      json.grade do
+        json.id grade[:id]
+        json.predicted_score grade[:predicted_score]
+        json.score grade[:score]
+        json.pass_fail_status grade[:pass_fail_status] if assignment.pass_fail
+      end
+    end
   end
 end
 

--- a/app/views/badges/student_predictor_data.json.jbuilder
+++ b/app/views/badges/student_predictor_data.json.jbuilder
@@ -9,7 +9,6 @@ json.badges @badges do |badge|
 
   # boolean states for icons
   json.has_info ! badge.description.blank?
-  json.is_a_condition badge.is_a_condition?
 
   json.is_locked ! badge.is_unlocked_for_student?(@student)
 
@@ -18,10 +17,9 @@ json.badges @badges do |badge|
     json.unlock_conditions badge.unlock_conditions.map { |condition| "#{condition.name} must be #{condition.condition_state}" }
   end
 
+  json.is_a_condition badge.is_a_condition?
   if badge.is_a_condition?
-    json.unlock_keys badge.unlock_keys.map { |key|
-      "#{key.unlockable.name} is unlocked by #{key.condition_state} #{key.condition.name}"
-    }
+    json.unlock_keys badge.unlock_keys.map { |key| "#{key.unlockable.name} is unlocked by #{key.condition_state} #{key.condition.name}" }
   end
 end
 

--- a/app/views/badges/student_predictor_data.json.jbuilder
+++ b/app/views/badges/student_predictor_data.json.jbuilder
@@ -2,19 +2,24 @@ json.badges @badges do |badge|
   next unless badge.visible_for_student?(@student)
   json.merge! badge.attributes
   json.icon badge.icon.url
-  json.info ! badge.description.blank?
   json.total_earned_points badge.earned_badge_total_points(@student)
   json.earned_badge_count badge.earned_badge_count_for_student(@student)
+
+
+  # boolean states for icons
+  json.has_info ! badge.description.blank?
 
   badge.student_predicted_earned_badge.tap do |prediction|
     json.prediction do
       json.id prediction.id
 
       if current_user.is_staff?(current_course)
+        # after tests pass, change to actual_times_earned
         json.times_earned badge.earned_badge_count_for_student(@student)
       else
         # We persist the student's last prediction, but the predictor will start the student's
         # predicted earning count at no less that the number of badges she already earned.
+        # after tests pass, change to times_earned_including_actual
         if prediction.times_earned < badge.earned_badge_count_for_student(@student)
          json.times_earned badge.earned_badge_count_for_student(@student)
         else

--- a/app/views/badges/student_predictor_data.json.jbuilder
+++ b/app/views/badges/student_predictor_data.json.jbuilder
@@ -9,7 +9,7 @@ json.badges @badges do |badge|
 
   # boolean states for icons
   json.has_info ! badge.description.blank?
-  json.condition badge.is_a_condition?
+  json.is_a_condition badge.is_a_condition?
 
   json.is_locked ! badge.is_unlocked_for_student?(@student)
 

--- a/app/views/badges/student_predictor_data.json.jbuilder
+++ b/app/views/badges/student_predictor_data.json.jbuilder
@@ -5,36 +5,19 @@ json.badges @badges do |badge|
   json.total_earned_points badge.earned_badge_total_points(@student)
   json.earned_badge_count badge.earned_badge_count_for_student(@student)
 
+  json.prediction badge.student_predicted_earned_badge
 
   # boolean states for icons
   json.has_info ! badge.description.blank?
+  json.condition badge.is_a_condition?
 
-  badge.student_predicted_earned_badge.tap do |prediction|
-    json.prediction do
-      json.id prediction.id
+  json.is_locked ! badge.is_unlocked_for_student?(@student)
 
-      if current_user.is_staff?(current_course)
-        # after tests pass, change to actual_times_earned
-        json.times_earned badge.earned_badge_count_for_student(@student)
-      else
-        # We persist the student's last prediction, but the predictor will start the student's
-        # predicted earning count at no less that the number of badges she already earned.
-        # after tests pass, change to times_earned_including_actual
-        if prediction.times_earned < badge.earned_badge_count_for_student(@student)
-         json.times_earned badge.earned_badge_count_for_student(@student)
-        else
-         json.times_earned prediction.times_earned
-        end
-      end
-    end
-  end
-
-  json.locked ! badge.is_unlocked_for_student?(@student)
-  json.unlocked badge.is_unlockable? && badge.is_unlocked_for_student?(@student)
+  json.has_been_unlocked badge.is_unlockable? && badge.is_unlocked_for_student?(@student)
   if badge.is_unlockable?
     json.unlock_conditions badge.unlock_conditions.map { |condition| "#{condition.name} must be #{condition.condition_state}" }
   end
-  json.condition badge.is_a_condition?
+
   if badge.is_a_condition?
     json.unlock_keys badge.unlock_keys.map { |key|
       "#{key.unlockable.name} is unlocked by #{key.condition_state} #{key.condition.name}"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,24 +63,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.datetime "updated_at",                null: false
   end
 
-  create_table "assignment_submissions", force: :cascade do |t|
-    t.integer  "assignment_id"
-    t.integer  "user_id"
-    t.string   "feedback",                limit: 255
-    t.string   "comment",                 limit: 255
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.string   "attachment_file_name",    limit: 255
-    t.string   "attachment_content_type", limit: 255
-    t.integer  "attachment_file_size"
-    t.datetime "attachment_updated_at"
-    t.string   "link",                    limit: 255
-    t.integer  "submittable_id"
-    t.string   "submittable_type",        limit: 255
-    t.text     "text_feedback"
-    t.text     "text_comment"
-  end
-
   create_table "assignment_types", force: :cascade do |t|
     t.string   "name",               limit: 255
     t.integer  "max_points"
@@ -172,19 +154,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.datetime "updated_at"
   end
 
-  create_table "badge_sets", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.integer  "course_id"
-    t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "badge_sets_courses", id: false, force: :cascade do |t|
-    t.integer "course_id"
-    t.integer "badge_set_id"
-  end
-
   create_table "badges", force: :cascade do |t|
     t.string   "name",                    limit: 255
     t.text     "description"
@@ -200,16 +169,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.integer  "position"
     t.boolean  "visible_when_locked",                 default: true
   end
-
-  create_table "categories", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.text     "description"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.integer  "course_id"
-  end
-
-  add_index "categories", ["course_id"], name: "index_categories_on_course_id", using: :btree
 
   create_table "challenge_files", force: :cascade do |t|
     t.string   "filename",        limit: 255
@@ -261,33 +220,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.string   "thumbnail",                limit: 255
     t.string   "media_credit",             limit: 255
     t.string   "media_caption",            limit: 255
-  end
-
-  create_table "course_badge_sets", force: :cascade do |t|
-    t.integer "course_id"
-    t.integer "badge_set_id"
-  end
-
-  create_table "course_categories", id: false, force: :cascade do |t|
-    t.integer "course_id"
-    t.integer "category_id"
-  end
-
-  create_table "course_grade_scheme_elements", force: :cascade do |t|
-    t.string   "name",                   limit: 255
-    t.string   "letter_grade",           limit: 255
-    t.integer  "low_range"
-    t.integer  "high_range"
-    t.integer  "course_grade_scheme_id"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-  end
-
-  create_table "course_grade_schemes", force: :cascade do |t|
-    t.string   "name",       limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "course_id"
   end
 
   create_table "course_memberships", force: :cascade do |t|
@@ -379,18 +311,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
 
   add_index "courses", ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree
 
-  create_table "dashboards", force: :cascade do |t|
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "duplicated_users", id: false, force: :cascade do |t|
-    t.integer "id"
-    t.string  "last_name",   limit: 255
-    t.string  "role",        limit: 255
-    t.integer "submissions", limit: 8
-  end
-
   create_table "earned_badges", force: :cascade do |t|
     t.integer  "badge_id"
     t.integer  "submission_id"
@@ -415,14 +335,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
 
   add_index "earned_badges", ["grade_id", "badge_id"], name: "index_earned_badges_on_grade_id_and_badge_id", unique: true, using: :btree
 
-  create_table "elements", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.string   "description", limit: 255
-    t.integer  "badge_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
   create_table "events", force: :cascade do |t|
     t.string   "name",          limit: 255
     t.text     "description"
@@ -435,16 +347,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "course_id"
-  end
-
-  create_table "faqs", force: :cascade do |t|
-    t.string   "question",   limit: 255
-    t.text     "answer"
-    t.integer  "order"
-    t.string   "category",   limit: 255
-    t.string   "audience",   limit: 255
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
   end
 
   create_table "flagged_users", force: :cascade do |t|
@@ -481,15 +383,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.integer  "course_id"
   end
 
-  create_table "grade_schemes", force: :cascade do |t|
-    t.integer  "assignment_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "course_id"
-    t.string   "name",          limit: 255
-    t.text     "description"
-  end
-
   create_table "grades", force: :cascade do |t|
     t.integer  "raw_score"
     t.integer  "assignment_id"
@@ -517,14 +410,14 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.text     "admin_notes"
     t.integer  "graded_by_id"
     t.integer  "team_id"
-    t.integer  "predicted_score"
+    t.integer  "predicted_score",                  default: 0,     null: false
     t.boolean  "instructor_modified",              default: false
     t.string   "pass_fail_status"
     t.boolean  "feedback_read",                    default: false
     t.datetime "feedback_read_at"
+    t.boolean  "is_custom_value",                  default: false
     t.boolean  "feedback_reviewed",                default: false
     t.datetime "feedback_reviewed_at"
-    t.boolean  "is_custom_value",                  default: false
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree
@@ -616,11 +509,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.datetime "updated_at"
   end
 
-  create_table "rubric_categories", force: :cascade do |t|
-    t.integer "rubric_id"
-    t.string  "name",      limit: 255
-  end
-
   create_table "rubric_grades", force: :cascade do |t|
     t.string   "metric_name",        limit: 255
     t.text     "metric_description"
@@ -643,15 +531,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.integer  "assignment_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "score_levels", force: :cascade do |t|
-    t.string   "name",               limit: 255
-    t.integer  "value"
-    t.integer  "assignment_type_id"
-    t.integer  "assignment_id"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -689,14 +568,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.integer "sat_score"
   end
 
-  create_table "student_assignment_type_weights", force: :cascade do |t|
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
-    t.integer  "student_id"
-    t.integer  "assignment_type_id"
-    t.integer  "weight",             null: false
-  end
-
   create_table "submission_files", force: :cascade do |t|
     t.string   "filename",        limit: 255,                 null: false
     t.integer  "submission_id",                               null: false
@@ -705,15 +576,6 @@ ActiveRecord::Schema.define(version: 20150926200505) do
     t.boolean  "file_processing",             default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "submission_files_duplicate", id: false, force: :cascade do |t|
-    t.string  "key",        limit: 255
-    t.string  "format",     limit: 255
-    t.integer "upload_id"
-    t.string  "full_name",  limit: 255
-    t.string  "last_name",  limit: 255
-    t.string  "first_name", limit: 255
   end
 
   create_table "submissions", force: :cascade do |t|

--- a/spec/controllers/assignment_types_controller_spec.rb
+++ b/spec/controllers/assignment_types_controller_spec.rb
@@ -128,9 +128,48 @@ describe AssignmentTypesController do
       end
     end
 
+    describe "GET student predictor data" do
+
+      it "returns assignment types as json with current student if id present" do
+        get :student_predictor_data, format: :json, :id => @student.id
+        expect(assigns(:student)).to eq(@student)
+        expect(assigns(:assignment_types)).to eq([@assignment_type])
+        expect(response).to render_template(:student_predictor_data)
+      end
+
+      it "returns assignment types with null student if no id present" do
+        get :student_predictor_data, format: :json
+        expect(assigns(:student).class).to eq(NullStudent)
+        expect(assigns(:assignment_types)).to eq([@assignment_type])
+        expect(response).to render_template(:student_predictor_data)
+      end
+    end
 	end
 
 	context "as student" do
+
+    describe "GET student predictor data" do
+
+      before do
+        @course = create(:course_accepting_groups)
+        @assignment_type = create(:assignment_type, course: @course)
+        @assignment = create(:assignment, assignment_type: @assignment_type)
+        @course.assignments << @assignment
+        @student = create(:user)
+        @student.courses << @course
+
+        login_user(@student)
+        session[:course_id] = @course.id
+        allow(Resque).to receive(:enqueue).and_return(true)
+      end
+
+      it "returns assignment types as json for the current course" do
+        get :student_predictor_data, format: :json
+        expect(assigns(:student)).to eq(@student)
+        expect(assigns(:assignment_types)).to eq([@assignment_type])
+        expect(response).to render_template(:student_predictor_data)
+      end
+    end
 
 		describe "protected routes" do
       [

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -140,9 +140,9 @@ describe BadgesController do
         end
 
         it "adds the prediction data to the badge model with prediction equal to earned" do
-          prediction = create(:predicted_earned_badge, badge: @badge, student: @student)
+          prediction = create(:predicted_earned_badge, badge: @badge, student: @student, times_earned: 4)
           get :student_predictor_data, format: :json, :id => @student.id
-          expect(assigns(:badges)[0].student_predicted_earned_badge).to eq(prediction)
+          expect(assigns(:badges)[0].student_predicted_earned_badge).to eq({ id: prediction.id, times_earned: 0 })
         end
       end
     end
@@ -176,7 +176,7 @@ describe BadgesController do
       it "adds the prediction data to the badge model" do
         prediction = create(:predicted_earned_badge, badge: @badge, student: @student)
         get :student_predictor_data, format: :json, :id => @student.id
-        expect(assigns(:badges)[0].student_predicted_earned_badge).to eq(prediction)
+        expect(assigns(:badges)[0].student_predicted_earned_badge).to eq({ id: prediction.id, times_earned: prediction.times_earned })
       end
     end
 

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -41,6 +41,16 @@ describe GradeSchemeElementsController do
       end
     end
 
+    describe "GET student predictor data" do
+
+      it "returns grade scheme elements with total points as json" do
+        @grade_scheme_element.update(low_range: 1000)
+        get :student_predictor_data, format: :json
+        expect(assigns(:grade_scheme_elements)).to eq(@grade_scheme_elements)
+        expect(assigns(:total_points)).to eq(1100)
+        expect(response).to render_template(:student_predictor_data)
+      end
+    end
   end
 
   context "as student" do

--- a/spec/factories/grade_factory.rb
+++ b/spec/factories/grade_factory.rb
@@ -9,8 +9,9 @@ FactoryGirl.define do
       status "Released"
     end
 
+    # minimal conditions when a grade has been graded but not visible to students
     factory :unreleased_grade do
-      score { Faker::Number.number(5) }
+      raw_score { Faker::Number.number(5) }
       status 'Graded'
       after(:create) do |grade|
         grade.assignment.update(release_necessary: true)

--- a/spec/factories/predicted_earned_badge.rb
+++ b/spec/factories/predicted_earned_badge.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :predicted_earned_badge do
+    association :badge
+    association :student, factory: :user
+    times_earned { rand(3) }
+  end
+end

--- a/spec/factories/unlock_condition_factory.rb
+++ b/spec/factories/unlock_condition_factory.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :unlock_condition do
-    association :unlockable, factory: :assignment
+    association :unlockable, factory: :badge
+    unlockable_type "Badge"
     association :condition, factory: :assignment
+    condition_type "Assignment"
  		condition_state 'Earned'
   end
 end

--- a/spec/models/predicted_earned_badge_spec.rb
+++ b/spec/models/predicted_earned_badge_spec.rb
@@ -1,0 +1,38 @@
+#predictedEarnedBadge_spec.rb
+require 'spec_helper'
+
+describe PredictedEarnedBadge do
+
+  before do
+    @predicted_earned_badge = create(:predicted_earned_badge)
+  end
+
+  subject { @predicted_earned_badge }
+
+  it { is_expected.to respond_to("student_id")}
+  it { is_expected.to respond_to("badge_id")}
+  it { is_expected.to respond_to("times_earned")}
+
+  it { is_expected.to be_valid }
+
+  it "caluculated the total points predicted" do
+    expect(@predicted_earned_badge.total_predicted_points).to eq(@predicted_earned_badge.times_earned * @predicted_earned_badge.badge.point_total)
+  end
+
+  context "when the badge has been earned by student" do
+
+    before do
+      3.times { create(:earned_badge, badge: @predicted_earned_badge.badge, student: @predicted_earned_badge.student, student_visible: true, course: @predicted_earned_badge.badge.course )}
+      @predicted_earned_badge.update(times_earned: 1)
+    end
+
+    it "reports the actual times the student earned a badge" do
+      expect(@predicted_earned_badge.actual_times_earned).to eq(3)
+    end
+
+    it "reports the predicted times earned taking into account the actual times earned" do
+      expect(@predicted_earned_badge.times_earned).to eq(1)
+      expect(@predicted_earned_badge.times_earned_including_actual).to eq(3)
+    end
+  end
+end

--- a/spec/views/assignment_types/student_predictor_data_spec.rb
+++ b/spec/views/assignment_types/student_predictor_data_spec.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+require 'spec_helper'
+include CourseTerms
+
+describe "assignment_types/student_predictor_data" do
+
+  before(:all) do
+    clean_models
+    @course = create(:course, assignment_term: "mission")
+    @assignment_type = create(:assignment_type, course: @course, student_weightable: true, max_points: 1234)
+    @assignment_types = [@assignment_type]
+    @student = create(:user)
+  end
+
+  before(:each) do
+    allow(@student).to receive(:weight_for_assignment_type).and_return(777)
+    allow(view).to receive(:current_course).and_return(@course)
+    render
+    @json = JSON.parse(response.body)
+  end
+
+  it "responds with an array of assignment_types" do
+    expect(@json["assignment_types"].length).to eq(1)
+  end
+
+  it "includes the assignment_type total points" do
+    expect(@json["assignment_types"].first["total_points"]).to eq(1234)
+  end
+
+  it "renders the student weight" do
+    expect(@json["assignment_types"].first["student_weight"]).to eq(777)
+  end
+
+  it "renders the term for assignment_type" do
+    expect(@json["term_for_assignment_type"]).to eq("mission type")
+  end
+end

--- a/spec/views/assignments/student_predictor_data_spec.rb
+++ b/spec/views/assignments/student_predictor_data_spec.rb
@@ -1,0 +1,148 @@
+# encoding: utf-8
+require 'spec_helper'
+include CourseTerms
+
+describe "assignments/student_predictor_data" do
+
+  before(:each) do
+    clean_models
+    @course = create(:course, assignment_term: "mission", pass_term: "paz", fail_term: "fayl")
+    @assignment = create(:assignment, description: "...")
+    @assignments = [@assignment]
+    @student = create(:user)
+    allow(view).to receive(:current_course).and_return(@course)
+    allow(view).to receive(:current_user).and_return(@student)
+  end
+
+  it "responds with an array of assignments" do
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"].length).to eq(1)
+  end
+
+  it "adds attribute 'fixed' to the assignments" do
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["fixed"]).to eq(true)
+  end
+
+  it "includes the current student grade with the assignment" do
+    @assignment.current_student_grade = { id: 1, pass_fail_status: "should not persist", score: 1000, predicted_score: 999 }
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["grade"]).to eq({ "id" => 1, "score" => 1000, "predicted_score" => 999 })
+  end
+
+  it "includes the pass fail status with the grade when the assignment is pass fail" do
+    @assignment.current_student_grade = { id: 1, pass_fail_status: "passed", score: 1000, predicted_score: 999 }
+    @assignment.update(pass_fail: true)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["grade"]).to eq({ "id" => 1, "pass_fail_status" => "passed", "score" => 1000, "predicted_score" => 999 })
+  end
+
+  it "does not include assignments with no points" do
+    @assignment.update(point_total: 0)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"].length).to eq(0)
+  end
+
+  it "does include pass/fail assignments with no points" do
+    @assignment.update(point_total: 0, pass_fail: true)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"].length).to eq(1)
+  end
+
+  it "does not include assignments invisible to students" do
+    @assignment.update(visible: false)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"].length).to eq(0)
+  end
+
+  it "not include assignments in predictor if include_in_predictor is false" do
+    @assignment.update(include_in_predictor: false)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"].length).to eq(0)
+  end
+
+  describe "passes boolean states for icons" do
+    it "adds is_required to model" do
+      @assignment.update(required: true)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["is_required"]).to be_truthy
+    end
+
+    it "adds has_info to model" do
+      @assignment.update(required: true)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["has_info"]).to be_truthy
+    end
+
+    it "adds is_late to model" do
+      allow(@assignment).to receive(:past?).and_return(true)
+      @assignment.update(accepts_submissions: true)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["is_late"]).to be_truthy
+    end
+
+    it "adds is_locked to model" do
+      allow(@assignment).to receive(:is_unlocked_for_student?).and_return(false)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["is_locked"]).to be_truthy
+    end
+
+    it "adds has_been_unlocked to model" do
+      allow(@assignment).to receive(:is_unlocked_for_student?).and_return(true)
+      allow(@assignment).to receive(:is_unlockable?).and_return(true)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["has_been_unlocked"]).to be_truthy
+    end
+
+    it "adds is_a_condition to model" do
+      allow(@assignment).to receive(:is_a_condition?).and_return(true)
+      render
+      @json = JSON.parse(response.body)
+      expect(@json["assignments"][0]["is_a_condition"]).to be_truthy
+    end
+  end
+
+  it "includes unlock keys when assignment is an unlock condition" do
+    @badge = create(:badge)
+    @unlock_key = create(:unlock_condition, unlockable: @badge, condition: @assignment)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["unlock_keys"]).to eq(["#{@badge.name} is unlocked by #{@unlock_key.condition_state} #{@assignment.name}"])
+  end
+
+  it "includes unlock conditions when assignment is a unlockable" do
+    @badge = create(:badge)
+    @unlock_condition = create(:unlock_condition, unlockable: @assignment, unlockable_type: "Assignment", condition: @badge, condition_type: "Badge")
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["unlock_conditions"]).to eq(["#{@badge.name} must be #{@unlock_condition.condition_state}"])
+  end
+
+  it "includes the assigment score levels" do
+    asl = create(:assignment_score_level, assignment: @assignment)
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["assignments"][0]["score_levels"]).to eq([{"name" => asl.name, "value" => asl.value}])
+  end
+
+  it "renders term for assignments, pass, and fail" do
+    render
+    @json = JSON.parse(response.body)
+    expect(@json["term_for_assignment"]).to eq("mission")
+    expect(@json["term_for_pass"]).to eq("paz")
+    expect(@json["term_for_fail"]).to eq("fayl")
+  end
+end

--- a/spec/views/assignments/student_predictor_data_spec.rb
+++ b/spec/views/assignments/student_predictor_data_spec.rb
@@ -78,7 +78,6 @@ describe "assignments/student_predictor_data" do
     end
 
     it "adds has_info to model" do
-      @assignment.update(required: true)
       render
       @json = JSON.parse(response.body)
       expect(@json["assignments"][0]["has_info"]).to be_truthy

--- a/spec/views/grade_scheme_elements/student_predictor_data_spec.rb
+++ b/spec/views/grade_scheme_elements/student_predictor_data_spec.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+require 'spec_helper'
+include CourseTerms
+
+describe "grade_scheme_elements/student_predictor_data" do
+
+  before(:all) do
+    clean_models
+    @grade_scheme_element = create(:grade_scheme_element_high)
+    @grade_scheme_elements = [@grade_scheme_element]
+    @total_points = 10000
+  end
+
+  before(:each) do
+    render
+    @json = JSON.parse(response.body)
+  end
+
+  it "responds with an array of assignment_types" do
+    # expect(@json["assignment_types"].length).to eq(1)
+  end
+
+  it "responds with total_points" do
+    expect(@json["total_points"]).to eq(10000)
+  end
+
+  it "responds with an array of grade_scheme_elements including name" do
+    expect(@json["grade_scheme_elements"].length).to eq(1)
+    expect(@json["grade_scheme_elements"][0]["name"]).to eq(@grade_scheme_element.name)
+  end
+end


### PR DESCRIPTION
    predicted badges controller
    grade scheme elements json spec
    grade scheme elements controller spec
    fixed attributes for assignment controller spec
    specs for unlock keys and conditions
    adapt predictor directive to new stateful naming
    adds stateful naming for icons in predictor
    fixed bug, checks if assignment is included in predictor
    assignment jbuilder specs
    remove icon padding
    added grades to assignment as hash for predictor
    specs for predictor assignments and grades
    predictor specs covering assignment_types