### PR TITLE
1289 duplicate ROLES definition

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,5 @@
 class Role
-  ROLES = %w(student professor gsi admin)
+  ROLES = %w(student professor gsi admin) unless defined? ROLES
 
   def self.all
     ROLES.freeze


### PR DESCRIPTION
Only define the roles if they don't exist. This will remove the warning when additional processes are started.

Closes #1289 