### PR TITLE
Change deliver to deliver_now since deliver has been depreciated

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -45,7 +45,7 @@ class EarnedBadgesController < ApplicationController
           # @mz TODO: add specs
           ScoreRecalculatorJob.new(user_id: @earned_badge.student_id, course_id: current_course.id).enqueue
         end
-        NotificationMailer.earned_badge_awarded(@earned_badge.id).deliver
+        NotificationMailer.earned_badge_awarded(@earned_badge.id).deliver_now
         format.html { redirect_to badge_path(@badge), notice: "The #{@badge.name} #{term_for :badge} was successfully awarded to #{@earned_badge.student.name}" }
       else
         @title = "Award #{@badge.name}"
@@ -144,7 +144,7 @@ class EarnedBadgesController < ApplicationController
   end
 
   def send_earned_badge_notifications
-    @valid_earned_badges.each do |earned_badge| 
+    @valid_earned_badges.each do |earned_badge|
       NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now
       logger.info "Sent an earned badge notification for EarnedBadge ##{earned_badge[:id]}"
     end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -44,10 +44,6 @@ class GroupsController < ApplicationController
     end
     respond_to do |format|
       if @group.save
-        #current_course.instructors_of_record.each do |professor|
-          #NotificationMailer.group_created(@group.id, professor).deliver
-        #end
-        #NotificationMailer.group_notify(@group.id).deliver
         format.html { respond_with @group }
       else
         @title = "Start a #{term_for :group}"
@@ -73,7 +69,6 @@ class GroupsController < ApplicationController
 
     respond_to do |format|
       if @group.update_attributes(params[:group])
-        #NotificationMailer.group_status_updated(@group.id).deliver
         format.html { respond_with @group }
       else
         if current_user_is_student?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -82,7 +82,7 @@ class SubmissionsController < ApplicationController
         user = { name: "#{@submission.student.first_name}", email: "#{@submission.student.email}" }
         submission = { name: "#{@submission.assignment.name}", time: "#{@submission.created_at}" }
         course = { courseno: "#{current_course.courseno}",  }
-        NotificationMailer.successful_submission(@submission.id).deliver
+        NotificationMailer.successful_submission(@submission.id).deliver_now
       end
     elsif @submission.errors[:link].any?
       redirect_to new_assignment_submission_path(@assignment, @submission), notice: "Please provide a valid link for #{@assignment.name} submissions."
@@ -126,7 +126,7 @@ class SubmissionsController < ApplicationController
         if current_user_is_student?
           format.html { redirect_to assignment_path(@assignment, :anchor => "fndtn-tabt3"), notice: "Your submission for #{@assignment.name} was successfully updated." }
           format.json { render json: @assignment, status: :created, location: @assignment }
-          NotificationMailer.updated_submission(@submission.id).deliver
+          NotificationMailer.updated_submission(@submission.id).deliver_now
         else
           format.html { redirect_to assignment_submission_path(@assignment, @submission), notice: "#{@assignment.name} was successfully updated." }
         end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -68,12 +68,12 @@ class UserSessionsController < ApplicationController
   def lti_error_notification
     user = { name: auth_hash['extra']['raw_info']['lis_person_name_full'], email: auth_hash['extra']['raw_info']['lis_person_contact_email_primary'], lti_uid: auth_hash['extra']['raw_info']['context_id'] }
     course = { name: auth_hash['extra']['raw_info']['context_label'], uid: auth_hash['extra']['raw_info']['context_id'] }
-    NotificationMailer.lti_error(user, course).deliver
+    NotificationMailer.lti_error(user, course).deliver_now
   end
 
   def kerberos_error_notification
     user = { uid: auth_hash['uid'] }
-    NotificationMailer.kerberos_error(user).deliver
+    NotificationMailer.kerberos_error(user).deliver_now
   end
 
   def redirect_back_or(default)


### PR DESCRIPTION
Although this does not fix #1281, this removes depreciation warnings that come with using `deliver` on a mailer rather than using `deliver_now`.