### PR TITLE
1227 DateTime picker for unlocks

### DIFF
--- a/app/assets/javascripts/datetimepicker.js
+++ b/app/assets/javascripts/datetimepicker.js
@@ -2244,9 +2244,11 @@
 
 }));
 
-$('.datetimepicker').datetimepicker({
-  controlType: 'select',
-  oneLine: true,
-  dateFormat: 'MM d, yy -',
-  timeFormat: 'h:mmtt'
+$(document).on('focus',".datetimepicker", function(){
+  $(this).datetimepicker({
+    controlType: 'select',
+    oneLine: true,
+    dateFormat: 'MM d, yy -',
+    timeFormat: 'h:mmtt'
+  });
 });


### PR DESCRIPTION
Fixes an issue on datetime pickers where the dom element is dynamically added after the datetime picker is applied to inputs.

Adds an event watcher `on` to the document for the `focus` event for datetime pickers so that dynamically added elements can attach the datetime picker.

Fixes #1227 