### PR TITLE
1310 sidebar badge caching bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,7 @@ group :test do
   gem 'rspec-rails', '~> 3.3.3'
   # add spec helpers for testing Resque objects and resque scheduler
   gem 'resque_spec', github: 'leshill/resque_spec'
+  gem 'rspec-html-matchers'
   gem 'selenium-webdriver'
   gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,11 +510,18 @@ GEM
       resque (~> 1.25)
     rollbar (2.4.0)
       multi_json
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
+    rspec-html-matchers (0.7.0)
+      nokogiri (~> 1)
+      rspec (~> 3)
     rspec-mocks (3.3.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
@@ -731,6 +738,7 @@ DEPENDENCIES
   resque-throttler
   resque_spec!
   rollbar (~> 2.4.0)
+  rspec-html-matchers
   rspec-rails (~> 3.3.3)
   ruby-saml (~> 1.0.0)
   rubystats

--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -1,0 +1,17 @@
+module BadgesHelper
+  def sidebar_earned_badge(badge, student)
+    content_tag(:a) do
+      concat image_tag(badge.icon, alt: "You have earned the #{badge.name} badge", class: "earned")
+    end.concat(
+      content_tag(:div, nil, class: "display_on_hover hover-style right") do
+        hover_content = "#{badge.name}#{", #{points badge.point_total} points" if badge.point_total.present? && badge.point_total > 0}"
+        if badge.is_unlockable?
+          lock_icon_class = badge.is_unlockable_for_student?(student) ? "fa-unlock-alt" : "fa-lock"
+          concat content_tag(:i, hover_content, class: "fa #{lock_icon_class}")
+        else
+          concat hover_content
+        end
+      end
+    )
+  end
+end

--- a/app/views/students/sidebar/_sidebar_badges.haml
+++ b/app/views/students/sidebar/_sidebar_badges.haml
@@ -4,36 +4,13 @@
   %ul.block-grid
     - cache multi_cache_key :student_sidebar_badges, current_student, current_course do
       - current_student.unique_student_earned_badges(current_course).includes(:unlock_conditions).each do |badge|
-        - cache ["v1", badge] do
-          %li
-            - if badge.point_total.present? && badge.point_total > 0
-              - if badge.is_unlockable?
-                - if badge.is_unlocked_for_student?(current_student)
-                  %a
-                    %img{:src => badge.icon, :alt => "You've earned the #{badge.name} badge", :class => "earned" }
-                  .display_on_hover.hover-style.right
-                    %i.fa.fa-unlock-alt= " #{badge.name}, #{badge.point_total} points"
-                - else
-                  %a
-                    %img{:src => badge.icon, :alt => "You've earned the #{badge.name} badge", :class => "earned" }
-                  .display_on_hover.hover-style.right
-                    %i.fa.fa-lock= " #{badge.name}, #{badge.point_total} points"
-              - else
-                %a
-                  %img{:src => badge.icon, :alt => "You've earned the #{badge.name} badge", :class => "earned" }
-                .display_on_hover.hover-style.right
-                  ="#{badge.name}, #{badge.point_total} points"
-            - else
-              %a
-                %img{:src => badge.icon, :alt => "You've earned the #{badge.name} badge", :class => "earned"}
-              .display_on_hover.hover-style.right
-                = "#{badge.name}"
+        %li= sidebar_earned_badge badge, current_student
 
       - current_student.student_visible_unearned_badges(current_course).each do |badge|
         - cache ["v1", badge] do
           %li
             %a
-              %img{:src => badge.try(:icon), :alt => "#{badge.try(:name)}", :class => "unearned"}
+              %img{:src => badge.icon, :alt => badge.name, :class => "unearned"}
             .display_on_hover.hover-style.right
               = "Not yet earned: #{badge.name}"
 

--- a/spec/helpers/badges_helper_spec.rb
+++ b/spec/helpers/badges_helper_spec.rb
@@ -1,0 +1,50 @@
+require "rails_spec_helper"
+
+describe BadgesHelper do
+  include RSpecHtmlMatchers
+
+  describe "#sidebar_earned_badge" do
+    let(:badge) { double(:badge, name: "badgy", icon: "badge.png", is_unlockable?: false, point_total: nil) }
+    let(:student) { double(:user) }
+
+    it "renders an empty anchor" do
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "a"
+    end
+
+    it "renders the image for the badge" do
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "img",
+        with: { src: "http://localhost:5000/images/badge.png", class: "earned", alt: "You have earned the badgy badge" }
+    end
+
+    it "renders an unlock icon if it's unlocked by the student" do
+      allow(badge).to receive(:is_unlockable?).and_return true
+      allow(badge).to receive(:is_unlockable_for_student?).with(student).and_return true
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "i", with: { class: "fa-unlock-alt" }
+    end
+
+    it "renders a lock icon if it's unlockable but not yet unlocked" do
+      allow(badge).to receive(:is_unlockable?).and_return true
+      allow(badge).to receive(:is_unlockable_for_student?).with(student).and_return false
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "i", with: { class: "fa-lock" }
+    end
+
+    it "renders the badge name in a hover state" do
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "div", with: { class: "display_on_hover" } do
+        with_text "badgy"
+      end
+    end
+
+    it "renders the points earned if it has points" do
+      allow(badge).to receive(:point_total).and_return 10_000
+      html = helper.sidebar_earned_badge(badge, student)
+      expect(html).to have_tag "div", with: { class: "display_on_hover" } do
+        with_text "badgy, 10,000 points"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes an issue with earned badges for students not being displayed for the correct badges in the student sidebar. This was a result of a caching issue, specifically with [this line](https://github.com/UM-USElab/gradecraft-development/compare/1310-sidebar-badge-caching-bug?expand=1#diff-d417bb554af632ad4935a429ab72a52dL11). Since the badge was being cached, the check for inside the cached view fragment for if the student unlocked the badge, the badge was not being displayed correctly because it was cached.

I removed the caching of the badge itself.

In addition, I removed the logic from the view for rendering an earned badge icon and placed it inside a helper with tests to remove logic from the view (always a good thing).

Closes #1310