### PR TITLE
1366 refactor and test assignment

### DIFF
--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -5,16 +5,13 @@ module TimelineHelper
   end
 
   def assignment_timeline_content(assignment)
-    content = ""
-    if assignment.course.show_see_details_link_in_timeline?
-      content = content_tag(:p) do
-        content_tag(:a, "See the details", href: assignment_path(assignment))
-      end
-    end
+    content = detail_link_timeline_content(assignment) || ""
     if assignment.assignment_files.present?
       files_content = content_tag(:ul, class: "attachments") do
         assignment.assignment_files.collect do |af|
-          concat content_tag(:li, content_tag(:a, af.filename, href: af.url), class: "document")
+          link_content = content_tag(:i, nil, class: "fa fa-file-o fa-fw")
+          link_content.concat content_tag(:a, af.filename, href: af.url)
+          concat content_tag(:li, link_content, class: "document")
         end
       end
       content.concat files_content
@@ -23,9 +20,31 @@ module TimelineHelper
   end
 
   def challenge_timeline_content(challenge)
+    content = detail_link_timeline_content(challenge) || ""
+    if challenge.challenge_files.present?
+      files_content = content_tag(:ul, class: "attachments") do
+        challenge.challenge_files.collect do |cf|
+          link_content = content_tag(:i, nil, class: "fa fa-file-o fa-fw")
+          link_content.concat content_tag(:a, cf.filename, href: cf.url)
+          concat content_tag(:li, link_content, class: "document")
+        end
+      end
+      content.concat files_content
+    end
+    content.concat challenge.description
   end
 
   def event_timeline_content(event)
     event.description
+  end
+
+  private
+
+  def detail_link_timeline_content(model)
+    if model.course.show_see_details_link_in_timeline?
+      content_tag(:p) do
+        content_tag(:a, "See the details", href: "#{url_for(model)}/#{model.id}")
+      end
+    end
   end
 end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -21,4 +21,11 @@ module TimelineHelper
     end
     content.concat assignment.description
   end
+
+  def challenge_timeline_content(challenge)
+  end
+
+  def event_timeline_content(event)
+    event.description
+  end
 end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -6,31 +6,13 @@ module TimelineHelper
 
   def assignment_timeline_content(assignment)
     content = detail_link_timeline_content(assignment) || ""
-    if assignment.assignment_files.present?
-      files_content = content_tag(:ul, class: "attachments") do
-        assignment.assignment_files.collect do |af|
-          link_content = content_tag(:i, nil, class: "fa fa-file-o fa-fw")
-          link_content.concat content_tag(:a, af.filename, href: af.url)
-          concat content_tag(:li, link_content, class: "document")
-        end
-      end
-      content.concat files_content
-    end
+    content.concat file_attachment_timeline_content(assignment.assignment_files) || ""
     content.concat assignment.description
   end
 
   def challenge_timeline_content(challenge)
     content = detail_link_timeline_content(challenge) || ""
-    if challenge.challenge_files.present?
-      files_content = content_tag(:ul, class: "attachments") do
-        challenge.challenge_files.collect do |cf|
-          link_content = content_tag(:i, nil, class: "fa fa-file-o fa-fw")
-          link_content.concat content_tag(:a, cf.filename, href: cf.url)
-          concat content_tag(:li, link_content, class: "document")
-        end
-      end
-      content.concat files_content
-    end
+    content.concat file_attachment_timeline_content(challenge.challenge_files) || ""
     content.concat challenge.description
   end
 
@@ -44,6 +26,18 @@ module TimelineHelper
     if model.course.show_see_details_link_in_timeline?
       content_tag(:p) do
         content_tag(:a, "See the details", href: "#{url_for(model)}/#{model.id}")
+      end
+    end
+  end
+
+  def file_attachment_timeline_content(files)
+    if files.present?
+      content_tag(:ul, class: "attachments") do
+        files.collect do |f|
+          link_content = content_tag(:i, nil, class: "fa fa-file-o fa-fw")
+          link_content.concat content_tag(:a, f.filename, href: f.url)
+          concat content_tag(:li, link_content, class: "document")
+        end
       end
     end
   end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -1,0 +1,24 @@
+module TimelineHelper
+  def timeline_content(event)
+    method = "#{event.class.name.demodulize.underscore}_timeline_content"
+    self.send(method, event) if self.respond_to? method
+  end
+
+  def assignment_timeline_content(assignment)
+    content = ""
+    if assignment.course.show_see_details_link_in_timeline?
+      content = content_tag(:p) do
+        content_tag(:a, "See the details", href: assignment_path(assignment))
+      end
+    end
+    if assignment.assignment_files.present?
+      files_content = content_tag(:ul, class: "attachments") do
+        assignment.assignment_files.collect do |af|
+          concat content_tag(:li, content_tag(:a, af.filename, href: af.url), class: "document")
+        end
+      end
+      content.concat files_content
+    end
+    content.concat assignment.description
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -108,24 +108,6 @@ class Assignment < ActiveRecord::Base
     super(options.merge(:only => [ :id, :content, :order, :done ] ))
   end
 
-  def content
-    content = ""
-    if course.show_see_details_link_in_timeline?
-      content << "<p><a href='/assignments/#{self.id}'>See the details</a></p>"
-    end
-    if assignment_files.present?
-      content << '<ul class="attachments">'
-      assignment_files.each do |af|
-        content << "<li class='document'><i class='fa fa-file-o fa-fw'></i><a href='#{af.url}'>#{af.filename}</a></li>"
-      end
-      content << '</ul>'
-    end
-    if description.present?
-      content << description
-    end
-    return content
-  end
-
   def point_total
     super.presence || 0
   end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -41,24 +41,6 @@ class Challenge < ActiveRecord::Base
     mass_grade = true
   end
 
-  def content
-    content = ""
-    if course.show_see_details_link_in_timeline?
-      content << "<p><a href='/challenges/#{self.id}'>See the details</a></p>"
-    end
-    if challenge_files.present?
-      content << '<ul class="attachments">'
-      challenge_files.each do |cf|
-        content << "<li class='document'><i class='fa fa-file-o fa-fw'></i><a href='#{cf.url}'>#{cf.filename}</a></li>"
-      end
-      content << '</ul>'
-    end
-    if description.present?
-      content << description
-    end
-    return content
-  end
-
   def challenge_grades_by_team_id
     @challenge_grade_for_team ||= challenge_grades.group_by(&:team_id)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,11 +10,4 @@ class Event < ActiveRecord::Base
 
   # Check to make sure the event has a name before saving
   validates_presence_of :name
-
-  def content
-    content = ""
-    if description.present?
-      content << description
-    end
-  end
 end

--- a/app/views/info/_timeline.jbuilder
+++ b/app/views/info/_timeline.jbuilder
@@ -23,7 +23,7 @@ json.set! :timeline do
         json.endDate event.due_at
       end
       json.headline event.name
-      json.text event.content
+      json.text timeline_content(event)
       json.set! :asset do
         if event.thumbnail && event.media
           json.thumbnail event.thumbnail_url

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -12,6 +12,24 @@ describe TimelineHelper do
         helper.timeline_content(assignment)
       end
     end
+
+    context "for a challenge" do
+      let(:challenge) { build(:challenge) }
+
+      it "calls the appropriate method based on the type" do
+        expect(helper).to receive(:challenge_timeline_content).with(challenge)
+        helper.timeline_content(challenge)
+      end
+    end
+
+    context "for an event" do
+      let(:event) { build(:event) }
+
+      it "calls the appropriate method based on the type" do
+        expect(helper).to receive(:event_timeline_content).with(event)
+        helper.timeline_content(event)
+      end
+    end
   end
 
   describe "#assignment_timeline_content" do
@@ -49,6 +67,19 @@ describe TimelineHelper do
       allow(assignment).to receive(:id).and_return 123
       allow(assignment).to receive(:description).and_return "This is a description"
       html = helper.assignment_timeline_content(assignment)
+      expect(html).to have_text "This is a description"
+    end
+  end
+
+  describe "#challenge_timeline_content" do
+  end
+
+  describe "#event_timeline_content" do
+    let(:event) { build(:event) }
+
+    it "displays the description if it's present" do
+      allow(event).to receive(:description).and_return "This is a description"
+      html = helper.event_timeline_content(event)
       expect(html).to have_text "This is a description"
     end
   end

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -33,10 +33,9 @@ describe TimelineHelper do
   end
 
   describe "#assignment_timeline_content" do
-    let(:assignment) { build(:assignment) }
+    let(:assignment) { build(:assignment, id: 123) }
 
     it "displays a link for the details if the course calls for it" do
-      allow(assignment).to receive(:id).and_return 123
       html = helper.assignment_timeline_content(assignment)
       expect(html).to have_tag "a", with: { href: assignment_path(assignment) } do
         with_text "See the details"
@@ -44,7 +43,6 @@ describe TimelineHelper do
     end
 
     it "does not display a link for the details if the course does not allow it" do
-      allow(assignment).to receive(:id).and_return 123
       allow(assignment.course).to receive(:show_see_details_link_in_timeline?).and_return false
       allow(assignment).to receive(:description).and_return ""
       html = helper.assignment_timeline_content(assignment)
@@ -52,7 +50,6 @@ describe TimelineHelper do
     end
 
     it "displays any attachments" do
-      allow(assignment).to receive(:id).and_return 123
       document1 = double(:attachment, filename: "Document1.png", url: "http://example.com/document1")
       allow(assignment).to receive(:assignment_files).and_return [document1]
       html = helper.assignment_timeline_content(assignment)
@@ -64,7 +61,6 @@ describe TimelineHelper do
     end
 
     it "displays the description if it's present" do
-      allow(assignment).to receive(:id).and_return 123
       allow(assignment).to receive(:description).and_return "This is a description"
       html = helper.assignment_timeline_content(assignment)
       expect(html).to have_text "This is a description"
@@ -72,6 +68,38 @@ describe TimelineHelper do
   end
 
   describe "#challenge_timeline_content" do
+    let(:challenge) { build(:challenge, id: 123) }
+
+    it "displays a link for the details if the course calls for it" do
+      html = helper.challenge_timeline_content(challenge)
+      expect(html).to have_tag "a", with: { href: challenge_path(challenge) } do
+        with_text "See the details"
+      end
+    end
+
+    it "does not display a link for the details if the course does not allow it" do
+      allow(challenge.course).to receive(:show_see_details_link_in_timeline?).and_return false
+      allow(challenge).to receive(:description).and_return ""
+      html = helper.challenge_timeline_content(challenge)
+      expect(html).to be_empty
+    end
+
+    it "displays any attachments" do
+      document1 = double(:attachment, filename: "Document1.png", url: "http://example.com/document1")
+      allow(challenge).to receive(:challenge_files).and_return [document1]
+      html = helper.challenge_timeline_content(challenge)
+      expect(html).to have_tag "ul", with: { class: "attachments" }
+      expect(html).to have_tag "li", with: { class: "document" }
+      expect(html).to have_tag "a", with: { href: "http://example.com/document1" } do
+        with_text "Document1.png"
+      end
+    end
+
+    it "displays the description if it's present" do
+      allow(challenge).to receive(:description).and_return "This is a description"
+      html = helper.challenge_timeline_content(challenge)
+      expect(html).to have_text "This is a description"
+    end
   end
 
   describe "#event_timeline_content" do

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -1,0 +1,55 @@
+require "rails_spec_helper"
+
+describe TimelineHelper do
+  include RSpecHtmlMatchers
+
+  describe "#timeline_content" do
+    context "for an assignment" do
+      let(:assignment) { build(:assignment) }
+
+      it "calls the appropriate method based on the type" do
+        expect(helper).to receive(:assignment_timeline_content).with(assignment)
+        helper.timeline_content(assignment)
+      end
+    end
+  end
+
+  describe "#assignment_timeline_content" do
+    let(:assignment) { build(:assignment) }
+
+    it "displays a link for the details if the course calls for it" do
+      allow(assignment).to receive(:id).and_return 123
+      html = helper.assignment_timeline_content(assignment)
+      expect(html).to have_tag "a", with: { href: assignment_path(assignment) } do
+        with_text "See the details"
+      end
+    end
+
+    it "does not display a link for the details if the course does not allow it" do
+      allow(assignment).to receive(:id).and_return 123
+      allow(assignment.course).to receive(:show_see_details_link_in_timeline?).and_return false
+      allow(assignment).to receive(:description).and_return ""
+      html = helper.assignment_timeline_content(assignment)
+      expect(html).to be_empty
+    end
+
+    it "displays any attachments" do
+      allow(assignment).to receive(:id).and_return 123
+      document1 = double(:attachment, filename: "Document1.png", url: "http://example.com/document1")
+      allow(assignment).to receive(:assignment_files).and_return [document1]
+      html = helper.assignment_timeline_content(assignment)
+      expect(html).to have_tag "ul", with: { class: "attachments" }
+      expect(html).to have_tag "li", with: { class: "document" }
+      expect(html).to have_tag "a", with: { href: "http://example.com/document1" } do
+        with_text "Document1.png"
+      end
+    end
+
+    it "displays the description if it's present" do
+      allow(assignment).to receive(:id).and_return 123
+      allow(assignment).to receive(:description).and_return "This is a description"
+      html = helper.assignment_timeline_content(assignment)
+      expect(html).to have_text "This is a description"
+    end
+  end
+end


### PR DESCRIPTION
Reduce the complexity of `Assignment` for #1366 by removing the `Assignment#content` method out of the model and into a helper. This belongs in a helper (or the presentation layer) rather than the model layer anyway. I moved the method to a `TimelineHelper`.

Found that the timeline json builder also uses the `#content` methods from `Challenge` and `Event` as well and so those were moved too.

I did a search for where `#content` was used in other places in the application but I could not find any. If any others are known, please advise and I will switch them to use the `TimelineHelper`.