### PR TITLE
bugfix rubric grade edit return path

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 mailcatcher: bundle exec mailcatcher -f
-web: bundle exec puma -p $PORT
+web: bundle exec puma -p 5000
 redis: redis-server --port $REDIS_PORT
 resque_scheduler: bundle exec rake resque:scheduler
 resque_worker: bundle exec rake resque:work

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -10,7 +10,7 @@
   $scope.pointsPossible = 0
   $scope.pointsGiven = 0
 
-  $scope.init = (rubricId, assignmentId, studentId, rubricGrades, gradeStatus, releaseNecessary)->
+  $scope.init = (rubricId, assignmentId, studentId, rubricGrades, gradeStatus, releaseNecessary, returnURL)->
     $scope.rubricId = rubricId
     $scope.assignmentId = assignmentId
     $scope.studentId = studentId
@@ -23,6 +23,8 @@
     $scope.releaseNecessary = releaseNecessary
     if not $scope.releaseNecessary
       $scope.gradeStatus = "Graded"
+
+    $scope.returnURL = returnURL
 
     $scope.addRubricGrades(rubricGrades)
 
@@ -193,7 +195,7 @@
     if confirm "Are you sure you want to submit the grade for this assignment?"
       # alert(self.gradedRubricParams().tier_badges.length)
       $http.put("/assignments/#{$scope.assignmentId}/grade/submit_rubric", self.gradedRubricParams()).success(
-        window.location = "/assignments/#{$scope.assignmentId}"
+        window.location = $scope.returnURL
       )
       .error(
       )

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -6,7 +6,7 @@ $(".make-lizards").dblclick(function() {
 });
 
 $( "#tabs" ).tabs({
-  event: "mouseover"
+  event: "click"
 });
 
  $('.froala').editable(

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -6,6 +6,7 @@ class GradesController < ApplicationController
 
   protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format == 'application/json' }
 
+  # GET /assignments/:assignment_id/grade?student_id=:id
   def show
     @assignment = current_course.assignments.find(params[:assignment_id])
     if current_user_is_student?
@@ -38,9 +39,9 @@ class GradesController < ApplicationController
 
   public
 
+  # GET /assignments/:assignment_id/grade/edit?student_id=:id
   def edit
     session[:return_to] = request.referer
-
     @student = current_student
 
     @grade = Grade.where(student_id: @student[:id], assignment_id: @assignment[:id]).first
@@ -55,6 +56,8 @@ class GradesController < ApplicationController
     if @assignment.rubric.present?
       @rubric = @assignment.rubric
       @rubric_grades = serialized_rubric_grades
+      # This is a patch for the Angular GradeRubricCtrl
+      @return_path = URI(request.referer).path
     end
 
     @serialized_init_data = serialized_init_data
@@ -265,7 +268,9 @@ class GradesController < ApplicationController
 
   public
 
+  # PUT /assignments/:assignment_id/grade/submit_rubric
   def submit_rubric
+
     if @submission = Submission.where(current_assignment_and_student_ids).first
       @submission.update_attributes(graded: true)
     end

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -1,5 +1,5 @@
 .pageContent
-  #rubric-grader(ng-app="gradecraft" ng-controller="GradeRubricCtrl" ng-init="init(#{@rubric[:id]}, #{@assignment[:id]}, #{params[:student_id]}, #{@rubric_grades}, \"#{@grade.status if @grade}\", #{@assignment.release_necessary?})")
+  #rubric-grader(ng-app="gradecraft" ng-controller="GradeRubricCtrl" ng-init="init(#{@rubric[:id]}, #{@assignment[:id]}, #{params[:student_id]}, #{@rubric_grades}, \"#{@grade.status if @grade}\", #{@assignment.release_necessary?}, '#{@return_path}')")
     .row
       #rubric-heading.columns
         %h3.text-right

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -113,6 +113,7 @@ describe GradesController do
       end
 
       it "if rubric present, assigns the rubric and rubric grades" do
+        allow(request).to receive(:referer).and_return('http://gradecraft.com/assignments/123')
         assignment = create(:assignment, course: @course)
         rubric = create(:rubric_with_metrics, assignment: assignment)
         metric = rubric.metrics.first
@@ -121,6 +122,7 @@ describe GradesController do
         get :edit, { :id => @grade.id, :assignment_id => assignment.id, :student_id => @student.id }
         expect(assigns(:rubric)).to eq(rubric)
         expect(JSON.parse(assigns(:rubric_grades))).to eq([{ "id" => rubric_grade.id, "metric_id" => metric.id, "tier_id" => tier.id, "comments" => nil }])
+        expect(assigns(:return_path)).to eq('/assignments/123')
       end
     end
 
@@ -132,6 +134,44 @@ describe GradesController do
         @grade.reload
         expect(response).to redirect_to(assignment_path(@grade.assignment))
         expect(@grade.score).to eq(1000)
+      end
+    end
+
+    describe "PUT submit_rubric"do
+
+      before(:each) do
+        # @rubric_assignment = create(:assignment, course: @course)
+        # @rubric = create(:rubric_with_metrics, assignment: @rubric_assignment)
+        # @metric = @rubric.metrics.first
+        # @tier = @rubric.metrics.first.tiers.first
+        # @rubric_grade = create(:rubric_grade, assignment: @rubric_assignment, student: @student, metric: @metric, tier: @tier)
+      end
+
+      it "updates the submission grading status" do
+      end
+
+      it "assigns the grade" do
+
+      end
+
+      it "deletes all preexisting rubric grades" do
+
+      end
+
+      it "creates the rubric grades" do
+
+      end
+
+      it "deletes existing earned badges" do
+
+      end
+
+      it "adds earned tier badges" do
+
+      end
+
+      it "renders nothing when request format is JSON" do
+
       end
     end
 


### PR DESCRIPTION
Contains the following bugfixes:

  * rubric grades edited from `\grading_status` now return correctly after submission
  * temporarily hardcode the port to 5000 until this issue is fixed with foreman
  * changes tabs to require click, not mouseover, to change view

Additionally checked that rubric grades edited from the assignment/:id/grade edit path return as before
fixes #1307 