### PR TITLE
1341 sorting scores not working

### DIFF
--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -22,11 +22,8 @@ $('table.nopage_dynatable').dynatable({
       return Number(el.innerHTML) || 0;
     },
     score: function(el, record) {
-      if($.trim(el.innerHTML) == '') {
-        return el.innerHTML;
-      } else {
-        return Number(el.innerHTML.replace(/,/g,""));
-      }
+      record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+      return el.innerHTML;
     },
     totalScore: function(el, record) {
       return Number(el.innerHTML.replace(/,/g,"")) || 0;
@@ -75,9 +72,6 @@ $('table.nopage_dynatable').dynatable({
     }
   },
   writers: {
-    score: function(record) {
-      return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    },
     min: function(record) {
       return record['min'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     },

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -109,16 +109,8 @@ $('table.nosearch_dynatable').dynatable({
       return Number(el.innerHTML) || 0;
     },
     score: function(el, record) {
-      if($.trim(el.innerHTML) == '') {
-        return el.innerHTML;
-      } else {
-        return Number(el.innerHTML.replace(/,/g,""));
-      }
-    }
-  },
-  writers: {
-    score: function(record) {
-      return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+      return el.innerHTML;
     }
   }
 });

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -6,16 +6,8 @@ $('table.dynatable').dynatable({
     }
     ,
     score: function(el, record) {
-      if($.trim(el.innerHTML) == '') {
-        return el.innerHTML;
-      } else {
-        return Number(el.innerHTML.replace(/,/g,""));
-      }
-    }
-  },
-  writers: {
-    score: function(record) {
-      return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+      return el.innerHTML;
     }
   }
 });

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -205,11 +205,8 @@ $('table.nofeatures_default_score_dynatable').dynatable({
   },
   readers: {
       score: function(el, record) {
-        if($.trim(el.innerHTML) == '') {
-          return el.innerHTML;
-        } else {
-          return Number(el.innerHTML.replace(/,/g,""));
-        }
+        record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+        return el.innerHTML;
       },
       dueDate: function(el, record) {
         record.parsedDate = Date.parse(el.innerHTML);
@@ -241,9 +238,6 @@ $('table.nofeatures_default_score_dynatable').dynatable({
       }
     },
     writers: {
-      score: function(record) {
-        return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-      },
       pointsEarned: function(record) {
         return record['pointsEarned'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
       }

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -244,19 +244,6 @@ $('table.nofeatures_default_score_dynatable').dynatable({
     }
 });
 
-$('table.nofeatures_default_desc_score_dynatable').dynatable({
-
-  features: {
-        paginate: false,
-        search: false,
-        recordCount: false,
-        sort: true
-      },
-  dataset: {
-    sorts: { 'score': -1 }
-  }
-});
-
 function alfaSort(as, bs, attr, direction) {
   //swap if reverse
   if(direction === -1) {
@@ -403,19 +390,11 @@ $('table.nofeatures_default_rank_dynatable').dynatable({
       return Number(el.innerHTML) || 0;
     },
     score: function(el, record) {
-      if($.trim(el.innerHTML) == '') {
-        return el.innerHTML;
-      } else {
-        return Number(el.innerHTML.replace(/,/g,""));
-      }
+      record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+      return el.innerHTML;
     },
     badgeCount: function(el, record) {
       return Number(el.innerHTML.replace(/,/g,""));
-    }
-  },
-  writers: {
-    score: function(record) {
-      return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     }
   }
 });

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -173,11 +173,8 @@ $('table.nofeatures_default_last_name_dynatable').dynatable({
       return Number(el.innerHTML.replace()) || 0;
     },
     score: function(el, record) {
-      if($.trim(el.innerHTML) == '') {
-        return el.innerHTML;
-      } else {
-        return Number(el.innerHTML.replace(/,/g,""));
-      }
+      record.numericScore = Number(el.innerHTML.replace(/,/g,""));
+      return el.innerHTML;
     },
     rawScore: function(el, record) {
       return Number(el.innerHTML.replace(/,/g,""));
@@ -187,9 +184,6 @@ $('table.nofeatures_default_last_name_dynatable').dynatable({
     }
   },
   writers: {
-    score: function(record) {
-      return record['score'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    },
     totalBadgeScore: function(record) {
       return record['totalBadgeScore'].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     }

--- a/app/views/analytics/_students_table.haml
+++ b/app/views/analytics/_students_table.haml
@@ -2,7 +2,7 @@
   %thead
     %tr
       %th{ :scope => "column", :width => "20%" }= course.user_term
-      %th{ :scope => "column", :width => "10%"} Score
+      %th{ :scope => "column", :width => "10%", "data-dynatable-sorts" => "numericScore"} Score
       - if course.has_badges?
         %th{ :scope => "column", :width => "5%" } Badges
       - if course.has_teams?

--- a/app/views/assignments/individual/_table_head.html.haml
+++ b/app/views/assignments/individual/_table_head.html.haml
@@ -6,7 +6,7 @@
 
   // If 'Score' only if the assignment type is not student_weightable
   - if !presenter.assignment_type.student_weightable? && !presenter.assignment.pass_fail?
-    %th{:scope => "col"} Score
+    %th{:scope => "col", "data-dynatable-sorts" => "numericScore"} Score
   - elsif presenter.assignment_type.student_weightable?
     %th{:scope => "col"} Raw Score
     %th{:scope => "col"} Multiplied Score

--- a/app/views/challenge_grades/edit_status.html.haml
+++ b/app/views/challenge_grades/edit_status.html.haml
@@ -4,12 +4,12 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   %table.nopage_dynatable
     %thead
       %tr
         %th= term_for :team
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         %th Current Status
     %tbody
       - for challenge_grade in @challenge_grades

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -20,7 +20,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   - if @challenge.challenge_files.present?
     %p
       %b Documents:
@@ -35,7 +35,7 @@
       %thead
         %tr
           %th= current_course.team_term
-          %th Score
+          %th{ "data-dynatable-sorts" => "numericScore" } Score
           - if @challenge.has_levels?
             %th Level
           - if @challenge.release_necessary?

--- a/app/views/grades/_import_results_table.html.haml
+++ b/app/views/grades/_import_results_table.html.haml
@@ -4,7 +4,7 @@
       %th First Name
       %th Last Name
       %th Email
-      %th Score
+      %th{ "data-dynatable-sorts" => "rawScore" } Score
       %th Feedback
   %tbody
     - grades.each do |grade|

--- a/app/views/info/_in_progress_grades_table.haml
+++ b/app/views/info/_in_progress_grades_table.haml
@@ -19,11 +19,11 @@
                 %th{:scope => "col", :width => "15%"}= "#{term_for :team}"
             - elsif assignment.has_groups?
               %th{:scope => "col"} Group
-            %th{:scope => "col", :width => "8%"} Score
+            %th{:scope => "col", :width => "8%", "data-dynatable-sorts" => "numericScore"} Score
             %th{:scope => "col"} Feedback
             %th{:scope => "col", "data-dynatable-no-sort" => "true", :width => "20%" }
               %span.sr-only Actions
-            %th{"data-dynatable-no-sort" => "true", :width => "120px" }  
+            %th{"data-dynatable-no-sort" => "true", :width => "120px" }
               %button.button.select-all= "Check"
               %button.button.select-none= "Uncheck"
           %tbody

--- a/app/views/info/_teams_table.haml
+++ b/app/views/info/_teams_table.haml
@@ -3,7 +3,7 @@
     %tr
       %th= course.team_term
       - if ! current_course.team_score_average
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
       %th Average #{course.user_term} Grade
       %th= course.team_leader_term
   %tbody

--- a/app/views/info/_unreleased_grades_table.haml
+++ b/app/views/info/_unreleased_grades_table.haml
@@ -21,11 +21,11 @@
               %th{:scope => "col"}= "#{term_for :groups}"
             - elsif course.has_teams?
               %th{:scope => "col", :width => "15%"}= "#{term_for :team}"
-            %th{:scope => "col", "data-dynatable-column" => "score", :width => "8%"} Score
+            %th{:scope => "col", "data-dynatable-column" => "score", "data-dynatable-sorts" => "numericScore", :width => "8%"} Score
             %th{:scope => "col"} Feedback
             %th{:scope => "col", "data-dynatable-no-sort" => "true", :style => "min-width: 200px"}
               %span.sr-only Actions
-            %th{"data-dynatable-no-sort" => "true", :width => "120px" }  
+            %th{"data-dynatable-no-sort" => "true", :width => "120px" }
               %button.button.select-all= "Check"
               %button.button.select-none= "Uncheck"
         %tbody

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -4,7 +4,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   %span.label.alert= "You have #{@resubmission_count} resubmissions to grade"
 
   - if current_course.has_teams?
@@ -28,7 +28,7 @@
               %th{:scope => "col", :width => "15%"}= "#{term_for :team}"
           - elsif assignment.has_groups?
             %th{:scope => "col"} Group
-          %th{:scope => "col", :width => "7%"} Current Score
+          %th{:scope => "col", :width => "7%", "data-dynatable-sorts" => "numericScore"} Current Score
           %th{:scope => "col", :width => "7%"} Graded
           %th{:scope => "col", :width => "7%"} Resubmitted
           %th{:scope => "col", :style => "min-width: 300px" }

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -11,7 +11,7 @@
         %th #{current_course.team_term}
       - if current_course.team_roles?
         %th Role
-      %th Score
+      %th{ "data-dynatable-sorts" => "numericScore" } Score
       %th Grade
       %th{ :style => "min-width: 200px" }
   %tbody

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -2,7 +2,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   %table.dynatable
     %thead
       %tr
@@ -11,7 +11,7 @@
         %th Task
         %th Submission
         %th Raw Score
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         %th Predicted Score
         %th Feedback
         %th Status

--- a/app/views/students/leaderboard.html.haml
+++ b/app/views/students/leaderboard.html.haml
@@ -22,7 +22,7 @@
         %th{:scope => "col"} Last Name
         - if current_course.in_team_leaderboard? || current_course.character_names?
           %th Pseudonyms
-        %th{:scope => "col", "data-dynatable-sorts" => "score"} Score
+        %th{:scope => "col", "data-dynatable-sorts" => "numericScore"} Score
         - if current_course.has_teams?
           %th{:scope => "col"} #{current_course.team_term}
         %th{:scope => "col"} Grade

--- a/app/views/teams/_in_team_rankings.html.haml
+++ b/app/views/teams/_in_team_rankings.html.haml
@@ -11,7 +11,7 @@
           %th Character Profile
         - if current_course.team_roles?
           %th Role
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
     %tbody
       - current_student.team_for_course(current_course).students.each do |student|
         - if student.display_name?

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -5,7 +5,7 @@
       %th Name
       %th{ "data-dynatable-column" => "averageScore"} Mean Student Score
       - if current_course.team_challenges?
-        %th{ "data-dynatable-column" => "score" } #{term_for :challenge} Score
+        %th{ "data-dynatable-column" => "numericScore" } #{term_for :challenge} Score
       %th{ "data-dynatable-column" => "students" } #{term_for :students}
       %th #{term_for :team_leaders}
       - if current_user_is_staff? && current_course.has_badges?

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -15,7 +15,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   %h4.subtitle= "#{term_for :student} Roster"
 
   %table.nofeatures_default_last_name_dynatable
@@ -26,7 +26,7 @@
         %th Email
         - if current_course.team_roles?
           %th Role
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         %th Level
         - if current_course.has_badges?
           %th{:scope => "col", "data-dynatable-sorts" => "badgeCount", :width => "20%" }= "#{term_for :badges} Earned"
@@ -50,7 +50,7 @@
                     %img{:src => badge.try(:icon), :alt => badge.try(:name), :width => "20", :title => badge.name }
                   .display_on_hover.hover-style
                     = badge.try(:name)
-                    
+
               %th{:style => "display: none"}= student.earned_badges_for_course(current_course).count
             %td
               .right
@@ -58,7 +58,7 @@
                   %li= link_to raw("<i class='fa fa-dashboard fa-fw'></i> Dashboard"), student_path(student), :class => 'button'
                   %li= link_to raw("<i class='fa fa-edit fa-fw'></i> Edit"), edit_user_path(student), :class => 'button'
 
-  %h4.subtitle #{term_for :challenge } Grades 
+  %h4.subtitle #{term_for :challenge } Grades
 
   %table.nofeatures_default_score_dynatable
     %thead

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -64,7 +64,7 @@
     %thead
       %tr
         %th Name
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         %th{:width => "80px"}
 
     %tbody

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,7 +4,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   - if current_course.has_teams?
     .team-filter
       = form_tag users_path, :name => "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
@@ -20,7 +20,7 @@
         %th Role
         %th Courses
         %th #{term_for :team}
-        %th Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         %th{:style => "min-width: 250px"}
     %tbody
       - @users.each do |user|


### PR DESCRIPTION
Modified the dynatable reader for scores so that it sorts on a `numericScore` value and updated the column to sort on that new `numericScore` column. The issue was that sometimes the score was a string and sometimes the score was a number. When dynatable tried to treat it as a string, `toLowerCase` would not work on a number.

The writers were removed since the readers for score now return the score as it was written but they sort on the `numericScore` column. All of the score columns in all dynatables were updated.

Fixes #1341 