### PR TITLE
pass in all metrics from rubric form

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -120,6 +120,24 @@
     $scope.selectedMetrics = metrics
     metrics
 
+  # Patch: (TODO test and then remove gradedMetricsParams)
+  # For params submitted, we want to include metrics with
+  # comments but no selected tier
+  $scope.metricsParams = ()->
+    params = []
+    angular.forEach($scope.metrics, (metric, index)->
+      # get params just from the metric object
+      metricParams = $scope.metricOnlyParams(metric,index)
+
+      # add params from the tier if a tier has been selected
+      if metric.selectedTier
+        jQuery.extend(metricParams, $scope.gradedTierParams(metric))
+
+      # create params for the rubric grade regardless
+      params.push metricParams
+    )
+    params
+
   $scope.gradedMetricsParams = ()->
     params = []
     angular.forEach($scope.gradedMetrics(), (metric, index)->
@@ -183,7 +201,7 @@
       rubric_id: $scope.rubricId,
       student_id: $scope.studentId,
       points_possible: $scope.pointsPossible,
-      rubric_grades: $scope.gradedMetricsParams(),
+      rubric_grades: $scope.metricsParams(),
       tier_badges: $scope.tierBadgesParams(),
       tier_ids: $scope.selectedTierIds(),
       metric_ids: $scope.allMetricIds(),

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -134,7 +134,6 @@ class GradesController < ApplicationController
 
   # PUT /assignments/:assignment_id/grade/submit_rubric
   def submit_rubric
-
     if @submission = Submission.where(current_assignment_and_student_ids).first
       @submission.update_attributes(graded: true)
     end


### PR DESCRIPTION
Changes the behavior of the Rubrics Form which is handled within Angular. All metrics are passed in, with or without an associated tier, so that comments can be preserved.