### PR TITLE
1165 not automatically instructor of record

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -124,7 +124,8 @@ class CoursesController < ApplicationController
     respond_to do |format|
       if @course.save
         if ! current_user_is_admin?
-          @course.course_memberships.create(:user_id => current_user.id, :role => current_user.role(current_course), instructor_of_record: true)
+          @course.course_memberships.create(user_id: current_user.id,
+                                            role: current_user.role(current_course))
         end
         session[:course_id] = @course.id
         bust_course_list_cache current_user

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -24,10 +24,8 @@ class CourseMembership < ActiveRecord::Base
       case extra['roles'].downcase
       when /instructor/
         self.update_attribute(:role, 'professor')
-        self.update_attribute(:instructor_of_record, true)
       when /teachingassistant/
         self.update_attribute(:role, 'gsi')
-        self.update_attribute(:instructor_of_record, true)
       else
         self.update_attribute(:role, 'student')
         self.update_attribute(:instructor_of_record, false)

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -1,23 +1,4 @@
 namespace :courses do
-  desc "Initializes the instructors of record for all existing courses"
-  task :update_instructors_of_record => :environment do
-    all = []
-    CourseMembership.find_each do |membership|
-      membership.update_attribute :instructor_of_record, false
-    end
-
-    Course.find_each do |course|
-      course_membership = course.course_memberships.where(role: "professor").first
-      if course_membership
-        course_membership.instructor_of_record = true
-        course_membership.save
-        all << course_membership
-      end
-    end
-
-    puts "\nSuccessfully updates all #{all.count} #{"course".pluralize(all.count)}."
-  end
-
   desc "Updates all the administrators in the system to have access to all courses"
   task :update_admins => :environment do
     courses = Course.all


### PR DESCRIPTION
This PR removes the automatic assigning of the instructors of record to when the user that created the course. In addition, it does not assign professors when LTI authorization occurs.

All professors of record are now manually updated via the `course#edit` view.

Closes #1165 