### PR TITLE
Adds student id to rubric edit params

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -47,7 +47,7 @@ class GradesController < ApplicationController
       @rubric = @assignment.rubric
       @rubric_grades = serialized_rubric_grades
       # This is a patch for the Angular GradeRubricCtrl
-      @return_path = URI(request.referer).path
+      @return_path = URI(request.referer).path + "?student_id=#{current_student.id}"
     end
 
     @serialized_init_data = serialized_init_data

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -120,7 +120,7 @@ describe GradesController do
         get :edit, { :id => @grade.id, :assignment_id => assignment.id, :student_id => @student.id }
         expect(assigns(:rubric)).to eq(rubric)
         expect(JSON.parse(assigns(:rubric_grades))).to eq([{ "id" => rubric_grade.id, "metric_id" => metric.id, "tier_id" => tier.id, "comments" => nil }])
-        expect(assigns(:return_path)).to eq('/assignments/123')
+        expect(assigns(:return_path)).to eq("/assignments/123?student_id=#{@student.id}")
       end
     end
 


### PR DESCRIPTION
  Appends the student id onto the redirect path for grades edited
  with a rubric.  This is within the patch for the Angular GradeRubricCtrl
  and may not account for all return paths possible, but should fix the current
  hard failure, and should be compatible with the current paths. Fixes 1483