### PR TITLE
Patch rubric stack errors resulting from extraneous touch: true calls

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,12 +1,12 @@
 class Metric < ActiveRecord::Base
-  belongs_to :rubric, touch: true
+  belongs_to :rubric
   has_many :tiers, dependent: :destroy
 
   has_many :metric_badges
   has_many :badges, through: :metric_badges
 
   has_many :rubric_grades
-  belongs_to :full_credit_tier, foreign_key: :full_credit_tier_id, class_name: "Tier", touch: true
+  belongs_to :full_credit_tier, foreign_key: :full_credit_tier_id, class_name: "Tier"
   attr_accessible :name, :max_points, :description, :order, :rubric_id, :full_credit_tier_id
   attr_accessor :add_default_tiers
 

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,5 +1,5 @@
 class Tier < ActiveRecord::Base
-  belongs_to :metric, :counter_cache => true, touch: true
+  belongs_to :metric
   has_many :tier_badges
   has_many :badges, through: :tier_badges
   has_many :rubric_grades

--- a/app/models/tier_badge.rb
+++ b/app/models/tier_badge.rb
@@ -1,6 +1,6 @@
 class TierBadge < ActiveRecord::Base
-  belongs_to :tier, touch: true
-  belongs_to :badge, touch: true
+  belongs_to :tier
+  belongs_to :badge
 
   attr_accessible :tier_id, :badge_id
 


### PR DESCRIPTION
Fixes the issues we were having with stack depth errors coming up around Rubrics because of touch: true being called on belongs_to associations. Was likely an issue caused by mis-configured or untested caching attempts. The need to address additional touch: true calls across the app is addressed in issue #1291.

This has been deployed to and testing in staging and seems to resolve the corresponding stack depth exception issues.

![image](https://cloud.githubusercontent.com/assets/95957/10864037/a39f0a2a-7fe0-11e5-83b6-c34363bd3f24.png)