### PR TITLE
Add improved logging for rescue conditions in CourseMembership

### DIFF
--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -4,6 +4,7 @@ class CourseMembership < ActiveRecord::Base
 
   # adds logging helpers for rescued-out errors
   include ModelAddons::ImprovedLogging
+  include ModelAddons::AdvancedRescue
 
   attr_accessible :auditing, :character_profile, :course, :course_id, :instructor_of_record, :user, :user_id, :role
 
@@ -78,22 +79,16 @@ class CourseMembership < ActiveRecord::Base
   private
 
   def assignment_type_totals_for_student
-    begin
+    rescue_with 0 do
       course.assignment_types.collect do |assignment_type|
         assignment_type.visible_score_for_student(user)
       end.compact.sum || 0
-    rescue
-      log_error_with_attributes("CourseMembership#assignment_type_totals_for_student was rescued to 0")
-      0
     end
   end
 
   def student_earned_badge_score
-    begin
+    rescue_with 0 do
       user.earned_badge_score_for_course(course_id) || 0
-    rescue
-      log_error_with_attributes("CourseMembership#student_earned_badge_score was rescued to 0")
-      0
     end
   end
 
@@ -102,11 +97,8 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def student_team_score
-    begin
+    rescue_with 0 do
       user.team_for_course(course_id).try(:score) || 0
-    rescue
-      log_error_with_attributes("CourseMembership#student_team_score was rescued to 0")
-      0
     end
   end
 

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -83,6 +83,7 @@ class CourseMembership < ActiveRecord::Base
         assignment_type.visible_score_for_student(user)
       end.compact.sum || 0
     rescue
+      log_error_with_attributes("CourseMembership#assignment_type_totals_for_student was rescued to 0")
       0
     end
   end
@@ -91,7 +92,7 @@ class CourseMembership < ActiveRecord::Base
     begin
       user.earned_badge_score_for_course(course_id) || 0
     rescue
-      log_with_attributes(:error, "CourseMembership#assignment_type_totals_for_student was rescued to 0")
+      log_error_with_attributes("CourseMembership#student_earned_badge_score was rescued to 0")
       0
     end
   end
@@ -104,6 +105,7 @@ class CourseMembership < ActiveRecord::Base
     begin
       user.team_for_course(course_id).try(:score) || 0
     rescue
+      log_error_with_attributes("CourseMembership#student_team_score was rescued to 0")
       0
     end
   end

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -79,7 +79,7 @@ class CourseMembership < ActiveRecord::Base
   private
 
   def assignment_type_totals_for_student
-    rescue_with 0 do
+    rescue_with_logging 0 do
       course.assignment_types.collect do |assignment_type|
         assignment_type.visible_score_for_student(user)
       end.compact.sum || 0
@@ -87,7 +87,7 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def student_earned_badge_score
-    rescue_with 0 do
+    rescue_with_logging 0 do
       user.earned_badge_score_for_course(course_id) || 0
     end
   end
@@ -97,7 +97,7 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def student_team_score
-    rescue_with 0 do
+    rescue_with_logging 0 do
       user.team_for_course(course_id).try(:score) || 0
     end
   end

--- a/lib/model_addons/advanced_rescue.rb
+++ b/lib/model_addons/advanced_rescue.rb
@@ -1,6 +1,6 @@
 module ModelAddons
   module AdvancedRescue
-    def rescue_with(returned_value, options={log_errors: true})
+    def rescue_with_logging(returned_value, options={log_errors: true})
       begin
         yield
       rescue
@@ -16,6 +16,7 @@ module ModelAddons
     end
 
     def caller_method
+      # get the method name from wherever rescue_with_logging was called
       caller_locations(4)[0].label
     end
   end

--- a/lib/model_addons/advanced_rescue.rb
+++ b/lib/model_addons/advanced_rescue.rb
@@ -1,0 +1,22 @@
+module ModelAddons
+  module AdvancedRescue
+    def rescue_with(returned_value, options={log_errors: true})
+      begin
+        yield
+      rescue
+        log_error_with_attributes(rescued_error_message(returned_value)) if options[:log_errors]
+        returned_value
+      end
+    end
+
+    protected
+
+    def rescued_error_message(value)
+      "#{self.class}##{caller_method} was rescued to #{value}"
+    end
+
+    def caller_method
+      caller_locations(4)[0].label
+    end
+  end
+end

--- a/lib/model_addons/improved_logging.rb
+++ b/lib/model_addons/improved_logging.rb
@@ -1,0 +1,19 @@
+module ModelAddons
+  module ImprovedLogging
+    def log_error_with_attributes(type=:info, message)
+      Rails.logger.send type, final_output(message)
+    end
+
+    def log_error_with_attributes(message)
+      log_with_attributes(:error, message)
+    end
+
+    protected
+    def final_log_output(message)
+      <<-output
+        #{message} in #{self}.
+        #{self} attributes: #{self.attributes}
+      output
+    end
+  end
+end

--- a/lib/model_addons/improved_logging.rb
+++ b/lib/model_addons/improved_logging.rb
@@ -2,9 +2,9 @@ module ModelAddons
   module ImprovedLogging
     def log_with_attributes(type=:info, message)
       if valid_logging_types.include? type # a valid logging type is being used
-        Rails.logger.send type, final_log_output(message)
+        Rails.logger.send type, formatted_log_output(message)
       else
-        Rails.logger.send :invalid, improper_logging_type_error
+        Rails.logger.send :error, invalid_logging_type_message
       end
     end
 
@@ -25,12 +25,12 @@ module ModelAddons
       [:debug, :info, :warn, :error, :fatal]
     end
 
-    def final_log_output(message)
+    def formatted_log_output(message)
       "#{message.capitalize} in object #{self}.\n#{self} attributes: #{self.attributes}"
     end
 
-    def invalid_logging_type_error
-      "Attempted to log with an incorrect type in ModelAddons::
+    def invalid_logging_type_message
+      formatted_log_output("Attempted to log with an incorrect type in ModelAddons::ImprovedLogging#log_with_attributes")
     end
   end
 end

--- a/lib/model_addons/improved_logging.rb
+++ b/lib/model_addons/improved_logging.rb
@@ -26,7 +26,7 @@ module ModelAddons
     end
 
     def formatted_log_output(message)
-      "#{message.capitalize} in object #{self}.\n#{self} attributes: #{self.attributes}"
+      "#{message} in object #{self}.\n#{self} attributes: #{self.attributes}"
     end
 
     def invalid_logging_type_message

--- a/lib/model_addons/improved_logging.rb
+++ b/lib/model_addons/improved_logging.rb
@@ -2,9 +2,9 @@ module ModelAddons
   module ImprovedLogging
     def log_with_attributes(type=:info, message)
       if valid_logging_types.include? type # a valid logging type is being used
-        Rails.logger.send type, formatted_log_output(message)
+        logger.send type, formatted_log_output(message)
       else
-        Rails.logger.send :error, invalid_logging_type_message
+        logger.send :error, invalid_logging_type_message
       end
     end
 

--- a/lib/model_addons/improved_logging.rb
+++ b/lib/model_addons/improved_logging.rb
@@ -1,19 +1,36 @@
 module ModelAddons
   module ImprovedLogging
-    def log_error_with_attributes(type=:info, message)
-      Rails.logger.send type, final_output(message)
+    def log_with_attributes(type=:info, message)
+      if valid_logging_types.include? type # a valid logging type is being used
+        Rails.logger.send type, final_log_output(message)
+      else
+        Rails.logger.send :invalid, improper_logging_type_error
+      end
     end
 
     def log_error_with_attributes(message)
       log_with_attributes(:error, message)
     end
 
+    def log_info_with_attributes(message)
+      log_with_attributes(:info, message)
+    end
+
+    def log_warning_with_attributes(message)
+      log_with_attributes(:warn, message)
+    end
+
     protected
+    def valid_logging_types
+      [:debug, :info, :warn, :error, :fatal]
+    end
+
     def final_log_output(message)
-      <<-output
-        #{message} in #{self}.
-        #{self} attributes: #{self.attributes}
-      output
+      "#{message.capitalize} in object #{self}.\n#{self} attributes: #{self.attributes}"
+    end
+
+    def invalid_logging_type_error
+      "Attempted to log with an incorrect type in ModelAddons::
     end
   end
 end

--- a/lib/resque_job/base.rb
+++ b/lib/resque_job/base.rb
@@ -1,6 +1,7 @@
 require 'resque-retry'
 require 'resque/errors'
 
+# mz todo: move a lot of this logic into an ApplicationJob file in /app/background_jobs
 module ResqueJob
   class Base
     # add resque-retry for all jobs

--- a/spec/lib/model_addons/advanced_rescue_spec.rb
+++ b/spec/lib/model_addons/advanced_rescue_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_spec_helper'
+
+# test logging on a waffle
+class Pancake
+  include ModelAddons::ImprovedLogging
+  include ModelAddons::AdvancedRescue
+
+  def logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  def attributes
+    { some_attr: "great_stuff" }
+  end
+
+  def failed_method
+    rescue_with "well that failed" do
+      raise "this block totally failed error"
+    end
+  end
+
+  def failed_method_no_logging
+    rescue_with "well that failed", log_errors: false do
+      raise "this block totally failed error"
+    end
+  end
+
+  def successful_method
+    rescue_with "better than nothing" do
+      "some normal output"
+    end
+  end
+
+  def contrived_caller_parent
+    caller_method
+  end
+end
+
+RSpec.describe ModelAddons::AdvancedRescue, type: :vendor_library do
+  before { @pancake= Pancake.new }
+
+  describe "rescue_with" do
+    context "the block yield raises an error" do
+      subject { @pancake.failed_method }
+
+      it "rescues out to a returned value" do
+        expect(subject).to eq("well that failed")
+      end
+
+      context "log_errors is true" do
+        it "logs an error with caller attributes" do
+          expect(@pancake).to receive(:log_error_with_attributes)
+          subject
+        end
+      end
+
+      context "log_errors is false" do
+        subject { @pancake.failed_method_no_logging }
+
+        it "doesn't log the error" do
+          expect(@pancake).not_to receive(:log_error_with_attributes)
+          subject
+        end
+      end
+    end
+
+    context "the block yield succeeds without error" do
+      subject { @pancake.successful_method }
+
+      it "returns the value of the block" do
+        expect(subject).to eq("some normal output")
+      end
+    end
+  end
+
+  describe "error_message" do
+    it "returns a formatted error message for logging" do
+      expected_message = "Pancake#some_weird_method was rescued to badger mouths"
+      allow(@pancake).to receive(:caller_method) { "some_weird_method" }
+      expect(@pancake.instance_eval { rescued_error_message("badger mouths") }).to eq(expected_message)
+    end
+  end
+
+  describe "#caller_method" do
+    it "returns the name of the containing parent method from the model" do
+      expect(@pancake.instance_eval { contrived_caller_parent }).to eq("contrived_caller_parent")
+    end
+  end
+end

--- a/spec/lib/model_addons/advanced_rescue_spec.rb
+++ b/spec/lib/model_addons/advanced_rescue_spec.rb
@@ -14,26 +14,27 @@ class Pancake
   end
 
   def failed_method
-    rescue_with "well that failed" do
+    rescue_with_logging "well that failed" do
       raise "this block totally failed error"
     end
   end
 
   def failed_method_no_logging
-    rescue_with "well that failed", log_errors: false do
+    rescue_with_logging "well that failed", log_errors: false do
       raise "this block totally failed error"
     end
   end
 
   def successful_method
-    rescue_with "better than nothing" do
+    rescue_with_logging "better than nothing" do
       "some normal output"
     end
   end
 
-  def contrived_caller_parent
-    caller_method
-  end
+  def caller_parent4; caller_parent3; end
+  def caller_parent3; caller_parent2; end
+  def caller_parent2; caller_parent1; end
+  def caller_parent1; caller_method; end
 end
 
 RSpec.describe ModelAddons::AdvancedRescue, type: :vendor_library do
@@ -83,7 +84,7 @@ RSpec.describe ModelAddons::AdvancedRescue, type: :vendor_library do
 
   describe "#caller_method" do
     it "returns the name of the containing parent method from the model" do
-      expect(@pancake.instance_eval { contrived_caller_parent }).to eq("contrived_caller_parent")
+      expect(@pancake.instance_eval { caller_parent4 }).to eq("caller_parent4")
     end
   end
 end

--- a/spec/lib/model_addons/improved_logging_spec.rb
+++ b/spec/lib/model_addons/improved_logging_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_spec_helper'
+
+# test logging on a waffle
+class Waffle
+  include ModelAddons::ImprovedLogging
+
+  def logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  def attributes
+    { some_attr: "great_stuff" }
+  end
+end
+
+RSpec.describe ModelAddons::ImprovedLogging, type: :vendor_library do
+  before { @waffle = Waffle.new }
+
+  describe "log_with_attributes" do
+    context "called with a valid logging type" do
+      it "logs a message with the correct type and output" do
+        allow(@waffle).to receive(:formatted_log_output) { "formatted snakes are great" }
+        expect(@waffle.logger).to receive(:send).with(:info, "formatted snakes are great")
+        @waffle.log_with_attributes(:info, "this is being stubbed over")
+      end
+    end
+
+    context "called with an invalid logging type" do
+      it "logs an error message" do
+        allow(@waffle).to receive(:invalid_logging_type_message) { "this is not a valid logger type" }
+        expect(@waffle.logger).to receive(:send).with(:error, "this is not a valid logger type")
+        @waffle.log_with_attributes(:invalid_type, "this is being stubbed over")
+      end
+    end
+  end
+
+  describe "log_error_with_attributes" do
+    it "logs a message with type :error" do
+      expect(@waffle).to receive(:log_with_attributes).with(:error, "error stuff")
+      @waffle.log_error_with_attributes("error stuff")
+    end
+  end
+
+  describe "log_info_with_attributes" do
+    it "logs a message with type :info" do
+      expect(@waffle).to receive(:log_with_attributes).with(:info, "info stuff")
+      @waffle.log_info_with_attributes("info stuff")
+    end
+  end
+
+  describe "log_warning_with_attributes" do
+    it "logs a message with type :warn" do
+      expect(@waffle).to receive(:log_with_attributes).with(:warn, "warning stuff")
+      @waffle.log_warning_with_attributes("warning stuff")
+    end
+  end
+
+  describe "valid_logging_types" do
+    it "returns an array of the valid logging message types" do
+      expect(@waffle.instance_eval { valid_logging_types }).to eq([:debug, :info, :warn, :error, :fatal])
+    end
+  end
+
+  describe "formatted_log_output" do
+    it "formats the logger message" do
+    end
+  end
+
+  describe "invalid_logging_type_message" do
+    it "returns a formatted message regarding the logging error" do
+      message = "Attempted to log with an incorrect type in ModelAddons::ImprovedLogging#log_with_attributes"
+      expect(@waffle).to receive(:formatted_log_output).with(message)
+      @waffle.instance_eval { invalid_logging_type_message }
+    end
+  end
+end

--- a/spec/lib/model_addons/improved_logging_spec.rb
+++ b/spec/lib/model_addons/improved_logging_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ModelAddons::ImprovedLogging, type: :vendor_library do
 
   describe "formatted_log_output" do
     it "formats the logger message" do
-      expected_message = "Robbers are here!! in object #{@waffle}.\n#{@waffle} attributes: #{@waffle.attributes}"
+      expected_message = "robbers are here!! in object #{@waffle}.\n#{@waffle} attributes: #{@waffle.attributes}"
       expect(@waffle.instance_eval { formatted_log_output("robbers are here!!") }).to eq(expected_message)
     end
   end

--- a/spec/lib/model_addons/improved_logging_spec.rb
+++ b/spec/lib/model_addons/improved_logging_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe ModelAddons::ImprovedLogging, type: :vendor_library do
   describe "log_with_attributes" do
     context "called with a valid logging type" do
       it "logs a message with the correct type and output" do
-        allow(@waffle).to receive(:formatted_log_output) { "formatted snakes are great" }
-        expect(@waffle.logger).to receive(:send).with(:info, "formatted snakes are great")
-        @waffle.log_with_attributes(:info, "this is being stubbed over")
+        formatted_output = @waffle.instance_eval { formatted_log_output("snakes are great") }
+        expect(@waffle.logger).to receive(:send).with(:info, formatted_output)
+        @waffle.log_with_attributes(:info, "snakes are great")
       end
     end
 
     context "called with an invalid logging type" do
       it "logs an error message" do
-        allow(@waffle).to receive(:invalid_logging_type_message) { "this is not a valid logger type" }
-        expect(@waffle.logger).to receive(:send).with(:error, "this is not a valid logger type")
-        @waffle.log_with_attributes(:invalid_type, "this is being stubbed over")
+        invalid_logger_message = @waffle.instance_eval { invalid_logging_type_message }
+        expect(@waffle.logger).to receive(:send).with(:error, invalid_logger_message)
+        @waffle.log_with_attributes(:invalid_type, "snakes are erroneous")
       end
     end
   end
@@ -63,6 +63,8 @@ RSpec.describe ModelAddons::ImprovedLogging, type: :vendor_library do
 
   describe "formatted_log_output" do
     it "formats the logger message" do
+      expected_message = "Robbers are here!! in object #{@waffle}.\n#{@waffle} attributes: #{@waffle.attributes}"
+      expect(@waffle.instance_eval { formatted_log_output("robbers are here!!") }).to eq(expected_message)
     end
   end
 

--- a/spec/models/course_membership/student_score_recalculation_spec.rb
+++ b/spec/models/course_membership/student_score_recalculation_spec.rb
@@ -1,4 +1,4 @@
-require "active_record_spec_helper"
+require "rails_spec_helper"
 
 RSpec.describe CourseMembership do
   let(:course_membership) { build(:student_course_membership, course: course, user: student) }
@@ -66,10 +66,18 @@ RSpec.describe CourseMembership do
     end
 
     context "some error occurs in the collect block" do
-      it "rescues out to zero for posterity's sake" do
+      before(:each) do
         allow(assignment_type1).to receive(:visible_score_for_student).and_raise "a strange error that abandons the other number"
         allow(assignment_type2).to receive(:visible_score_for_student) { 1400 }
+      end
+
+      it "rescues out to zero for posterity's sake" do
         expect(subject).to eq(0)
+      end
+
+      it "logs an error with full object attributes" do
+        expect(course_membership).to receive(:log_error_with_attributes)
+        subject
       end
     end
   end
@@ -103,9 +111,17 @@ RSpec.describe CourseMembership do
     end
 
     context "student's earned badge score for the course raises an error" do
-      it "rescues out to zero" do
+      before(:each) do
         allow(student).to receive(:earned_badge_score_for_course).and_raise "some error"
+      end
+
+      it "rescues out to zero" do
         expect(subject).to eq(0)
+      end
+
+      it "logs an error with full object attributes" do
+        expect(course_membership).to receive(:log_error_with_attributes)
+        subject
       end
     end
 
@@ -128,9 +144,17 @@ RSpec.describe CourseMembership do
     end
 
     context "user#team_for_course raises an error" do
-      it "rescues out to zero" do
+      before(:each) do
         allow(student).to receive(:team_for_course).and_raise "some weird exception"
+      end
+
+      it "rescues out to zero" do
         expect(subject).to eq(0)
+      end
+
+      it "logs an error with full object attributes" do
+        expect(course_membership).to receive(:log_error_with_attributes)
+        subject
       end
     end
 


### PR DESCRIPTION
This Pull Requests adds a couple of new model helper modules in /lib/model_addons.

ModelAddons::ImprovedLogging adds a simple DSL for sending well-formatted messages to the rails logger with full attributes about the object being called from, as well as the attributes on this object. This will make it a lot easier to send advanced logging details to Loggly without having to duplicate logging formats or logging code in various places around the app.

ModelAddons::AdvancedRescue adds a simple DSL for wrapping blocks of codes in rescue_with_logging blocks, effectively adding logging and rescue behavior an entire block of code with a single call. rescue_with_logging intelligently constructs messages about the class name and method from which the rescue block is being performed, sends them to helper methods in ModelAddons::ImprovedLogging, logs the output, then returns whatever is requested in the rescue_with_logging argument.