### PR TITLE
Fix broken conditional team score caching issues

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -448,8 +448,6 @@ class GradesController < ApplicationController
       @grade.status = "Graded"
       respond_to do |format|
         if @grade.save
-          pp @grade.errors.messages
-
           # @mz TODO: add specs
           @grade_updater_job = GradeUpdaterJob.new(grade_id: @grade.id)
           @grade_updater_job.enqueue

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -432,6 +432,7 @@ class GradesController < ApplicationController
   def self_log
     @assignment = current_course.assignments.find(params[:id])
     if @assignment.open?
+
       @grade = current_student.grade_for_assignment(@assignment)
       if params[:present] == "true"
         if params[:grade].present? && params[:grade][:raw_score].present?
@@ -442,10 +443,12 @@ class GradesController < ApplicationController
       else
         @grade.raw_score = 0
       end
+
       @grade.instructor_modified = true
       @grade.status = "Graded"
       respond_to do |format|
         if @grade.save
+          pp @grade.errors.messages
 
           # @mz TODO: add specs
           @grade_updater_job = GradeUpdaterJob.new(grade_id: @grade.id)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -97,10 +97,10 @@ class Team < ActiveRecord::Base
   #The second way is that the teams compete in team challenges that earn the team points. At the end of the
   #semester these usually get added back into students' scores - this has not yet been built into GC.
   def cache_score
-    if course.team_challenges?
-      self.score = challenge_grade_score
-    else
+    if course.team_score_average
       self.score = average_points
+    else
+      self.score = challenge_grade_score
     end
   end
 
@@ -111,6 +111,6 @@ class Team < ActiveRecord::Base
   private
 
   def revised_team_score
-    course.team_challenges ? challenge_grade_score : average_points
+    course.team_score_average ? average_points : challenge_grade_score
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -389,7 +389,11 @@ class User < ActiveRecord::Base
             total_score += assignment_type.visible_score_for_student(self)
           end
           total_score += earned_badge_score_for_course(course_id)
-          total_score += (self.team_for_course(course_id).try(:score) || 0)
+          # @mz todo: refactor this mo
+          # don't need to check current_course.add_team_score_to_student? because that's being called above
+          unless current_course.team_score_average
+            total_score += (self.team_for_course(course_id).try(:score) || 0)
+          end
         )
       else
         membership.update_attribute :score, (
@@ -417,7 +421,11 @@ class User < ActiveRecord::Base
             total_score += assignment_type.visible_score_for_student(self)
           end
           total_score += earned_badge_score_for_course(course_id)
-          total_score += (self.team_for_course(course_id).try(:score) || 0)
+
+          # don't need to check current_course.add_team_score_to_student? because that's being called above
+          unless current_course.team_score_average
+            total_score += (self.team_for_course(course_id).try(:score) || 0)
+          end
         )
       else
         membership.update_attribute :score, (

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -188,7 +188,7 @@ describe GradesController do
       end
     end
 
-    describe "POST self_log", focus: true do
+    describe "POST self_log" do
       before(:all) do
         @course = create(:course)
         @assignment = create(:assignment, course: @course)

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -188,7 +188,31 @@ describe GradesController do
       end
     end
 
-    describe "POST self_log" do
+    describe "POST self_log", focus: true do
+      before(:all) do
+        @course = create(:course)
+        @assignment = create(:assignment, course: @course)
+
+        @student = create(:user)
+        @student.courses << @course
+      end
+
+      before(:each) do
+        session[:course_id] = @course.id
+        allow(Resque).to receive(:enqueue).and_return(true)
+      end
+
+      before(:all) do
+        @professor = create(:user)
+        CourseMembership.create user: @professor, course: @course, role: "professor"
+      end
+      before (:each) do
+        @grade = create(:grade)
+        @assignment.grades << @grade
+        login_user(@professor)
+      end
+
+
       it "creates a maximum score by the student" do
         post :self_log, id: @assignment.id, present: "true"
         grade = @assignment.grades.last

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -189,40 +189,16 @@ describe GradesController do
     end
 
     describe "POST self_log" do
-      before(:all) do
-        @course = create(:course)
-        @assignment = create(:assignment, course: @course)
-
-        @student = create(:user)
-        @student.courses << @course
-      end
-
-      before(:each) do
-        session[:course_id] = @course.id
-        allow(Resque).to receive(:enqueue).and_return(true)
-      end
-
-      before(:all) do
-        @professor = create(:user)
-        CourseMembership.create user: @professor, course: @course, role: "professor"
-      end
-      before (:each) do
-        @grade = create(:grade)
-        @assignment.grades << @grade
-        login_user(@professor)
-      end
-
-
       it "creates a maximum score by the student" do
         post :self_log, id: @assignment.id, present: "true"
-        grade = @assignment.grades.last
+        grade = @student.grade_for_assignment(@assignment)
         expect(grade.raw_score).to eq @assignment.point_total
       end
 
       context "with assignment levels" do
         it "creates a score for the student at the specified level" do
           post :self_log, id: @assignment.id, present: "true", grade: { raw_score: "10000" }
-          grade = @assignment.grades.last
+          grade = @student.grade_for_assignment(@assignment)
           expect(grade.raw_score).to eq 10000
         end
       end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -30,7 +30,7 @@ describe Team do
   describe "challenge_grade_score" do
   end
 
-  describe "revised_team_score", focus: true do
+  describe "revised_team_score" do
     let(:course) { create :course }
     let(:team) { create(:team, course: course) }
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -29,4 +29,25 @@ describe Team do
 
   describe "challenge_grade_score" do
   end
+
+  describe "revised_team_score", focus: true do
+    let(:course) { create :course }
+    let(:team) { create(:team, course: course) }
+
+    context "course is using team average for team score" do
+      it "returns the average points for the team" do
+        allow(course).to receive(:team_score_average) { true }
+        allow(team).to receive(:average_points) { 500 }
+        expect( team.instance_eval { revised_team_score } ).to eq(500)
+      end
+    end
+
+    context "course is using challenge grade total for team score" do
+      it "returns the challenge grade score for the team" do
+        allow(course).to receive(:team_score_average) { false }
+        allow(team).to receive(:challenge_grade_score) { 3000 }
+        expect( team.instance_eval { revised_team_score } ).to eq(3000)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Couple of things were happening here:
* team scores were being added to student scores if add_team_score_to_student was true, but was doing so regardless of whether the team score was being pulled from challenge grade scores.
* when determining student score caching scenarios, course#challenge_grades? was being used instead of the course[:team_score_average] boolean.

After recalculation this should fix whatever issues we were having with score recalculation. Added some specs for the more svelte methods in this domain. All specs passing after local run.

![image](https://cloud.githubusercontent.com/assets/95957/10776878/e4c9107c-7d15-11e5-9c23-86170875baca.png)
