### PR TITLE
1276 assignments controller

### DIFF
--- a/app/controllers/assignment_types_controller.rb
+++ b/app/controllers/assignment_types_controller.rb
@@ -1,4 +1,5 @@
 class AssignmentTypesController < ApplicationController
+  include SortsPosition
 
   before_filter :ensure_staff?, :except => [:predictor_data]
   before_action :find_assignment_type, only: [:show, :edit, :update, :export_scores, :all_grades, :destroy]
@@ -55,10 +56,7 @@ class AssignmentTypesController < ApplicationController
   end
 
   def sort
-    params[:"assignment-type"].each_with_index do |id, index|
-      current_course.assignment_types.update(id, position: index + 1)
-    end
-    render nothing: true
+    sort_position_for "assignment-type"
   end
 
   def export_scores
@@ -72,7 +70,7 @@ class AssignmentTypesController < ApplicationController
       respond_to do |format|
         format.csv { send_data AssignmentTypeExporter.new.export_summary_scores current_course.assignment_types, current_course, current_course.students }
       end
-    else 
+    else
       redirect_to dashboard_path, :flash => { :error => "Sorry! You have not yet created an #{(term_for :assignment_type).titleize} for this course" }
     end
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,5 +1,6 @@
 class AssignmentsController < ApplicationController
   include AssignmentsHelper
+  include SortsPosition
 
   before_filter :ensure_staff?, except: [:show, :index, :predictor_data]
 
@@ -69,10 +70,7 @@ class AssignmentsController < ApplicationController
   end
 
   def sort
-    params[:"assignment"].each_with_index do |id, index|
-      current_course.assignments.update(id, position: index + 1)
-    end
-    render nothing: true
+    sort_position_for :assignment
   end
 
   def update_rubrics

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -82,33 +82,8 @@ class AssignmentsController < ApplicationController
   end
 
   def rubric_grades_review
-    @assignment = current_course.assignments.find(params[:id])
-    @title = @assignment.name
-    @groups = @assignment.groups
-
-    @teams = current_course.teams
-
-    if params[:team_id].present?
-      @team = @teams.find_by(team_params)
-      @students = current_course.students_being_graded.joins(:teams).where(:teams => team_params)
-      @auditors = current_course.students_auditing.joins(:teams).where(:teams => team_params)
-    else
-      @students = current_course.students_being_graded
-      @auditors = current_course.students_auditing
-    end
-
-    @students.sort_by { |student| [ student.last_name, student.first_name ] }
-
-    @rubric = @assignment.fetch_or_create_rubric
-    @metrics = @rubric.metrics.ordered
-    @metrics.each do |m|
-      m.tiers = m.tiers.includes(:tier_badges).order("points ASC")
-    end
-    @assignment_score_levels = @assignment.assignment_score_levels.order_by_value
-    @course_student_ids = current_course.students.map(&:id)
-
-    @viewable_rubric_grades = @assignment.rubric_grades
-    render :rubric_grades_review, AssignmentPresenter.build({ assignment: @assignment, course: current_course,
+    assignment = current_course.assignments.find(params[:id])
+    render :rubric_grades_review, AssignmentPresenter.build({ assignment: assignment, course: current_course,
                                                               team_id: params[:team_id], view_context: view_context })
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -198,49 +198,6 @@ class AssignmentsController < ApplicationController
 
   private
 
-  def predictor_assignments_data
-    current_course.assignments.select(
-      :accepts_resubmissions_until,
-      :accepts_submissions,
-      :accepts_submissions_until,
-      :assignment_type_id,
-      :course_id,
-      :description,
-      :due_at,
-      :grade_scope,
-      :id,
-      :include_in_predictor,
-      :name,
-      :open_at,
-      :pass_fail,
-      :point_total,
-      :points_predictor_display,
-      :position,
-      :release_necessary,
-      :required,
-      :resubmissions_allowed,
-      :student_logged,
-      :thumbnail,
-      :use_rubric,
-      :visible,
-      :visible_when_locked
-    )
-  end
-
-  def predictor_grades(student)
-    student.grades.where(:course_id => current_course).select(
-      :assignment_id,
-      :final_score,
-      :id,
-      :predicted_score,
-      :pass_fail_status,
-      :status,
-      :student_id,
-      :raw_score,
-      :score
-    )
-  end
-
   def set_assignment_weights(assignment)
     return unless assignment.student_weightable?
     assignment.weights = current_course.students.map do |student|

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,4 +1,6 @@
 class AssignmentsController < ApplicationController
+  include AssignmentsHelper
+
   before_filter :ensure_staff?, :except => [:show, :index, :predictor_data]
   respond_to :html, :json
 
@@ -26,15 +28,7 @@ class AssignmentsController < ApplicationController
   def show
     assignment = current_course.assignments.find_by(id: params[:id])
     if assignment
-      if current_user_is_student?
-        if current_student.grade_released_for_assignment?(assignment)
-          grade = current_student.grade_for_assignment(assignment)
-          if grade && !grade.new_record?
-            grade.feedback_reviewed!
-          end
-        end
-      end
-
+      mark_assignment_reviewed! assignment, current_user
       render :show, AssignmentPresenter.build({ assignment: assignment, course: current_course,
                                                 team_id: params[:team_id], view_context: view_context })
     else

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -18,25 +18,26 @@ class AssignmentsController < ApplicationController
 
   def show
     assignment = current_course.assignments.find_by(id: params[:id])
-    if assignment
-      mark_assignment_reviewed! assignment, current_user
-      render :show, AssignmentPresenter.build({ assignment: assignment, course: current_course,
+    redirect_to assignments_path,
+      alert: "The #{(term_for :assignment)} could not be found." and return unless assignment.present?
+
+    mark_assignment_reviewed! assignment, current_user
+    render :show, AssignmentPresenter.build({ assignment: assignment, course: current_course,
                                                 team_id: params[:team_id], view_context: view_context })
-    else
-      redirect_to assignments_path, alert: "The #{(term_for :assignment)} could not be found."
-    end
   end
 
   def new
-    @title = "Create a New #{term_for :assignment}"
-    @assignment = current_course.assignments.new
-    render :new, AssignmentPresenter.build({ assignment: @assignment, course: current_course, view_context: view_context })
+    render :new, AssignmentPresenter.build({ assignment: current_course.assignments.new,
+                                             course: current_course,
+                                             view_context: view_context })
   end
 
   def edit
-    @assignment = current_course.assignments.find(params[:id])
-    @title = "Editing #{@assignment.name}"
-    render :edit, AssignmentPresenter.build({ assignment: @assignment, course: current_course, view_context: view_context })
+    assignment = current_course.assignments.find(params[:id])
+    @title = "Editing #{assignment.name}"
+    render :edit, AssignmentPresenter.build({ assignment: assignment,
+                                              course: current_course,
+                                              view_context: view_context })
   end
 
   # Duplicate an assignment - important for super repetitive items like attendance and reading reactions

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -58,7 +58,7 @@ class AssignmentsController < ApplicationController
   end
 
   def update
-    assignment = current_course.assignments.includes(:assignment_score_levels).find(params[:id])
+    assignment = current_course.assignments.find(params[:id])
     if assignment.update_attributes(params[:assignment])
       set_assignment_weights(assignment)
       redirect_to assignments_path, notice: "#{(term_for :assignment).titleize}  <strong>#{assignment.name }</strong> successfully updated" and return
@@ -76,9 +76,9 @@ class AssignmentsController < ApplicationController
   end
 
   def update_rubrics
-    @assignment = current_course.assignments.find params[:id]
-    @assignment.update_attributes use_rubric: params[:use_rubric]
-    redirect_to assignment_path(@assignment)
+    assignment = current_course.assignments.find params[:id]
+    assignment.update_attributes use_rubric: params[:use_rubric]
+    redirect_to assignment_path(assignment)
   end
 
   def rubric_grades_review

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -1,22 +1,13 @@
 class AssignmentsController < ApplicationController
   include AssignmentsHelper
 
-  before_filter :ensure_staff?, :except => [:show, :index, :predictor_data]
+  before_filter :ensure_staff?, except: [:show, :index, :predictor_data]
   respond_to :html, :json
 
   def index
-    if current_user_is_student?
-      redirect_to syllabus_path
-    else
-      @title = "#{term_for :assignments}"
-      @assignment_types = current_course.assignment_types.includes(:assignments)
-      @assignments = current_course.assignments.includes(:rubric)
-
-      respond_to do |format|
-        format.html
-        format.csv { send_data @assignments.csv_for_course(current_course) }
-      end
-    end
+    redirect_to syllabus_path and return if current_user_is_student?
+    @title = "#{term_for :assignments}"
+    @assignment_types = current_course.assignment_types.includes(:assignments)
   end
 
   #Gives the instructor the chance to quickly check all assignment settings for the whole course

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -99,10 +99,10 @@ class AssignmentsController < ApplicationController
     end
 
     @assignments = predictor_assignments_data
-    @grades = predictor_grades(@student)
+    grades = predictor_grades(@student)
 
     @assignments.each do |assignment|
-      @grades.where(:assignment_id => assignment.id).first.tap do |grade|
+      grades.where(:assignment_id => assignment.id).first.tap do |grade|
         if grade.nil?
           grade = Grade.create(:assignment => assignment, :student => @student)
         end
@@ -119,10 +119,9 @@ class AssignmentsController < ApplicationController
   end
 
   def destroy
-    @assignment = current_course.assignments.find(params[:id])
-    @name = @assignment.name
-    @assignment.destroy
-    redirect_to assignments_url, notice: "#{(term_for :assignment).titleize} #{@name} successfully deleted"
+    assignment = current_course.assignments.find(params[:id])
+    assignment.destroy
+    redirect_to assignments_url, notice: "#{(term_for :assignment).titleize} #{assignment.name} successfully deleted"
   end
 
   def download_current_grades
@@ -221,7 +220,7 @@ class AssignmentsController < ApplicationController
   private
 
   def predictor_assignments_data
-    @assignments = current_course.assignments.select(
+    current_course.assignments.select(
       :accepts_resubmissions_until,
       :accepts_submissions,
       :accepts_submissions_until,
@@ -250,7 +249,7 @@ class AssignmentsController < ApplicationController
   end
 
   def predictor_grades(student)
-    @grades = student.grades.where(:course_id => current_course).select(
+    student.grades.where(:course_id => current_course).select(
       :assignment_id,
       :final_score,
       :id,
@@ -261,10 +260,6 @@ class AssignmentsController < ApplicationController
       :raw_score,
       :score
     )
-  end
-
-  def team_params
-    @team_params ||= params[:team_id] ? { id: params[:team_id] } : {}
   end
 
   def set_assignment_weights(assignment)

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,4 +1,5 @@
 class BadgesController < ApplicationController
+  include SortsPosition
 
   before_filter :ensure_staff?, :except => [:predictor_data, :predict_times_earned]
   before_filter :ensure_student?, only: [:predict_times_earned]
@@ -74,10 +75,7 @@ class BadgesController < ApplicationController
   end
 
   def sort
-    params[:"badge"].each_with_index do |id, index|
-      current_course.badges.update(id, position: index + 1)
-    end
-    render nothing: true
+    sort_position_for :badge
   end
 
   def destroy

--- a/app/controllers/concerns/sorts_position.rb
+++ b/app/controllers/concerns/sorts_position.rb
@@ -1,0 +1,15 @@
+module SortsPosition
+  extend ActiveSupport::Concern
+
+  private
+
+  def sort_position_for(type)
+    method = type.to_s.underscore.pluralize
+    if current_course.respond_to? method
+      params[type].each_with_index do |id, index|
+        current_course.send(method).update(id, position: index + 1)
+      end
+    end
+    render nothing: true
+  end
+end

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -1,9 +1,10 @@
 module AssignmentsHelper
-  def assignment_has_rubric?(assignment)
-    "Yes" if assignment.has_rubric?
-  end
-
-  def tier_percent_of_total_graded(tier)
-    (tier.rubric_grades.size/@graded_count).to_f rescue 0
+  def mark_assignment_reviewed!(assignment, user)
+    if user.is_student?(assignment.course)
+      if user.grade_released_for_assignment?(assignment)
+        grade = user.grade_for_assignment(assignment)
+        grade.feedback_reviewed! if grade && !grade.new_record?
+      end
+    end
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -74,6 +74,12 @@ class Assignment < ActiveRecord::Base
 
   delegate :student_weightable?, to: :assignment_type
 
+  # needed in order to support multiple file uploads
+  def assignment_files_attributes=(attributes)
+    files = attributes["0"]["file"]
+    super files.map { |f| { file: f, filename: f.original_filename } }
+  end
+
   def copy
     copy = self.dup
     copy.name.prepend "Copy of "

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -52,4 +52,8 @@ class NullGrade
   def updated_at
     nil
   end
+
+  def student
+    nil
+  end
 end

--- a/app/models/predicted_assignment.rb
+++ b/app/models/predicted_assignment.rb
@@ -1,0 +1,17 @@
+class PredictedAssignment < SimpleDelegator
+  attr_reader :user
+
+  def initialize(assignment, user)
+    @assignment = assignment
+    @user = user
+    super assignment
+  end
+
+  def grade
+    @grade ||= PredictedGrade.new(Grade.find_or_create(assignment, user))
+  end
+
+  private
+
+  attr_reader :assignment
+end

--- a/app/models/predicted_assignment.rb
+++ b/app/models/predicted_assignment.rb
@@ -8,7 +8,11 @@ class PredictedAssignment < SimpleDelegator
   end
 
   def grade
-    @grade ||= PredictedGrade.new(Grade.find_or_create(assignment, user))
+    if @grade.nil?
+      grade = user.present? ? Grade.find_or_create(assignment, user) : NullGrade.new
+      @grade = PredictedGrade.new(grade)
+    end
+    @grade
   end
 
   private

--- a/app/models/predicted_assignment_collection.rb
+++ b/app/models/predicted_assignment_collection.rb
@@ -12,6 +12,10 @@ class PredictedAssignmentCollection
     assignments.each { |assignment| yield PredictedAssignment.new(assignment, user) }
   end
 
+  def [](index)
+    to_a[index]
+  end
+
   private
 
   def pluck_attributes(assignments)

--- a/app/models/predicted_assignment_collection.rb
+++ b/app/models/predicted_assignment_collection.rb
@@ -1,0 +1,45 @@
+class PredictedAssignmentCollection
+  include Enumerable
+
+  attr_reader :assignments, :user
+
+  def initialize(assignments, user)
+    @assignments = pluck_attributes assignments
+    @user = user
+  end
+
+  def each
+    assignments.each { |assignment| yield PredictedAssignment.new(assignment, user) }
+  end
+
+  private
+
+  def pluck_attributes(assignments)
+    assignments.select(
+      :accepts_resubmissions_until,
+      :accepts_submissions,
+      :accepts_submissions_until,
+      :assignment_type_id,
+      :course_id,
+      :description,
+      :due_at,
+      :grade_scope,
+      :id,
+      :include_in_predictor,
+      :name,
+      :open_at,
+      :pass_fail,
+      :point_total,
+      :points_predictor_display,
+      :position,
+      :release_necessary,
+      :required,
+      :resubmissions_allowed,
+      :student_logged,
+      :thumbnail,
+      :use_rubric,
+      :visible,
+      :visible_when_locked
+    )
+  end
+end

--- a/app/models/predicted_grade.rb
+++ b/app/models/predicted_grade.rb
@@ -8,7 +8,7 @@ class PredictedGrade
   end
 
   def predicted_score
-    grade.predicted_score if grade.student.is_student?(grade.course)
+    grade.predicted_score if grade.student && grade.student.is_student?(grade.course)
   end
 
   def raw_score

--- a/app/models/predicted_grade.rb
+++ b/app/models/predicted_grade.rb
@@ -1,0 +1,29 @@
+class PredictedGrade
+  def id
+    grade.id
+  end
+
+  def pass_fail_status
+    grade.pass_fail_status if grade.is_student_visible?
+  end
+
+  def predicted_score
+    grade.predicted_score if grade.student.is_student?(grade.course)
+  end
+
+  def raw_score
+    grade.raw_score if grade.is_student_visible?
+  end
+
+  def score
+    grade.score if grade.is_student_visible?
+  end
+
+  def initialize(grade)
+    @grade = grade
+  end
+
+  private
+
+  attr_reader :grade
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,7 @@ class User < ActiveRecord::Base
     :team_role, :course_memberships_attributes, :team_id, :lti_uid, :course_team_ids, :internal
 
   # all student display pages are ordered by last name except for the leaderboard, and top 10/bottom 10
-  default_scope { order('last_name ASC') }
+  default_scope { order('last_name ASC, first_name ASC') }
 
   scope :order_by_high_score, -> { includes(:course_memberships).order 'course_memberships.score DESC' }
   scope :order_by_low_score, -> { includes(:course_memberships).order 'course_memberships.score ASC' }

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -159,6 +159,10 @@ class AssignmentPresenter < Showtime::Presenter
     for_team? ? course.students_by_team(team) : course.students
   end
 
+  def students_being_graded
+    for_team? ? course.students_being_graded_by_team(team) : course.students_being_graded
+  end
+
   def submission_date_for(student)
     submission = submissions_for(student).first
     submission.updated_at if submission
@@ -199,8 +203,10 @@ class AssignmentPresenter < Showtime::Presenter
     course.teams
   end
 
-  def viewable_rubric_grades(student_id)
-    assignment.rubric_grades.where(student_id: student_id)
+  def viewable_rubric_grades(student_id=nil)
+    query = assignment.rubric_grades
+    query = query.where(student_id: student_id) if student_id.present?
+    query
   end
 
   def viewable_rubric_tier_earned?(student_id, tier_id)

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -1,6 +1,6 @@
-= render partial: 'layouts/alerts', locals: { model: @assignment, term: term_for(:assignment) }
+= render partial: 'layouts/alerts', locals: { model: presenter.assignment, term: term_for(:assignment) }
 
-= simple_form_for(@assignment, :html => { :novalidate => true }) do |f|
+= simple_form_for(presenter.assignment, :html => { :novalidate => true }) do |f|
   %section
     %h4 Basic Info
     .form-item
@@ -17,7 +17,7 @@
           = f.check_box :pass_fail
 
     .form-item
-      - if @assignment.pass_fail?
+      - if f.object.pass_fail?
         .pass-fail-contingent.hidden
           = f.label :point_total, "Total Points Possible"
           = f.text_field :point_total
@@ -27,13 +27,13 @@
           = f.text_field :point_total
 
     .form-item
-      = f.input :open_at, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker', :value => @assignment.try(:open_at) }
+      = f.input :open_at, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker' }
 
     .form-item
-      = f.input :due_at, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker', :value => @assignment.try(:due_at) }
+      = f.input :due_at, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker' }
 
     .form-item
-      = f.input :accepts_submissions_until, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker', :value => @assignment.try(:accepts_submissions_until) }, :label => "Accept until"
+      = f.input :accepts_submissions_until, as: :string, :include_blank => true, :input_html => { :class => 'datetimepicker' }, :label => "Accept until"
 
     .form-item
       = f.label :grade_scope, "Individual or Group?"
@@ -136,8 +136,8 @@
   %section
     %h4 Timeline
 
-    = render partial: "layouts/thumbnail_image_form_item", locals: { f: f, model: @assignment }
-    = render partial: "layouts/media_image_form_item", locals: { f: f, model: @assignment }
+    = render partial: "layouts/thumbnail_image_form_item", locals: { f: f, model: presenter.assignment }
+    = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
 
   %section
     %h4 Unlocks
@@ -150,7 +150,7 @@
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: 'form-inline', child_index: 'child_index' do |ucf|
             = render 'layouts/unlock_condition_fields', f: ucf
-      - @assignment.unlock_conditions.each do |condition|
+      - presenter.assignment.unlock_conditions.each do |condition|
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, condition, class: 'form-inline' do |ucf|
             = render 'layouts/unlock_condition_fields', f: ucf
@@ -164,7 +164,7 @@
         %fieldset.assignment-score-level
           = f.simple_fields_for :assignment_score_levels, AssignmentScoreLevel.new, class: 'form-inline', child_index: 'child_index' do |slf|
             = render 'assignment_score_level_fields', f: slf
-      - @assignment.assignment_score_levels.order_by_value.each do |assignment_score_level|
+      - presenter.assignment.assignment_score_levels.order_by_value.each do |assignment_score_level|
         %fieldset.assignment-score-level
           = f.simple_fields_for :assignment_score_levels, assignment_score_level, class: 'form-inline' do |slf|
             = render 'assignment_score_level_fields', f: slf
@@ -172,12 +172,12 @@
 
   %section
     %h4.uppercase Attachments
-    = f.simple_fields_for :assignment_files, @assignment.assignment_files.new do |af|
+    = f.simple_fields_for :assignment_files, presenter.assignment.assignment_files.new do |af|
       = af.file_field :file, :multiple => true
-    - if @assignment.assignment_files.exists?
+    - if presenter.assignment.assignment_files.exists?
       %h5.bold Uploaded files
       %ul.uploaded-files
-        - @assignment.assignment_files.each do |af|
+        - presenter.assignment.assignment_files.each do |af|
           - next if af.new_record?
           %li
             - if af.file_processing
@@ -188,8 +188,8 @@
                 Refresh page to confirm upload has completed
             - else
               = link_to af.filename, af.url, :target => "_blank"
-              = link_to "(Remove)", remove_uploads_path({ :model => "AssignmentFile", :assignment_id => @assignment.id, :upload_id => af.id } )
+              = link_to "(Remove)", remove_uploads_path({ :model => "AssignmentFile", :assignment_id => presenter.assignment.id, :upload_id => af.id } )
   .submit-buttons
     %ul
-      %li= f.button :submit, "#{@assignment.persisted? ? 'Update' : 'Create'} #{term_for :assignment}"
+      %li= f.button :submit, "#{presenter.assignment.persisted? ? 'Update' : 'Create'} #{term_for :assignment}"
       %li= link_to raw("<i class='fa fa-times-circle fa-fw'></i> Cancel"), assignments_path, :class => "button"

--- a/app/views/assignments/edit.html.haml
+++ b/app/views/assignments/edit.html.haml
@@ -1,4 +1,4 @@
-= content_nav_for @assignment, "Edit #{term_for :assignment}"
+= content_nav_for presenter.assignment, "Edit #{term_for :assignment}"
 
 %h3.pagetitle= @title
 

--- a/app/views/assignments/edit.html.haml
+++ b/app/views/assignments/edit.html.haml
@@ -5,4 +5,4 @@
 = render partial: "buttons", locals: { presenter: presenter }
 
 .pageContent
-  = render 'form'
+  = render partial: "form", locals: { presenter: presenter }

--- a/app/views/assignments/new.html.haml
+++ b/app/views/assignments/new.html.haml
@@ -1,8 +1,8 @@
 = content_nav_for Assignment, "New #{term_for :assignment}"
 
-%h3.pagetitle= @title
+%h3.pagetitle= "New #{term_for :assignment}"
 
 = render partial: "buttons", locals: { presenter: presenter }
 
 .pageContent
-  = render 'form'
+  = render partial: "form", locals: { presenter: presenter }

--- a/app/views/assignments/predictor_data.json.jbuilder
+++ b/app/views/assignments/predictor_data.json.jbuilder
@@ -1,6 +1,6 @@
 json.assignments @assignments do |assignment|
   next unless assignment.point_total > 0 || assignment.pass_fail?
-  next unless assignment.visible_for_student?(@student)
+  next unless assignment.visible_for_student?(assignment.user)
   next unless assignment.include_in_predictor?
   json.merge! assignment.attributes
   json.score_levels assignment.assignment_score_levels.map {|asl| {name: asl.name, value: asl.value}}
@@ -11,12 +11,12 @@ json.assignments @assignments do |assignment|
   # boolean states for icons
   json.is_required assignment.required
   json.has_info ! assignment.description.blank?
-  json.is_late assignment.overdue? && assignment.accepts_submissions && ! @student.submission_for_assignment(assignment).present? ? true : false
+  json.is_late assignment.overdue? && assignment.accepts_submissions && !assignment.user.submission_for_assignment(assignment).present?
   json.is_earned_by_group assignment.grade_scope == "Group"
 
-  json.is_locked ! assignment.is_unlocked_for_student?(@student)
+  json.is_locked ! assignment.is_unlocked_for_student?(assignment.user)
 
-  json.has_been_unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(@student)
+  json.has_been_unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(assignment.user)
   if assignment.is_unlockable?
     json.unlock_conditions assignment.unlock_conditions.map{ |condition|
       "#{condition.name} must be #{condition.condition_state}"
@@ -32,14 +32,14 @@ json.assignments @assignments do |assignment|
 
   # student's grade info inserted into each assignment
   # student's prediction info inserted into each grade
-  if assignment.current_student_grade
-    assignment.current_student_grade.tap do |grade|
+  if assignment.grade
+    assignment.grade.tap do |grade|
       json.grade do
-        json.id grade[:id]
-        json.predicted_score grade[:predicted_score]
-        json.score grade[:score]
-        json.raw_score grade[:raw_score]
-        json.pass_fail_status grade[:pass_fail_status] if assignment.pass_fail
+        json.id grade.id
+        json.predicted_score grade.predicted_score
+        json.score grade.score
+        json.raw_score grade.raw_score
+        json.pass_fail_status grade.pass_fail_status if assignment.pass_fail
       end
     end
   end
@@ -48,6 +48,6 @@ end
 json.term_for_assignment term_for :assignment
 json.term_for_pass current_course.pass_term
 json.term_for_fail current_course.fail_term
-json.update_assignments @update_assignments
+json.update_assignments @assignments.user == current_user
 
 json.student current_user.is_student?(current_course)

--- a/app/views/assignments/rubric_grades_review.html.haml
+++ b/app/views/assignments/rubric_grades_review.html.haml
@@ -1,31 +1,31 @@
-= content_nav_for @assignment, "Review Rubric Grades"
+= content_nav_for presenter.assignment, "Review Rubric Grades"
 
-%h3.pagetitle= "#{@title} Review Rubric Grades (#{ points @assignment.point_total } points)"
+%h3.pagetitle= "#{presenter.assignment.name} Review Rubric Grades (#{ points presenter.assignment.point_total } points)"
 
 = render partial: "buttons", locals: { presenter: presenter }
 
 .pageContent
   = render 'layouts/alerts'
 
-  - if @assignment.open_at?
+  - if presenter.assignment.open_at?
     .small-12.large-4.columns.panel
       .bold Open date:
-      = @assignment.open_at
+      = presenter.assignment.open_at
 
-  - if @assignment.due_at?
+  - if presenter.assignment.due_at?
     .small-12.large-4.columns.panel
       .bold Due date:
-      = @assignment.due_at
+      = presenter.assignment.due_at
 
-  - if @assignment.accepts_submissions_until?
+  - if presenter.assignment.accepts_submissions_until?
     .small-12.large-4.columns.panel
       .bold Accept submissions until:
-      = @assignment.accepts_submissions_until
+      = presenter.assignment.accepts_submissions_until
 
-  - if @assignment.description?
-    %p= raw @assignment.description
+  - if presenter.assignment.description?
+    %p= raw presenter.assignment.description
 
-  - assignment_files = @assignment.assignment_files
+  - assignment_files = presenter.assignment.assignment_files
   - if assignment_files.present?
     %p
       %b Attachments:
@@ -33,25 +33,24 @@
         - assignment_files.each do |assignment_file|
           %li
             = link_to assignment_file.filename, assignment_file.url
-            = link_to " (Remove)", remove_uploads_path({ :model => "AssignmentFile", :upload_id => assignment_file.id, :redirect => { :controller => "assignments", :id => @assignment.id} } )
+            = link_to " (Remove)", remove_uploads_path({ :model => "AssignmentFile", :upload_id => assignment_file.id, :redirect => { :controller => "assignments", :id => presenter.assignment.id} } )
 
-  - if current_course.has_teams? && @assignment.is_individual?
+  - if presenter.has_teams? && presenter.assignment.is_individual?
     .team-filter
-      = form_tag rubric_grades_review_assignment_path(@assignment), :name => "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
+      = form_tag rubric_grades_review_assignment_path(presenter.assignment), :name => "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
         %label.sr-only{:for => "team_id"}
           Select #{term_for :team}
-        = select_tag :team_id, options_for_select(@teams.map { |t| [t.name, t.id] }, @team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
+        = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  -rubric = @assignment.rubric
-  - if rubric and rubric.designed?
-    - @students.each do |student|
+  - if presenter.rubric_designed?
+    - presenter.students_being_graded.each do |student|
       .small-12.columns
-        - grade_for_assignment = student.grade_for_assignment(@assignment)
+        - grade_for_assignment = student.grade_for_assignment(presenter.assignment)
         - if grade_for_assignment.present? && grade_for_assignment.instructor_modified?
           %h4.uppercase= student.name
           .left
-            %h5.bold= "#{grade_for_assignment.score} / #{@assignment.point_total} points "
-          .right= link_to "Edit Grade", edit_assignment_grade_path(@assignment, :student_id => student.id), :class => 'button'
+            %h5.bold= "#{grade_for_assignment.score} / #{presenter.assignment.point_total} points "
+          .right= link_to "Edit Grade", edit_assignment_grade_path(presenter.assignment, :student_id => student.id), :class => 'button'
           %br
           %br
           %table#grade-rubric-table.small-12
@@ -60,7 +59,7 @@
                 %td
                   %strong Criterion
                   .not_bold.italic Max points
-                %td(colspan="#{@assignment.rubric.try(:max_tier_count)}")
+                %td(colspan="#{presenter.rubric.max_tier_count}")
                   .larger
                     %strong Level
                     .not_bold.italic Points
@@ -68,7 +67,7 @@
                   %strong
                     Comments
             %tbody
-              - @metrics.each do |metric|
+              - presenter.metrics.each do |metric|
                 %tr
                   %td.metric(style="font-size: 12px !important; width: 10%")
                     .metric-heading
@@ -94,10 +93,10 @@
                               %img{:src => badge.badge.icon, width: "30px", height: "30px" }
                         %br
                         %br
-                        - @viewable_rubric_grades.where(student_id: student.id, tier_id: tier.id).each do |rg|
+                        - presenter.viewable_rubric_grades.where(student_id: student.id, tier_id: tier.id).each do |rg|
                           .italic{style: "color: #00BD39; font-size: 110%"} #{student.first_name} earned this level
-                  - if metric.tiers.size < @rubric.max_tier_count
-                    %td.filler(colspan="#{@rubric.max_tier_count - metric.tiers.size}")
+                  - if metric.tiers.size < presenter.rubric.max_tier_count
+                    %td.filler(colspan="#{presenter.rubric.max_tier_count - metric.tiers.size}")
                   %td.comments.italic{style: "font-size: 100%"}
-                    - @viewable_rubric_grades.where(student_id: student.id, metric_id: metric.id).each do |rg|
+                    - presenter.viewable_rubric_grades.where(student_id: student.id, metric_id: metric.id).each do |rg|
                       = rg.comments

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -146,11 +146,11 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET update_rubrics" do
+    describe "PUT update_rubrics" do
       it "assigns true or false to assignment use_rubric" do
         @assignment.update(:use_rubric => false)
-        post :update_rubrics, :id => @assignment, :use_rubric => true
-        expect(@assignment.reload.use_rubric).to be_truthy
+        put :update_rubrics, id: @assignment, use_rubric: true
+        expect(@assignment.reload.use_rubric).to eq true
       end
     end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -106,6 +106,7 @@ describe AssignmentsController do
         post :create, :assignment => params
         assignment = Assignment.where(name: params[:name]).last
         expect expect(assignment.assignment_files.count).to eq(1)
+        expect expect(assignment.assignment_files[0].filename).to eq("test_file.txt")
       end
 
       it "redirects to new from with invalid attributes" do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -155,63 +155,9 @@ describe AssignmentsController do
     end
 
     describe "GET rubric_grades_review" do
-      it "assigns attributes for display" do
-        group = create(:group, course: @course)
-        group.assignments << @assignment
-
+      it "renders the correct template" do
         get :rubric_grades_review, :id => @assignment
-        expect(assigns(:title)).to eq(@assignment.name)
-        expect(assigns(:assignment)).to eq(@assignment)
-        expect(assigns(:groups)).to eq([group])
         expect(response).to render_template(:rubric_grades_review)
-      end
-
-      it "assigns the rubric as rubric" do
-        rubric = create(:rubric_with_metrics, assignment: @assignment)
-        get :rubric_grades_review, :id => @assignment.id
-        expect(assigns(:rubric)).to eq(rubric)
-      end
-
-      it "assigns assignment score levels ordered by value" do
-        assignment_score_level_second = create(:assignment_score_level, assignment: @assignment, value: "1000")
-        assignment_score_level_first = create(:assignment_score_level, assignment: @assignment, value: "100")
-        get :rubric_grades_review, :id => @assignment.id
-        expect(assigns(:assignment_score_levels)).to eq([assignment_score_level_first,assignment_score_level_second])
-      end
-
-      it "assigns student ids" do
-        get :rubric_grades_review, :id => @assignment.id
-        expect(assigns(:course_student_ids)).to eq([@student.id])
-      end
-
-      describe "with team id in params" do
-        it "assigns team and students for team" do
-          # we verify only students on team assigned as @students
-          other_student = create(:user)
-          other_student.courses << @course
-
-          team = create(:team, course: @course)
-          team.students << @student
-
-          get :rubric_grades_review, {:id => @assignment.id, :team_id => team.id}
-          expect(assigns(:team)).to eq(team)
-          expect(assigns(:students)).to eq([@student])
-        end
-      end
-
-      describe "with no team id in params" do
-        it "assigns all students if no team supplied" do
-          # we verify non-team members also assigned as @students
-          other_student = create(:user)
-          other_student.courses << @course
-
-          team = create(:team, course: @course)
-          team.students << @student
-
-          get :rubric_grades_review, :id => @assignment.id
-          expect(assigns(:students)).to include(@student)
-          expect(assigns(:students)).to include(other_student)
-        end
       end
     end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -165,12 +165,11 @@ describe AssignmentsController do
       context "with a student id" do
         it "assigns the assignments with no call to update" do
           get :predictor_data, format: :json, :id => @student.id
-          expect(assigns(:student)).to eq(@student)
-          #expect(assigns(:assignments)[0].attributes.length).to eq(predictor_assignment_attributes.length)
+          expect(assigns(:assignments).user).to eq(@student)
           predictor_assignment_attributes().each do |attr|
-            expect(assigns(:assignments)[0][attr]).to eq(@assignment[attr])
+            expect(assigns(:assignments).assignments[0][attr]).to \
+              eq(@assignment[attr])
           end
-          expect(assigns(:update_assignments)).to be_falsy
           expect(response).to render_template(:predictor_data)
         end
       end
@@ -178,7 +177,7 @@ describe AssignmentsController do
       context "with no student" do
         it "assigns student as null student and no call to update" do
           get :predictor_data, format: :json
-          expect(assigns(:student).class).to eq(NullStudent)
+          expect(assigns(:assignments).user.class).to eq(NullStudent)
           expect(assigns(:update_assignments)).to be_falsy
         end
       end
@@ -266,39 +265,19 @@ describe AssignmentsController do
 
       it "assigns the assignments with the call to update" do
         get :predictor_data, format: :json, :id => @student.id
-        expect(assigns(:student)).to eq(@student)
-        # expect(assigns(:assignments)[0].attributes.length).to eq(predictor_assignment_attributes.length)
+        expect(assigns(:assignments).user).to eq(@student)
         predictor_assignment_attributes().each do |attr|
-          expect(assigns(:assignments)[0][attr]).to eq(@assignment[attr])
+          expect(assigns(:assignments).assignments[0][attr]).to \
+            eq(@assignment[attr])
         end
-        expect(assigns(:update_assignments)).to be_truthy
         expect(response).to render_template(:predictor_data)
-      end
-
-      it "includes the student's grade with score for assignment when released" do
-        grade = create(:scored_grade, student: @student, assignment: @assignment, course_id: @course.id)
-        get :predictor_data, format: :json, :id => @student.id
-        [
-          :assignment_id,
-          :final_score,
-          :id,
-          :predicted_score,
-          :pass_fail_status,
-          :status,
-          :student_id,
-          :raw_score,
-          :score
-        ].each do |attr|
-           expect(assigns(:grades)[0][attr]).to eq(grade[attr])
-        end
-        expect(assigns(:assignments)[0].current_student_grade).to eq({ id: grade.id, pass_fail_status: nil, raw_score: grade.raw_score, score: grade.score, predicted_score: grade.predicted_score })
       end
 
       it "includes student grade with no score if not released" do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id)
         get :predictor_data, format: :json, :id => @student.id
-        expect(assigns(:assignments)[0].current_student_grade[:score]).to eq(nil)
-        expect(assigns(:assignments)[0].current_student_grade[:raw_score]).to eq(nil)
+        expect(assigns(:assignments)[0].grade.score).to eq(nil)
+        expect(assigns(:assignments)[0].grade.raw_score).to eq(nil)
       end
 
       it "assigns data for displaying student grading distribution" do
@@ -325,13 +304,13 @@ describe AssignmentsController do
       it "includes pass/fail status for released pass/fail grades" do
         grade = create(:scored_grade, student: @student, assignment: @assignment, course_id: @course.id, pass_fail_status: "Pass")
         get :predictor_data, format: :json, :id => @student.id
-        expect(assigns(:assignments)[0].current_student_grade[:pass_fail_status]).to eq("Pass")
+        expect(assigns(:assignments)[0].grade.pass_fail_status).to eq("Pass")
       end
 
       it "includes student grade with no pass fail status if not released" do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id, pass_fail_status: "Pass")
         get :predictor_data, format: :json, :id => @student.id
-        expect(assigns(:assignments)[0].current_student_grade[:pass_fail_status]).to be_nil
+        expect(assigns(:assignments)[0].grade.pass_fail_status).to be_nil
       end
     end
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -28,7 +28,6 @@ describe AssignmentsController do
         get :index
         expect(assigns(:title)).to eq("assignments")
         expect(assigns(:assignment_types)).to eq([@assignment_type])
-        expect(assigns(:assignments)).to eq([@assignment])
         expect(response).to render_template(:index)
       end
     end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -134,12 +134,12 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET sort" do
+    describe "POST sort" do
       it "sorts the assignments by params" do
         second_assignment = create(:assignment, assignment_type: @assignment_type)
         @course.assignments << second_assignment
-        params = [second_assignment.id, @assignment.id]
-        post :sort, :assignment => params
+
+        post :sort, assignment: [second_assignment.id, @assignment.id]
 
         expect(@assignment.reload.position).to eq(2)
         expect(second_assignment.reload.position).to eq(1)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -50,24 +50,6 @@ describe AssignmentsController do
       end
     end
 
-    describe "GET new" do
-      it "assigns title and assignments" do
-        get :new
-        expect(assigns(:title)).to eq("Create a New assignment")
-        expect(assigns(:assignment)).to be_a_new(Assignment)
-        expect(response).to render_template(:new)
-      end
-    end
-
-    describe "GET edit" do
-      it "assigns title and assignments" do
-        get :edit, :id => @assignment.id
-        expect(assigns(:title)).to eq("Editing #{@assignment.name}")
-        expect(assigns(:assignment)).to eq(@assignment)
-        expect(response).to render_template(:edit)
-      end
-    end
-
     describe "POST copy" do
       before(:each) do
         Assignment.delete_all

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "./app/helpers/assignments_helper"
+
+describe AssignmentsHelper do
+  class Helper
+    include AssignmentsHelper
+  end
+
+  subject(:helper) { Helper.new }
+
+  describe "#mark_assignment_reviewed!" do
+    let(:assignment) { double(:assignment, course: course) }
+    let(:course) { double(:course) }
+    let(:grade) { double(:grade, new_record?: false) }
+    let(:user) { double(:user) }
+
+    it "it marks the grade feedback as reviewed for the current user" do
+      allow(user).to receive(:is_student?).with(course).and_return true
+      allow(user).to receive(:grade_released_for_assignment?).with(assignment)
+        .and_return true
+      allow(user).to receive(:grade_for_assignment).with(assignment).and_return grade
+      expect(grade).to receive(:feedback_reviewed!)
+      helper.mark_assignment_reviewed! assignment, user
+    end
+  end
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -57,6 +57,17 @@ describe Assignment do
     end
   end
 
+  describe "#assignment_files_attributes=" do
+    it "supports multiple file uploads" do
+      file_attribute_1 = fixture_file "test_file.txt", "txt"
+      file_attribute_2 = fixture_file "test_image.jpg", "image/jpg"
+      subject.assignment_files_attributes = { "0" => { "file" => [file_attribute_1, file_attribute_2] }}
+      expect(subject.assignment_files.length).to eq 2
+      expect(subject.assignment_files[0].filename).to eq "test_file.txt"
+      expect(subject.assignment_files[1].filename).to eq "test_image.jpg"
+    end
+  end
+
   describe "#average" do
     before { subject.save }
 

--- a/spec/models/predicted_assignment_collection_spec.rb
+++ b/spec/models/predicted_assignment_collection_spec.rb
@@ -1,0 +1,58 @@
+require "active_record_spec_helper"
+require "./app/models/predicted_assignment_collection"
+
+describe PredictedAssignmentCollection do
+  let(:assignment1) { create :assignment }
+  let(:assignment2) { create :assignment }
+  let(:assignments) { Assignment.where(id: [assignment1.id, assignment2.id]) }
+  let(:user) { double(:user) }
+
+  describe "#initialize" do
+
+    it "requires assignments and a user as the context" do
+      subject = described_class.new assignments, user
+      expect(subject.assignments.size).to eq assignments.size
+      expect(subject.user).to eq user
+    end
+
+    it "plucks the assignment fields it exposes" do
+      subject = described_class.new assignments, user
+      assignment = subject.assignments.first
+      [:accepts_resubmissions_until,
+       :accepts_submissions,
+       :accepts_submissions_until,
+       :assignment_type_id,
+       :course_id,
+       :description,
+       :due_at,
+       :grade_scope,
+       :id,
+       :include_in_predictor,
+       :name,
+       :open_at,
+       :pass_fail,
+       :point_total,
+       :points_predictor_display,
+       :position,
+       :release_necessary,
+       :required,
+       :resubmissions_allowed,
+       :student_logged,
+       :thumbnail,
+       :use_rubric,
+       :visible,
+       :visible_when_locked].each do |attribute|
+         expect(assignment).to respond_to attribute
+       end
+    end
+  end
+
+  describe "#each" do
+    it "enumerates over the assignments and creates predicted assignments" do
+      subject = described_class.new assignments, user
+      subject.each do |assignment|
+        expect(assignment).to be_instance_of PredictedAssignment
+      end
+    end
+  end
+end

--- a/spec/models/predicted_assignment_collection_spec.rb
+++ b/spec/models/predicted_assignment_collection_spec.rb
@@ -8,7 +8,6 @@ describe PredictedAssignmentCollection do
   let(:user) { double(:user) }
 
   describe "#initialize" do
-
     it "requires assignments and a user as the context" do
       subject = described_class.new assignments, user
       expect(subject.assignments.size).to eq assignments.size
@@ -53,6 +52,14 @@ describe PredictedAssignmentCollection do
       subject.each do |assignment|
         expect(assignment).to be_instance_of PredictedAssignment
       end
+    end
+  end
+
+  describe "#[]" do
+    it "can be indexed" do
+      subject = described_class.new assignments, user
+      expect(subject[0]).to be_an_instance_of PredictedAssignment
+      expect(subject[0].id).to eq assignments[0].id
     end
   end
 end

--- a/spec/models/predicted_assignment_spec.rb
+++ b/spec/models/predicted_assignment_spec.rb
@@ -1,0 +1,30 @@
+require "active_record_spec_helper"
+require "./app/models/predicted_assignment"
+
+describe PredictedAssignment do
+  let(:assignment) { create :assignment }
+  let(:user) { create :user }
+  subject { described_class.new assignment, user }
+
+  it "responds to any method on the assignment" do
+    expect(subject.id).to eq assignment.id
+  end
+
+  describe "#grade" do
+    it "creates a grade if it does not have one for the assignment" do
+      current_time = DateTime.now
+      grade = subject.grade
+      expect(Grade.find(grade.id).created_at).to be > current_time
+    end
+
+    it "returns the grade if one already exists for the user and assignment" do
+      existing_grade = Grade.create(assignment: assignment, student: user)
+      expect(subject.grade.id).to eq existing_grade.id
+    end
+
+    it "returns an instance of a predicted grade" do
+      expect(subject.grade).to be_instance_of PredictedGrade
+    end
+  end
+end
+

--- a/spec/models/predicted_assignment_spec.rb
+++ b/spec/models/predicted_assignment_spec.rb
@@ -25,6 +25,11 @@ describe PredictedAssignment do
     it "returns an instance of a predicted grade" do
       expect(subject.grade).to be_instance_of PredictedGrade
     end
+
+    it "returns a nil predicted grade if the user cannot create grades" do
+      subject = described_class.new assignment, NullStudent.new
+      expect(subject.grade.id).to eq 0
+    end
   end
 end
 

--- a/spec/models/predicted_grade_spec.rb
+++ b/spec/models/predicted_grade_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+require "./app/models/predicted_grade"
+
+describe PredictedGrade do
+  let(:course) { double(:course) }
+  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, raw_score: 84, student: user, course: course, is_student_visible?: true) }
+  let(:user) { double(:user) }
+  subject { described_class.new grade }
+
+  describe "#id" do
+    it "returns the grade's id" do
+      expect(subject.id).to eq grade.id
+    end
+  end
+
+  describe "#pass_fail_status" do
+    it "returns the grade's pass fail status if it's visible" do
+      expect(subject.pass_fail_status).to eq grade.pass_fail_status
+    end
+
+    it "returns nil if it's not visible" do
+      allow(grade).to receive(:is_student_visible?).and_return false
+      expect(subject.pass_fail_status).to be_nil
+    end
+  end
+
+  describe "#score" do
+    it "returns the grade's score if it's visible" do
+      expect(subject.score).to eq grade.score
+    end
+
+    it "returns nil if it's not visible" do
+      allow(grade).to receive(:is_student_visible?).and_return false
+      expect(subject.score).to be_nil
+    end
+  end
+
+  describe "#raw_score" do
+    it "returns the grade's raw score if it's visible" do
+      expect(subject.raw_score).to eq grade.raw_score
+    end
+
+    it "returns nil if it's not visible" do
+      allow(grade).to receive(:is_student_visible?).and_return false
+      expect(subject.raw_score).to be_nil
+    end
+  end
+
+  describe "#predicted_score" do
+    it "returns the grade's predicted score if the user is a student" do
+      allow(grade.student).to \
+        receive(:is_student?).with(grade.course).and_return true
+      expect(subject.predicted_score).to eq grade.predicted_score
+    end
+
+    it "returns nil if it's not visible" do
+      allow(grade.student).to \
+        receive(:is_student?).with(grade.course).and_return false
+      expect(subject.predicted_score).to be_nil
+    end
+  end
+end

--- a/spec/views/assignments/rubric_grades_review_spec.rb
+++ b/spec/views/assignments/rubric_grades_review_spec.rb
@@ -3,7 +3,7 @@ require 'rails_spec_helper'
 
 describe "assignments/rubric_grades_review" do
 
-  let(:presenter) { AssignmentPresenter.new({ assignment: @assignment }) }
+  let(:presenter) { AssignmentPresenter.new({ assignment: @assignment, course: @course }) }
 
   before(:all) do
     @course = create(:course)
@@ -12,7 +12,6 @@ describe "assignments/rubric_grades_review" do
 
   before(:each) do
     assign(:title, "Assignment")
-    assign(:assignment, @assignment)
     allow(view).to receive(:current_course).and_return(@course)
     allow(view).to receive(:term_for).and_return("Assignment")
     allow(view).to receive(:presenter).and_return presenter
@@ -20,6 +19,6 @@ describe "assignments/rubric_grades_review" do
 
   it "renders successfully" do
     render
-    assert_select "h3", text: "Assignment Review Rubric Grades (#{ points @assignment.point_total } points)", :count => 1
+    assert_select "h3", text: "#{@assignment.name} Review Rubric Grades (#{ points @assignment.point_total } points)", :count => 1
   end
 end


### PR DESCRIPTION
This improves the test coverage and increases the GPA grade for the `AssignmentsController`.

Reduced the line count for all methods (except `export_submissions`) to be below 8 lines which should improve complexity.

`export_submissions` was not included as it is fixed in the [`smart_archiver`](https://github.com/UM-USElab/gradecraft-development/tree/smart_archiver) branch.

Closes #1276 