### PR TITLE
1303 editable submissions bug

### DIFF
--- a/app/views/submissions/_student_show.haml
+++ b/app/views/submissions/_student_show.haml
@@ -1,8 +1,7 @@
 %br
 
 - if presenter.assignment.is_individual?
-  - if (presenter.assignment.open? && !presenter.grades_available_for?(current_student)) ||
-    (presenter.assignment.open? && presenter.assignment.resubmissions_allowed?)
+  - if (presenter.assignment.open? && !presenter.grades_available_for?(current_student)) || (presenter.assignment.open? && presenter.assignment.resubmissions_allowed?)
 
     = link_to "Edit My Submission", edit_assignment_submission_path(presenter.assignment, presenter.submission_for_assignment(current_student)), :class => "button"
     .clear

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -1,0 +1,22 @@
+require "rails_spec_helper"
+
+feature "viewing submissions" do
+  context "as a student" do
+    let!(:submission) do
+      create :submission, course: membership.course, assignment: assignment, student: student
+    end
+
+    let(:assignment) { create :assignment, accepts_submissions: true, course: membership.course }
+    let(:membership) { create :student_course_membership, user: student }
+    let(:student) { create :user }
+
+    before do
+      login_as student
+      visit assignment_path assignment
+    end
+
+    scenario "allows an editable submission if it's before the due date" do
+      expect(find_link("Edit My Submission")).to be_visible
+    end
+  end
+end

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -72,6 +72,7 @@ RSpec.configure do |config|
   config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
   config.include Sorcery::TestHelpers::Rails::Integration, type: :feature
   config.include GradeCraft::Matchers::Integration, type: :feature
+  config.include GradeCraft::Integration::TestHelpers::Authentication, type: :feature
 
   config.include BackgroundJobs
   config.tty = true

--- a/spec/support/integration/authentication.rb
+++ b/spec/support/integration/authentication.rb
@@ -1,0 +1,12 @@
+module GradeCraft
+  module Integration
+    module TestHelpers
+      module Authentication
+        def login_as(user, password="secret")
+          params = { user: { email: user.email, password: password }}
+          page.driver.send(:post, user_sessions_path, params)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed a display issue that allowed students to edit their submission if they are before the due date. This was due to a Haml parser issue for the if statement in the view.

A feature spec was also added to ensure that the edit option is available to a student for their submission.

Fixes #1303