### PR TITLE
hotfix: check permissions for grade predicted score

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -94,7 +94,7 @@ class AssignmentsController < ApplicationController
     else
       student = NullStudent.new(current_course)
     end
-    @assignments = PredictedAssignmentCollection.new current_course.assignments, student
+    @assignments = PredictedAssignmentCollection.new current_course.assignments, current_user, student
   end
 
   def destroy

--- a/app/models/predicted_assignment.rb
+++ b/app/models/predicted_assignment.rb
@@ -1,16 +1,17 @@
 class PredictedAssignment < SimpleDelegator
-  attr_reader :user
+  attr_reader :current_user, :student
 
-  def initialize(assignment, user)
+  def initialize(assignment, current_user, student)
     @assignment = assignment
-    @user = user
+    @current_user = current_user
+    @student = student
     super assignment
   end
 
   def grade
     if @grade.nil?
-      grade = user.present? ? Grade.find_or_create(assignment, user) : NullGrade.new
-      @grade = PredictedGrade.new(grade)
+      grade = student.present? ? Grade.find_or_create(assignment, student) : NullGrade.new
+      @grade = PredictedGrade.new(grade, current_user)
     end
     @grade
   end

--- a/app/models/predicted_assignment_collection.rb
+++ b/app/models/predicted_assignment_collection.rb
@@ -1,19 +1,24 @@
 class PredictedAssignmentCollection
   include Enumerable
 
-  attr_reader :assignments, :user
+  attr_reader :assignments, :current_user, :student
 
-  def initialize(assignments, user)
+  def initialize(assignments, current_user, student)
     @assignments = pluck_attributes assignments
-    @user = user
+    @current_user = current_user
+    @student = student
   end
 
   def each
-    assignments.each { |assignment| yield PredictedAssignment.new(assignment, user) }
+    assignments.each { |assignment| yield PredictedAssignment.new(assignment, current_user, student) }
   end
 
   def [](index)
     to_a[index]
+  end
+
+  def permission_to_update?
+    @current_user == @student
   end
 
   private

--- a/app/models/predicted_assignment_collection.rb
+++ b/app/models/predicted_assignment_collection.rb
@@ -18,7 +18,7 @@ class PredictedAssignmentCollection
   end
 
   def permission_to_update?
-    @current_user == @student
+    current_user == student
   end
 
   private

--- a/app/models/predicted_grade.rb
+++ b/app/models/predicted_grade.rb
@@ -1,4 +1,6 @@
 class PredictedGrade
+  attr_reader :current_user
+
   def id
     grade.id
   end
@@ -8,7 +10,7 @@ class PredictedGrade
   end
 
   def predicted_score
-    grade.predicted_score if grade.student && grade.student.is_student?(grade.course)
+    grade.student == @current_user ? grade.predicted_score : 0
   end
 
   def raw_score
@@ -19,8 +21,9 @@ class PredictedGrade
     grade.score if grade.is_student_visible?
   end
 
-  def initialize(grade)
+  def initialize(grade, current_user)
     @grade = grade
+    @current_user = current_user
   end
 
   private

--- a/app/models/predicted_grade.rb
+++ b/app/models/predicted_grade.rb
@@ -10,7 +10,7 @@ class PredictedGrade
   end
 
   def predicted_score
-    grade.student == @current_user ? grade.predicted_score : 0
+    grade.student == current_user ? grade.predicted_score : 0
   end
 
   def raw_score

--- a/app/views/assignments/predictor_data.json.jbuilder
+++ b/app/views/assignments/predictor_data.json.jbuilder
@@ -1,6 +1,6 @@
 json.assignments @assignments do |assignment|
   next unless assignment.point_total > 0 || assignment.pass_fail?
-  next unless assignment.visible_for_student?(assignment.user)
+  next unless assignment.visible_for_student?(assignment.student)
   next unless assignment.include_in_predictor?
   json.merge! assignment.attributes
   json.score_levels assignment.assignment_score_levels.map {|asl| {name: asl.name, value: asl.value}}
@@ -11,12 +11,12 @@ json.assignments @assignments do |assignment|
   # boolean states for icons
   json.is_required assignment.required
   json.has_info ! assignment.description.blank?
-  json.is_late assignment.overdue? && assignment.accepts_submissions && !assignment.user.submission_for_assignment(assignment).present?
+  json.is_late assignment.overdue? && assignment.accepts_submissions && !assignment.student.submission_for_assignment(assignment).present?
   json.is_earned_by_group assignment.grade_scope == "Group"
 
-  json.is_locked ! assignment.is_unlocked_for_student?(assignment.user)
+  json.is_locked ! assignment.is_unlocked_for_student?(assignment.student)
 
-  json.has_been_unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(assignment.user)
+  json.has_been_unlocked assignment.is_unlockable? && assignment.is_unlocked_for_student?(assignment.student)
   if assignment.is_unlockable?
     json.unlock_conditions assignment.unlock_conditions.map{ |condition|
       "#{condition.name} must be #{condition.condition_state}"
@@ -48,6 +48,6 @@ end
 json.term_for_assignment term_for :assignment
 json.term_for_pass current_course.pass_term
 json.term_for_fail current_course.fail_term
-json.update_assignments @assignments.user == current_user
+json.update_assignments @assignments.permission_to_update?
 
 json.student current_user.is_student?(current_course)

--- a/spec/controllers/assignment_type_weights_controller_spec.rb
+++ b/spec/controllers/assignment_type_weights_controller_spec.rb
@@ -50,19 +50,19 @@ describe AssignmentTypeWeightsController do
       end
 
       it "updates assignment weights" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(@student.weight_spent?(@course)).to eq(true)
       end
 
       it "updates points for corresponding grades" do
-        grade = create :scored_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
-        grade_2 = create :scored_grade, assignment: @assignment_type_weightable_2.assignments.first, student: @student, course: @course, raw_score: 1000
-        grade_3 = create :scored_grade, assignment: @assignment_type_weightable_3.assignments.first, student: @student, course: @course, raw_score: 1000
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"}, 
+        grade = create :released_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
+        grade_2 = create :released_grade, assignment: @assignment_type_weightable_2.assignments.first, student: @student, course: @course, raw_score: 1000
+        grade_3 = create :released_grade, assignment: @assignment_type_weightable_3.assignments.first, student: @student, course: @course, raw_score: 1000
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(@assignment_type_weightable.visible_score_for_student(@student)).to eq(2000)
@@ -71,8 +71,8 @@ describe AssignmentTypeWeightsController do
       end
 
       it "returns an error message if the student has assigned more weight to an assignment type than is allowed" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -85,8 +85,8 @@ describe AssignmentTypeWeightsController do
       end
 
       it "returns an error if the student has assigned more total weights than allowed" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "4"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "4"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -98,10 +98,10 @@ describe AssignmentTypeWeightsController do
         @assignment_type_weightable_5 = create :assignment_type, course: @course,
           student_weightable: true
 
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "1"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"}, 
-        "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "1" }, 
-        "3" => { "assignment_type_id" => @assignment_type_weightable_4.id, "weight" => "1" }, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "1"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"},
+        "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "1" },
+        "3" => { "assignment_type_id" => @assignment_type_weightable_4.id, "weight" => "1" },
         "4" => { "assignment_type_id" => @assignment_type_weightable_5.id, "weight" => "2" }} }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -168,19 +168,19 @@ describe AssignmentTypeWeightsController do
       end
 
       it "updates assignment weights" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(@student.weight_spent?(@course)).to eq(true)
       end
 
       it "updates points for corresponding grades" do
-        grade = create :scored_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
-        grade_2 = create :scored_grade, assignment: @assignment_type_weightable_2.assignments.first, student: @student, course: @course, raw_score: 1000
-        grade_3 = create :scored_grade, assignment: @assignment_type_weightable_3.assignments.first, student: @student, course: @course, raw_score: 1000
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"}, 
+        grade = create :released_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
+        grade_2 = create :released_grade, assignment: @assignment_type_weightable_2.assignments.first, student: @student, course: @course, raw_score: 1000
+        grade_3 = create :released_grade, assignment: @assignment_type_weightable_3.assignments.first, student: @student, course: @course, raw_score: 1000
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "2"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "2"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(@assignment_type_weightable.visible_score_for_student(@student)).to eq(2000)
@@ -189,8 +189,8 @@ describe AssignmentTypeWeightsController do
       end
 
       it "returns an error message if the student has assigned more weight to an assignment type than is allowed" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -203,8 +203,8 @@ describe AssignmentTypeWeightsController do
       end
 
       it "returns an error if the student has assigned more total weights than allowed" do
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "4"}, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "3"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "4"},
         "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "2" } } }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -216,10 +216,10 @@ describe AssignmentTypeWeightsController do
         @assignment_type_weightable_5 = create :assignment_type, course: @course,
           student_weightable: true
 
-        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "1"}, 
-        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"}, 
-        "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "1" }, 
-        "3" => { "assignment_type_id" => @assignment_type_weightable_4.id, "weight" => "1" }, 
+        params = { "student" => { "assignment_type_weights_attributes" => { "0" => { "assignment_type_id" => @assignment_type_weightable.id, "weight" => "1"},
+        "1" => { "assignment_type_id" => @assignment_type_weightable_2.id, "weight" => "1"},
+        "2" => { "assignment_type_id" => @assignment_type_weightable_3.id, "weight" => "1" },
+        "3" => { "assignment_type_id" => @assignment_type_weightable_4.id, "weight" => "1" },
         "4" => { "assignment_type_id" => @assignment_type_weightable_5.id, "weight" => "2" }} }, student_id: @student.id }
         post :mass_update, params
         expect(response).to render_template(:mass_edit)
@@ -249,7 +249,7 @@ describe AssignmentTypeWeightsController do
       end
 
       it "updates points for corresponding grades" do
-        grade = create :scored_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
+        grade = create :released_grade, assignment: @assignment_type_weightable.assignments.first, student: @student, course: @course, raw_score: 1000
         post :update, :id => @assignment_type_weightable.id, :weight => 2, :format => :json
         expect(@assignment_type_weightable.visible_score_for_student(@student)).to eq(2000)
       end

--- a/spec/factories/grade_factory.rb
+++ b/spec/factories/grade_factory.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :grade do
-    association :assignment 
+    association :assignment
     association :student, factory: :user
 
-    factory :scored_grade do
+    factory :released_grade do
       raw_score { Faker::Number.number(5) }
       status "Released"
     end

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
 
     factory :graded_submission do
       # TODO, verify this method exists and works, or fails with no method error: submission.graded?
-      association :grade, factory: :scored_grade
+      association :grade, factory: :released_grade
     end
   end
 end

--- a/spec/models/predicted_assignment_collection_spec.rb
+++ b/spec/models/predicted_assignment_collection_spec.rb
@@ -6,16 +6,17 @@ describe PredictedAssignmentCollection do
   let(:assignment2) { create :assignment }
   let(:assignments) { Assignment.where(id: [assignment1.id, assignment2.id]) }
   let(:user) { double(:user) }
+  let(:other_user) { double(:other_user) }
 
   describe "#initialize" do
     it "requires assignments and a user as the context" do
-      subject = described_class.new assignments, user
+      subject = described_class.new assignments, user, user
       expect(subject.assignments.size).to eq assignments.size
-      expect(subject.user).to eq user
+      expect(subject.current_user).to eq user
     end
 
     it "plucks the assignment fields it exposes" do
-      subject = described_class.new assignments, user
+      subject = described_class.new assignments, user, user
       assignment = subject.assignments.first
       [:accepts_resubmissions_until,
        :accepts_submissions,
@@ -48,7 +49,7 @@ describe PredictedAssignmentCollection do
 
   describe "#each" do
     it "enumerates over the assignments and creates predicted assignments" do
-      subject = described_class.new assignments, user
+      subject = described_class.new assignments, user, user
       subject.each do |assignment|
         expect(assignment).to be_instance_of PredictedAssignment
       end
@@ -57,9 +58,21 @@ describe PredictedAssignmentCollection do
 
   describe "#[]" do
     it "can be indexed" do
-      subject = described_class.new assignments, user
+      subject = described_class.new assignments, user, user
       expect(subject[0]).to be_an_instance_of PredictedAssignment
       expect(subject[0].id).to eq assignments[0].id
+    end
+  end
+
+  describe "permissions" do
+    it "allows updates when current_user is same as student" do
+      subject = described_class.new assignments, user, user
+      expect(subject.permission_to_update?).to be_truthy
+    end
+
+    it "doens't allow updates when current user is other than student" do
+      subject = described_class.new assignments, other_user, user
+      expect(subject.permission_to_update?).to be_falsy
     end
   end
 end

--- a/spec/models/predicted_assignment_spec.rb
+++ b/spec/models/predicted_assignment_spec.rb
@@ -4,7 +4,7 @@ require "./app/models/predicted_assignment"
 describe PredictedAssignment do
   let(:assignment) { create :assignment }
   let(:user) { create :user }
-  subject { described_class.new assignment, user }
+  subject { described_class.new assignment, user, user }
 
   it "responds to any method on the assignment" do
     expect(subject.id).to eq assignment.id
@@ -27,7 +27,7 @@ describe PredictedAssignment do
     end
 
     it "returns a nil predicted grade if the user cannot create grades" do
-      subject = described_class.new assignment, NullStudent.new
+      subject = described_class.new assignment, user, NullStudent.new
       expect(subject.grade.id).to eq 0
     end
   end

--- a/spec/models/predicted_grade_spec.rb
+++ b/spec/models/predicted_grade_spec.rb
@@ -5,7 +5,8 @@ describe PredictedGrade do
   let(:course) { double(:course) }
   let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, raw_score: 84, student: user, course: course, is_student_visible?: true) }
   let(:user) { double(:user) }
-  subject { described_class.new grade }
+  let(:other_user) { double(:other_user) }
+  subject { described_class.new grade, user }
 
   describe "#id" do
     it "returns the grade's id" do
@@ -53,10 +54,13 @@ describe PredictedGrade do
       expect(subject.predicted_score).to eq grade.predicted_score
     end
 
-    it "returns nil if it's not visible" do
-      allow(grade.student).to \
-        receive(:is_student?).with(grade.course).and_return false
-      expect(subject.predicted_score).to be_nil
+    it "returns 0 predicted_score if user is not same as student for grade" do
+      expect((described_class.new grade, other_user).predicted_score).to eq 0
+    end
+
+    it "returns predicted score for student even if it's not visible" do
+      allow(grade).to receive(:is_student_visible?).and_return false
+      expect(subject.predicted_score).to eq grade.predicted_score
     end
   end
 end

--- a/spec/views/assignments/predictor_data_spec.rb
+++ b/spec/views/assignments/predictor_data_spec.rb
@@ -10,7 +10,7 @@ describe "assignments/predictor_data" do
 
   before(:each) do
     @assignment = create(:assignment, description: "...", course: @course)
-    @assignments = PredictedAssignmentCollection.new Assignment.where(id: @assignment.id), @student
+    @assignments = PredictedAssignmentCollection.new Assignment.where(id: @assignment.id), @student, @student
     allow(view).to receive(:current_course).and_return(@course)
     allow(view).to receive(:current_user).and_return(@student)
   end


### PR DESCRIPTION
  * Fixes a but where professors were able to see student grades
  * Passes current_user into PredictedAssignmentCollection, PredictedAssignment, PredictedGrade
  * Handles permissions within these models
  * Simplifies logic: predicted score and permission to update are only granted to current student
