### PR TITLE
display raw scores in predictor, no duplicate weighting

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -113,11 +113,12 @@
     _.where(assignments, {assignment_type_id: id})
 
   # Total points predicted for a collection of assignments
+  # Use raw score to keep weighting calculation on assignment type level
   $scope.assignmentsPointTotal = (assignments)->
     total = 0
     _.each(assignments, (assignment)->
-      if assignment.grade.score > 0
-        total += assignment.grade.score
+      if assignment.grade.raw_score > 0
+        total += assignment.grade.raw_score
       else if ! assignment.pass_fail
         total += assignment.grade.predicted_score
     )
@@ -200,8 +201,8 @@
   $scope.allPointsEarned = ()->
     total = 0
     _.each($scope.assignments, (assignment)->
-      if assignment.grade.score > 0
-        total += assignment.grade.score
+      if assignment.grade.raw_score > 0
+        total += assignment.grade.raw_score
       )
     _.each($scope.badges,(badge)->
         total += badge.total_earned_points

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -14,7 +14,7 @@
 
     .article-graded{'ng-if' => 'articleGraded(assignment)'}
       .grade{'ng-if' => 'assignment.pass_fail == false'}
-        {{assignment.grade.score | number}} / {{assignment.point_total | number}}
+        {{assignment.grade.raw_score | number}} / {{assignment.point_total | number}}
       .grade{'ng-if' => 'assignment.pass_fail == true'}
         .no-status{{'ng-if'=>'!assignment.grade.pass_fail_status'}}
           {{termFor["pass"]}} / {{termFor["fail"]}}

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -225,6 +225,7 @@ class AssignmentsController < ApplicationController
           id: grade.id,
           pass_fail_status: grade.is_student_visible? ? grade.pass_fail_status : nil,
           score: grade.is_student_visible? ? grade.score : nil,
+          raw_score: grade.is_student_visible? ? grade.raw_score : nil,
           predicted_score: current_user.is_student?(current_course) ? grade.predicted_score : 0
         }
       end

--- a/app/models/null_student.rb
+++ b/app/models/null_student.rb
@@ -75,6 +75,10 @@ class NullStudentGrade
     nil
   end
 
+  def raw_score
+    nil
+  end
+
   def final_score
     nil
   end

--- a/app/views/assignments/predictor_data.json.jbuilder
+++ b/app/views/assignments/predictor_data.json.jbuilder
@@ -38,6 +38,7 @@ json.assignments @assignments do |assignment|
         json.id grade[:id]
         json.predicted_score grade[:predicted_score]
         json.score grade[:score]
+        json.raw_score grade[:raw_score]
         json.pass_fail_status grade[:pass_fail_status] if assignment.pass_fail
       end
     end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -311,13 +311,14 @@ describe AssignmentsController do
         ].each do |attr|
            expect(assigns(:grades)[0][attr]).to eq(grade[attr])
         end
-        expect(assigns(:assignments)[0].current_student_grade).to eq({ id: grade.id, pass_fail_status: nil, score: grade.score, predicted_score: grade.predicted_score })
+        expect(assigns(:assignments)[0].current_student_grade).to eq({ id: grade.id, pass_fail_status: nil, raw_score: grade.raw_score, score: grade.score, predicted_score: grade.predicted_score })
       end
 
       it "includes student grade with no score if not released" do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id)
         get :predictor_data, format: :json, :id => @student.id
         expect(assigns(:assignments)[0].current_student_grade[:score]).to eq(nil)
+        expect(assigns(:assignments)[0].current_student_grade[:raw_score]).to eq(nil)
       end
 
       it "assigns data for displaying student grading distribution" do

--- a/spec/factories/grade_factory.rb
+++ b/spec/factories/grade_factory.rb
@@ -19,7 +19,8 @@ FactoryGirl.define do
     end
 
     factory :in_progress_grade do
-      score { Faker::Number.number(5) }
+      raw_score { Faker::Number.number(5) }
+      score { raw_score }
       status 'In Progress'
     end
   end

--- a/spec/models/null_student_spec.rb
+++ b/spec/models/null_student_spec.rb
@@ -50,6 +50,7 @@ describe NullStudent do
       expect(grade.point_total).to eq(555)
       expect(grade.predicted_score).to eq(0)
       expect(grade.score).to eq(nil)
+      expect(grade.raw_score).to eq(nil)
       expect(grade.status).to eq(nil)
       expect(grade.team_id).to eq(0)
       expect(grade.final_score).to eq(nil)

--- a/spec/views/assignments/predictor_data_spec.rb
+++ b/spec/views/assignments/predictor_data_spec.rb
@@ -28,18 +28,18 @@ describe "assignments/predictor_data" do
   end
 
   it "includes the current student grade with the assignment" do
-    @assignment.current_student_grade = { id: 1, pass_fail_status: "should not persist", score: 1000, predicted_score: 999 }
+    @assignment.current_student_grade = { id: 1, pass_fail_status: "should not persist", raw_score: 1000, score: 1000, predicted_score: 999 }
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => 1, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => 1, "raw_score" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "includes the pass fail status with the grade when the assignment is pass fail" do
-    @assignment.current_student_grade = { id: 1, pass_fail_status: "passed", score: 1000, predicted_score: 999 }
+    @assignment.current_student_grade = { id: 1, pass_fail_status: "passed", raw_score: 1000, score: 1000, predicted_score: 999 }
     @assignment.update(pass_fail: true)
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => 1, "pass_fail_status" => "passed", "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => 1, "pass_fail_status" => "passed", "raw_score" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "does not include assignments with no points" do

--- a/spec/views/info/grading_status_spec.rb
+++ b/spec/views/info/grading_status_spec.rb
@@ -40,7 +40,7 @@ describe "info/grading_status" do
     end
   end
 
-  describe "with in progress grades" do
+  describe "with in progress grades"  do
     before(:each) do
       @grades = [create(:in_progress_grade, course: @course, assignment: @assignment, student: @student)]
       @ungraded_submissions_by_assignment = []


### PR DESCRIPTION
This patch resolves an issue in the predictor where weighted assignments with grades were showing the weights applied to the final score, which effectively doubled the weighting.

The new behavior is such that:

  * All predictor widgets now show the raw score, unaffected by weighting.
  * Weighting is shown and calculated at the assignment type level only
  * The Earned Points bar graph shows total earned points with no weights
  * The Predicted Points bar graph updates with changes to the weights, and shows the weights calculated on both earned and predicted grades.