### PR TITLE
ignore predictions if points aren't null

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -118,7 +118,7 @@
     total = 0
     _.each(assignments, (assignment)->
       # use raw score to keep weighting calculation on assignment type level
-      if assignment.grade.raw_score > 0
+      if assignment.grade.raw_score != null
         total += assignment.grade.raw_score
       else if ! assignment.pass_fail && includePredicted
         total += assignment.grade.predicted_score


### PR DESCRIPTION
Check for any presence of grade points in predictor, and use this in the sum rather than the predicted points.

closes #1515