### PR TITLE
1349 refactor assignment grade import

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -204,9 +204,9 @@ class AssignmentsController < ApplicationController
   end
 
   def export_grades
-    @assignment = current_course.assignments.find(params[:id])
+    assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
-      format.csv { send_data @assignment.gradebook_for_assignment }
+      format.csv { send_data AssignmentExporter.new.export assignment, assignment.course.students }
     end
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -196,7 +196,7 @@ class AssignmentsController < ApplicationController
     redirect_to assignments_url, notice: "#{(term_for :assignment).titleize} #{@name} successfully deleted"
   end
 
-  def download_sample_grades
+  def download_current_grades
     assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
       format.csv { send_data GradeExporter.new.export(assignment, current_course.students) }

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -196,7 +196,7 @@ class AssignmentsController < ApplicationController
     redirect_to assignments_url, notice: "#{(term_for :assignment).titleize} #{@name} successfully deleted"
   end
 
-  def grade_import
+  def download_sample_grades
     assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
       format.csv { send_data GradeExporter.new.export(assignment, current_course.students) }

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -197,9 +197,9 @@ class AssignmentsController < ApplicationController
   end
 
   def grade_import
-    @assignment = current_course.assignments.find(params[:id])
+    assignment = current_course.assignments.find(params[:id])
     respond_to do |format|
-      format.csv { send_data @assignment.grade_import(current_course.students) }
+      format.csv { send_data GradeExporter.new.export(assignment, current_course.students) }
     end
   end
 
@@ -232,7 +232,7 @@ class AssignmentsController < ApplicationController
           error_log = ""
 
           open( "#{export_dir}/_grade_import_template.csv",'w' ) do |f|
-            f.puts @assignment.grade_import(@students)
+            f.puts GradeExporter.new.export(@assignment, @students)
           end
 
           @students.each do |student|

--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -1,0 +1,14 @@
+class AssignmentExporter
+  def export(assignment, students, options={})
+    CSV.generate(options) do |csv|
+      csv << headers
+    end
+  end
+
+  private
+
+  def headers
+    ["First Name", "Last Name", "Uniqname", "Score", "Raw Score",
+     "Statement", "Feedback", "Last Updated"].freeze
+  end
+end

--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -4,13 +4,12 @@ class AssignmentExporter
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
+        grade = NullGrade.new if grade.nil? || !(grade.instructor_modified? || grade.graded_or_released?)
         submission = student.submission_for_assignment(assignment)
-        if grade and (grade.instructor_modified? || grade.graded_or_released?)
-          csv << [student.first_name, student.last_name,
-                  student.username, grade.try(:score) || "", grade.try(:raw_score) || "",
-                  submission.try(:text_comment) || "", grade.try(:feedback) || "",
-                  grade.try(:updated_at) || ""]
-        end
+        csv << [student.first_name, student.last_name,
+                student.username, grade.score || "", grade.raw_score || "",
+                submission.try(:text_comment) || "", grade.feedback || "",
+                grade.updated_at || ""]
       end
     end
   end

--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -2,6 +2,16 @@ class AssignmentExporter
   def export(assignment, students, options={})
     CSV.generate(options) do |csv|
       csv << headers
+      students.each do |student|
+        grade = student.grade_for_assignment(assignment)
+        submission = student.submission_for_assignment(assignment)
+        if grade and (grade.instructor_modified? || grade.graded_or_released?)
+          csv << [student.first_name, student.last_name,
+                  student.username, grade.try(:score) || "", grade.try(:raw_score) || "",
+                  submission.try(:text_comment) || "", grade.try(:feedback) || "",
+                  grade.try(:updated_at) || ""]
+        end
+      end
     end
   end
 

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -1,0 +1,14 @@
+class GradeExporter
+  def export(assignment, students, options={})
+    data = CSV.generate(options) do |csv|
+      csv << headers
+    end
+    CSV.new data
+  end
+
+  private
+
+  def headers
+    ["First Name", "Last Name", "Email", "Score", "Feedback"].freeze
+  end
+end

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -3,9 +3,9 @@ class GradeExporter
     CSV.generate(options) do |csv|
       csv << headers
       students.each do |student|
-        grade = student.grade_for_assignment(assignment)
+        grade = student.grade_for_assignment(assignment) || NullGrade.new
         csv << [student.first_name, student.last_name,
-                student.email, grade.try(:score) || "", grade.try(:feedback) || ""]
+                student.email, grade.score || "", grade.feedback || ""]
       end
     end
   end

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -4,7 +4,8 @@ class GradeExporter
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
-        csv << [student.first_name, student.last_name, student.email, grade.score, grade.feedback]
+        csv << [student.first_name, student.last_name,
+                student.email, grade.try(:score), grade.try(:feedback)]
       end
     end
     CSV.new data

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -2,6 +2,10 @@ class GradeExporter
   def export(assignment, students, options={})
     data = CSV.generate(options) do |csv|
       csv << headers
+      students.each do |student|
+        grade = student.grade_for_assignment(assignment)
+        csv << [student.first_name, student.last_name, student.email, grade.score, grade.feedback]
+      end
     end
     CSV.new data
   end

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -1,6 +1,6 @@
 class GradeExporter
   def export(assignment, students, options={})
-    data = CSV.generate(options) do |csv|
+    CSV.generate(options) do |csv|
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
@@ -8,7 +8,6 @@ class GradeExporter
                 student.email, grade.try(:score) || "", grade.try(:feedback) || ""]
       end
     end
-    CSV.new data
   end
 
   private

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -5,7 +5,7 @@ class GradeExporter
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
-                student.email, grade.try(:score), grade.try(:feedback)]
+                student.email, grade.try(:score) || "", grade.try(:feedback) || ""]
       end
     end
     CSV.new data

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -450,21 +450,6 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  # Single assignment gradebook
-  def gradebook_for_assignment(options = {})
-    CSV.generate(options) do |csv|
-      csv << ["First Name", "Last Name", "Uniqname", "Score", "Raw Score", "Statement", "Feedback", "Last Updated" ]
-      course.students.each do |student|
-        grade = student.grade_for_assignment(self)
-        if grade and (grade.instructor_modified? || grade.graded_or_released?)
-          csv << [student.first_name, student.last_name, student.username, student.grade_for_assignment(self).score, student.grade_for_assignment(self).raw_score, student.submission_for_assignment(self).try(:text_comment), student.grade_for_assignment(self).try(:feedback), student.grade_for_assignment(self).updated_at ]
-        else
-          csv << [student.first_name, student.last_name, student.username, "", "", student.submission_for_assignment(self).try(:text_comment), "" ]
-        end
-      end
-    end
-  end
-
   # Calculating how many of each score exists
   def score_count
     Hash[grades.graded_or_released.group_by{ |g| g.score }.map{ |k, v| [k, v.size] }]

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -465,20 +465,6 @@ class Assignment < ActiveRecord::Base
     end
   end
 
-  def grade_import(students, options = {})
-    CSV.generate(options) do |csv|
-      csv << ["First Name", "Last Name", "Email", "Score", "Feedback"]
-      students.each do |student|
-        grade = student.grade_for_assignment(self)
-        if grade and (grade.instructor_modified? || grade.graded_or_released?)
-          csv << [student.first_name, student.last_name, student.email, student.grade_for_assignment(self).score, student.grade_for_assignment(self).try(:feedback) ]
-        else
-          csv << [student.first_name, student.last_name, student.email, "", "" ]
-        end
-      end
-    end
-  end
-
   # Calculating how many of each score exists
   def score_count
     Hash[grades.graded_or_released.group_by{ |g| g.score }.map{ |k, v| [k, v.size] }]

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -1,0 +1,55 @@
+class NullGrade
+  attr_accessor :predicted_score
+
+  def initialize
+    @predicted_score = 0
+  end
+
+  def is_student_visible?
+    true
+  end
+
+  def id
+    0
+  end
+
+  def team_id
+    0
+  end
+
+  def challenge_id
+    0
+  end
+
+  def point_total
+    555
+  end
+
+  def score
+    nil
+  end
+
+  def raw_score
+    nil
+  end
+
+  def final_score
+    nil
+  end
+
+  def status
+    nil
+  end
+
+  def pass_fail_status
+    nil
+  end
+
+  def feedback
+    nil
+  end
+
+  def updated_at
+    nil
+  end
+end

--- a/app/models/null_student.rb
+++ b/app/models/null_student.rb
@@ -39,59 +39,9 @@ class NullStudentGrades
   end
 
   def first
-    NullStudentGrade.new
+    NullGrade.new
   end
 end
-
-
-class NullStudentGrade
-  attr_accessor :predicted_score
-
-  def initialize
-    @predicted_score = 0
-  end
-
-  def is_student_visible?
-    true
-  end
-
-  def id
-    0
-  end
-
-  def team_id
-    0
-  end
-
-  def challenge_id
-    0
-  end
-
-  def point_total
-    555
-  end
-
-  def score
-    nil
-  end
-
-  def raw_score
-    nil
-  end
-
-  def final_score
-    nil
-  end
-
-  def status
-    nil
-  end
-
-  def pass_fail_status
-    nil
-  end
-end
-
 
 class NullTeam
   def id

--- a/app/views/grades/import.html.haml
+++ b/app/views/grades/import.html.haml
@@ -15,7 +15,7 @@
 
     %p
       Columns should be in the following order:
-      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", download_sample_grades_assignment_path(format: 'csv'), :class => "bold"}
+      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", download_current_grades_assignment_path(format: 'csv'), :class => "bold"}
 
     = form_tag({:action => :upload}, :multipart => true) do
       = file_field_tag 'file'

--- a/app/views/grades/import.html.haml
+++ b/app/views/grades/import.html.haml
@@ -15,7 +15,7 @@
 
     %p
       Columns should be in the following order:
-      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", grade_import_assignment_path(format: 'csv'), :class => "bold"}
+      %br #{term_for :student}'s first name, #{term_for :student}'s last name, #{term_for :student}'s email or username, score, and any text feedback you'd like to include. #{link_to "Download Sample File", download_sample_grades_assignment_path(format: 'csv'), :class => "bold"}
 
     = form_tag({:action => :upload}, :multipart => true) do
       = file_field_tag 'file'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ GradeCraft::Application.routes.draw do
       put 'group_grade' => 'grades#group_update'
       get 'export_grades'
       get 'export_submissions'
-      get 'download_sample_grades' => 'assignments#download_sample_grades'
+      get 'download_current_grades' => 'assignments#download_current_grades'
       get 'rubric_grades_review'
       put :update_rubrics
       scope 'grades', as: :grades, controller: :grades do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ GradeCraft::Application.routes.draw do
       put 'group_grade' => 'grades#group_update'
       get 'export_grades'
       get 'export_submissions'
-      get 'grade_import' => 'assignments#grade_import'
+      get 'download_sample_grades' => 'assignments#download_sample_grades'
       get 'rubric_grades_review'
       put :update_rubrics
       scope 'grades', as: :grades, controller: :grades do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -262,10 +262,10 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET download_sample_grades" do
+    describe "GET download_current_grades" do
       context "with CSV format" do
         it "returns sample csv data" do
-          get :download_sample_grades, :id => @assignment, :format => :csv
+          get :download_current_grades, :id => @assignment, :format => :csv
           expect(response.body).to include("First Name,Last Name,Email,Score,Feedback")
         end
       end
@@ -427,7 +427,7 @@ describe AssignmentsController do
         :update,
         :destroy,
         :export_grades,
-        :download_sample_grades,
+        :download_current_grades,
         :update_rubrics,
         :rubric_grades_review
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -262,10 +262,10 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET grade_import" do
+    describe "GET download_sample_grades" do
       context "with CSV format" do
         it "returns sample csv data" do
-          get :grade_import, :id => @assignment, :format => :csv
+          get :download_sample_grades, :id => @assignment, :format => :csv
           expect(response.body).to include("First Name,Last Name,Email,Score,Feedback")
         end
       end
@@ -427,7 +427,7 @@ describe AssignmentsController do
         :update,
         :destroy,
         :export_grades,
-        :grade_import,
+        :download_sample_grades,
         :update_rubrics,
         :rubric_grades_review
 

--- a/spec/exporters/assignment_exporter_spec.rb
+++ b/spec/exporters/assignment_exporter_spec.rb
@@ -1,0 +1,24 @@
+require "active_record_spec_helper"
+require "./app/exporters/assignment_exporter"
+
+describe AssignmentExporter do
+  let(:assignment) { create(:assignment) }
+  let(:students) { create_list :user, 2 }
+  subject { AssignmentExporter.new }
+
+  describe "#export" do
+    it "generates an empty CSV if there is no assignment specified" do
+      csv = subject.export(nil, [])
+      expect(csv).to eq "First Name,Last Name,Uniqname,Score,Raw Score,Statement,Feedback,Last Updated\n"
+    end
+
+    it "generates an empty CSV if there are no students specified" do
+      csv = subject.export(assignment, [])
+      expect(csv).to eq "First Name,Last Name,Uniqname,Score,Raw Score,Statement,Feedback,Last Updated\n"
+    end
+
+    xit "generates a CSV with student grades for the assignment"
+    xit "includes students that do not have grades for the assignment"
+    xit "does not include the grade if it has not been graded or released"
+  end
+end

--- a/spec/exporters/assignment_exporter_spec.rb
+++ b/spec/exporters/assignment_exporter_spec.rb
@@ -51,7 +51,20 @@ describe AssignmentExporter do
       expect(csv[2][7]).to eq "#{updated_at}"
     end
 
-    xit "includes students that do not have grades for the assignment"
-    xit "does not include the grade if it has not been graded or released"
+    it "includes students that do not have grades for the assignment" do
+      allow(students[0]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return nil
+      csv = CSV.new(subject.export(assignment, students)).read
+      expect(csv[1][3]).to eq ""
+    end
+
+    it "does not include the grade if it has not been graded or released" do
+      allow(students[0]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, instructor_modified?: false, graded_or_released?: false)
+      csv = CSV.new(subject.export(assignment, students)).read
+      expect(csv[1][3]).to eq ""
+    end
   end
 end

--- a/spec/exporters/assignment_exporter_spec.rb
+++ b/spec/exporters/assignment_exporter_spec.rb
@@ -17,7 +17,40 @@ describe AssignmentExporter do
       expect(csv).to eq "First Name,Last Name,Uniqname,Score,Raw Score,Statement,Feedback,Last Updated\n"
     end
 
-    xit "generates a CSV with student grades for the assignment"
+    it "generates a CSV with student grades for the assignment" do
+      updated_at = DateTime.now
+      allow(students[0]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, instructor_modified?: true, graded_or_released?: false,
+                              score: 123, raw_score: 789, feedback: nil, updated_at: updated_at)
+      allow(students[1]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, instructor_modified?: false, graded_or_released?: true,
+                              score: 456, raw_score: 456, feedback: "Grrrrreat!", updated_at: updated_at)
+      allow(students[1]).to \
+        receive(:submission_for_assignment).with(assignment)
+          .and_return double(:submission, text_comment: "Hello there")
+
+      csv = CSV.new(subject.export(assignment, students)).read
+      expect(csv.length).to eq 3
+      expect(csv[1][0]).to eq students[0].first_name
+      expect(csv[2][0]).to eq students[1].first_name
+      expect(csv[1][1]).to eq students[0].last_name
+      expect(csv[2][1]).to eq students[1].last_name
+      expect(csv[1][2]).to eq students[0].username
+      expect(csv[2][2]).to eq students[1].username
+      expect(csv[1][3]).to eq "123"
+      expect(csv[2][3]).to eq "456"
+      expect(csv[1][4]).to eq "789"
+      expect(csv[2][4]).to eq "456"
+      expect(csv[1][5]).to eq ""
+      expect(csv[2][5]).to eq "Hello there"
+      expect(csv[1][6]).to eq ""
+      expect(csv[2][6]).to eq "Grrrrreat!"
+      expect(csv[1][7]).to eq "#{updated_at}"
+      expect(csv[2][7]).to eq "#{updated_at}"
+    end
+
     xit "includes students that do not have grades for the assignment"
     xit "does not include the grade if it has not been graded or released"
   end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -1,4 +1,5 @@
-require "rails_spec_helper"
+require "active_record_spec_helper"
+require "./app/exporters/grade_exporter"
 
 describe GradeExporter do
   let(:assignment) { create(:assignment) }

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -8,12 +8,12 @@ describe GradeExporter do
   describe "#export" do
     it "generates an empty CSV if there is no assignment specified" do
       csv = subject.export(nil, [])
-      expect(csv.read.length).to eq 1 # headers
+      expect(csv).to eq "First Name,Last Name,Email,Score,Feedback\n"
     end
 
     it "generates an empty CSV if there are no students specified" do
       csv = subject.export(assignment, [])
-      expect(csv.read.length).to eq 1 # headers
+      expect(csv).to eq "First Name,Last Name,Email,Score,Feedback\n"
     end
 
     it "generates a CSV with student scores" do
@@ -24,7 +24,7 @@ describe GradeExporter do
         receive(:grade_for_assignment).with(assignment)
           .and_return double(:grade, score: 456, feedback: "Grrrrreat!")
 
-      csv = subject.export(assignment, students).read
+      csv = CSV.new(subject.export(assignment, students)).read
       expect(csv.length).to eq 3
       expect(csv[1][0]).to eq students[0].first_name
       expect(csv[2][0]).to eq students[1].first_name
@@ -42,7 +42,7 @@ describe GradeExporter do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return nil
-      csv = subject.export(assignment, students).read
+      csv = CSV.new(subject.export(assignment, students)).read
       expect(csv[1][3]).to eq ""
     end
   end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -1,15 +1,41 @@
 require "rails_spec_helper"
 
 describe GradeExporter do
+  let(:assignment) { create(:assignment) }
+  let(:students) { create_list :user, 2 }
   subject { GradeExporter.new }
 
   describe "#export" do
     it "generates an empty CSV if there is no assignment specified" do
       csv = subject.export(nil, [])
-      expect(csv.read.length) == 1 # headers
+      expect(csv.read.length).to eq 1 # headers
     end
 
-    xit "generates an empty CSV if there are no students specified"
-    xit "generates a CSV with student scores"
+    it "generates an empty CSV if there are no students specified" do
+      csv = subject.export(assignment, [])
+      expect(csv.read.length).to eq 1 # headers
+    end
+
+    it "generates a CSV with student scores" do
+      allow(students[0]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, score: 123, feedback: nil)
+      allow(students[1]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, score: 456, feedback: "Grrrrreat!")
+
+      csv = subject.export(assignment, students).read
+      expect(csv.length).to eq 3
+      expect(csv[1][0]).to eq students[0].first_name
+      expect(csv[2][0]).to eq students[1].first_name
+      expect(csv[1][1]).to eq students[0].last_name
+      expect(csv[2][1]).to eq students[1].last_name
+      expect(csv[1][2]).to eq students[0].email
+      expect(csv[2][2]).to eq students[1].email
+      expect(csv[1][3]).to eq "123"
+      expect(csv[2][3]).to eq "456"
+      expect(csv[1][4]).to eq nil
+      expect(csv[2][4]).to eq "Grrrrreat!"
+    end
   end
 end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -34,7 +34,7 @@ describe GradeExporter do
       expect(csv[2][2]).to eq students[1].email
       expect(csv[1][3]).to eq "123"
       expect(csv[2][3]).to eq "456"
-      expect(csv[1][4]).to eq nil
+      expect(csv[1][4]).to eq ""
       expect(csv[2][4]).to eq "Grrrrreat!"
     end
 
@@ -43,7 +43,7 @@ describe GradeExporter do
         receive(:grade_for_assignment).with(assignment)
           .and_return nil
       csv = subject.export(assignment, students).read
-      expect(csv[1][3]).to be_nil
+      expect(csv[1][3]).to eq ""
     end
   end
 end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -1,0 +1,15 @@
+require "rails_spec_helper"
+
+describe GradeExporter do
+  subject { GradeExporter.new }
+
+  describe "#export" do
+    it "generates an empty CSV if there is no assignment specified" do
+      csv = subject.export(nil, [])
+      expect(csv.read.length) == 1 # headers
+    end
+
+    xit "generates an empty CSV if there are no students specified"
+    xit "generates a CSV with student scores"
+  end
+end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -37,5 +37,13 @@ describe GradeExporter do
       expect(csv[1][4]).to eq nil
       expect(csv[2][4]).to eq "Grrrrreat!"
     end
+
+    it "includes students that do not have grades for the assignment" do
+      allow(students[0]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return nil
+      csv = subject.export(assignment, students).read
+      expect(csv[1][3]).to be_nil
+    end
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -21,27 +21,6 @@ describe Assignment do
     end
   end
 
-  describe "gradebook for assignment" do
-    it "returns sample csv data, including ungraded students" do
-      course = create(:course)
-      course.assignments << subject
-      student = create(:user)
-      student.courses << course
-      submission = create(:submission, student: student, assignment: subject)
-      expect(subject.gradebook_for_assignment).to eq("First Name,Last Name,Uniqname,Score,Raw Score,Statement,Feedback,Last Updated\n#{student.first_name},#{student.last_name},#{student.username},\"\",\"\",\"#{submission.text_comment}\",\"\"\n")
-    end
-
-    it "also returns grade fields with instructor modified grade" do
-      course = create(:course)
-      course.assignments << subject
-      student = create(:user)
-      student.courses << course
-      grade = create(:grade, raw_score: 100, assignment: subject, student: student, feedback: "good jorb!", instructor_modified: true)
-      submission = create(:submission, grade: grade, student: student, assignment: subject)
-      expect(subject.gradebook_for_assignment(converters: :date_time)).to eq("First Name,Last Name,Uniqname,Score,Raw Score,Statement,Feedback,Last Updated\n#{student.first_name},#{student.last_name},#{student.username},100,100,\"#{submission.text_comment}\",good jorb!,\"#{grade.updated_at}\"\n")
-    end
-  end
-
   describe "pass-fail assignments" do
     it "sets point total to zero on save" do
       subject.point_total = 3000

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -51,26 +51,6 @@ describe Assignment do
     end
   end
 
-  describe "grade import" do
-    it "returns sample csv data, including ungraded students" do
-      course = create(:course)
-      course.assignments << subject
-      student = create(:user)
-      student.courses << course
-      expect(subject.grade_import(course.students)).to eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},\"\",\"\"\n")
-    end
-
-    it "also returns grade fields with instructor modified grade" do
-      course = create(:course)
-      course.assignments << subject
-      student = create(:user)
-      student.courses << course
-      grade = create(:grade, assignment: subject, student: student, feedback: "good jorb!", instructor_modified: true)
-      submission = create(:submission, grade: grade, student: student, assignment: subject)
-      expect(subject.grade_import(course.students)).to eq("First Name,Last Name,Email,Score,Feedback\n#{student.first_name},#{student.last_name},#{student.email},#{grade.score},#{grade.feedback}\n")
-    end
-  end
-
   describe "#copy" do
     let(:assignment) { build :assignment }
     subject { assignment.copy }

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -1,0 +1,55 @@
+require "./app/models/null_grade"
+
+describe NullGrade do
+  subject { NullGrade.new }
+
+  it "has a nil score" do
+    expect(subject.score).to be_nil
+  end
+
+  it "has a nil raw score" do
+    expect(subject.raw_score).to be_nil
+  end
+
+  it "has a nil final score" do
+    expect(subject.final_score).to eq(nil)
+  end
+
+  it "has nil feedback" do
+    expect(subject.feedback).to be_nil
+  end
+
+  it "has a nil pass/fail status" do
+    expect(subject.pass_fail_status).to eq(nil)
+  end
+
+  it "has a nil status" do
+    expect(subject.status).to eq(nil)
+  end
+
+  it "has a nil updated at timestamp" do
+    expect(subject.updated_at).to eq(nil)
+  end
+
+  it "has a team id of zero" do
+    expect(subject.team_id).to eq(0)
+  end
+
+  it "is student visible" do
+    expect(subject).to be_is_student_visible
+  end
+
+  it "can have an assigned predicted score" do
+    expect(subject.predicted_score).to eq(0)
+    subject.predicted_score = 100
+    expect(subject.predicted_score).to eq 100
+  end
+
+  it "has a zero id" do
+    expect(subject.id).to eq(0)
+  end
+
+  it "returns 555 for the point total" do
+    expect(subject.point_total).to eq(555)
+  end
+end

--- a/spec/models/null_student_spec.rb
+++ b/spec/models/null_student_spec.rb
@@ -34,35 +34,9 @@ describe NullStudent do
 
     it "handles student.grades.first" do
       student = NullStudent.new
-      expect(student.grades.first.class).to eq(NullStudentGrade)
+      expect(student.grades.first.class).to eq(NullGrade)
     end
   end
-
-  describe "a single NullStudentGrade" do
-    it "handles grade.is_student_visible?" do
-      grade = NullStudentGrade.new
-      expect(grade.is_student_visible?).to eq(true)
-    end
-
-    it "handles methods for student and team grades" do
-      grade = NullStudentGrade.new
-      expect(grade.id).to eq(0)
-      expect(grade.point_total).to eq(555)
-      expect(grade.predicted_score).to eq(0)
-      expect(grade.score).to eq(nil)
-      expect(grade.raw_score).to eq(nil)
-      expect(grade.status).to eq(nil)
-      expect(grade.team_id).to eq(0)
-      expect(grade.final_score).to eq(nil)
-      expect(grade.pass_fail_status).to eq(nil)
-    end
-
-    it "handles assignment of predicted_score" do
-      grade = NullStudentGrade.new
-      expect(grade.predicted_score = 100).to eq(100)
-    end
-  end
-
 
   describe "NullStudentTeam and it's grades" do
     it "returns true for team for course present?" do


### PR DESCRIPTION
Refactored both the `AssignmentsController#import_grades` and `AssignmentsController#export_grades` to use exporter objects.

Created `GradeExporter` and `AssignmentExporter` with specs and removed the corresponding methods from the `Assignment` object.

Closes #1349 