### PR TITLE
1184 last current course

### DIFF
--- a/app/controllers/current_courses_controller.rb
+++ b/app/controllers/current_courses_controller.rb
@@ -1,12 +1,11 @@
 class CurrentCoursesController < ApplicationController
   skip_before_filter :verify_authenticity_token
-  respond_to :json
 
   # Switch between enrolled courses
   def change
     if course = current_user.courses.where(:id => params[:course_id]).first
       unless session[:course_id] == course.id
-        session[:course_id] = course.id
+        session[:course_id] = CourseRouter.change!(current_user, course).id
         log_course_login_event
       end
     end

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -17,7 +17,7 @@ class SamlController < ApplicationController
       unless @user.blank?
         auto_login @user
         User.increment_counter(:visit_count, @user.id)
-        session[:course_id] = @user.default_course.id
+        session[:course_id] = CourseRouter.current_course_for @user
         respond_with @user, location: dashboard_path
       else
         redirect_to um_pilot_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -112,7 +112,6 @@ class UsersController < ApplicationController
     @title = "Edit My Profile"
     @user = current_user
     @course_membership = @user.course_memberships.where(course_id: current_course).first
-    @default_course_options = @user.courses
   end
 
   def update_profile
@@ -128,7 +127,6 @@ class UsersController < ApplicationController
     else
       @title = "Edit My Profile"
       @course_membership = @user.course_memberships.where(course_id: current_course).first
-      @default_course_options = @user.courses
       render :edit_profile
     end
   end

--- a/app/models/course_router.rb
+++ b/app/models/course_router.rb
@@ -1,0 +1,7 @@
+class CourseRouter
+  def self.change!(user, course)
+    user.default_course_id = course.id
+    user.save
+    course
+  end
+end

--- a/app/models/course_router.rb
+++ b/app/models/course_router.rb
@@ -1,7 +1,17 @@
 class CourseRouter
-  def self.change!(user, course)
-    user.default_course_id = course.id
-    user.save
-    course
+  class << self
+    def change!(user, course)
+      user.default_course_id = course.id
+      user.save
+      course
+    end
+
+    def current_course_for(user, current_course_id=nil)
+      return nil if user.nil?
+      course = user.courses.find_by(id: current_course_id) unless current_course_id.nil?
+      course ||= user.default_course
+      course ||= user.courses.first
+      course
+    end
   end
 end

--- a/app/models/course_router.rb
+++ b/app/models/course_router.rb
@@ -1,7 +1,7 @@
 class CourseRouter
   class << self
     def change!(user, course)
-      user.default_course_id = course.id
+      user.current_course_id = course.id
       user.save
       course
     end
@@ -9,7 +9,7 @@ class CourseRouter
     def current_course_for(user, current_course_id=nil)
       return nil if user.nil?
       course = user.courses.find_by(id: current_course_id) unless current_course_id.nil?
-      course ||= user.default_course
+      course ||= user.current_course
       course ||= user.courses.first
       course
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,10 +183,6 @@ class User < ActiveRecord::Base
     activation_state == "active"
   end
 
-  def default_course
-    super || courses.first
-  end
-
   def name
     @name = [first_name,last_name].reject(&:blank?).join(' ').presence || "User #{id}"
   end
@@ -497,10 +493,6 @@ class User < ActiveRecord::Base
 
   def final_earnable_course_badges_sql(grade)
     earnable_course_badges_sql_conditions(grade).where_values.join(" OR ")
-  end
-
-  def set_default_course
-    self.default_course ||= courses.first
   end
 
   def cache_last_login

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ActiveRecord::Base
   attr_accessor :password, :password_confirmation, :cached_last_login_at, :score, :team
   attr_accessible :username, :email, :password, :password_confirmation, :activation_state,
     :avatar_file_name, :first_name, :last_name, :user_id, :kerberos_uid, :display_name,
-    :default_course_id, :last_activity_at, :last_login_at, :last_logout_at, :team_ids,
+    :current_course_id, :last_activity_at, :last_login_at, :last_logout_at, :team_ids,
     :courses, :course_ids, :earned_badges, :earned_badges_attributes, :student_academic_history_attributes,
     :team_role, :course_memberships_attributes, :team_id, :lti_uid, :course_team_ids, :internal
 
@@ -89,7 +89,7 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :courses
   accepts_nested_attributes_for :course_memberships, allow_destroy: true
 
-  belongs_to :default_course, :class_name => 'Course', touch: true
+  belongs_to :current_course, :class_name => 'Course', touch: true
 
   has_many :student_academic_histories, :foreign_key => :student_id, :dependent => :destroy
   accepts_nested_attributes_for :student_academic_histories

--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -41,11 +41,6 @@
               .form_label What's the background of your character in this class? What skills do you have and what are you motivated by?
               = p.input :character_profile, :label => false
 
-      .form-item
-        = f.input :default_course_id, :collection => (@default_course_options)
-        .form_label This course will be automatically loaded when you log in to GradeCraft
-
-
       .submit-buttons
         %ul
           %li= submit_tag 'Update Settings', :class => 'button'

--- a/db/migrate/20140910171347_transfer_role_to_course_memberships.rb
+++ b/db/migrate/20140910171347_transfer_role_to_course_memberships.rb
@@ -8,7 +8,10 @@ class TransferRoleToCourseMemberships < ActiveRecord::Migration
 
   def down
     User.all.each do |u|
-      u.update_attribute(:role, u.course_memberships.where(course_id: u.default_course).first.role) unless u.course_memberships.empty?
+      unless u.course_memberships.empty?
+        course_id = u.current_course_id || u.courses.first.id
+        u.update_attribute(:role, u.course_memberships.where(course_id: course_id).first.role)
+      end
     end
   end
 end

--- a/db/migrate/20151210174029_change_default_course_id_to_current_course_id_on_users.rb
+++ b/db/migrate/20151210174029_change_default_course_id_to_current_course_id_on_users.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultCourseIdToCurrentCourseIdOnUsers < ActiveRecord::Migration
+  def change
+    rename_column :users, :default_course_id, :current_course_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151205135720) do
+ActiveRecord::Schema.define(version: 20151210174029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -853,7 +853,7 @@ ActiveRecord::Schema.define(version: 20151205135720) do
     t.integer  "rank"
     t.string   "display_name",                    limit: 255
     t.boolean  "private_display",                             default: false
-    t.integer  "default_course_id"
+    t.integer  "current_course_id"
     t.string   "final_grade",                     limit: 255
     t.integer  "visit_count"
     t.integer  "predictor_views"

--- a/lib/current_scopes.rb
+++ b/lib/current_scopes.rb
@@ -6,8 +6,7 @@ module CurrentScopes
 
   def current_course
     return unless current_user
-    @__current_course ||= current_user.courses.find_by(id: session[:course_id]) if session[:course_id]
-    @__current_course ||= current_user.default_course
+    @__current_course ||= CourseRouter.current_course_for(current_user, session[:course_id])
   end
 
   def current_user_is_staff?

--- a/spec/controllers/current_courses_controller_spec.rb
+++ b/spec/controllers/current_courses_controller_spec.rb
@@ -31,7 +31,7 @@ describe CurrentCoursesController do
 
     it "stores the course to the current course for the user" do
       post :change, course_id: another_course.id
-      expect(user.reload.default_course_id).to eq another_course.id
+      expect(user.reload.current_course_id).to eq another_course.id
     end
   end
 

--- a/spec/controllers/current_courses_controller_spec.rb
+++ b/spec/controllers/current_courses_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_spec_helper'
 
 describe CurrentCoursesController do
-  before do
-    course = create(:course)
-    @course_2 = create(:course)
-    user = create(:user)
-    user.courses << [course, @course_2]
+  let(:course) { create :course }
+  let(:another_course) { create :course }
+  let(:user) { create :user }
 
+  before do
+    user.courses << [course, another_course]
     login_user(user)
     session[:course_id] = course.id
     allow(Resque).to receive(:enqueue).and_return(true)
@@ -14,9 +14,24 @@ describe CurrentCoursesController do
 
   describe "POST change" do
     it "switches the course context" do
-      post :change, :course_id => @course_2.id
+      post :change, course_id: another_course.id
       expect(response).to redirect_to(root_url)
-      expect(session[:course_id]).to eq(@course_2.id)
+      expect(session[:course_id]).to eq(another_course.id)
+    end
+
+    it "logs the course login event if the course changed" do
+      expect(subject).to receive(:log_course_login_event)
+      post :change, course_id: another_course.id.to_s
+    end
+
+    it "does not log the course login event if the course does not change" do
+      expect(subject).to_not receive(:log_course_login_event)
+      post :change, course_id: course.id.to_s
+    end
+
+    it "stores the course to the current course for the user" do
+      post :change, course_id: another_course.id
+      expect(user.reload.default_course_id).to eq another_course.id
     end
   end
 

--- a/spec/models/course_router_spec.rb
+++ b/spec/models/course_router_spec.rb
@@ -5,10 +5,10 @@ describe CourseRouter do
   let(:course) { double(:course, id: 456) }
 
   describe ".change!" do
-    let(:user) { double(:user, :default_course_id= => nil, save: true) }
+    let(:user) { double(:user, :current_course_id= => nil, save: true) }
 
     it "updates the default course id for the user" do
-      expect(user).to receive(:default_course_id=).with(456)
+      expect(user).to receive(:current_course_id=).with(456)
       expect(user).to receive(:save)
       described_class.change! user, course
     end
@@ -35,13 +35,13 @@ describe CourseRouter do
 
       it "returns the default course if one is not specified" do
         allow(courses).to receive(:find_by).and_return nil
-        allow(user).to receive(:default_course).and_return course
+        allow(user).to receive(:current_course).and_return course
         expect(described_class.current_course_for(user, course.id)).to eq course
       end
 
       it "returns the first course if there is not one set as the default" do
         allow(courses).to receive(:find_by).and_return nil
-        allow(user).to receive(:default_course).and_return nil
+        allow(user).to receive(:current_course).and_return nil
         allow(courses).to receive(:first).and_return course
         expect(described_class.current_course_for(user, course.id)).to eq course
       end

--- a/spec/models/course_router_spec.rb
+++ b/spec/models/course_router_spec.rb
@@ -2,8 +2,9 @@ require "spec_helper"
 require "./app/models/course_router"
 
 describe CourseRouter do
+  let(:course) { double(:course, id: 456) }
+
   describe ".change!" do
-    let(:course) { double(:course, id: 456) }
     let(:user) { double(:user, :default_course_id= => nil, save: true) }
 
     it "updates the default course id for the user" do
@@ -15,6 +16,35 @@ describe CourseRouter do
     it "returns the new course" do
       result = described_class.change! user, course
       expect(result).to eq course
+    end
+  end
+
+  describe ".current_course_for" do
+    let(:courses) { double(:active_record_relation) }
+    let(:user) { double(:user, courses: courses) }
+
+    it "returns nil if the user is nil" do
+      expect(described_class.current_course_for(nil)).to be_nil
+    end
+
+    context "with a current course id" do
+      it "returns the course that the user has access to" do
+        allow(courses).to receive(:find_by).and_return course
+        expect(described_class.current_course_for(user, course.id)).to eq course
+      end
+
+      it "returns the default course if one is not specified" do
+        allow(courses).to receive(:find_by).and_return nil
+        allow(user).to receive(:default_course).and_return course
+        expect(described_class.current_course_for(user, course.id)).to eq course
+      end
+
+      it "returns the first course if there is not one set as the default" do
+        allow(courses).to receive(:find_by).and_return nil
+        allow(user).to receive(:default_course).and_return nil
+        allow(courses).to receive(:first).and_return course
+        expect(described_class.current_course_for(user, course.id)).to eq course
+      end
     end
   end
 end

--- a/spec/models/course_router_spec.rb
+++ b/spec/models/course_router_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "./app/models/course_router"
+
+describe CourseRouter do
+  describe ".change!" do
+    let(:course) { double(:course, id: 456) }
+    let(:user) { double(:user, :default_course_id= => nil, save: true) }
+
+    it "updates the default course id for the user" do
+      expect(user).to receive(:default_course_id=).with(456)
+      expect(user).to receive(:save)
+      described_class.change! user, course
+    end
+
+    it "returns the new course" do
+      result = described_class.change! user, course
+      expect(result).to eq course
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,24 +136,6 @@ describe User do
     end
   end
 
-  describe "#default_course" do
-    let(:student) { create :user, default_course: world.course }
-    let(:second_course) {create :course}
-    before do
-      create(:course_membership, course: world.course, user: student)
-      create(:course_membership, course: second_course, user: student)
-    end
-
-    it "returns the users default course if they've set one" do
-      expect(student.default_course).to eq(world.course)
-    end
-
-    it "returns the first course they have if they haven't set one" do
-      student.default_course = nil
-      expect(student.default_course).to eq(student.courses.first)
-    end
-  end
-
   describe "#name" do
     let(:student) {create :user, first_name: "Daniel", last_name: "Hall"}
 

--- a/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
+++ b/spec/toolkits/background_jobs/predictor_event_jobs_toolkit.rb
@@ -17,7 +17,7 @@ module PredictorEventJobsToolkit
 
   def stub_current_user
     @current_user = double(:current_user).as_null_object
-    allow(@current_user).to receive_messages(default_course: double(:default_course))
+    allow(@current_user).to receive_messages(current_course: double(:course))
     allow(controller).to receive_messages(current_user: @current_user)
   end
 end

--- a/spec/toolkits/workers/pageview_event_logger_toolkit.rb
+++ b/spec/toolkits/workers/pageview_event_logger_toolkit.rb
@@ -12,7 +12,7 @@ module PageviewEventLoggerToolkit
 
   def stub_current_user
     @current_user = double(:current_user).as_null_object
-    allow(@current_user).to receive_messages(default_course: double(:default_course))
+    allow(@current_user).to receive_messages(current_course: double(:course))
     allow(controller).to receive_messages(current_user: @current_user)
   end
 end


### PR DESCRIPTION
Stores the course id for the user when they switch courses so that they are signed into that course when they log back in.

* Added a `CourseRouter` class to perform the job of retrieving the current course for the `User` as well as storing it
* Changed `User#default_course_id` to `User#current_course_id`
* Removed the ability for a user to update their default course

Closes #1184 