### PR TITLE
Rescue predictor job calls and persist Predictor Events directly to Mongo

### DIFF
--- a/spec/controllers/application_controller_filters_spec.rb
+++ b/spec/controllers/application_controller_filters_spec.rb
@@ -18,6 +18,8 @@ class ApplicationControllerFiltersTest < ApplicationController
 end
 
 RSpec.describe ApplicationControllerFiltersTest, type: :controller do
+  include PageviewEventLoggerToolkit
+
   describe "#increment_page_views" do
 
     before do
@@ -91,22 +93,5 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
     after do
       Rails.application.reload_routes!
     end
-  end
-
-  def stub_current_user
-    @current_user = double(:current_user).as_null_object
-    allow(@current_user).to receive_messages(default_course: double(:default_course))
-    allow(controller).to receive_messages(current_user: @current_user)
-  end
-
-  def pageview_logger_attrs_expectation
-    {
-      course_id: 50,
-      user_id: 70,
-      student_id: 90,
-      user_role: "great role",
-      page: "/a/great/path",
-      created_at: Time.parse("Jan 20 1972")
-    }
   end
 end

--- a/spec/controllers/application_controller_filters_spec.rb
+++ b/spec/controllers/application_controller_filters_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
     end
 
     before(:each) do
-      allow(controller).to receive_messages(pageview_logger_attrs: pageview_logger_attrs_expectation)
+      allow(controller).to receive_messages(pageview_logger_attrs: pageview_logger_attrs)
     end
 
     # if current_user && request.format.html?
     context "no user is logged in" do
       it "should not increment the page views" do
         allow(controller).to receive_messages(current_user: nil)
-        expect(PageviewEventLogger).not_to receive(:new).with pageview_logger_attrs_expectation
+        expect(PageviewEventLogger).not_to receive(:new).with pageview_logger_attrs
         get :html_page
       end
     end
@@ -46,7 +46,7 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
     context "the request is not html" do
       it "should not increment the page views" do
         stub_current_user
-        expect(PageviewEventLogger).not_to receive(:new).with pageview_logger_attrs_expectation
+        expect(PageviewEventLogger).not_to receive(:new).with pageview_logger_attrs
         get :json_page, format: "json"
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
       end
 
       it "should create a new pageview logger" do
-        expect(PageviewEventLogger).to receive(:new).with(pageview_logger_attrs_expectation) { @pageview_event_logger }
+        expect(PageviewEventLogger).to receive(:new).with(pageview_logger_attrs) { @pageview_event_logger }
       end
 
       it "should enqueue the new pageview logger in 2 hours" do
@@ -81,7 +81,7 @@ RSpec.describe ApplicationControllerFiltersTest, type: :controller do
       end
 
       it "performs the pageview event log directly from the controller" do
-        expect(PageviewEventLogger).to receive(:perform).with('pageview', pageview_logger_attrs_expectation)
+        expect(PageviewEventLogger).to receive(:perform).with('pageview', pageview_logger_attrs)
         get :html_page
       end
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -183,13 +183,13 @@ describe GradesController do
         expect(JSON.parse(response.body)).to eq({"id" => @assignment.id, "points_earned" => predicted_points})
       end
 
-      it "enqueues_the_predictor_event_job", focus: true do
+      it "enqueues_the_predictor_event_job" do
         expect(controller).to receive(:enqueue_predictor_event_job)
         get :predict_score, { :id => @assignment.id, predicted_score: predicted_points, format: :json }
       end
     end
 
-    describe "enqueue_predictor_event_job", focus: true do
+    describe "enqueue_predictor_event_job" do
       context "Resque connects to redis and enqueues the damn job" do
         before(:each) do
           @predictor_event_job = double(:predictor_event_job)

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -214,7 +214,7 @@ describe GradesController do
 
       context "Resque fails to reach Redis and returns a getaddrinfo socket error" do
         before do
-          allow(PredictorEventJob).to receive(:new).and_raise("Could not connect to Redis: getaddrinfo socket error.")
+          allow(PredictorEventJob).to receive_message_chain(:new, :enqueue).and_raise("MOCK FAUX LAME NONERROR: Could not connect to Redis: getaddrinfo socket error.")
           allow(controller).to receive(:predictor_event_attrs) { predictor_event_attrs_expectation }
         end
 

--- a/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
+++ b/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
@@ -1,5 +1,5 @@
-module PageviewEventLoggerToolkit
-  def pageview_logger_attrs
+module PredictorEventJobsToolkit
+  def predictor_event_attrs_expectation
     {
       course_id: 50,
       user_id: 70,

--- a/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
+++ b/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
@@ -5,10 +5,15 @@ module PredictorEventJobsToolkit
       user_id: 70,
       student_id: 90,
       user_role: "great role",
-      page: "/a/great/path",
-      created_at: Time.parse("Jan 20 1972")
+      created_at: Time.parse("Jan 20 1972"),
+      prediction_type: "grade",
+      assignment_id: 80,
+      predicted_points: 9000,
+      possible_points: 10000,
+      prediction_saved_successfully: true
     }
   end
+
 
   def stub_current_user
     @current_user = double(:current_user).as_null_object

--- a/spec/toolkits/workers/pageview_event_logger_toolkit.rb
+++ b/spec/toolkits/workers/pageview_event_logger_toolkit.rb
@@ -1,5 +1,5 @@
 module PageviewEventLoggerToolkit
-  def pageview_logger_attrs
+  def pageview_logger_attrs_expectation
     {
       course_id: 50,
       user_id: 70,

--- a/spec/toolkits/workers/pageview_event_logger_toolkit.rb
+++ b/spec/toolkits/workers/pageview_event_logger_toolkit.rb
@@ -1,5 +1,5 @@
 module PageviewEventLoggerToolkit
-  def pageview_logger_attrs_expectation
+  def pageview_logger_attrs
     {
       course_id: 50,
       user_id: 70,


### PR DESCRIPTION
This pull request adds the same rescue -> perform functionality that was added for the PageviewEventLogger in the Application controller. If Resque can't find Redis for whatever reason, this commit adds a rescue block that then just directly calls #perform on the PredictorEventJob with all of the necessary attrs for the mongo record. Because the #perform block is being called on PredictorEventJob, which is subclassed from ResqueJob::Base, all of the corresponding logging for job start and failure etc will be made despite circumventing Resque and Redis.

Additionally, because ResqueJob::Base is built specifically to service Resque, any exceptions raised in the #perform block will be rescued out, but then will automatically re-raise a custom ResqueRetryError in order to attempt to trigger resque-retry. This means ultimately that no new exceptions will be raised, but ones that occur in the #perform block will still throw some kind of error and potentially obstruct the user experience. This will be resolved in a future pull request.    

![Rescue Randy](https://cloud.githubusercontent.com/assets/95957/10798182/b6dc0ee4-7da6-11e5-8ba6-8cdb14899628.png)