### PR TITLE
Add zeus and a simple custom plan for Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,7 @@ group :development, :test do
   gem 'pry-stack_explorer'
   gem 'pry-byebug'
   gem 'spring-commands-rspec'
+  gem 'zeus'
 end
 
 group :test do

--- a/custom_plan.rb
+++ b/custom_plan.rb
@@ -1,7 +1,12 @@
-require 'zeus/parallel_tests'
+# ./custom_plan.rb
+require 'zeus/rails'
 
-class CustomPlan < Zeus::ParallelTests::Rails
-  # Your custom methods go here
+class CustomPlan < Zeus::Rails
+  # def test
+  #   Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+  #   Dir[Rails.root.join('spec/controllers/shared_specs/**/*.rb')].each { |f| puts "reloading #{f}";load f }
+  #   super
+  # end
 end
 
 Zeus.plan = CustomPlan.new


### PR DESCRIPTION
Adds plain ol' 'zeus' to the Gemfile, as well as a simple custom plan that includes the Zeus::Rails plan and gives us a place to start building an app-specific Zeus plan if we need it (maybe this could get parallel_rspec working?).

Everyone needs to run `bundle` once this is committed if they want access to Zeus.