### PR TITLE
1276 assignments controller

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -38,7 +38,7 @@ class AssignmentsController < ApplicationController
       render :show, AssignmentPresenter.build({ assignment: assignment, course: current_course,
                                                 team_id: params[:team_id], view_context: view_context })
     else
-      redirect_to assignments_path, alert: "I'm so sorry, I couldn't find that #{(term_for :assignment)}."
+      redirect_to assignments_path, alert: "The #{(term_for :assignment)} could not be found."
     end
   end
 
@@ -377,22 +377,6 @@ class AssignmentsController < ApplicationController
 
   def team_params
     @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
-  end
-
-  def serialized_rubric_grades
-    ActiveModel::ArraySerializer.new(fetch_rubric_grades, each_serializer: ExistingRubricGradesSerializer).to_json
-  end
-
-  def fetch_rubric_grades
-    RubricGrade.where(fetch_rubric_grades_params)
-  end
-
-  def fetch_rubric_grades_params
-    { student_id: params[:student_id], assignment_id: params[:assignment_id], metric_id: existing_metric_ids }
-  end
-
-  def existing_metric_ids
-    rubric_metrics_with_tiers.collect {|metric| metric[:id] }
   end
 
   def find_or_create_assignment_rubric

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -232,73 +232,6 @@ class AssignmentsController < ApplicationController
     end
   end
 
-  private
-
-    def predictor_assignments_data
-      @assignments = current_course.assignments.select(
-        :accepts_resubmissions_until,
-        :accepts_submissions,
-        :accepts_submissions_until,
-        :assignment_type_id,
-        :course_id,
-        :description,
-        :due_at,
-        :grade_scope,
-        :id,
-        :include_in_predictor,
-        :name,
-        :open_at,
-        :pass_fail,
-        :point_total,
-        :points_predictor_display,
-        :position,
-        :release_necessary,
-        :required,
-        :resubmissions_allowed,
-        :student_logged,
-        :thumbnail,
-        :use_rubric,
-        :visible,
-        :visible_when_locked
-      )
-    end
-
-    def predictor_grades(student)
-      @grades = student.grades.where(:course_id => current_course).select(
-        :assignment_id,
-        :final_score,
-        :id,
-        :predicted_score,
-        :pass_fail_status,
-        :status,
-        :student_id,
-        :raw_score,
-        :score
-      )
-    end
-
-    def team_params
-      @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
-    end
-
-    def serialized_rubric_grades
-      ActiveModel::ArraySerializer.new(fetch_rubric_grades, each_serializer: ExistingRubricGradesSerializer).to_json
-    end
-
-    def fetch_rubric_grades
-      RubricGrade.where(fetch_rubric_grades_params)
-    end
-
-    def fetch_rubric_grades_params
-      { student_id: params[:student_id], assignment_id: params[:assignment_id], metric_id: existing_metric_ids }
-    end
-
-    def existing_metric_ids
-      rubric_metrics_with_tiers.collect {|metric| metric[:id] }
-    end
-
-  public
-
   def destroy
     @assignment = current_course.assignments.find(params[:id])
     @name = @assignment.name
@@ -321,7 +254,6 @@ class AssignmentsController < ApplicationController
   end
 
   def export_submissions
-
     @assignment = current_course.assignments.find(params[:id])
 
     if params[:team_id].present?
@@ -402,6 +334,69 @@ class AssignmentsController < ApplicationController
 
   private
 
+  def predictor_assignments_data
+    @assignments = current_course.assignments.select(
+      :accepts_resubmissions_until,
+      :accepts_submissions,
+      :accepts_submissions_until,
+      :assignment_type_id,
+      :course_id,
+      :description,
+      :due_at,
+      :grade_scope,
+      :id,
+      :include_in_predictor,
+      :name,
+      :open_at,
+      :pass_fail,
+      :point_total,
+      :points_predictor_display,
+      :position,
+      :release_necessary,
+      :required,
+      :resubmissions_allowed,
+      :student_logged,
+      :thumbnail,
+      :use_rubric,
+      :visible,
+      :visible_when_locked
+    )
+  end
+
+  def predictor_grades(student)
+    @grades = student.grades.where(:course_id => current_course).select(
+      :assignment_id,
+      :final_score,
+      :id,
+      :predicted_score,
+      :pass_fail_status,
+      :status,
+      :student_id,
+      :raw_score,
+      :score
+    )
+  end
+
+  def team_params
+    @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
+  end
+
+  def serialized_rubric_grades
+    ActiveModel::ArraySerializer.new(fetch_rubric_grades, each_serializer: ExistingRubricGradesSerializer).to_json
+  end
+
+  def fetch_rubric_grades
+    RubricGrade.where(fetch_rubric_grades_params)
+  end
+
+  def fetch_rubric_grades_params
+    { student_id: params[:student_id], assignment_id: params[:assignment_id], metric_id: existing_metric_ids }
+  end
+
+  def existing_metric_ids
+    rubric_metrics_with_tiers.collect {|metric| metric[:id] }
+  end
+
   def find_or_create_assignment_rubric
     @assignment.rubric || Rubric.create(assignment_id: @assignment[:id])
   end
@@ -431,5 +426,4 @@ class AssignmentsController < ApplicationController
   def rubric_metrics_with_tiers
     @rubric.metrics.order(:order)
   end
-
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -379,14 +379,6 @@ class AssignmentsController < ApplicationController
     @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
   end
 
-  def find_or_create_assignment_rubric
-    @assignment.rubric || Rubric.create(assignment_id: @assignment[:id])
-  end
-
-  def assignment_params
-    params.require(:assignment).permit(:assignment_rubrics_attributes => [:id, :rubric_id, :_destroy])
-  end
-
   def set_assignment_weights
     return unless @assignment.student_weightable?
     @assignment.weights = current_course.students.map do |student|
@@ -395,17 +387,5 @@ class AssignmentsController < ApplicationController
       assignment_weight
     end
     @assignment.save
-  end
-
-  def serialized_course_badges
-    MultiJson.dump(ActiveModel::ArraySerializer.new(course_badges, each_serializer: CourseBadgeSerializer))
-  end
-
-  def course_badges
-    @course_badges ||= @assignment.course.badges.visible
-  end
-
-  def rubric_metrics_with_tiers
-    @rubric.metrics.order(:order)
   end
 end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,7 +1,5 @@
 class AssignmentsController < ApplicationController
-
-  before_filter :ensure_staff?, :except => [:show, :index, :description_and_downloads, :predictor_data]
-
+  before_filter :ensure_staff?, :except => [:show, :index, :predictor_data]
   respond_to :html, :json
 
   def index

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -56,50 +56,9 @@ class AssignmentsController < ApplicationController
 
   # Duplicate an assignment - important for super repetitive items like attendance and reading reactions
   def copy
-    session[:return_to] = request.referer
-    @assignment = current_course.assignments.find(params[:id])
-    new_assignment = @assignment.dup
-    new_assignment.name.prepend("Copy of ")
-    new_assignment.save
-    if @assignment.assignment_score_levels.present?
-      @assignment.assignment_score_levels.each do |asl|
-        new_asl = asl.dup
-        new_asl.assignment_id = new_assignment.id
-        new_asl.save
-      end
-    end
-    if @assignment.rubric.present?
-      new_rubric = @assignment.rubric.dup
-      new_rubric.assignment_id = new_assignment.id
-      new_rubric.save
-      if @assignment.rubric.metrics.present?
-        @assignment.rubric.metrics.each do |metric|
-          new_metric = metric.dup
-          new_metric.rubric_id = new_rubric.id
-          new_metric.add_default_tiers = false
-          new_metric.save
-          if metric.tiers.present?
-            metric.tiers.each do |tier|
-              new_tier = tier.dup
-              new_tier.metric_id = new_metric.id
-              new_tier.save
-              if tier.tier_badges.present?
-                tier.tier_badges.each do |tier_badge|
-                  new_tier_badge = tier_badge.dup
-                  new_tier_badge.tier_id = new_tier.id
-                  new_tier_badge.save
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-    if session[:return_to].present?
-      redirect_to session[:return_to]
-    else
-      redirect_to assignments_path
-    end
+    assignment = current_course.assignments.find(params[:id])
+    duplicated = assignment.copy
+    redirect_to assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
   end
 
   def create

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -105,6 +105,15 @@ class Assignment < ActiveRecord::Base
 
   scope :released, ->(student) { where('EXISTS (SELECT 1 FROM released_grades WHERE ((released_grades.assignment_id = assignments.id) AND (released_grades.student_id = ?)))', student.id) }
 
+  def copy
+    copy = self.dup
+    copy.name.prepend "Copy of "
+    copy.save unless self.new_record?
+    copy.assignment_score_levels << self.assignment_score_levels.map(&:copy)
+    copy.rubric = self.rubric.copy if self.rubric.present?
+    copy
+  end
+
   def to_json(options = {})
     super(options.merge(:only => [ :id, :content, :order, :done ] ))
   end

--- a/app/models/assignment_score_level.rb
+++ b/app/models/assignment_score_level.rb
@@ -6,12 +6,16 @@ class AssignmentScoreLevel < ActiveRecord::Base
   validates_presence_of :value, :name
 
   validates_associated :assignment
-  
+
   scope :order_by_value, -> { order 'value DESC' }
 
   #Displaying the name and the point value together in grading lists
   def formatted_name
     "#{name} (#{value} points)"
+  end
+
+  def copy
+    self.dup
   end
 
 end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -24,6 +24,14 @@ class Metric < ActiveRecord::Base
     description.nil? or description.blank?
   end
 
+  def copy
+    copy = self.dup
+    copy.add_default_tiers = false
+    copy.save unless self.new_record?
+    copy.tiers << self.tiers.map(&:copy)
+    copy
+  end
+
   include DisplayHelpers
 
   protected

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -16,4 +16,11 @@ class Rubric < ActiveRecord::Base
   def designed?
     metrics.count > 0
   end
+
+  def copy
+    copy = self.dup
+    copy.save unless self.new_record?
+    copy.metrics << self.metrics.map(&:copy)
+    copy
+  end
 end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -13,4 +13,11 @@ class Tier < ActiveRecord::Base
 
   include DisplayHelpers
 
+  def copy
+    copy = self.dup
+    copy.save unless self.new_record?
+    copy.badges << self.badges.map(&:dup)
+    copy
+  end
+
 end

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -6,6 +6,7 @@
           %i.fa.fa-plus.fa-fw
           New #{(term_for :assignment).titleize}
       %li= link_to raw('<i class="fa fa-edit fa-fw"> </i> Edit'), edit_assignment_path(presenter.assignment)
+      %li= link_to raw('<i class="fa fa-copy fa-fw"> </i> Copy'), copy_assignments_path(id: presenter.assignment), method: :copy
       - if presenter.assignment.has_groups?
         %li= link_to raw("<i class='fa fa-users fa-fw'> </i> Create #{term_for :group}"), new_group_path
       - if presenter.for_team? && !presenter.rubric_available?

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -83,6 +83,25 @@ describe AssignmentsController do
         expect(duplicated.assignment_score_levels.first.name).to eq "Level 1"
         expect(duplicated.assignment_score_levels.first.value).to eq 10_000
       end
+
+      it "duplicates rubrics" do
+        @assignment.create_rubric
+        @assignment.rubric.metrics.create name: "Rubric 1", max_points: 10_000, order: 1
+        @assignment.rubric.metrics.first.tiers.first.tier_badges.create
+        post :copy, id: @assignment.id
+        duplicated = Assignment.last
+        expect(duplicated.rubric).to_not be_nil
+        expect(duplicated.rubric.metrics.first.name).to eq "Rubric 1"
+        expect(duplicated.rubric.metrics.first.tiers.first.name).to eq "Full Credit"
+        expect(duplicated.rubric.metrics.first.tiers.first.tier_badges.count).to \
+          eq 1
+      end
+
+      it "redirects to the referer" do
+        allow(request).to receive(:referer).and_return assignments_path
+        post :copy, id: @assignment.id
+        expect(response).to redirect_to(assignments_path)
+      end
     end
 
     describe "POST create" do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -93,7 +93,7 @@ describe AssignmentsController do
       it "duplicates rubrics" do
         @assignment.create_rubric
         @assignment.rubric.metrics.create name: "Rubric 1", max_points: 10_000, order: 1
-        @assignment.rubric.metrics.first.tiers.first.tier_badges.create
+        @assignment.rubric.metrics.first.tiers.first.badges.create! name: "Blah", course: @course
         post :copy, id: @assignment.id
         duplicated = Assignment.last
         expect(duplicated.rubric).to_not be_nil
@@ -103,10 +103,10 @@ describe AssignmentsController do
           eq 1
       end
 
-      it "redirects to the referer" do
-        allow(request).to receive(:referer).and_return assignments_path
+      it "redirects to the duplicated assignment" do
         post :copy, id: @assignment.id
-        expect(response).to redirect_to(assignments_path)
+        duplicated = Assignment.last
+        expect(response).to redirect_to(assignment_path(duplicated))
       end
     end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -134,6 +134,11 @@ describe AssignmentsController do
         expect(@assignment.reload.name).to eq("new name")
       end
 
+      it "renders the template again if there are validation errors" do
+        post :update, id: @assignment.id, assignment: { name: "" }
+        expect(response).to render_template(:edit)
+      end
+
       it "manages file uploads" do
         params = {:assignment_files_attributes => {"0" => {"file" => [fixture_file('test_file.txt', 'txt')]}}}
         post :update, id: @assignment.id, :assignment => params

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -288,6 +288,13 @@ describe AssignmentsController do
           get :export_submissions, :id => @assignment, :format => :zip
           expect(response.content_type).to eq("application/zip")
         end
+
+        it "uses the team name was specified" do
+          team = create(:team, course: @course)
+          team.students << create(:user)
+          get :export_submissions, id: @assignment, team_id: team.id, :format => :zip
+          expect(response.headers["Content-Disposition"]).to eq "attachment; filename=\"#{@assignment.name}_#{team.name}.zip\""
+        end
       end
     end
   end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -70,6 +70,12 @@ describe AssignmentsController do
     end
 
     describe "POST copy" do
+      before(:each) do
+        Assignment.delete_all
+        @assignment =
+          create(:assignment, assignment_type: @assignment_type, course: @course)
+      end
+
       it "duplicates an assignment" do
         post :copy, id: @assignment.id
         expect expect(@course.assignments.count).to eq(2)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -74,6 +74,15 @@ describe AssignmentsController do
         post :copy, id: @assignment.id
         expect expect(@course.assignments.count).to eq(2)
       end
+
+      it "duplicates score levels" do
+        @assignment.assignment_score_levels.create(name: "Level 1", value: 10_000)
+        post :copy, id: @assignment.id
+        duplicated = Assignment.last
+        expect(duplicated.id).to_not eq @assignment.id
+        expect(duplicated.assignment_score_levels.first.name).to eq "Level 1"
+        expect(duplicated.assignment_score_levels.first.value).to eq 10_000
+      end
     end
 
     describe "POST create" do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -71,7 +71,7 @@ describe AssignmentsController do
 
     describe "POST copy" do
       it "duplicates an assignment" do
-        post :copy, :id => @assignment.id
+        post :copy, id: @assignment.id
         expect expect(@course.assignments.count).to eq(2)
       end
     end
@@ -274,6 +274,12 @@ describe AssignmentsController do
         get :show, :id => @assignment.id
         expect(grade.reload).to be_feedback_reviewed
       end
+
+      it "redirects to the assignments path of the assignment does not exist for the current course" do
+        another_assignment = create(:assignment)
+        get :show, id: another_assignment.id
+        expect(response).to redirect_to assignments_path
+      end
     end
 
     describe "GET predictor_data" do
@@ -419,4 +425,3 @@ def predictor_assignment_attributes
     :visible_when_locked
   ]
 end
-

--- a/spec/factories/tier_factory.rb
+++ b/spec/factories/tier_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :tier do
+    name Faker::Lorem.word
+    points Faker::Number.number(4)
+    association :metric
+  end
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -70,4 +70,38 @@ describe Assignment do
       expect(subject.grade_import(course.students)).to eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
     end
   end
+
+  describe "#copy" do
+    let(:assignment) { build :assignment }
+    subject { assignment.copy }
+
+    it "prepends the name with 'Copy of'" do
+      assignment.name = "Table of elements"
+      expect(subject.name).to eq "Copy of Table of elements"
+    end
+
+    it "makes a shallow copy of the fields" do
+      assignment.description = "This is a great assignment"
+      expect(subject.description).to eq "This is a great assignment"
+    end
+
+    it "saves the copy if the assignment is saved" do
+      assignment.save
+      expect(subject).to_not be_new_record
+    end
+
+    it "copies the assignment score levels" do
+      assignment.save
+      assignment.assignment_score_levels.create
+      expect(subject.assignment_score_levels.size).to eq 1
+      expect(subject.assignment_score_levels.map(&:assignment_id)).to eq [subject.id]
+    end
+
+    it "copies the rubric" do
+      assignment.save
+      assignment.build_rubric
+      expect(subject.rubric.assignment_id).to eq subject.id
+      expect(subject.rubric).to_not be_new_record
+    end
+  end
 end

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -3,6 +3,26 @@ require "active_record_spec_helper"
 describe Metric do
   subject { build(:metric) }
 
+  describe "#copy" do
+    let(:metric) { build :metric }
+    subject { metric.copy }
+
+    it "sets the default tiers to false" do
+      expect(subject.add_default_tiers).to eq false
+    end
+
+    it "saves the copy if the metric is copied" do
+      metric.save
+      expect(subject).to_not be_new_record
+    end
+
+    it "copies the tiers" do
+      metric.save
+      expect(subject.tiers.count).to eq 2 # default tiers already there
+      expect(subject.tiers.map(&:metric_id)).to eq [subject.id, subject.id]
+    end
+  end
+
   context "creation" do
     context "metric is flagged as duplicated" do
       it "should not create tiers" do

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -1,0 +1,15 @@
+require "active_record_spec_helper"
+
+describe Rubric do
+  describe "#copy" do
+    let(:rubric) { build :rubric }
+    subject { rubric.copy }
+
+    it "copies the metrics" do
+      rubric.save
+      rubric.metrics.create max_points: 10_000, name: "Metric ton", order: 1
+      expect(subject.metrics.size).to eq 1
+      expect(subject.metrics.map(&:rubric_id)).to eq [subject.id]
+    end
+  end
+end

--- a/spec/models/tier_spec.rb
+++ b/spec/models/tier_spec.rb
@@ -1,0 +1,15 @@
+require "active_record_spec_helper"
+
+describe Tier do
+  describe "#copy" do
+    let(:tier) { build :tier }
+    subject { tier.copy }
+
+    it "copies the badges for the tiers" do
+      tier.save
+      tier.badges.create! name: "Blah", course: create(:course)
+      expect(subject.badges.size).to eq 1
+      expect(subject.tier_badges.map(&:tier_id)).to eq [subject.id]
+    end
+  end
+end


### PR DESCRIPTION
Added test coverage for all the areas of the `AssignmentsController` except for the `export_submissions` method as that is getting a total refactoring via the [smart_archiver branch](https://github.com/UM-USElab/gradecraft-development/tree/smart_archiver).

This should improve the overall gpa for the controller and the code coverage but this issue should be left open so that it can be reviewed again once the `smart_archiver` branch is merged.

Helps with test coverage for #1276