### PR TITLE
Get the GradeSchemeElements#mass_update spec working

### DIFF
--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -32,15 +32,13 @@ describe GradeSchemeElementsController do
       end
     end
 
-    describe "POST mass_update" do
+    describe "PUT mass_update" do
       it "updates the grade scheme elements all at once" do
-        skip "not working"
-        params = { "grade_scheme_elements_attributes" => [{ id: @grade_scheme_element.id, letter: "C", level: "Sea Slug", 
-          low_range: 0, high_range: 100000, course_id: @course.id }, { id: GradeSchemeElement.new, letter: "B", level: "Snail", 
-          low_range: 100001, high_range: 200000, course_id: @course.id }], 
+        params = { "grade_scheme_elements_attributes" => [{ id: @grade_scheme_element.id, letter: "C", level: "Sea Slug", low_range: 0, high_range: 100000, course_id: @course.id }, { id: GradeSchemeElement.new.id, letter: "B", level: "Snail",
+          low_range: 100001, high_range: 200000, course_id: @course.id }],
         "deleted_ids"=>nil, "grade_scheme_element"=>{} }
-        put :mass_edit, params
-        expect(@course.grade_scheme_elements.count).to eq(2)
+        put :mass_update, params.merge(format: :json)
+        expect(@course.reload.grade_scheme_elements.count).to eq(2)
         expect(@grade_scheme_element.reload.level).to eq("Sea Slug")
       end
     end


### PR DESCRIPTION
Fixed an issue where the test was calling the `GET#mass_edit` controller method. Another issue was that it was not sending the `json` format.