### PR TITLE
1167 delete course membership

### DIFF
--- a/app/controllers/course_memberships_controller.rb
+++ b/app/controllers/course_memberships_controller.rb
@@ -11,8 +11,8 @@ class CourseMembershipsController < ApplicationController
   end
 
   def destroy
-    @course_membership = current_course.course_memberships.find(params[:id])
-    @course_membership.destroy
+    course_membership = current_course.course_memberships.find(params[:id])
+    CancelsCourseMembership.for_student course_membership
 
     respond_to do |format|
       format.html { redirect_to students_path, notice: 'Student was successfully removed from course.' }

--- a/app/models/announcement_state.rb
+++ b/app/models/announcement_state.rb
@@ -1,4 +1,9 @@
 class AnnouncementState < ActiveRecord::Base
   belongs_to :announcement
   belongs_to :user
+
+  scope :for_course, ->(course) do
+    joins(:announcement).where(announcements: {course_id: course.id})
+  end
+  scope :for_user, ->(user) { where(user_id: user.id) }
 end

--- a/app/models/assignment_weight.rb
+++ b/app/models/assignment_weight.rb
@@ -17,7 +17,8 @@ class AssignmentWeight < ActiveRecord::Base
   # validate :course_total_assignment_weight_not_exceeded, :course_max_assignment_weight_not_exceeded
 
   scope :except_weight, ->(weight) { where('assignment_weights.id != ?', weight.id) }
-  scope :for_course, ->(course) { where(:assignment_id => course.assignments.pluck(:id)) }
+  scope :for_course, ->(course) { where(course_id: course.id) }
+  scope :for_student, ->(student) { where(student_id: student.id) }
 
   def self.weight
     limit(1).pluck(:weight).first || 0
@@ -48,7 +49,7 @@ class AssignmentWeight < ActiveRecord::Base
   end
 
   def course_max_assignment_weight_not_exceeded
-    if course.max_assignment_weight? 
+    if course.max_assignment_weight?
       if weight > course.max_assignment_weight
         errors.add :base, "Please select a lower #{course.weight_term.downcase} value"
       end

--- a/app/models/earned_badge.rb
+++ b/app/models/earned_badge.rb
@@ -27,6 +27,9 @@ class EarnedBadge < ActiveRecord::Base
 
   delegate :name, :description, :icon, :to => :badge
 
+  scope :for_course, ->(course) { where(course_id: course.id) }
+  scope :for_student, ->(student) { where(student_id: student.id) }
+
   def self.score
     pluck('SUM(score)').first || 0
   end

--- a/app/models/flagged_user.rb
+++ b/app/models/flagged_user.rb
@@ -3,6 +3,9 @@ class FlaggedUser < ActiveRecord::Base
   belongs_to :flagger, class_name: "User"
   belongs_to :flagged, class_name: "User"
 
+  scope :for_course, ->(course) { where(course_id: course.id) }
+  scope :for_flagged, ->(user) { where(flagged_id: user.id) }
+
   validates :course, presence: true
   validates :flagger, presence: true, course_membership: true, staff_flagger: true
   validates :flagged, presence: true, course_membership: true

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -58,6 +58,7 @@ class Grade < ActiveRecord::Base
   scope :instructor_modified, -> { where('instructor_modified = ?', true) }
   scope :positive, -> { where('score > 0')}
   scope :predicted_to_be_done, -> { where('predicted_score > 0')}
+  scope :for_student, ->(student) { where(student_id: student.id) }
 
   # @mz todo: add specs
   scope :student_visible, -> { joins(:assignment).where(student_visible_sql) }
@@ -147,7 +148,7 @@ class Grade < ActiveRecord::Base
     student_id == user.id
   end
 
-  # @mz todo: port this over to cache_team_and_student_scores once 
+  # @mz todo: port this over to cache_team_and_student_scores once
   # related methods have tests
   # want to make sure that nothing depends on the output of this method
   def save_student_and_team_scores
@@ -193,22 +194,22 @@ class Grade < ActiveRecord::Base
     failure_attrs = {}
     if course.has_teams? && student.team_for_course(course).present?
       unless @team_update_successful
-        failure_attrs.merge! team: @team.attributes 
+        failure_attrs.merge! team: @team.attributes
       end
 
       unless @student_update_successful
-        failure_attrs.merge! student: @student.attributes 
+        failure_attrs.merge! student: @student.attributes
       end
 
       unless @team_update_successful and @student_update_successful
-        failure_attrs.merge! grade: self.attributes 
+        failure_attrs.merge! grade: self.attributes
       end
     end
 
     failure_attrs
   end
 
-  public 
+  public
 
   def altered?
     self.score_changed? == true  || self.feedback_changed? == true

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -58,6 +58,7 @@ class Grade < ActiveRecord::Base
   scope :instructor_modified, -> { where('instructor_modified = ?', true) }
   scope :positive, -> { where('score > 0')}
   scope :predicted_to_be_done, -> { where('predicted_score > 0')}
+  scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }
 
   # @mz todo: add specs

--- a/app/models/group_membership.rb
+++ b/app/models/group_membership.rb
@@ -4,6 +4,10 @@ class GroupMembership < ActiveRecord::Base
   belongs_to :group
   belongs_to :student, class_name: 'User'
 
-  validates_uniqueness_of :student_id, { :scope => :group_id }
+  scope :for_course, ->(course) do
+    joins(:group).where(groups: {course_id: course.id})
+  end
+  scope :for_student, ->(student) { where(student_id: student.id) }
 
+  validates_uniqueness_of :student_id, { :scope => :group_id }
 end

--- a/app/models/predicted_earned_badge.rb
+++ b/app/models/predicted_earned_badge.rb
@@ -5,6 +5,11 @@ class PredictedEarnedBadge < ActiveRecord::Base
   belongs_to :badge
   belongs_to :student, :class_name => 'User'
 
+  scope :for_course, ->(course) do
+    joins(:badge).where(badges: {course_id: course.id})
+  end
+  scope :for_student, ->(student) { where(student_id: student.id) }
+
   def total_predicted_points
     self.badge.point_total * times_earned
   end

--- a/app/models/predicted_earned_challenge.rb
+++ b/app/models/predicted_earned_challenge.rb
@@ -5,4 +5,9 @@ class PredictedEarnedChallenge < ActiveRecord::Base
   belongs_to :challenge
   belongs_to :student, :class_name => 'User'
 
+  scope :for_course, ->(course) do
+    joins(:challenge).where(challenges: {course_id: course.id})
+  end
+  scope :for_student, ->(student) { where(student_id: student.id) }
+
 end

--- a/app/models/rubric_grade.rb
+++ b/app/models/rubric_grade.rb
@@ -5,6 +5,14 @@ class RubricGrade < ActiveRecord::Base
   belongs_to :student, class_name: "User"
   belongs_to :assignment
 
+  scope :for_course, ->(course) do
+    joins("LEFT OUTER JOIN assignments ON rubric_grades.assignment_id =\
+           assignments.id")
+      .joins("LEFT OUTER JOIN submissions ON rubric_grades.submission_id =\
+              submissions.id")
+      .where("assignments.course_id = :course_id \
+              OR submissions.course_id = :course_id", course_id: course.id)
+  end
   scope :for_student, ->(student) { where(student_id: student.id) }
 
   attr_accessible :metric_name, :metric_description, :max_points, :tier_name,

--- a/app/models/rubric_grade.rb
+++ b/app/models/rubric_grade.rb
@@ -2,8 +2,10 @@ class RubricGrade < ActiveRecord::Base
   belongs_to :submission
   belongs_to :metric
   belongs_to :tier
-  belongs_to :student, :class_name => 'User'
+  belongs_to :student, class_name: "User"
   belongs_to :assignment
+
+  scope :for_student, ->(student) { where(student_id: student.id) }
 
   attr_accessible :metric_name, :metric_description, :max_points, :tier_name,
     :tier_description, :points, :submission_id, :metric_id, :tier_id, :order,
@@ -17,7 +19,7 @@ class RubricGrade < ActiveRecord::Base
 
   private
 
-    def submission_or_assignment_present
-      submission_id.present? or assignment_id.present?
-    end
+  def submission_or_assignment_present
+    submission_id.present? or assignment_id.present?
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,6 +28,8 @@ class Submission < ActiveRecord::Base
   scope :graded, -> { where(:grade) }
   scope :resubmitted, -> { where('EXISTS(SELECT 1 FROM grades WHERE (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (updated_at < submissions.updated_at) AND (status = ? OR status = ?))', "Graded", "Released") }
   scope :date_submitted, -> { order('created_at ASC') }
+  scope :for_course, ->(course) { where(course_id: course.id) }
+  scope :for_student, ->(student) { where(student_id: student.id) }
 
   before_validation :cache_associations
 
@@ -96,7 +98,7 @@ class Submission < ActiveRecord::Base
     false
   end
 
-  def check_unlockables 
+  def check_unlockables
     if self.assignment.is_a_condition?
       unlock_conditions = UnlockCondition.where(:condition_id => self.assignment.id, :condition_type => "Assignment").each do |condition|
         if condition.unlockable_type == "Assignment"

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -5,6 +5,11 @@ class TeamMembership < ActiveRecord::Base
   belongs_to :team
   belongs_to :student, class_name: 'User'
 
+  scope :for_course, ->(course) do
+    joins(:team).where(teams: {course_id: course.id})
+  end
+  scope :for_student, ->(student) { where(student_id: student.id) }
+
   def team_score
     Grade
       .where(course_id: course.id)

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -5,6 +5,7 @@ class CancelsCourseMembership
       .removes_grades(membership)
       .removes_rubric_grades(membership)
       .removes_assignment_weights(membership)
+      .removes_earned_badges(membership)
   end
 
   private
@@ -16,6 +17,13 @@ class CancelsCourseMembership
 
   def self.removes_assignment_weights(membership)
     AssignmentWeight.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_earned_badges(membership)
+    EarnedBadge.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -9,6 +9,7 @@ class CancelsCourseMembership
       .removes_predicted_earned_badges(membership)
       .removes_predicted_earned_challenges(membership)
       .removes_group_memberships(membership)
+      .removes_team_memberships(membership)
   end
 
   private
@@ -69,6 +70,13 @@ class CancelsCourseMembership
 
   def self.removes_rubric_grades(membership)
     RubricGrade.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_team_memberships(membership)
+    TeamMembership.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -4,12 +4,20 @@ class CancelsCourseMembership
       .removes_submissions(membership)
       .removes_grades(membership)
       .removes_rubric_grades(membership)
+      .removes_assignment_weights(membership)
   end
 
   private
 
   def self.deletes_membership(membership)
     membership.destroy
+    self
+  end
+
+  def self.removes_assignment_weights(membership)
+    AssignmentWeight.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
     self
   end
 

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,0 +1,12 @@
+class CancelsCourseMembership
+  def self.for_student(membership)
+    removes_grades(membership.user)
+  end
+
+  private
+
+  def self.removes_grades(student)
+    Grade.for_student(student).destroy_all
+    self
+  end
+end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,7 +1,8 @@
 class CancelsCourseMembership
   def self.for_student(membership)
     deletes_membership(membership)
-      .removes_grades(membership.user)
+      .removes_submissions(membership)
+      .removes_grades(membership)
       .removes_rubric_grades(membership.user)
   end
 
@@ -12,8 +13,17 @@ class CancelsCourseMembership
     self
   end
 
-  def self.removes_grades(student)
-    Grade.for_student(student).destroy_all
+  def self.removes_grades(membership)
+    Grade.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_submissions(membership)
+    Submission.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
     self
   end
 

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -3,7 +3,7 @@ class CancelsCourseMembership
     deletes_membership(membership)
       .removes_submissions(membership)
       .removes_grades(membership)
-      .removes_rubric_grades(membership.user)
+      .removes_rubric_grades(membership)
   end
 
   private
@@ -27,8 +27,10 @@ class CancelsCourseMembership
     self
   end
 
-  def self.removes_rubric_grades(student)
-    RubricGrade.for_student(student).destroy_all
+  def self.removes_rubric_grades(membership)
+    RubricGrade.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
     self
   end
 end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -6,6 +6,7 @@ class CancelsCourseMembership
       .removes_rubric_grades(membership)
       .removes_assignment_weights(membership)
       .removes_earned_badges(membership)
+      .removes_predicted_earned_badges(membership)
   end
 
   private
@@ -31,6 +32,13 @@ class CancelsCourseMembership
 
   def self.removes_grades(membership)
     Grade.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_predicted_earned_badges(membership)
+    PredictedEarnedBadge.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -2,6 +2,7 @@ class CancelsCourseMembership
   def self.for_student(membership)
     deletes_membership(membership)
       .removes_grades(membership.user)
+      .removes_rubric_grades(membership.user)
   end
 
   private
@@ -13,6 +14,11 @@ class CancelsCourseMembership
 
   def self.removes_grades(student)
     Grade.for_student(student).destroy_all
+    self
+  end
+
+  def self.removes_rubric_grades(student)
+    RubricGrade.for_student(student).destroy_all
     self
   end
 end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,9 +1,15 @@
 class CancelsCourseMembership
   def self.for_student(membership)
-    removes_grades(membership.user)
+    deletes_membership(membership)
+      .removes_grades(membership.user)
   end
 
   private
+
+  def self.deletes_membership(membership)
+    membership.destroy
+    self
+  end
 
   def self.removes_grades(student)
     Grade.for_student(student).destroy_all

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -8,6 +8,7 @@ class CancelsCourseMembership
       .removes_earned_badges(membership)
       .removes_predicted_earned_badges(membership)
       .removes_predicted_earned_challenges(membership)
+      .removes_group_memberships(membership)
   end
 
   private
@@ -33,6 +34,13 @@ class CancelsCourseMembership
 
   def self.removes_grades(membership)
     Grade.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_group_memberships(membership)
+    GroupMembership.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -10,12 +10,20 @@ class CancelsCourseMembership
       .removes_predicted_earned_challenges(membership)
       .removes_group_memberships(membership)
       .removes_team_memberships(membership)
+      .removes_announcement_states(membership)
   end
 
   private
 
   def self.deletes_membership(membership)
     membership.destroy
+    self
+  end
+
+  def self.removes_announcement_states(membership)
+    AnnouncementState.for_course(membership.course)
+      .for_user(membership.user)
+      .destroy_all
     self
   end
 

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -11,6 +11,7 @@ class CancelsCourseMembership
       .removes_group_memberships(membership)
       .removes_team_memberships(membership)
       .removes_announcement_states(membership)
+      .removes_flagged_users(membership)
   end
 
   private
@@ -37,6 +38,13 @@ class CancelsCourseMembership
   def self.removes_earned_badges(membership)
     EarnedBadge.for_course(membership.course)
       .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_flagged_users(membership)
+    FlaggedUser.for_course(membership.course)
+      .for_flagged(membership.user)
       .destroy_all
     self
   end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -7,6 +7,7 @@ class CancelsCourseMembership
       .removes_assignment_weights(membership)
       .removes_earned_badges(membership)
       .removes_predicted_earned_badges(membership)
+      .removes_predicted_earned_challenges(membership)
   end
 
   private
@@ -39,6 +40,13 @@ class CancelsCourseMembership
 
   def self.removes_predicted_earned_badges(membership)
     PredictedEarnedBadge.for_course(membership.course)
+      .for_student(membership.user)
+      .destroy_all
+    self
+  end
+
+  def self.removes_predicted_earned_challenges(membership)
+    PredictedEarnedChallenge.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -32,4 +32,97 @@ namespace :courses do
       end
     end
   end
+
+  desc "Removes all the orphaned data for course memberships"
+  task :remove_orphaned_memberships, [:dry_run] => :environment do |t, args|
+    args.with_defaults(dry_run: true)
+    dry_run = args[:dry_run] != "false"
+
+    puts "*** DRY RUN: NO DATA WILL BE DELETED ***" if dry_run
+    memberships = CourseMembership.where(role: :student)
+    puts "There are #{memberships.count} student #{"membership".pluralize(memberships.count)} to validate"
+
+    # Submissions
+    remove_orphans collect_orphans(memberships, Submission.all),
+      Submission, dry_run
+
+    # Grades
+    remove_orphans collect_orphans(memberships, Grade.all),
+      Grade, dry_run
+
+    # RubricGrades
+    rubric_grades = collect_orphans memberships, RubricGrade.all do |rg, m|
+      RubricGrade.for_course(m.course).where(student_id: m.user_id).present?
+    end
+    remove_orphans rubric_grades, RubricGrade, dry_run
+
+    # AssignmentWeights
+    remove_orphans collect_orphans(memberships, AssignmentWeight.all),
+      AssignmentWeight, dry_run
+
+    # EarnedBadges
+    remove_orphans collect_orphans(memberships, EarnedBadge.all),
+      EarnedBadge, dry_run
+
+    # PredictedEarnedBadges
+    badges = collect_orphans memberships, PredictedEarnedBadge.joins(:badge).all do |peb, m|
+      peb.badge.present? && peb.badge.course_id == m.course_id &&
+        peb.student_id == m.user_id
+    end
+    remove_orphans badges, PredictedEarnedBadge, dry_run
+
+    # PredictedEarnedChallenges
+    challenges = collect_orphans memberships, PredictedEarnedChallenge.joins(:challenge).all do |pec, m|
+      pec.challenge.present? && pec.challenge.course_id == m.course_id &&
+        pec.student_id == m.user_id
+    end
+    remove_orphans challenges, PredictedEarnedChallenge, dry_run
+
+    # GroupMemberships
+    groups = collect_orphans memberships, GroupMembership.joins(:group).all do |gm, m|
+      gm.group.present? && gm.group.course_id == m.course_id &&
+        gm.student_id == m.user_id
+    end
+    remove_orphans groups, GroupMembership, dry_run
+
+    # TeamMemberships
+    teams = collect_orphans memberships, TeamMembership.joins(:team).all do |tm, m|
+      tm.team.present? && tm.team.course_id == m.course_id &&
+        tm.student_id == m.user_id
+    end
+    remove_orphans teams, TeamMembership, dry_run
+
+    # AnnouncementStates
+    states = collect_orphans memberships, AnnouncementState.joins(:announcement).all do |as, m|
+      as.announcement.present? && as.announcement.course_id == m.course_id &&
+        as.student_id == m.user_id
+    end
+    remove_orphans states, AnnouncementState, dry_run
+
+    # FlaggedUsers
+    remove_orphans collect_orphans(memberships, FlaggedUser.all, :course_id, :flagged_id), FlaggedUser, dry_run
+  end
+
+  def collect_orphans(memberships, query, course_id_method=:course_id,
+                      student_id_method=:student_id)
+    orphans = []
+    query.find_in_batches do |group|
+      group.each do |orphan|
+        orphans << orphan if memberships.none? do |m|
+          if block_given?
+            yield orphan, m
+          else
+            m.course_id == orphan.send(course_id_method) &&
+              m.user_id == orphan.send(student_id_method)
+          end
+        end
+      end
+    end
+    orphans
+  end
+
+  def remove_orphans(orphans, type, dry_run)
+    puts "Deleting #{orphans.size} #{type.name.pluralize(orphans.size)}..."
+    orphans.each(&:destroy) unless dry_run
+  end
 end

--- a/spec/factories/assignment_weight_factory.rb
+++ b/spec/factories/assignment_weight_factory.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :assignment_weight do
+    association :course
+    association :assignment_type
+    association :assignment
+    association :student, factory: :user
+    weight Faker::Number.number(2)
+  end
+end

--- a/spec/factories/flagged_user.rb
+++ b/spec/factories/flagged_user.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :flagged_user do
+    association :course
+    association :flagger, factory: :user
+    association :flagged, factory: :user
+  end
+end

--- a/spec/factories/group_membership_factory.rb
+++ b/spec/factories/group_membership_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :group_membership do
+    association :group
+    association :student, factory: :user
+  end
+end

--- a/spec/factories/rubric_grade_factory.rb
+++ b/spec/factories/rubric_grade_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
- factory :rubric_grade do
-   association :student, factory: :user
-   association :assignment
-   max_points Faker::Number.number(5)
-   metric_name "Well written"
-   order Faker::Number.number(2)
- end
+  factory :rubric_grade do
+    association :student, factory: :user
+    association :assignment
+    max_points Faker::Number.number(5)
+    metric_name "Well written"
+    order Faker::Number.number(2)
+  end
 end

--- a/spec/models/announcement_state_spec.rb
+++ b/spec/models/announcement_state_spec.rb
@@ -1,0 +1,24 @@
+require "active_record_spec_helper"
+
+describe AnnouncementState do
+  describe ".for_course" do
+    it "returns all the announcement states for a specific course" do
+      course = create(:course)
+      course_announcement_state = create(:announcement_state,
+                            announcement: create(:announcement, course: course))
+      another_announcement_state = create(:announcement_state)
+      results = AnnouncementState.for_course(course)
+      expect(results).to eq [course_announcement_state]
+    end
+  end
+
+  describe ".for_user" do
+    it "returns all the announcement states for a specific student" do
+      user = create(:user)
+      user_announcement_state = create(:announcement_state, user: user)
+      another_announcement_state = create(:announcement_state)
+      results = AnnouncementState.for_user(user)
+      expect(results).to eq [user_announcement_state]
+    end
+  end
+end

--- a/spec/models/assignment_weight_spec.rb
+++ b/spec/models/assignment_weight_spec.rb
@@ -1,0 +1,23 @@
+require "active_record_spec_helper"
+
+describe AssignmentWeight do
+  describe ".for_course" do
+    it "returns all assignment weights for a specific course" do
+      course = create(:course)
+      course_assignment_weight = create(:assignment_weight, course: course)
+      another_assignment_weight = create(:assignment_weight)
+      results = AssignmentWeight.for_course(course)
+      expect(results).to eq [course_assignment_weight]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all assignment weights for a specific student" do
+      student = create(:user)
+      student_assignment_weight = create(:assignment_weight, student: student)
+      another_assignment_weight = create(:assignment_weight)
+      results = AssignmentWeight.for_student(student)
+      expect(results).to eq [student_assignment_weight]
+    end
+  end
+end

--- a/spec/models/earned_badge_spec.rb
+++ b/spec/models/earned_badge_spec.rb
@@ -1,0 +1,23 @@
+require "active_record_spec_helper"
+
+describe EarnedBadge do
+  describe ".for_course" do
+    it "returns all earned badge for a specific course" do
+      course = create(:course)
+      course_earned_badge = create(:earned_badge, course: course)
+      another_earned_badge = create(:earned_badge)
+      results = EarnedBadge.for_course(course)
+      expect(results).to eq [course_earned_badge]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all earned badges for a specific student" do
+      student = create(:user)
+      student_earned_badge = create(:earned_badge, student: student)
+      another_earned_badge = create(:earned_badge)
+      results = EarnedBadge.for_student(student)
+      expect(results).to eq [student_earned_badge]
+    end
+  end
+end

--- a/spec/models/flagged_user_spec.rb
+++ b/spec/models/flagged_user_spec.rb
@@ -68,6 +68,34 @@ describe FlaggedUser do
     end
   end
 
+  describe ".for_course" do
+    it "returns all the flagged users for a specific course" do
+      course_flagged_user = create(:flagged_user, flagger: professor, flagged: student, course: course)
+      another_course = create(:course)
+      another_professor = create :course_membership, course: another_course,
+        user: professor, role: "professor"
+      another_student = create :course_membership, course: another_course,
+        user: student, role: "student"
+      create(:flagged_user, flagger: another_professor.user,
+             flagged: another_student.user, course: another_course)
+      results = FlaggedUser.for_course(course)
+      expect(results).to eq [course_flagged_user]
+    end
+  end
+
+  describe ".for_flagged" do
+    it "returns all the flagged users for a specific flagged user" do
+      student_flagged_user = create(:flagged_user, flagger: professor,
+                                    flagged: student, course: course)
+      another_student = create(:user)
+      another_student.courses << course
+      another_flagged_user = create(:flagged_user, flagger: professor,
+                                    flagged: another_student, course: course)
+      results = FlaggedUser.for_flagged(student)
+      expect(results).to eq [student_flagged_user]
+    end
+  end
+
   describe ".unflag!" do
     before { FlaggedUser.flag!(course, professor, student.id) }
 

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -71,6 +71,16 @@ describe Grade do
     end
   end
 
+  describe ".for_course" do
+    it "returns all grades for a specific course" do
+      course = create(:course)
+      course_grade = create(:grade, course: course)
+      another_grade = create(:grade)
+      results = Grade.for_course(course)
+      expect(results).to eq [course_grade]
+    end
+  end
+
   describe ".for_student" do
     it "returns all grades for a specific student" do
       student = create(:user)

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -70,4 +70,14 @@ describe Grade do
       expect(elapsed).to be < 5
     end
   end
+
+  describe ".for_student" do
+    it "returns all grades for a specific student" do
+      student = create(:user)
+      student_grade = create(:grade, student: student)
+      another_grade = create(:grade)
+      results = Grade.for_student(student)
+      expect(results).to eq [student_grade]
+    end
+  end
 end

--- a/spec/models/group_membership_spec.rb
+++ b/spec/models/group_membership_spec.rb
@@ -1,0 +1,24 @@
+require "active_record_spec_helper"
+
+describe GroupMembership do
+  describe ".for_course" do
+    it "returns all the group memberships for a specific course" do
+      course = create(:course)
+      course_group_membership = create(:group_membership,
+                                      group: create(:group, course: course))
+      another_group_membership = create(:group_membership)
+      results = GroupMembership.for_course(course)
+      expect(results).to_not include [another_group_membership]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all the group memberships for a specific student" do
+      student = create(:user)
+      student_group_membership = create(:group_membership, student: student)
+      another_group_membership = create(:group_membership)
+      results = GroupMembership.for_student(student)
+      expect(results).to eq [student_group_membership]
+    end
+  end
+end

--- a/spec/models/predicted_earned_badge_spec.rb
+++ b/spec/models/predicted_earned_badge_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_spec_helper'
+require "active_record_spec_helper"
 
 describe PredictedEarnedBadge do
 

--- a/spec/models/predicted_earned_badge_spec.rb
+++ b/spec/models/predicted_earned_badge_spec.rb
@@ -1,4 +1,3 @@
-#predictedEarnedBadge_spec.rb
 require 'rails_spec_helper'
 
 describe PredictedEarnedBadge do
@@ -33,6 +32,27 @@ describe PredictedEarnedBadge do
     it "reports the predicted times earned taking into account the actual times earned" do
       expect(@predicted_earned_badge.times_earned).to eq(1)
       expect(@predicted_earned_badge.times_earned_including_actual).to eq(3)
+    end
+  end
+
+  describe ".for_course" do
+    it "returns all predicted earned badges for a specific course" do
+      course = create(:course)
+      course_predicted_badge = create(:predicted_earned_badge,
+                                      badge: create(:badge, course: course))
+      another_predicted_badge = create(:predicted_earned_badge)
+      results = PredictedEarnedBadge.for_course(course)
+      expect(results).to eq [course_predicted_badge]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all predicted earned badges for a specific student" do
+      student = create(:user)
+      student_predicted_badge = create(:predicted_earned_badge, student: student)
+      another_predicted_badge = create(:predicted_earned_badge)
+      results = PredictedEarnedBadge.for_student(student)
+      expect(results).to eq [student_predicted_badge]
     end
   end
 end

--- a/spec/models/predicted_earned_challenge_spec.rb
+++ b/spec/models/predicted_earned_challenge_spec.rb
@@ -1,4 +1,3 @@
-#predictedEarnedBadge_spec.rb
 require 'rails_spec_helper'
 
 describe PredictedEarnedChallenge do
@@ -15,4 +14,25 @@ describe PredictedEarnedChallenge do
 
   it { is_expected.to be_valid }
 
+  describe ".for_course" do
+    it "returns all predicted earned challenges for a specific course" do
+      course = create(:course)
+      course_predicted_challenge = create(:predicted_earned_challenge,
+                                    challenge: create(:challenge, course: course))
+      another_predicted_challenge = create(:predicted_earned_challenge)
+      results = PredictedEarnedChallenge.for_course(course)
+      expect(results).to eq [course_predicted_challenge]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all predicted earned challenges for a specific student" do
+      student = create(:user)
+      student_predicted_challenge = create(:predicted_earned_challenge,
+                                           student: student)
+      another_predicted_challenge = create(:predicted_earned_challenge)
+      results = PredictedEarnedChallenge.for_student(student)
+      expect(results).to eq [student_predicted_challenge]
+    end
+  end
 end

--- a/spec/models/predicted_earned_challenge_spec.rb
+++ b/spec/models/predicted_earned_challenge_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_spec_helper'
+require "active_record_spec_helper"
 
 describe PredictedEarnedChallenge do
 

--- a/spec/models/rubric_grade_spec.rb
+++ b/spec/models/rubric_grade_spec.rb
@@ -1,6 +1,26 @@
 require "active_record_spec_helper"
 
 describe RubricGrade do
+  describe ".for_course" do
+    it "returns all grades for assignments that belong to a specific course" do
+      course = create(:course)
+      course_assignment = create(:assignment, course: course)
+      course_grade = create(:rubric_grade, assignment: course_assignment)
+      another_grade = create(:rubric_grade)
+      results = RubricGrade.for_course(course)
+      expect(results).to eq [course_grade]
+    end
+
+    it "returns all grades for submissions that belong to a specific course" do
+      course = create(:course)
+      course_submission = create(:submission, course: course)
+      course_grade = create(:rubric_grade, assignment: nil, submission: course_submission)
+      another_grade = create(:rubric_grade, assignment: nil)
+      results = RubricGrade.for_course(course)
+      expect(results).to eq [course_grade]
+    end
+  end
+
   describe ".for_student" do
     it "returns all rubric grades for a specific student" do
       student = create(:user)

--- a/spec/models/rubric_grade_spec.rb
+++ b/spec/models/rubric_grade_spec.rb
@@ -1,0 +1,13 @@
+require "active_record_spec_helper"
+
+describe RubricGrade do
+  describe ".for_student" do
+    it "returns all rubric grades for a specific student" do
+      student = create(:user)
+      student_grade = create(:rubric_grade, student: student)
+      another_grade = create(:rubric_grade)
+      results = RubricGrade.for_student(student)
+      expect(results).to eq [student_grade]
+    end
+  end
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -44,4 +44,24 @@ describe Submission do
     subject.save!
     expect expect(subject.errors.size).to eq(0)
   end
+
+  describe ".for_course" do
+    it "returns all submissions for a specific course" do
+      course = create(:course)
+      course_submission = create(:submission, course: course)
+      another_submission = create(:submission)
+      results = Submission.for_course(course)
+      expect(results).to eq [course_submission]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all submissions for a specific student" do
+      student = create(:user)
+      student_submission = create(:submission, student: student)
+      another_submission = create(:submission)
+      results = Submission.for_student(student)
+      expect(results).to eq [student_submission]
+    end
+  end
 end

--- a/spec/models/team_membership_spec.rb
+++ b/spec/models/team_membership_spec.rb
@@ -1,0 +1,24 @@
+require "active_record_spec_helper"
+
+describe TeamMembership do
+  describe ".for_course" do
+    it "returns all the team memberships for a specific course" do
+      course = create(:course)
+      course_team_membership = create(:team_membership,
+                                      team: create(:team, course: course))
+      another_team_membership = create(:team_membership)
+      results = TeamMembership.for_course(course)
+      expect(results).to_not include [another_team_membership]
+    end
+  end
+
+  describe ".for_student" do
+    it "returns all the team memberships for a specific student" do
+      student = create(:user)
+      student_team_membership = create(:team_membership, student: student)
+      another_team_membership = create(:team_membership)
+      results = TeamMembership.for_student(student)
+      expect(results).to eq [student_team_membership]
+    end
+  end
+end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -16,7 +16,12 @@ describe CancelsCourseMembership do
       expect(membership.user.reload.grades).to be_empty
     end
 
-    xit "removes the rubric grades for the student"
+    it "removes the rubric grades for the student" do
+      create :rubric_grade, student: membership.user
+      described_class.for_student membership
+      expect(RubricGrade.where(student_id: membership.user.id)).to be_empty
+    end
+
     xit "removes the assignment weights for the student"
     xit "removes the assignment type weights for the student"
     xit "removes the submissions for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -69,7 +69,16 @@ describe CancelsCourseMembership do
         eq [another_earned_badge]
     end
 
-    xit "removes the predicted earned challenges for the student"
+    it "removes the predicted earned challenges for the student" do
+      another_earned_challenge = create :predicted_earned_challenge,
+        student: student
+      course_earned_challenge = create :predicted_earned_challenge,
+        student: student, challenge: create(:challenge, course: course)
+      described_class.for_student membership
+      expect(PredictedEarnedChallenge.where(student_id: student.id)).to \
+        eq [another_earned_challenge]
+    end
+
     xit "removes the group memberships for the student"
     xit "removes the team memberships for the student"
     xit "removes the announcement states for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -79,7 +79,15 @@ describe CancelsCourseMembership do
         eq [another_earned_challenge]
     end
 
-    xit "removes the group memberships for the student"
+    it "removes the group memberships for the student" do
+      another_group_membership = create :group_membership, student: student
+      course_group_membership = create :group_membership, student: student,
+        group: create(:group, course: course)
+      described_class.for_student membership
+      expect(GroupMembership.where(student_id: student.id)).to \
+        eq [another_group_membership]
+    end
+
     xit "removes the team memberships for the student"
     xit "removes the announcement states for the student"
     xit "removes the flagged states for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -1,0 +1,26 @@
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership"
+
+describe CancelsCourseMembership do
+  describe ".for_student" do
+    let(:membership) { create(:student_course_membership) }
+
+    it "removes the grades for the student" do
+      create :grade, student: membership.user, course: membership.course
+      described_class.for_student membership
+      expect(membership.user.reload.grades).to be_empty
+    end
+
+    xit "removes the rubric grades for the student"
+    xit "removes the assignment weights for the student"
+    xit "removes the assignment type weights for the student"
+    xit "removes the submissions for the student"
+    xit "removes the earned badges for the student"
+    xit "removes the predicted earned badges for the student"
+    xit "removes the predicted earned challenges for the student"
+    xit "removes the group memberships for the student"
+    xit "removes the team memberships for the student"
+    xit "removes the announcement states for the student"
+    xit "removes the flagged states for the student"
+  end
+end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -3,28 +3,38 @@ require "./app/services/cancels_course_membership"
 
 describe CancelsCourseMembership do
   describe ".for_student" do
+    let(:course) { membership.course }
     let(:membership) { create(:student_course_membership) }
+    let(:student) { membership.user }
 
     it "removes the course membership" do
       described_class.for_student membership
       expect(CourseMembership.exists?(membership.id)).to eq false
     end
 
-    it "removes the grades for the student" do
-      create :grade, student: membership.user, course: membership.course
+    it "removes the grades for the student and course" do
+      another_grade = create :grade, student: student
+      course_grade = create :grade, student: student, course: course
       described_class.for_student membership
-      expect(membership.user.reload.grades).to be_empty
+      expect(student.reload.grades).to eq [another_grade]
     end
 
-    it "removes the rubric grades for the student" do
+    it "removes the submissions for the student" do
+      another_submission = create :submission, student: student
+      course_submission = create :submission, student: student, course: course
+      described_class.for_student membership
+      expect(student.reload.submissions).to eq [another_submission]
+    end
+
+    xit "removes the rubric grades for the student and course submissions" do
       create :rubric_grade, student: membership.user
       described_class.for_student membership
-      expect(RubricGrade.where(student_id: membership.user.id)).to be_empty
+      expect(RubricGrade.for_student(membership.user)).to be_empty
     end
 
+    xit "removes the rubric grades for the student and course assignments"
     xit "removes the assignment weights for the student"
     xit "removes the assignment type weights for the student"
-    xit "removes the submissions for the student"
     xit "removes the earned badges for the student"
     xit "removes the predicted earned badges for the student"
     xit "removes the predicted earned challenges for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -53,8 +53,13 @@ describe CancelsCourseMembership do
       expect(student.reload.assignment_weights).to eq [another_assignment_weight]
     end
 
-    xit "removes the assignment type weights for the student"
-    xit "removes the earned badges for the student"
+    it "removes the earned badges for the student" do
+      another_earned_badge = create :earned_badge, student: student
+      course_earned_badge = create :earned_badge, student: student, course: course
+      described_class.for_student membership
+      expect(student.reload.earned_badges).to eq [another_earned_badge]
+    end
+
     xit "removes the predicted earned badges for the student"
     xit "removes the predicted earned challenges for the student"
     xit "removes the group memberships for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -46,7 +46,13 @@ describe CancelsCourseMembership do
       expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
     end
 
-    xit "removes the assignment weights for the student"
+    it "removes the assignment weights for the student" do
+      another_assignment_weight = create :assignment_weight, student: student
+      course_assignment_weight = create :assignment_weight, student: student, course: course
+      described_class.for_student membership
+      expect(student.reload.assignment_weights).to eq [another_assignment_weight]
+    end
+
     xit "removes the assignment type weights for the student"
     xit "removes the earned badges for the student"
     xit "removes the predicted earned badges for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -26,13 +26,26 @@ describe CancelsCourseMembership do
       expect(student.reload.submissions).to eq [another_submission]
     end
 
-    xit "removes the rubric grades for the student and course submissions" do
-      create :rubric_grade, student: membership.user
+    it "removes the rubric grades for the student and course submissions" do
+      another_submission = create :submission, student: student
+      course_submission = create :submission, student: student, course: course
+      another_grade = create :rubric_grade, submission: another_submission,
+        student: student
+      course_grade = create :rubric_grade, submission: course_submission,
+        student: student
       described_class.for_student membership
-      expect(RubricGrade.for_student(membership.user)).to be_empty
+      expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
     end
 
-    xit "removes the rubric grades for the student and course assignments"
+    it "removes the rubric grades for the student and course assignments" do
+      course_assignment = create :assignment, course: course
+      another_grade = create :rubric_grade, student: student
+      course_grade = create :rubric_grade, assignment: course_assignment,
+        student: student
+      described_class.for_student membership
+      expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
+    end
+
     xit "removes the assignment weights for the student"
     xit "removes the assignment type weights for the student"
     xit "removes the earned badges for the student"

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -97,7 +97,15 @@ describe CancelsCourseMembership do
         eq [another_team_membership]
     end
 
-    xit "removes the announcement states for the student"
+    it "removes the announcement states for the student" do
+      another_announcement = create :announcement_state, user: student
+      course_announcement = create :announcement_state, user: student,
+        announcement: create(:announcement, course: course)
+      described_class.for_student membership
+      expect(AnnouncementState.where(user_id: student.id)).to \
+        eq [another_announcement]
+    end
+
     xit "removes the flagged states for the student"
   end
 end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -88,7 +88,15 @@ describe CancelsCourseMembership do
         eq [another_group_membership]
     end
 
-    xit "removes the team memberships for the student"
+    it "removes the team memberships for the student" do
+      another_team_membership = create :team_membership, student: student
+      course_team_membership = create :team_membership, student: student,
+        team: create(:team, course: course)
+      described_class.for_student membership
+      expect(TeamMembership.where(student_id: student.id)).to \
+        eq [another_team_membership]
+    end
+
     xit "removes the announcement states for the student"
     xit "removes the flagged states for the student"
   end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -5,6 +5,11 @@ describe CancelsCourseMembership do
   describe ".for_student" do
     let(:membership) { create(:student_course_membership) }
 
+    it "removes the course membership" do
+      described_class.for_student membership
+      expect(CourseMembership.exists?(membership.id)).to eq false
+    end
+
     it "removes the grades for the student" do
       create :grade, student: membership.user, course: membership.course
       described_class.for_student membership

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -106,6 +106,17 @@ describe CancelsCourseMembership do
         eq [another_announcement]
     end
 
-    xit "removes the flagged states for the student"
+    it "removes the flagged states for the student" do
+      another_flagger = create(:professor_course_membership)
+      student.courses << another_flagger.course
+      another_flagged_user = create :flagged_user, flagged: student,
+        flagger: another_flagger.user, course: another_flagger.course
+      flagger = create(:professor_course_membership, course: course)
+      course_flagged_user = create :flagged_user, flagged: student,
+        course: course, flagger: flagger.user
+      described_class.for_student membership
+      expect(FlaggedUser.where(flagged_id: student.id)).to \
+        eq [another_flagged_user]
+    end
   end
 end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -60,7 +60,15 @@ describe CancelsCourseMembership do
       expect(student.reload.earned_badges).to eq [another_earned_badge]
     end
 
-    xit "removes the predicted earned badges for the student"
+    it "removes the predicted earned badges for the student" do
+      another_earned_badge = create :predicted_earned_badge, student: student
+      course_earned_badge = create :predicted_earned_badge, student: student,
+        badge: create(:badge, course: course)
+      described_class.for_student membership
+      expect(PredictedEarnedBadge.where(student_id: student.id)).to \
+        eq [another_earned_badge]
+    end
+
     xit "removes the predicted earned challenges for the student"
     xit "removes the group memberships for the student"
     xit "removes the team memberships for the student"


### PR DESCRIPTION
This PR removes `course`/`student` relationships when a `CourseMembership` for a `Student` is deleted.

In order to do this, a service called `CancelsCourseMembership` was created to perform the various delete actions when a `CourseMembership` is destroyed.

A rake task called `courses:remove_orphaned_memberships` was created temporarily to remove any existing orphaned data for a `CourseMembership`. You can run it with a dry run (no data will be deleted) as the default. If you want to run it and delete data, you can run it via:

```
bundle exec rake "courses:remove_orphaned_memberships[false]"
```

Closes #1167 