### PR TITLE
1304 multiplied gradebook

### DIFF
--- a/app/background_jobs/multiplied_gradebook_exporter_job.rb
+++ b/app/background_jobs/multiplied_gradebook_exporter_job.rb
@@ -1,0 +1,4 @@
+class MultipliedGradebookExporterJob < ResqueJob::Base
+  @queue = :multiplied_gradebook_exporter
+  @performer_class = MultipliedGradebookExportPerformer
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,6 +57,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def redirect_back_or_default(path=root_path, options={})
+    if request.env["HTTP_REFERER"].present? and
+       request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
+      redirect_to :back
+    else
+      redirect_to path, options
+    end
+  end
+
   protected
 
   # Core role authentication

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -81,14 +81,21 @@ class InfoController < ApplicationController
     @count_ungraded = @ungraded_submissions.count
   end
 
-  #grade index export
   def gradebook
-    session[:return_to] = request.referer || root_path
-
     GradebookExporterJob.new(user_id: current_user.id, course_id: current_course.id).enqueue
 
     flash[:notice]="Your request to export the gradebook for \"#{current_course.name}\" is currently being processed. We will email you the data shortly."
-    redirect_to session[:return_to]
+    redirect_back_or_default
+  end
+
+  def multiplied_gradebook
+    MultipliedGradebookExporterJob
+      .new(user_id: current_user.id, course_id: current_course.id).enqueue
+
+    flash[:notice]="Your request to export the multiplied gradebook \
+                    for \"#{current_course.name}\" is currently being processed. \
+                    We will email you the data shortly."
+    redirect_back_or_default
   end
 
   def final_grades

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -61,7 +61,7 @@ class InfoController < ApplicationController
   def resubmissions
     @title = "Resubmitted Assignments"
     resubmissions = current_course.submissions.resubmitted
-    
+
     @teams = current_course.teams
     @team = current_course.teams.find_by(id: params[:team_id]) if params[:team_id]
     if @team
@@ -85,9 +85,7 @@ class InfoController < ApplicationController
   def gradebook
     session[:return_to] = request.referer || root_path
 
-    # TODO: RESQUE CLEAN-UP: Add controller specs for resque job methods.
-    @gradebook_exporter_job = GradebookExporterJob.new(user_id: current_user.id, course_id: current_course.id)
-    @gradebook_exporter_job.enqueue
+    GradebookExporterJob.new(user_id: current_user.id, course_id: current_course.id).enqueue
 
     flash[:notice]="Your request to export the gradebook for \"#{current_course.name}\" is currently being processed. We will email you the data shortly."
     redirect_to session[:return_to]

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -16,20 +16,25 @@ class NotificationMailer < ActionMailer::Base
     end
   end
 
-  def grade_export(course,user,csv_data)
+  def grade_export(course, user, csv_data)
     @user = user
     @course = course
     attachments["#{course.id}.csv"] = {:mime_type => 'text/csv',:content => csv_data }
-    mail(:to =>  @user.email, :bcc=>"admin@gradecraft.com", :subject => "#{course.name} grade export is attached") do |format|
+    mail(:to =>  @user.email,
+         :bcc=>"admin@gradecraft.com",
+         :subject => "#{course.name} grade export is attached") do |format|
       format.text
     end
   end
 
-  def gradebook_export(course,user,csv_data)
+  def gradebook_export(course, user, export_type, csv_data)
     @user = user
     @course = course
-    attachments["#{course.id}.csv"] = {:mime_type => 'text/csv',:content => csv_data }
-    mail(:to =>  @user.email, :bcc=>"admin@gradecraft.com", :subject => "#{course.name} grade export is attached") do |format|
+    @export_type = export_type
+    attachments["#{@course.id}.csv"] = {:mime_type => 'text/csv',:content => csv_data }
+    mail(:to =>  @user.email,
+         :bcc=>"admin@gradecraft.com",
+         :subject => "#{@course.name} #{@export_type} is attached") do |format|
       format.text
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -457,7 +457,6 @@ class Course < ActiveRecord::Base
       assignments.inject(student_data) do |memo, assignment|
         grade = assignment.grade_for_student(student)
         if grade and grade.is_student_visible?
-          memo << grade.try(:raw_score)
           memo << grade.try(:score)
         end
         memo

--- a/app/performers/gradebook_export_performer.rb
+++ b/app/performers/gradebook_export_performer.rb
@@ -33,7 +33,9 @@ class GradebookExportPerformer < ResqueJob::Performer
   end
 
   def notify_gradebook_export
-    NotificationMailer.gradebook_export(@course, @user, @csv_data).deliver_now
+    NotificationMailer
+      .gradebook_export(@course, @user, "gradebook export", @csv_data)
+      .deliver_now
   end
 
   def fetch_csv_messages

--- a/app/performers/gradebook_export_performer.rb
+++ b/app/performers/gradebook_export_performer.rb
@@ -17,8 +17,8 @@ class GradebookExportPerformer < ResqueJob::Performer
     end
   end
 
-  private
-  
+  protected
+
   def fetch_user
     User.find @attrs[:user_id]
   end
@@ -26,11 +26,6 @@ class GradebookExportPerformer < ResqueJob::Performer
   # todo: speed this up by condensing the CSV generator into a single query
   def fetch_course # TODO: add specs for includes
     Course.find @attrs[:course_id]
-  end
-
-  # todo spec
-  def sanitized_csv_excerpt
-    fetch_csv_data.gsub("\n","").split(//).last(50).join
   end
 
   def fetch_csv_data

--- a/app/performers/multiplied_gradebook_export_performer.rb
+++ b/app/performers/multiplied_gradebook_export_performer.rb
@@ -5,4 +5,10 @@ class MultipliedGradebookExportPerformer < GradebookExportPerformer
   def fetch_csv_data
     @csv_data = @course.csv_multiplied_gradebook
   end
+
+  def notify_gradebook_export
+    NotificationMailer
+      .gradebook_export(@course, @user, "multiplied gradebook export", @csv_data)
+      .deliver_now
+  end
 end

--- a/app/performers/multiplied_gradebook_export_performer.rb
+++ b/app/performers/multiplied_gradebook_export_performer.rb
@@ -1,0 +1,8 @@
+class MultipliedGradebookExportPerformer < GradebookExportPerformer
+
+  protected
+
+  def fetch_csv_data
+    @csv_data = @course.csv_multipled_gradebook
+  end
+end

--- a/app/performers/multiplied_gradebook_export_performer.rb
+++ b/app/performers/multiplied_gradebook_export_performer.rb
@@ -3,6 +3,6 @@ class MultipliedGradebookExportPerformer < GradebookExportPerformer
   protected
 
   def fetch_csv_data
-    @csv_data = @course.csv_multipled_gradebook
+    @csv_data = @course.csv_multiplied_gradebook
   end
 end

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -54,6 +54,9 @@
   %li= link_to_unless_current raw('<i class="fa fa-list-ul fa-fw"></i> Final Grades'), final_grades_path(format: 'csv')
   %li
     %a{:href => gradebook_path(format: 'csv')} <i class="fa fa-table fa-fw"></i> Full Gradebook
+  - if current_course.student_weighted?
+    %li
+      %a{:href => multiplied_gradebook_path(format: 'csv')} <i class="fa fa-table fa-fw"></i> Multiplied Gradebook
   %li
     %a{:href => export_all_scores_assignment_types_path(format: 'csv')} <i class="fa fa-th-large fa-fw"></i> #{term_for :assignment_type } Summaries
 

--- a/app/views/notification_mailer/gradebook_export.text.haml
+++ b/app/views/notification_mailer/gradebook_export.text.haml
@@ -1,6 +1,6 @@
 Dear #{ @user.first_name },
 
-The gradebook export you have requested for #{ @course.name } is attached.
+The #{ @export_type } you have requested for #{ @course.name } is attached.
 
 Thanks,
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,7 @@ GradeCraft::Application.routes.draw do
   get 'resubmissions' => 'info#resubmissions'
   get 'ungraded_submissions' => 'info#ungraded_submissions'
   get 'gradebook' => 'info#gradebook'
+  get 'multiplied_gradebook' => 'info#multiplied_gradebook'
   get 'final_grades' => 'info#final_grades'
   get 'research_gradebook' => 'info#research_gradebook'
   get 'export_earned_badges' => 'courses#export_earned_badges'

--- a/lib/resque_job/base.rb
+++ b/lib/resque_job/base.rb
@@ -7,11 +7,15 @@ module ResqueJob
     # add resque-retry for all jobs
     extend Resque::Plugins::Retry
     extend Resque::Plugins::ExponentialBackoff
-    
+
     # defaults
     @queue = :main # put all jobs in the 'main' queue
     @performer_class = ResqueJob::Performer
     @backoff_strategy = [0, 15, 30, 45, 60, 90, 120, 150, 180, 240, 300, 360, 420, 540, 660, 780, 900, 1140, 1380, 1520, 1760, 3600, 7200, 14400, 28800]
+
+    class << self
+      attr_reader :performer_class, :queue
+    end
 
     # perform block that is ultimately called by Resque
     def self.perform(attrs={})
@@ -24,7 +28,7 @@ module ResqueJob
         # build a new background job logger
         # puts "@peformer_class: #{@performer_class}"
         # puts @logger
-        puts this_message = self.start_message(attrs) # this wasn't running because 
+        puts this_message = self.start_message(attrs) # this wasn't running because
         # @logger.info this_message
         logger.info this_message
         # log_message "This is retry ##{@retry_attempt}" if @retry_attempt > 0 # add specs for this
@@ -118,7 +122,7 @@ module ResqueJob
     end
 
     # Inheritance Behaviors
-   
+
     ## allow sub-classes to inherit class-level instance variables
     def self.inherited(subclass)
       self.instance_variable_names.each do |ivar|
@@ -137,7 +141,7 @@ module ResqueJob
         queue: :main,
         performer_class: ResqueJob::Performer,
         backoff_strategy: [0, 15, 30, 45, 60, 90, 120, 150, 180, 240, 300, 360, 420, 540, 660, 780, 900, 1140, 1380, 1520, 1760, 3600, 7200, 14400, 28800]
-      }   
+      }
     end
 
     # need to figure out how to integrate this more cleanly

--- a/spec/background_jobs/multiplied_gradebook_exporter_job_spec.rb
+++ b/spec/background_jobs/multiplied_gradebook_exporter_job_spec.rb
@@ -1,0 +1,13 @@
+require "rails_spec_helper"
+
+RSpec.describe MultipliedGradebookExporterJob do
+  include InQueueHelper # pulled from ResqueSpec
+
+  it "queues the job in the proper queue" do
+    expect(described_class.queue).to eq :multiplied_gradebook_exporter
+  end
+
+  it "runs the correct performer" do
+    expect(described_class.performer_class).to eq MultipliedGradebookExportPerformer
+  end
+end

--- a/spec/controllers/background_jobs/info_controller_background_job_spec.rb
+++ b/spec/controllers/background_jobs/info_controller_background_job_spec.rb
@@ -30,10 +30,5 @@ RSpec.describe InfoController, type: :controller, background_job: true do
       expect(GradebookExporterJob).to respond_to(:new).with(1).argument
       get :gradebook
     end
-
-    it "creates a new GradebookExporterJob" do
-      get :gradebook
-      expect(assigns(:gradebook_exporter_job).class).to eq(GradebookExporterJob)
-    end
   end
 end

--- a/spec/controllers/info_controller_spec.rb
+++ b/spec/controllers/info_controller_spec.rb
@@ -72,8 +72,29 @@ describe InfoController do
       end
 
       it "redirects to the referer if there is one" do
-        allow(request).to receive(:referer).and_return dashboard_path
+        request.env["HTTP_REFERER"] = dashboard_path
         get :gradebook
+        expect(response).to redirect_to dashboard_path
+      end
+    end
+
+    describe "GET multipled_gradebook" do
+      it "retrieves the multiplied gradebook" do
+        expect(MultipliedGradebookExporterJob).to \
+          receive(:new).with(user_id: @professor.id, course_id: @course.id)
+            .and_call_original
+        expect_any_instance_of(MultipliedGradebookExporterJob).to receive(:enqueue)
+        get :multiplied_gradebook
+      end
+
+      it "redirects to the root path if there is no referer" do
+        get :multiplied_gradebook
+        expect(response).to redirect_to root_path
+      end
+
+      it "redirects to the referer if there is one" do
+        request.env["HTTP_REFERER"] = dashboard_path
+        get :multiplied_gradebook
         expect(response).to redirect_to dashboard_path
       end
     end
@@ -140,6 +161,7 @@ describe InfoController do
         :resubmissions,
         :ungraded_submissions,
         :gradebook,
+        :multiplied_gradebook,
         :final_grades,
         :research_gradebook,
         :choices,

--- a/spec/controllers/info_controller_spec.rb
+++ b/spec/controllers/info_controller_spec.rb
@@ -59,9 +59,22 @@ describe InfoController do
 
     describe "GET gradebook" do
       it "retrieves the gradebook" do
-        skip "implement"
+        expect(GradebookExporterJob).to \
+          receive(:new).with(user_id: @professor.id, course_id: @course.id)
+            .and_call_original
+        expect_any_instance_of(GradebookExporterJob).to receive(:enqueue)
         get :gradebook
-        expect(response).to render_template(:gradebook)
+      end
+
+      it "redirects to the root path if there is no referer" do
+        get :gradebook
+        expect(response).to redirect_to root_path
+      end
+
+      it "redirects to the referer if there is one" do
+        allow(request).to receive(:referer).and_return dashboard_path
+        get :gradebook
+        expect(response).to redirect_to dashboard_path
       end
     end
 

--- a/spec/performers/gradebook_export_performer_spec.rb
+++ b/spec/performers/gradebook_export_performer_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe GradebookExportPerformer, type: :background_job do
 
 
   # private methods
-  
+
   describe "private methods" do
     describe "fetch_user" do
       subject { performer.instance_eval{fetch_user} }

--- a/spec/performers/gradebook_export_performer_spec.rb
+++ b/spec/performers/gradebook_export_performer_spec.rb
@@ -150,9 +150,10 @@ RSpec.describe GradebookExportPerformer, type: :background_job do
       after(:each) { subject }
       before(:each) { allow(NotificationMailer).to receive(:gradebook_export).and_return(csv_double) }
 
-      it "should create a new gradebook export notifier with @course, @user, and @csv_data" do
+      it "should create a new gradebook export notifier with proper parameters" do
         performer.instance_eval { fetch_csv_data }
-        expect(NotificationMailer).to receive(:gradebook_export).with(course, user, csv_data)
+        expect(NotificationMailer).to receive(:gradebook_export)
+          .with(course, user, "gradebook export", csv_data)
         expect(csv_double).to receive(:deliver_now)
       end
 

--- a/spec/performers/multiplied_gradebook_export_performer_spec.rb
+++ b/spec/performers/multiplied_gradebook_export_performer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MultipliedGradebookExportPerformer, type: :background_job do
 
     it "should call csv_multipled_gradebook on the course" do
       performer.instance_variable_set(:@course, course_double)
-      expect(course_double).to receive(:csv_multipled_gradebook)
+      expect(course_double).to receive(:csv_multiplied_gradebook)
       subject
     end
   end

--- a/spec/performers/multiplied_gradebook_export_performer_spec.rb
+++ b/spec/performers/multiplied_gradebook_export_performer_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_spec_helper'
+
+RSpec.describe MultipliedGradebookExportPerformer, type: :background_job do
+  let(:course) { create(:course) }
+  let(:user) { create(:user) }
+  let(:attrs) {{ user_id: user.id, course_id: course.id }}
+  let(:performer) { MultipliedGradebookExportPerformer.new(attrs) }
+
+  describe "fetch_csv_data" do
+    let(:course_double) { double(:course) }
+    subject { performer.instance_eval{fetch_csv_data} }
+
+    it "should call csv_multipled_gradebook on the course" do
+      performer.instance_variable_set(:@course, course_double)
+      expect(course_double).to receive(:csv_multipled_gradebook)
+      subject
+    end
+  end
+end

--- a/spec/performers/multiplied_gradebook_export_performer_spec.rb
+++ b/spec/performers/multiplied_gradebook_export_performer_spec.rb
@@ -16,4 +16,16 @@ RSpec.describe MultipliedGradebookExportPerformer, type: :background_job do
       subject
     end
   end
+
+  describe "notify_gradebook_export" do
+    let(:csv_data) { performer.instance_variable_get(:@csv_data) }
+    subject { performer.instance_eval { notify_gradebook_export } }
+
+    it "should create a new gradebook export notifier with proper parameters" do
+      expect(NotificationMailer).to receive(:gradebook_export)
+        .with(course, user, "multiplied gradebook export", csv_data)
+        .and_call_original
+      subject
+    end
+  end
 end

--- a/spec/toolkits/workers/resque_job_shared_examples_toolkit.rb
+++ b/spec/toolkits/workers/resque_job_shared_examples_toolkit.rb
@@ -10,8 +10,8 @@ module ResqueJobSharedExamplesToolkit
     end
 
     it "builds a new #{job_klass}" do
+      expect(job_klass).to receive(:new).and_call_original
       subject
-      expect(assigns(job_klass.to_s.underscore.to_sym).class).to eq(job_klass)
     end
   end
 


### PR DESCRIPTION
This PR adds the ability for staff users to export a multiplied gradebook if the current course is student weighted.

* Created a new route for `GET info_controller#multiplied_gradebook` which calls the correct background job
* Created a new `MultipliedGradebookExportJob` that runs the `MultipliedGradebookExportPerformer`
* Created a `MultipliedGradebookExportPerformer` that inherits from `GradebookExportPerformer` but runs the appropriate method on `Course`
* Removed the `raw_score` from the `Course#csv_multiplied_gradebook` values

Closes #1304 