### PR TITLE
1376 - Default course edit year to current course year

### DIFF
--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -22,7 +22,7 @@
 
     .form-item
       = f.label :year
-      = f.select :year, (Date.today.year - 3)..(Date.today.year + 2), :selected => "#{Date.today.year}"
+      = f.select :year, (Date.today.year - 3)..(Date.today.year + 2), :selected => "#{@course.year || Date.today.year}"
 
     .form-item
       = f.label :point_total, "Max Number of Points"


### PR DESCRIPTION
This fixes an issue where when editing a course, the year that the course was saved with was not being displayed, instead, the current year was.

I changed this in the view to use the current course year if available, otherwise use the current year.

Fixes #1376 