### PR TITLE
1277 Fix tier badges icon bug

### DIFF
--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -60,7 +60,7 @@
               {{tier.description}}
             .row.badge-row
               .tier-badge-image(ng-repeat="(tierBadgeId, tierBadge) in tier.badges")
-                %img(src="{{tierBadge.badge.icon}}" height="50px")
+                %img(ng-src="{{tierBadge.badge.icon}}" height="50px")
               .clear
           %td.filler(ng-show="metric.tiers.length < #{@rubric.max_tier_count}" colspan="{{#{@rubric.max_tier_count} - metric.tiers.length}}")
           %td.comments-box
@@ -92,6 +92,6 @@
               %option(value="" disabled) Select grade status for this submission...
             .align-right.form_label Can the student see this grade?
 
-    .clear 
+    .clear
     .right
       %button#submit-grade(ng-click="submitGrade()" ng-disabled="selectedTiers().length == 0") Submit Grade

--- a/app/views/grades/standard_edit/_badges_available.html.haml
+++ b/app/views/grades/standard_edit/_badges_available.html.haml
@@ -5,7 +5,7 @@
 
   .grade-badge.hexagon.available(title="{{badge.point_total}} Points: {{badge.description}}" ng-repeat="badge in badges" ng-class="{unearned: badge.unearned(), earned: badge.earned()}" ng-click="earnBadgeForStudent(badge)" hide-after-fade)
 
-    %img(src="{{badge.icon}}" alt="You've earned the {{badge.name}} badge" class="unearned")
+    %img(ng-src="{{badge.icon}}" alt="You've earned the {{badge.name}} badge" class="unearned")
 
     .ribbon
       .ribbon-stitches-top

--- a/app/views/grades/standard_edit/_badges_awarded.html.haml
+++ b/app/views/grades/standard_edit/_badges_awarded.html.haml
@@ -6,7 +6,7 @@
 
   .grade-badge.hexagon.awarded(title="{{badge.point_total}} Points: {{badge.description}}" ng-repeat="badge in badges" ng-class="{unearned: badge.unearned(), earned: badge.earned()}" ng-click="badge.deleteEarnedStudentBadge()" hide-after-fade)
 
-    %img(src="{{badge.icon}}" alt="You've earned the {{badge.name}} badge" class="earned")
+    %img(ng-src="{{badge.icon}}" alt="You've earned the {{badge.name}} badge" class="earned")
 
     .ribbon
       .ribbon-stitches-top
@@ -17,4 +17,4 @@
     .gold-stars
       %i.fa.fa-star.fa-fw
         .earned-count {{badge.totalEarnedBadges()}}
-      .badges-earned.blue 
+      .badges-earned.blue

--- a/app/views/rubrics/_new_tier.html.haml
+++ b/app/views/rubrics/_new_tier.html.haml
@@ -7,7 +7,7 @@
   .badge-row.clickable(ng-click="tier.editBadges()" ng-show="tier.isSaved()")
     .badge-messages Badges
     .tier-badge-image(ng-repeat="(tierBadgeId, tierBadge) in tier.badges")
-      %img(src="{{tierBadge.badge.icon}}" width="35px" height="35px")
+      %img(ng-src="{{tierBadge.badge.icon}}" width="35px" height="35px")
 
 .modal-window(ng-show="tier.editingBadges")
   %select(ng-disabled="! tier.isSaved()" ng-change="tier.selectBadge()" ng-model="tier.selectedBadge" ng-options="availableBadge as availableBadge.name for (availableBadgeId, availableBadge) in tier.availableBadges")
@@ -15,7 +15,7 @@
     %option.default(value="" selected disabled ng-show="tier.availableBadges.length == 0") all available badges selected
 
   .tier-badge(ng-repeat="(tierBadgeId, tierBadge) in tier.badges")
-    %img(src="{{tierBadge.badge.icon}}" width="20px" height="20px")
+    %img(ng-src="{{tierBadge.badge.icon}}" width="20px" height="20px")
     {{tierBadge.name}}
     %button.delete(type="button" ng-click="tier.deleteTierBadge(tierBadge)") X
 


### PR DESCRIPTION
Replaced `img(src="{{}}")` with ng-src for images that are data-bound to urls.

There were some 404 errors in the error log for requests to something like:

```
/assignments/1807/grade/%7B%7Bbadge.icon%7D%7D
```

This was because something else was failing on the page and the view was trying to get the request for `/assignments/1807/grade/{{badge.icon}}` instead of the databound value.

Using ng-src [should solve this issue](http://stackoverflow.com/a/27554935) as it does not set the `src` attribute if it's not a valid url and the browser will not make the request for it (the attribute is not rendered).

Fixes #1277