### PR TITLE
refactor self log process

### DIFF
--- a/app/views/assignments/_self_log_form.html.haml
+++ b/app/views/assignments/_self_log_form.html.haml
@@ -1,9 +1,7 @@
 = simple_form_for current_student.grade_for_assignment(assignment), :url => self_log_grades_assignment_path(assignment), :method => :post do |f|
-  - present = student.self_reported_done?(assignment)
-  = hidden_field_tag :present, !present
-  - if !present
+  - if ! student.self_reported_done?(assignment)
     - if assignment.has_levels?
       = f.select :raw_score, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.value] }, :prompt => "Select your grade"
+      = f.submit "Submit", :class => "button success"
     - else
-      = f.select :raw_score, [["I have completed this work", assignment.point_total]], :prompt => "Select your grade"
-    = f.submit "Submit", :class => "button #{present ? 'alert' : 'success'}"
+      = f.submit "I have completed this #{term_for :assignment}", :class => "button success"

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -592,27 +592,21 @@ describe GradesController do
         end
 
         it "creates a maximum score by the student if present" do
-          post :self_log, id: @assignment.id, present: "true"
+          post :self_log, id: @assignment.id
           grade = @student.grade_for_assignment(@assignment)
           expect(grade.raw_score).to eq @assignment.point_total
         end
 
-        it "creates a zero score if the student is not present" do
-          post :self_log, id: @assignment.id, present: "false"
-          grade = @student.grade_for_assignment(@assignment)
-          expect(grade.raw_score).to eq 0
-        end
-
         it "reports errors on failure to save" do
           allow_any_instance_of(Grade).to receive(:save).and_return false
-          post :self_log, id: @assignment.id, present: "true"
+          post :self_log, id: @assignment.id
           grade = @student.grade_for_assignment(@assignment)
           expect(flash[:notice]).to eq("We're sorry, there was an error saving your grade.")
         end
 
         context "with assignment levels" do
           it "creates a score for the student at the specified level" do
-            post :self_log, id: @assignment.id, present: "true", grade: { raw_score: "10000" }
+            post :self_log, id: @assignment.id, grade: { raw_score: "10000" }
             grade = @student.grade_for_assignment(@assignment)
             expect(grade.raw_score).to eq 10000
           end
@@ -625,7 +619,7 @@ describe GradesController do
         end
 
         it "creates should not change the student score" do
-          post :self_log, id: @assignment.id, present: "true"
+          post :self_log, id: @assignment.id
           grade = @student.grade_for_assignment(@assignment)
           expect(grade.raw_score).to eq nil
         end


### PR DESCRIPTION
Simplifies the self log process
  * Preserves the dropdown if grade levels are present
  * Users are only presented with a submit button when full points is the only option
  * the keyword "present" is not passed in the params
  * the route no longer manages assigning 0 points, since this was not used
  * the route no longer queries format, as only HTML was used

(If it was desirable for students to be able to self log 0 points, this would be relatively easy feature to add.)