### PR TITLE
current_course was being called inside User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -390,8 +390,8 @@ class User < ActiveRecord::Base
           end
           total_score += earned_badge_score_for_course(course_id)
           # @mz todo: refactor this mo
-          # don't need to check current_course.add_team_score_to_student? because that's being called above
-          unless current_course.team_score_average
+          # don't need to check .add_team_score_to_student? because that's being called above
+          unless course.team_score_average
             total_score += (self.team_for_course(course_id).try(:score) || 0)
           end
         )
@@ -422,8 +422,8 @@ class User < ActiveRecord::Base
           end
           total_score += earned_badge_score_for_course(course_id)
 
-          # don't need to check current_course.add_team_score_to_student? because that's being called above
-          unless current_course.team_score_average
+          # don't need to check .add_team_score_to_student? because that's being called above
+          unless course.team_score_average
             total_score += (self.team_for_course(course_id).try(:score) || 0)
           end
         )


### PR DESCRIPTION
This fixes the error where current_course was being called inside the User model in cache_course_score or the ScoreRecalculator method. Should repair the job error that was happening in production.