### PR TITLE
1347 add course numbers to search fields

### DIFF
--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -22,7 +22,8 @@
               return '<li><a href="#">' + label + '</a></li>';
             },
             filter: function(item, query) {
-              return item.name.match(new RegExp(query, 'i'));
+              var regex = new RegExp(query, 'i');
+              return item.name.match(regex) || item.courseno.match(regex);
             }
           }).on('omniselect:select', function(event, id) {
             var form = document.createElement("form");

--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -13,7 +13,8 @@
             resultsClass: 'typeahead dropdown-menu course-result',
             activeClass: 'active',
             itemLabel: function(course) {
-              return course.courseno + " " + course.name;
+              return course.courseno + " " + course.name +
+                " (" + course.semester + " " + course.year + ")";
             },
             itemId: function(course) {
               return course.id;

--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -13,7 +13,7 @@
             resultsClass: 'typeahead dropdown-menu course-result',
             activeClass: 'active',
             itemLabel: function(course) {
-              return course.name;
+              return course.courseno + " " + course.name;
             },
             itemId: function(course) {
               return course.id;

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,10 +8,8 @@ class CoursesController < ApplicationController
     @courses = Course.all
     respond_to do |format|
       format.html { }
-      format.json do
-        json = @courses.map { |c| { id: c.id, name: c.name } }
-        render json: MultiJson.dump(json)
-      end
+      format.json { render json: @courses.to_json(only: [:id, :name, :courseno,
+                                                         :year, :semester]) }
     end
   end
 
@@ -107,7 +105,7 @@ class CoursesController < ApplicationController
     respond_to do |format|
       if new_course.save
         if ! current_user_is_admin?
-          new_course.course_memberships.create(:user_id => current_user.id, 
+          new_course.course_memberships.create(:user_id => current_user.id,
                                                 :role => current_user.role(current_course))
         end
         session[:course_id] = new_course.id

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -21,6 +21,16 @@ describe CoursesController do
         expect(assigns(:courses)).to eq(Course.all)
         expect(response).to render_template(:index)
       end
+
+      context "with json format" do
+        it "returns all courses in json format" do
+          get :index, format: :json
+          json = JSON.parse(response.body)
+          expect(json.length).to eq Course.count
+          expect(json[0].keys).to eq ["id", "name", "courseno",
+                                      "year", "semester"]
+        end
+      end
     end
 
     describe "GET show" do


### PR DESCRIPTION
Allows a staff member to search courses by course number. This also adds the course number, semester, and year to the output for a course.
 
![course-search](https://cloud.githubusercontent.com/assets/35017/11313096/6e3ce104-8fa8-11e5-80d5-4bda3e72e999.gif)

NOTE: There is an existing CSS issue with the results display. I did not change this but I did try and fix it with z-index. This is not the issue but it may because this has absolute positioning. I can look into fixing this issue if you wish.

Closes #1347 