### PR TITLE
Convert cancels course membership to light service

### DIFF
--- a/app/controllers/course_memberships_controller.rb
+++ b/app/controllers/course_memberships_controller.rb
@@ -1,3 +1,5 @@
+require_relative "../services/cancels_course_membership"
+
 class CourseMembershipsController < ApplicationController
 
   before_filter :ensure_staff?
@@ -13,7 +15,7 @@ class CourseMembershipsController < ApplicationController
   def destroy
     course_membership = current_course.course_memberships.find(params[:id])
     @name = course_membership.user.name
-    CancelsCourseMembership.for_student course_membership
+    Services::CancelsCourseMembership.for_student course_membership
 
     respond_to do |format|
       format.html { redirect_to students_path, notice: "#{@name} was successfully removed from course." }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+require_relative "../services/cancels_course_membership"
 require_relative "../services/creates_new_user"
 
 class UsersController < ApplicationController
@@ -59,7 +60,9 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    if @user.update_attributes(params[:user])
+    @user.assign_attributes params[:user]
+    @user.course_memberships.select(&:marked_for_destruction?).map { |cm| Services::CancelsCourseMembership.for_student(cm) }
+    if @user.save
       if @user.is_student?(current_course)
         redirect_to students_path, :notice => "#{term_for :student} #{@user.name} was successfully updated!" and return
       elsif @user.is_staff?(current_course)
@@ -149,11 +152,5 @@ class UsersController < ApplicationController
         .import(current_course)
       render :import_results
     end
-  end
-
-  private
-
-  def increment_predictor_views
-    User.increment_counter(:predictor_views, current_user.id) if current_user && request.format.html?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,7 +61,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     @user.assign_attributes params[:user]
-    @user.course_memberships.select(&:marked_for_destruction?).map { |cm| Services::CancelsCourseMembership.for_student(cm) }
+    cancel_course_memberships @user
     if @user.save
       if @user.is_student?(current_course)
         redirect_to students_path, :notice => "#{term_for :student} #{@user.name} was successfully updated!" and return

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,8 +1,8 @@
-require "sorcery"
-
 module UsersHelper
-  def generate_random_password
-    Sorcery::Model::TemporaryToken.generate_random_token
+  def cancel_course_memberships(user)
+    user.course_memberships.select(&:marked_for_destruction?).map do |cm|
+      Services::CancelsCourseMembership.for_student(cm)
+    end
   end
 
   def flagged_user_icon(course, flagger, flagged_id)

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "cancels_course_membership/destroys_assignment_weights"
 require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
@@ -45,13 +46,6 @@ class CancelsCourseMembership
   def self.removes_announcement_states(membership)
     AnnouncementState.for_course(membership.course)
       .for_user(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_assignment_weights(membership)
-    AssignmentWeight.for_course(membership.course)
-      .for_student(membership.user)
       .destroy_all
     self
   end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,3 +1,27 @@
+require "light-service"
+require_relative "cancels_course_membership/destroys_membership"
+
+module Services
+  class CancelsCourseMembership
+    extend LightService::Organizer
+
+    def self.for_student(membership)
+      with(membership: membership).reduce(
+        Actions::DestroysMembership,
+        Actions::DestroysSubmissions,
+        Actions::DestroysGrades,
+        Actions::DestroysAssignmentWeights,
+        Actions::DestroysEarnedBadges,
+        Actions::DestroysEarnedChallenges,
+        Actions::DestroysGroupMemberships,
+        Actions::DestroysTeamMemberships,
+        Actions::DestroysAnnouncementStates,
+        Actions::DestroysFlaggedUsers
+      )
+    end
+  end
+end
+
 class CancelsCourseMembership
   def self.for_student(membership)
     deletes_membership(membership)

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,5 +1,6 @@
 require "light-service"
 require_relative "cancels_course_membership/destroys_assignment_weights"
+require_relative "cancels_course_membership/destroys_earned_badges"
 require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
@@ -50,13 +51,6 @@ class CancelsCourseMembership
     self
   end
 
-  def self.removes_earned_badges(membership)
-    EarnedBadge.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
   def self.removes_flagged_users(membership)
     FlaggedUser.for_course(membership.course)
       .for_flagged(membership.user)
@@ -66,13 +60,6 @@ class CancelsCourseMembership
 
   def self.removes_group_memberships(membership)
     GroupMembership.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_predicted_earned_badges(membership)
-    PredictedEarnedBadge.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "cancels_course_membership/destroys_announcement_states"
 require_relative "cancels_course_membership/destroys_assignment_weights"
 require_relative "cancels_course_membership/destroys_earned_badges"
 require_relative "cancels_course_membership/destroys_earned_challenges"
@@ -46,13 +47,6 @@ class CancelsCourseMembership
   end
 
   private
-
-  def self.removes_announcement_states(membership)
-    AnnouncementState.for_course(membership.course)
-      .for_user(membership.user)
-      .destroy_all
-    self
-  end
 
   def self.removes_flagged_users(membership)
     FlaggedUser.for_course(membership.course)

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
 
@@ -41,11 +42,6 @@ class CancelsCourseMembership
 
   private
 
-  def self.deletes_membership(membership)
-    membership.destroy
-    self
-  end
-
   def self.removes_announcement_states(membership)
     AnnouncementState.for_course(membership.course)
       .for_user(membership.user)
@@ -74,13 +70,6 @@ class CancelsCourseMembership
     self
   end
 
-  def self.removes_grades(membership)
-    Grade.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
   def self.removes_group_memberships(membership)
     GroupMembership.for_course(membership.course)
       .for_student(membership.user)
@@ -104,13 +93,6 @@ class CancelsCourseMembership
 
   def self.removes_submissions(membership)
     Submission.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_rubric_grades(membership)
-    RubricGrade.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -3,6 +3,7 @@ require_relative "cancels_course_membership/destroys_assignment_weights"
 require_relative "cancels_course_membership/destroys_earned_badges"
 require_relative "cancels_course_membership/destroys_earned_challenges"
 require_relative "cancels_course_membership/destroys_grades"
+require_relative "cancels_course_membership/destroys_group_memberships"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
 
@@ -55,13 +56,6 @@ class CancelsCourseMembership
   def self.removes_flagged_users(membership)
     FlaggedUser.for_course(membership.course)
       .for_flagged(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_group_memberships(membership)
-    GroupMembership.for_course(membership.course)
-      .for_student(membership.user)
       .destroy_all
     self
   end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -3,6 +3,7 @@ require_relative "cancels_course_membership/destroys_announcement_states"
 require_relative "cancels_course_membership/destroys_assignment_weights"
 require_relative "cancels_course_membership/destroys_earned_badges"
 require_relative "cancels_course_membership/destroys_earned_challenges"
+require_relative "cancels_course_membership/destroys_flagged_users"
 require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_group_memberships"
 require_relative "cancels_course_membership/destroys_membership"
@@ -27,31 +28,5 @@ module Services
         Actions::DestroysFlaggedUsers
       )
     end
-  end
-end
-
-class CancelsCourseMembership
-  def self.for_student(membership)
-    deletes_membership(membership)
-      .removes_submissions(membership)
-      .removes_grades(membership)
-      .removes_rubric_grades(membership)
-      .removes_assignment_weights(membership)
-      .removes_earned_badges(membership)
-      .removes_predicted_earned_badges(membership)
-      .removes_predicted_earned_challenges(membership)
-      .removes_group_memberships(membership)
-      .removes_team_memberships(membership)
-      .removes_announcement_states(membership)
-      .removes_flagged_users(membership)
-  end
-
-  private
-
-  def self.removes_flagged_users(membership)
-    FlaggedUser.for_course(membership.course)
-      .for_flagged(membership.user)
-      .destroy_all
-    self
   end
 end

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,6 +1,7 @@
 require "light-service"
 require_relative "cancels_course_membership/destroys_assignment_weights"
 require_relative "cancels_course_membership/destroys_earned_badges"
+require_relative "cancels_course_membership/destroys_earned_challenges"
 require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
@@ -60,20 +61,6 @@ class CancelsCourseMembership
 
   def self.removes_group_memberships(membership)
     GroupMembership.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_predicted_earned_challenges(membership)
-    PredictedEarnedChallenge.for_course(membership.course)
-      .for_student(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_submissions(membership)
-    Submission.for_course(membership.course)
       .for_student(membership.user)
       .destroy_all
     self

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -1,5 +1,6 @@
 require "light-service"
 require_relative "cancels_course_membership/destroys_membership"
+require_relative "cancels_course_membership/destroys_submissions"
 
 module Services
   class CancelsCourseMembership

--- a/app/services/cancels_course_membership.rb
+++ b/app/services/cancels_course_membership.rb
@@ -6,6 +6,7 @@ require_relative "cancels_course_membership/destroys_grades"
 require_relative "cancels_course_membership/destroys_group_memberships"
 require_relative "cancels_course_membership/destroys_membership"
 require_relative "cancels_course_membership/destroys_submissions"
+require_relative "cancels_course_membership/destroys_team_memberships"
 
 module Services
   class CancelsCourseMembership
@@ -56,13 +57,6 @@ class CancelsCourseMembership
   def self.removes_flagged_users(membership)
     FlaggedUser.for_course(membership.course)
       .for_flagged(membership.user)
-      .destroy_all
-    self
-  end
-
-  def self.removes_team_memberships(membership)
-    TeamMembership.for_course(membership.course)
-      .for_student(membership.user)
       .destroy_all
     self
   end

--- a/app/services/cancels_course_membership/destroys_announcement_states.rb
+++ b/app/services/cancels_course_membership/destroys_announcement_states.rb
@@ -1,20 +1,16 @@
 module Services
   module Actions
-    class DestroysMembership
+    class DestroysAnnouncementStates
       extend LightService::Action
 
       expects :membership
 
       executed do |context|
         membership = context[:membership]
-        membership.destroy
-      end
-    end
 
-    class DestroysFlaggedUsers
-      extend LightService::Action
-
-      executed do |context|
+        AnnouncementState.for_course(membership.course)
+          .for_user(membership.user)
+          .destroy_all
       end
     end
   end

--- a/app/services/cancels_course_membership/destroys_assignment_weights.rb
+++ b/app/services/cancels_course_membership/destroys_assignment_weights.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class DestroysAssignmentWeights
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        AssignmentWeight.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_earned_badges.rb
+++ b/app/services/cancels_course_membership/destroys_earned_badges.rb
@@ -1,0 +1,21 @@
+module Services
+  module Actions
+    class DestroysEarnedBadges
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        EarnedBadge.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+
+        PredictedEarnedBadge.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_earned_challenges.rb
+++ b/app/services/cancels_course_membership/destroys_earned_challenges.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class DestroysEarnedChallenges
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        PredictedEarnedChallenge.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_flagged_users.rb
+++ b/app/services/cancels_course_membership/destroys_flagged_users.rb
@@ -1,13 +1,16 @@
 module Services
   module Actions
-    class DestroysMembership
+    class DestroysFlaggedUsers
       extend LightService::Action
 
       expects :membership
 
       executed do |context|
         membership = context[:membership]
-        membership.destroy
+
+        FlaggedUser.for_course(membership.course)
+          .for_flagged(membership.user)
+          .destroy_all
       end
     end
   end

--- a/app/services/cancels_course_membership/destroys_grades.rb
+++ b/app/services/cancels_course_membership/destroys_grades.rb
@@ -1,0 +1,21 @@
+module Services
+  module Actions
+    class DestroysGrades
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        Grade.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+
+        RubricGrade.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_group_memberships.rb
+++ b/app/services/cancels_course_membership/destroys_group_memberships.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class DestroysGroupMemberships
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        GroupMembership.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysGroupMemberships
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysTeamMemberships
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysAssignmentWeights
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysEarnedBadges
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -3,7 +3,11 @@ module Services
     class DestroysMembership
       extend LightService::Action
 
+      expects :membership
+
       executed do |context|
+        membership = context[:membership]
+        membership.destroy
       end
     end
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysEarnedBadges
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysEarnedChallenges
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysEarnedChallenges
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysGroupMemberships
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -7,6 +7,7 @@ module Services
 
       executed do |context|
         membership = context[:membership]
+        context.skip_all! unless membership.student?
         membership.destroy
       end
     end

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysSubmissions
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysGrades
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysTeamMemberships
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysAnnouncementStates
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -1,0 +1,73 @@
+module Services
+  module Actions
+    class DestroysMembership
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysSubmissions
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysGrades
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysAssignmentWeights
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysEarnedBadges
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysEarnedChallenges
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysGroupMemberships
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysTeamMemberships
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysAnnouncementStates
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+
+    class DestroysFlaggedUsers
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_membership.rb
+++ b/app/services/cancels_course_membership/destroys_membership.rb
@@ -11,13 +11,6 @@ module Services
       end
     end
 
-    class DestroysGrades
-      extend LightService::Action
-
-      executed do |context|
-      end
-    end
-
     class DestroysAssignmentWeights
       extend LightService::Action
 

--- a/app/services/cancels_course_membership/destroys_submissions.rb
+++ b/app/services/cancels_course_membership/destroys_submissions.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class DestroysSubmissions
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        Submission.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/app/services/cancels_course_membership/destroys_team_memberships.rb
+++ b/app/services/cancels_course_membership/destroys_team_memberships.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class DestroysTeamMemberships
+      extend LightService::Action
+
+      expects :membership
+
+      executed do |context|
+        membership = context[:membership]
+
+        TeamMembership.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
+      end
+    end
+  end
+end

--- a/spec/features/removing_a_course_membership_spec.rb
+++ b/spec/features/removing_a_course_membership_spec.rb
@@ -1,0 +1,27 @@
+require "rails_spec_helper"
+
+feature "removing a course membership" do
+  context "as an administrator" do
+    let!(:admin_course_membership) { create :admin_course_membership, course: course, user: admin }
+    let(:admin) { create :user }
+    let(:course) { create :course }
+
+    before(:each) { login_as admin }
+
+    context "by editing a student" do
+      let!(:grade) { create :grade, student: student, course: course }
+      let(:student) { create :user }
+      let!(:student_course_membership) { create :student_course_membership, course: course, user: student }
+
+      before(:each) { visit edit_user_path(student) }
+
+      scenario "successfully" do
+        EditUserPage.new(student).submit(courses: [admin_course_membership.course])
+        expect(current_path).to eq user_path(student)
+
+        expect(student.reload.course_memberships).to be_empty
+        expect(student.grades).to be_empty
+      end
+    end
+  end
+end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -8,10 +8,16 @@ describe UsersHelper do
 
   subject(:helper) { Helper.new }
 
-  describe "#generate_random_password" do
-    it "generates a random password" do
-      passwords = 50.times.collect { helper.generate_random_password }
-      expect(passwords.uniq.count).to eq 50
+  describe "#cancel_course_memberships" do
+    let(:service) { double(:cancels_course_memberships) }
+    before { stub_const("Services::CancelsCourseMembership", service) }
+
+    it "cancels any course memberships that are marked for deletion" do
+      active_course_membership = double(:course_membership, marked_for_destruction?: false)
+      deleted_course_membership = double(:course_membership, marked_for_destruction?: true)
+      user = double(:user, course_memberships: [active_course_membership, deleted_course_membership])
+      expect(service).to receive(:for_student).with(deleted_course_membership)
+      helper.cancel_course_memberships user
     end
   end
 end

--- a/spec/services/cancels_course_membership/destroys_announcement_states_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_announcement_states_spec.rb
@@ -1,0 +1,23 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_announcement_states"
+
+describe Services::Actions::DestroysAnnouncementStates do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the announcement states to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the announcement states" do
+    another_announcement = create :announcement_state, user: student
+    course_announcement = create :announcement_state, user: student,
+      announcement: create(:announcement, course: course)
+    described_class.execute membership: membership
+    expect(AnnouncementState.where(user_id: student.id)).to \
+      eq [another_announcement]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_assignment_weights_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_assignment_weights_spec.rb
@@ -1,0 +1,21 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_assignment_weights"
+
+describe Services::Actions::DestroysAssignmentWeights do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the assignment weights to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the assignment weights" do
+    another_assignment_weight = create :assignment_weight, student: student
+    course_assignment_weight = create :assignment_weight, student: student, course: course
+    described_class.execute membership: membership
+    expect(student.reload.assignment_weights).to eq [another_assignment_weight]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_earned_badges_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_earned_badges_spec.rb
@@ -1,0 +1,30 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_earned_badges"
+
+describe Services::Actions::DestroysEarnedBadges do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the earned badges to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the earned badges" do
+    another_earned_badge = create :earned_badge, student: student
+    course_earned_badge = create :earned_badge, student: student, course: course
+    described_class.execute membership: membership
+    expect(student.reload.earned_badges).to eq [another_earned_badge]
+  end
+
+  it "destroys the predicted earned badges" do
+    another_earned_badge = create :predicted_earned_badge, student: student
+    course_earned_badge = create :predicted_earned_badge, student: student,
+      badge: create(:badge, course: course)
+    described_class.execute membership: membership
+    expect(PredictedEarnedBadge.where(student_id: student.id)).to \
+      eq [another_earned_badge]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_earned_challenges_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_earned_challenges_spec.rb
@@ -1,0 +1,24 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_earned_challenges"
+
+describe Services::Actions::DestroysEarnedChallenges do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the earned challenges to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the earned challenges" do
+    another_earned_challenge = create :predicted_earned_challenge,
+      student: student
+    course_earned_challenge = create :predicted_earned_challenge,
+      student: student, challenge: create(:challenge, course: course)
+    described_class.execute membership: membership
+    expect(PredictedEarnedChallenge.where(student_id: student.id)).to \
+      eq [another_earned_challenge]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_flagged_users_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_flagged_users_spec.rb
@@ -1,0 +1,27 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_flagged_users"
+
+describe Services::Actions::DestroysFlaggedUsers do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the flagged users to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the flagged users" do
+    another_flagger = create(:professor_course_membership)
+    student.courses << another_flagger.course
+    another_flagged_user = create :flagged_user, flagged: student,
+      flagger: another_flagger.user, course: another_flagger.course
+    flagger = create(:professor_course_membership, course: course)
+    course_flagged_user = create :flagged_user, flagged: student,
+      course: course, flagger: flagger.user
+    described_class.execute membership: membership
+    expect(FlaggedUser.where(flagged_id: student.id)).to \
+      eq [another_flagged_user]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_grades_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_grades_spec.rb
@@ -7,7 +7,7 @@ describe Services::Actions::DestroysGrades do
   let(:membership) { create :student_course_membership }
   let(:student) { membership.user }
 
-  it "expects the membership to find the submissions to destroy" do
+  it "expects the membership to find the grades to destroy" do
     expect { described_class.execute }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end

--- a/spec/services/cancels_course_membership/destroys_grades_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_grades_spec.rb
@@ -1,0 +1,41 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_grades"
+
+describe Services::Actions::DestroysGrades do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the submissions to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the grade" do
+    another_grade = create :grade, student: student
+    course_grade = create :grade, student: student, course: course
+    described_class.execute membership: membership
+    expect(student.reload.grades).to eq [another_grade]
+  end
+
+  it "destroys the rubric grades for the course submission" do
+    another_submission = create :submission, student: student
+    course_submission = create :submission, student: student, course: course
+    another_grade = create :rubric_grade, submission: another_submission,
+      student: student
+    course_grade = create :rubric_grade, submission: course_submission,
+      student: student
+    described_class.execute membership: membership
+    expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
+  end
+
+  it "destroys the rubric grades for the course assignments" do
+    course_assignment = create :assignment, course: course
+    another_grade = create :rubric_grade, student: student
+    course_grade = create :rubric_grade, assignment: course_assignment,
+      student: student
+    described_class.execute membership: membership
+    expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_group_memberships_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_group_memberships_spec.rb
@@ -1,0 +1,23 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_group_memberships"
+
+describe Services::Actions::DestroysGroupMemberships do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the group memberships to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the group memberships" do
+    another_group_membership = create :group_membership, student: student
+    course_group_membership = create :group_membership, student: student,
+      group: create(:group, course: course)
+    described_class.execute membership: membership
+    expect(GroupMembership.where(student_id: student.id)).to \
+      eq [another_group_membership]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_membership_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_membership_spec.rb
@@ -14,4 +14,10 @@ describe Services::Actions::DestroysMembership do
     described_class.execute membership: membership
     expect(CourseMembership.exists?(membership.id)).to eq false
   end
+
+  it "skips the rest of the actions if the membership is not for a student" do
+    admin_membership = create(:admin_course_membership)
+    result = described_class.execute membership: admin_membership
+    expect(result).to be_skip_all
+  end
 end

--- a/spec/services/cancels_course_membership/destroys_membership_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_membership_spec.rb
@@ -1,0 +1,17 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_membership"
+
+describe Services::Actions::DestroysMembership do
+  let(:membership) { create :student_course_membership }
+
+  it "expects the membership to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the membership" do
+    described_class.execute membership: membership
+    expect(CourseMembership.exists?(membership.id)).to eq false
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_submissions_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_submissions_spec.rb
@@ -1,0 +1,21 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_submissions"
+
+describe Services::Actions::DestroysSubmissions do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the submissions to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the submissions" do
+    another_submission = create :submission, student: student
+    course_submission = create :submission, student: student, course: course
+    described_class.execute membership: membership
+    expect(student.reload.submissions).to eq [another_submission]
+  end
+end

--- a/spec/services/cancels_course_membership/destroys_team_memberships_spec.rb
+++ b/spec/services/cancels_course_membership/destroys_team_memberships_spec.rb
@@ -1,0 +1,23 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/cancels_course_membership/destroys_team_memberships"
+
+describe Services::Actions::DestroysTeamMemberships do
+  let(:course) { membership.course }
+  let(:membership) { create :student_course_membership }
+  let(:student) { membership.user }
+
+  it "expects the membership to find the team memberships to destroy" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "destroys the group memberships" do
+    another_team_membership = create :team_membership, student: student
+    course_team_membership = create :team_membership, student: student,
+      team: create(:team, course: course)
+    described_class.execute membership: membership
+    expect(TeamMembership.where(student_id: student.id)).to \
+      eq [another_team_membership]
+  end
+end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -1,7 +1,7 @@
 require "active_record_spec_helper"
 require "./app/services/cancels_course_membership"
 
-describe Services::CancelsCourseMembership, focus: true do
+describe Services::CancelsCourseMembership do
   let(:course) { membership.course }
   let(:membership) { create(:student_course_membership) }
   let(:student) { membership.user }
@@ -62,27 +62,6 @@ describe Services::CancelsCourseMembership, focus: true do
       expect(Services::Actions::DestroysFlaggedUsers).to \
         receive(:execute).and_call_original
       described_class.for_student membership
-    end
-  end
-end
-
-describe CancelsCourseMembership do
-  describe ".for_student" do
-    let(:course) { membership.course }
-    let(:membership) { create(:student_course_membership) }
-    let(:student) { membership.user }
-
-    it "removes the flagged states for the student" do
-      another_flagger = create(:professor_course_membership)
-      student.courses << another_flagger.course
-      another_flagged_user = create :flagged_user, flagged: student,
-        flagger: another_flagger.user, course: another_flagger.course
-      flagger = create(:professor_course_membership, course: course)
-      course_flagged_user = create :flagged_user, flagged: student,
-        course: course, flagger: flagger.user
-      described_class.for_student membership
-      expect(FlaggedUser.where(flagged_id: student.id)).to \
-        eq [another_flagged_user]
     end
   end
 end

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,15 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the announcement states for the student" do
-      another_announcement = create :announcement_state, user: student
-      course_announcement = create :announcement_state, user: student,
-        announcement: create(:announcement, course: course)
-      described_class.for_student membership
-      expect(AnnouncementState.where(user_id: student.id)).to \
-        eq [another_announcement]
-    end
-
     it "removes the flagged states for the student" do
       another_flagger = create(:professor_course_membership)
       student.courses << another_flagger.course

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,15 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the group memberships for the student" do
-      another_group_membership = create :group_membership, student: student
-      course_group_membership = create :group_membership, student: student,
-        group: create(:group, course: course)
-      described_class.for_student membership
-      expect(GroupMembership.where(student_id: student.id)).to \
-        eq [another_group_membership]
-    end
-
     it "removes the team memberships for the student" do
       another_team_membership = create :team_membership, student: student
       course_team_membership = create :team_membership, student: student,

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -1,6 +1,71 @@
 require "active_record_spec_helper"
 require "./app/services/cancels_course_membership"
 
+describe Services::CancelsCourseMembership, focus: true do
+  let(:course) { membership.course }
+  let(:membership) { create(:student_course_membership) }
+  let(:student) { membership.user }
+
+  describe ".for_student" do
+    it "destroys the membership" do
+      expect(Services::Actions::DestroysMembership).to receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the submissions for the student and course" do
+      expect(Services::Actions::DestroysSubmissions).to receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the grades for the student and course" do
+      expect(Services::Actions::DestroysGrades).to receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the assignment weights for the student and course" do
+      expect(Services::Actions::DestroysAssignmentWeights).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the earned badges for the student and course" do
+      expect(Services::Actions::DestroysEarnedBadges).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the earned challenges for the student and course" do
+      expect(Services::Actions::DestroysEarnedChallenges).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the group memberships for the student and course" do
+      expect(Services::Actions::DestroysGroupMemberships).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the team memberships for the student and course" do
+      expect(Services::Actions::DestroysTeamMemberships).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the announcement states for the student and course" do
+      expect(Services::Actions::DestroysAnnouncementStates).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+
+    it "destroys the flagged users for the student and course" do
+      expect(Services::Actions::DestroysFlaggedUsers).to \
+        receive(:execute).and_call_original
+      described_class.for_student membership
+    end
+  end
+end
+
 describe CancelsCourseMembership do
   describe ".for_student" do
     let(:course) { membership.course }

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,22 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the earned badges for the student" do
-      another_earned_badge = create :earned_badge, student: student
-      course_earned_badge = create :earned_badge, student: student, course: course
-      described_class.for_student membership
-      expect(student.reload.earned_badges).to eq [another_earned_badge]
-    end
-
-    it "removes the predicted earned badges for the student" do
-      another_earned_badge = create :predicted_earned_badge, student: student
-      course_earned_badge = create :predicted_earned_badge, student: student,
-        badge: create(:badge, course: course)
-      described_class.for_student membership
-      expect(PredictedEarnedBadge.where(student_id: student.id)).to \
-        eq [another_earned_badge]
-    end
-
     it "removes the predicted earned challenges for the student" do
       another_earned_challenge = create :predicted_earned_challenge,
         student: student

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,13 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the assignment weights for the student" do
-      another_assignment_weight = create :assignment_weight, student: student
-      course_assignment_weight = create :assignment_weight, student: student, course: course
-      described_class.for_student membership
-      expect(student.reload.assignment_weights).to eq [another_assignment_weight]
-    end
-
     it "removes the earned badges for the student" do
       another_earned_badge = create :earned_badge, student: student
       course_earned_badge = create :earned_badge, student: student, course: course

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,16 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the predicted earned challenges for the student" do
-      another_earned_challenge = create :predicted_earned_challenge,
-        student: student
-      course_earned_challenge = create :predicted_earned_challenge,
-        student: student, challenge: create(:challenge, course: course)
-      described_class.for_student membership
-      expect(PredictedEarnedChallenge.where(student_id: student.id)).to \
-        eq [another_earned_challenge]
-    end
-
     it "removes the group memberships for the student" do
       another_group_membership = create :group_membership, student: student
       course_group_membership = create :group_membership, student: student,

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,15 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the team memberships for the student" do
-      another_team_membership = create :team_membership, student: student
-      course_team_membership = create :team_membership, student: student,
-        team: create(:team, course: course)
-      described_class.for_student membership
-      expect(TeamMembership.where(student_id: student.id)).to \
-        eq [another_team_membership]
-    end
-
     it "removes the announcement states for the student" do
       another_announcement = create :announcement_state, user: student
       course_announcement = create :announcement_state, user: student,

--- a/spec/services/cancels_course_membership_spec.rb
+++ b/spec/services/cancels_course_membership_spec.rb
@@ -72,45 +72,6 @@ describe CancelsCourseMembership do
     let(:membership) { create(:student_course_membership) }
     let(:student) { membership.user }
 
-    it "removes the course membership" do
-      described_class.for_student membership
-      expect(CourseMembership.exists?(membership.id)).to eq false
-    end
-
-    it "removes the grades for the student and course" do
-      another_grade = create :grade, student: student
-      course_grade = create :grade, student: student, course: course
-      described_class.for_student membership
-      expect(student.reload.grades).to eq [another_grade]
-    end
-
-    it "removes the submissions for the student" do
-      another_submission = create :submission, student: student
-      course_submission = create :submission, student: student, course: course
-      described_class.for_student membership
-      expect(student.reload.submissions).to eq [another_submission]
-    end
-
-    it "removes the rubric grades for the student and course submissions" do
-      another_submission = create :submission, student: student
-      course_submission = create :submission, student: student, course: course
-      another_grade = create :rubric_grade, submission: another_submission,
-        student: student
-      course_grade = create :rubric_grade, submission: course_submission,
-        student: student
-      described_class.for_student membership
-      expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
-    end
-
-    it "removes the rubric grades for the student and course assignments" do
-      course_assignment = create :assignment, course: course
-      another_grade = create :rubric_grade, student: student
-      course_grade = create :rubric_grade, assignment: course_assignment,
-        student: student
-      described_class.for_student membership
-      expect(RubricGrade.for_student(membership.user)).to eq [another_grade]
-    end
-
     it "removes the assignment weights for the student" do
       another_assignment_weight = create :assignment_weight, student: student
       course_assignment_weight = create :assignment_weight, student: student, course: course

--- a/spec/support/pages/edit_user_page.rb
+++ b/spec/support/pages/edit_user_page.rb
@@ -1,10 +1,10 @@
 require_relative "user_page"
 
-class NewUserPage < UserPage
+class EditUserPage < UserPage
   include Capybara::DSL
 
   def submit(fields={})
     fill_out_form fields
-    click_button "Create User"
+    click_button "Update User"
   end
 end

--- a/spec/support/pages/user_page.rb
+++ b/spec/support/pages/user_page.rb
@@ -1,0 +1,28 @@
+class UserPage
+  include Capybara::DSL
+
+  attr_accessor :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  protected
+
+  def fill_out_form(fields={})
+    fill_in "First name", with: fields[:first_name] || user.first_name
+    fill_in "Last name", with: fields[:last_name] || user.last_name
+    fill_in "Email", with: fields[:email] || user.email
+    fill_in "Display name", with: fields[:display_name] || user.display_name
+
+    courses = fields[:courses]
+    courses.each_with_index do |course, index|
+      destroyed = find(:xpath, ".//input[@id='user_course_memberships_attributes_#{index}__destroy']")
+      if destroyed.value == "true"
+        destroyed.set false
+      else
+        destroyed.set true
+      end
+    end if courses
+  end
+end


### PR DESCRIPTION
This PR converts the `CancelsCourseMembership` service into a [LightService](https://github.com/adomokos/light-service) service. It was also enhanced to skip over all the actions if the `CourseMembership` is not a student's course membership.

In addition, the service is now being called when a user is updated for any course that they removed themselves from (references #1391). A feature test was added to ensure that the change does remove the associated course membership data.