### PR TITLE
Rescue excepted pageview logger jobs and persist directly to Mongo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'resque-scheduler', require: "resque/scheduler"
 gem 'resque-throttler', require: "resque/throttler"
 
 gem 'responders'
-gem 'rollbar'
+gem 'rollbar', '~> 2.4.0'
 gem 'sampler'
 gem 'sanitize'
 gem 'sassc-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,8 @@ GEM
       rufus-scheduler (~> 3.0)
     resque-throttler (0.1.5)
       resque (~> 1.25)
-    rollbar (2.1.2)
+    rollbar (2.4.0)
+      multi_json
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -729,7 +730,7 @@ DEPENDENCIES
   resque-scheduler
   resque-throttler
   resque_spec!
-  rollbar
+  rollbar (~> 2.4.0)
   rspec-rails (~> 3.3.3)
   ruby-saml (~> 1.0.0)
   rubystats

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
+
 require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'

--- a/spec/controllers/application_controller_filters_spec.rb
+++ b/spec/controllers/application_controller_filters_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
       end
     end
 
-    context "Resque fails to reach Redis and returns a getaddrinfo socket error", focus: true do
+    context "Resque fails to reach Redis and returns a getaddrinfo socket error" do
       before do
         stub_current_user
         allow(PageviewEventLogger).to receive(:new).and_raise("Could not connect to Redis: getaddrinfo socket error.")

--- a/spec/controllers/application_controller_filters_spec.rb
+++ b/spec/controllers/application_controller_filters_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
       end
     end
 
-    context "Resque fails to reach Redis and returns a getaddrinfo socket error" do
+    context "Resque fails to reach Redis and returns a getaddrinfo socket error", focus: true do
       before do
         stub_current_user
         allow(PageviewEventLogger).to receive(:new).and_raise("Could not connect to Redis: getaddrinfo socket error.")
@@ -80,14 +80,11 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
 
       it "performs the pageview event log directly from the controller" do
         expect(PageviewEventLogger).to receive(:perform).with('pageview', pageview_logger_attrs_expectation)
+        get :html_page
       end
 
       it "adds an additional pageview record to mongo" do
         expect { get :html_page }.to change{ Analytics::Event.count }.by(1)
-      end
-
-      after(:each) do
-        get :html_page
       end
     end
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -191,14 +191,14 @@ describe GradesController do
     describe "POST self_log" do
       it "creates a maximum score by the student" do
         post :self_log, id: @assignment.id, present: "true"
-        grade = @assignment.grades.last
+        grade = @student.grade_for_assignment(@assignment)
         expect(grade.raw_score).to eq @assignment.point_total
       end
 
       context "with assignment levels" do
         it "creates a score for the student at the specified level" do
           post :self_log, id: @assignment.id, present: "true", grade: { raw_score: "10000" }
-          grade = @assignment.grades.last
+          grade = @student.grade_for_assignment(@assignment)
           expect(grade.raw_score).to eq 10000
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'capybara/rspec'
 require 'resque_spec/scheduler' # allow resque spec to test scheduled jobs
 
 # try to load the mongoid config
-Mongoid.load!(Rails.root.join("/config/mongoid.yml"))
+# Mongoid.load!(Rails.root.join("/config/mongoid.yml"))
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,37 +1,4 @@
 ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path("../../config/environment", __FILE__)
-require 'rspec/rails'
-require 'capybara/rspec'
-
-# ResqueSpec libraries
-require 'resque_spec/scheduler' # allow resque spec to test scheduled jobs
-
-# try to load the mongoid config
-# Mongoid.load!(Rails.root.join("/config/mongoid.yml"))
-
-# Requires supporting ruby files with custom matchers and macros, etc,
-# in spec/support/ and its subdirectories.
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-Dir[Rails.root.join("spec/toolkits/**/*.rb")].each { |f| require f }
-
-# Checks for pending migrations before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
-# ActiveRecord::Migration.maintain_test_schema!
-
-# fixture file no longer works, this is a workaround
-# here is an alternative solution that didn't work for me:
-# http://stackoverflow.com/questions/9011425/fixture-file-upload-has-file-does-not-exist-error
-def fixture_file(file, filetype='image/jpg')
-  Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'files', file), filetype)
-end
-
-def clean_models
-  User.destroy_all
-  Course.destroy_all
-  AssignmentType.destroy_all
-  Assignment.destroy_all
-end
 
 RSpec.configure do |config|
   config.filter_run :focus

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,37 @@
 ENV["RAILS_ENV"] ||= 'test'
+require File.expand_path("../../config/environment", __FILE__)
+require 'rspec/rails'
+require 'capybara/rspec'
+
+# ResqueSpec libraries
+require 'resque_spec/scheduler' # allow resque spec to test scheduled jobs
+
+# try to load the mongoid config
+Mongoid.load!(Rails.root.join("/config/mongoid.yml"))
+
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/toolkits/**/*.rb")].each { |f| require f }
+
+# Checks for pending migrations before tests are run.
+# If you are not using ActiveRecord, you can remove this line.
+ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
+# ActiveRecord::Migration.maintain_test_schema!
+
+# fixture file no longer works, this is a workaround
+# here is an alternative solution that didn't work for me:
+# http://stackoverflow.com/questions/9011425/fixture-file-upload-has-file-does-not-exist-error
+def fixture_file(file, filetype='image/jpg')
+  Rack::Test::UploadedFile.new(Rails.root.join('spec', 'fixtures', 'files', file), filetype)
+end
+
+def clean_models
+  User.destroy_all
+  Course.destroy_all
+  AssignmentType.destroy_all
+  Assignment.destroy_all
+end
 
 RSpec.configure do |config|
   config.filter_run :focus


### PR DESCRIPTION
Rescue out the call to Redis from Resque in the increment_page_views method in application controller if Redis can't be found. Alternatively just call #perform from PageviewEventLogger directly which directly persists the record to mongo and still uses all of the Loggly logging and workflow. Kind of a badass workaround for our stupid Redis-hunting socket issues.

![harry-and-the-hendersons](https://cloud.githubusercontent.com/assets/95957/10772998/43203dd4-7cf9-11e5-86e0-60cca03142e0.jpg)
