### PR TITLE
Revise conditions for notification mailing in grade updater jobs

### DIFF
--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -19,7 +19,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
 
   def require_notify_released_success
     # @mz TODO: chech the #is_student_visible? call with cait
-    if @grade.is_student_visible?
+    if @grade.assignment.notify_released? and @grade.is_student_visible? 
       require_success(notify_released_messages, max_result_size: 200) { notify_grade_released } 
     end
   end

--- a/app/performers/multiple_grade_update_performer.rb
+++ b/app/performers/multiple_grade_update_performer.rb
@@ -22,7 +22,7 @@ class MultipleGradeUpdatePerformer < ResqueJob::Performer
   end
 
   def require_notify_released_success(grade)
-    if grade.assignment.notify_released?
+    if grade.assignment.notify_released? and grade.is_student_visible?
       require_success(notify_released_messages(grade), max_result_size: 200) { notify_grade_released(grade) } 
     end
   end


### PR DESCRIPTION
This pull request modifies the notifications conditions in grade updater and multiple grade updater performers so that notifications are sent only if the grade is student visible and the assignment attached to the grade is marked as notify_released?.

Additionally the specs for both of these performers have been updated to reflect all of the necessary conditions for sending notifications related to grade updates.

