### PR TITLE
1293 rubric available calculation

### DIFF
--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -111,7 +111,7 @@ class AssignmentPresenter < Showtime::Presenter
     assignment.fetch_or_create_rubric
   end
 
-  def rubric_available?
+  def rubric_designed?
     !assignment.rubric.nil? && assignment.rubric.designed?
   end
 

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -112,7 +112,7 @@ class AssignmentPresenter < Showtime::Presenter
   end
 
   def rubric_available?
-    assignment.use_rubric? && !assignment.rubric.nil? && assignment.rubric.designed?
+    !assignment.rubric.nil? && assignment.rubric.designed?
   end
 
   def rubric_grades(user)
@@ -128,6 +128,10 @@ class AssignmentPresenter < Showtime::Presenter
 
   def rubric_tier_earned?(user, tier_id)
     rubric_grades(user).any? { |rubric_grade| rubric_grade.tier_id == tier_id }
+  end
+
+  def use_rubric?
+    assignment.use_rubric?
   end
 
   def scores

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -9,9 +9,9 @@
       %li= link_to raw('<i class="fa fa-copy fa-fw"> </i> Copy'), copy_assignments_path(id: presenter.assignment), method: :copy
       - if presenter.assignment.has_groups?
         %li= link_to raw("<i class='fa fa-users fa-fw'> </i> Create #{term_for :group}"), new_group_path
-      - if presenter.for_team? && !presenter.rubric_available?
+      - if presenter.for_team? && !presenter.rubric_available? && !presenter.use_rubric?
         %li= link_to raw('<i class="fa fa-check fa-fw"> </i> Quick Grade'), mass_grade_assignment_path(presenter.assignment, team: presenter.team)
-      - elsif !presenter.rubric_available?
+      - elsif !presenter.rubric_available? && !presenter.use_rubric?
         %li= link_to raw('<i class="fa fa-check fa-fw"> </i> Quick Grade'), mass_grade_assignment_path(presenter.assignment)
       / - if presenter.assignment.submissions.present?
       /   %li

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -9,9 +9,9 @@
       %li= link_to raw('<i class="fa fa-copy fa-fw"> </i> Copy'), copy_assignments_path(id: presenter.assignment), method: :copy
       - if presenter.assignment.has_groups?
         %li= link_to raw("<i class='fa fa-users fa-fw'> </i> Create #{term_for :group}"), new_group_path
-      - if presenter.for_team? && !presenter.rubric_available? && !presenter.use_rubric?
+      - if presenter.for_team? && !presenter.rubric_designed? && !presenter.use_rubric?
         %li= link_to raw('<i class="fa fa-check fa-fw"> </i> Quick Grade'), mass_grade_assignment_path(presenter.assignment, team: presenter.team)
-      - elsif !presenter.rubric_available? && !presenter.use_rubric?
+      - elsif !presenter.rubric_designed? && !presenter.use_rubric?
         %li= link_to raw('<i class="fa fa-check fa-fw"> </i> Quick Grade'), mass_grade_assignment_path(presenter.assignment)
       / - if presenter.assignment.submissions.present?
       /   %li
@@ -29,12 +29,12 @@
       %li
         %a{:href => design_assignment_rubric_path(presenter.assignment) }
           %i.fa.fa-sliders.fa-fw
-          - if presenter.rubric_available?
+          - if presenter.rubric_designed?
             Edit Rubric
           - else
             Create Rubric
 
-      - if presenter.rubric_available?
+      - if presenter.rubric_designed?
         - if presenter.has_reviewable_grades?
           %li
             %a{:href => rubric_grades_review_assignment_path(presenter.assignment) }

--- a/app/views/assignments/_view_assignment_grades.html.haml
+++ b/app/views/assignments/_view_assignment_grades.html.haml
@@ -9,7 +9,7 @@
     %ul.ui-tabs-nav{:role => "tablist"}
       %li
         %a{ "href" => "#tab1"} Description & Downloads
-      - if presenter.rubric_available? && !presenter.grades_available_for?(current_student)
+      - if presenter.rubric_designed? && !presenter.grades_available_for?(current_student)
         %li
           %a{ "href" => "#tab2"} Grading Rubric
       - if presenter.has_submission_for?(current_student)
@@ -26,7 +26,7 @@
     #tabt1.ui-tabs-panel.ui-widget-content{:role => "tabpanel"}
       #tab1.active
         = render partial: 'assignments/description_and_downloads', locals: { presenter: presenter }
-      - if presenter.rubric_available? && !presenter.grades_available_for?(current_student)
+      - if presenter.rubric_designed? && !presenter.grades_available_for?(current_student)
         #tab2= render partial: 'assignments/rubric_preview', locals: { presenter: presenter }
       - if presenter.has_submission_for?(current_student)
         #tab3= render partial: "submissions/student_show", locals: { presenter: presenter }

--- a/app/views/assignments/_view_assignment_management.html.haml
+++ b/app/views/assignments/_view_assignment_management.html.haml
@@ -14,7 +14,7 @@
         %a{ "href" => "#tab"} Grades
       %li
         %a{ "href" => "#tabt2"} Description & Downloads
-      - if presenter.rubric_available?
+      - if presenter.rubric_designed?
         %li
           %a{ "href" => "#tabt3"} Grading Rubric
       - if presenter.has_grades?
@@ -30,7 +30,7 @@
       .ui-tabs-panel#tabt2{:role => "tabpanel", "aria-hidden" => false }
         = render partial: 'assignments/description_and_downloads', locals: { presenter: presenter }
 
-      - if presenter.rubric_available?
+      - if presenter.rubric_designed?
         .content#tabt3{:role => "tabpanel", "aria-hidden" => false }
           %br
           = render partial: 'assignments/rubric_preview', locals: { presenter: presenter }

--- a/app/views/grades/_individual_show.html.haml
+++ b/app/views/grades/_individual_show.html.haml
@@ -35,7 +35,7 @@
           %li
             = link_to gf.filename, gf.url, :target => "_blank"
 
-  - if presenter.rubric_available?
+  - if presenter.rubric_designed?
     .rubric-container= render partial: 'grades/rubric_grade_results', locals: { presenter: presenter }
 
   .right

--- a/spec/presenters/assignment_presenter_spec.rb
+++ b/spec/presenters/assignment_presenter_spec.rb
@@ -100,28 +100,21 @@ describe AssignmentPresenter do
     let(:rubric) { double(:rubric, designed?: true) }
 
     it "is not available if there is no rubric attached to the assignment" do
-      allow(assignment).to receive(:use_rubric?).and_return true
       allow(assignment).to receive(:rubric).and_return nil
       expect(subject.rubric_available?).to eq false
     end
 
-    it "is not available if the assignment should not use a rubric" do
-      allow(assignment).to receive(:use_rubric?).and_return false
-      allow(assignment).to receive(:rubric).and_return rubric
-      expect(subject.rubric_available?).to eq false
-    end
-
     it "is not available if the rubric was not designed" do
-      allow(assignment).to receive(:use_rubric?).and_return true
       allow(assignment).to receive(:rubric).and_return rubric
       allow(rubric).to receive(:designed?).and_return false
       expect(subject.rubric_available?).to eq false
     end
+  end
 
-    it "is available if the rubric is designed and the assignment should use it" do
-      allow(assignment).to receive(:use_rubric?).and_return true
-      allow(assignment).to receive(:rubric).and_return rubric
-      expect(subject.rubric_available?).to eq true
+  describe "#use_rubric?" do
+    it "is not to be used if the assignment should not use a rubric" do
+      allow(assignment).to receive(:use_rubric?).and_return false
+      expect(subject.rubric_available?).to eq false
     end
   end
 

--- a/spec/presenters/assignment_presenter_spec.rb
+++ b/spec/presenters/assignment_presenter_spec.rb
@@ -96,25 +96,25 @@ describe AssignmentPresenter do
     end
   end
 
-  describe "#rubric_available?" do
+  describe "#rubric_designed?" do
     let(:rubric) { double(:rubric, designed?: true) }
 
-    it "is not available if there is no rubric attached to the assignment" do
+    it "is not designed if there is no rubric attached to the assignment" do
       allow(assignment).to receive(:rubric).and_return nil
-      expect(subject.rubric_available?).to eq false
+      expect(subject.rubric_designed?).to eq false
     end
 
-    it "is not available if the rubric was not designed" do
+    it "is not designed if the rubric was not designed" do
       allow(assignment).to receive(:rubric).and_return rubric
       allow(rubric).to receive(:designed?).and_return false
-      expect(subject.rubric_available?).to eq false
+      expect(subject.rubric_designed?).to eq false
     end
   end
 
   describe "#use_rubric?" do
     it "is not to be used if the assignment should not use a rubric" do
       allow(assignment).to receive(:use_rubric?).and_return false
-      expect(subject.rubric_available?).to eq false
+      expect(subject.use_rubric?).to eq false
     end
   end
 


### PR DESCRIPTION
Fixes an issue where the ability to edit a rubric was not available when the rubric was designed.

The reason for this bug was because the presenter assumed that the `use_rubric?` setting needed to be turned on as well.

This PR splits out the `rubric_designed?` and `use_rubric` checks appropriately.

Fixes #1293 