### PR TITLE
Update documentation for mail

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
+mailcatcher: bundle exec mailcatcher -f
 web: bundle exec puma -p $PORT
 redis: redis-server --port $REDIS_PORT
 resque_scheduler: bundle exec rake resque:scheduler

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ To run all of the spec examples with code coverage, you can run the following:
 bundle exec rake spec:coverage
 ```
 
+## Viewing email
+
+The application is using [Mailcatcher](http://mailcatcher.me/) to collect email on development.
+
+Mailcatcher runs a daemon in the background which is started by Foreman and opens up an SMTP port on `localhost:1025`.
+
+In order to view the emails that are sent, you can visit `http://localhost:1080` to view emails that were delivered by the application.
+
 ## Contributing
 
 1. Clone the repository `git clone https://github.com/UM-USElab/gradecraft-development`


### PR DESCRIPTION
Update the [README](https://github.com/UM-USElab/gradecraft-development/blob/36eb93e8622936ab63dac8d943f470be308dd03c/README.md) to document how a developer can view the sent email. 

Update the [Procfile](https://github.com/UM-USElab/gradecraft-development/blob/36eb93e8622936ab63dac8d943f470be308dd03c/Procfile) so that it starts [mailcatcher](http://mailcatcher.me) automatically.