### PR TITLE
1371 disable update grade status

### DIFF
--- a/app/assets/javascripts/behaviors/toggle_disable_list_command.js
+++ b/app/assets/javascripts/behaviors/toggle_disable_list_command.js
@@ -1,7 +1,12 @@
 $(function() {
   $(document).on("change", "[data-behavior~=toggle-disable-list-command]", function(e) {
     var commandButtonsSelector = $(e.target).data("commands");
-    var commandButtons = $(e.target).closest(commandButtonsSelector);
-    console.log(commandButtons.length);
+    var commandButtons = $(document).find(commandButtonsSelector);
+    var list = $(document).find("[name='" + $(e.target).attr("name") + "']:checked");
+    if (list.length > 0) {
+      commandButtons.removeClass("disabled").attr("disabled", false);
+    } else {
+      commandButtons.addClass("disabled").attr("disabled", true);
+    }
   });
 });

--- a/app/assets/javascripts/behaviors/toggle_disable_list_command.js
+++ b/app/assets/javascripts/behaviors/toggle_disable_list_command.js
@@ -1,0 +1,7 @@
+$(function() {
+  $(document).on("change", "[data-behavior~=toggle-disable-list-command]", function(e) {
+    var commandButtonsSelector = $(e.target).data("commands");
+    var commandButtons = $(e.target).closest(commandButtonsSelector);
+    console.log(commandButtons.length);
+  });
+});

--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -26,6 +26,13 @@
   &.secondary
     background-color: $color-green-3
 
+  &.disabled
+    color: $color-white
+    cursor: default
+    opacity: 0.7
+    &:hover
+      background-color: $color-blue-1
+
 .submit-buttons
   margin-top: 1rem
   position: relative

--- a/app/views/assignments/individual/_individual_show.haml
+++ b/app/views/assignments/individual/_individual_show.haml
@@ -13,6 +13,6 @@
   - if presenter.assignment.release_necessary? && presenter.has_grades?
     .right
       %br
-      = submit_tag "Update Selected Grade Statuses", :class => "button"
+      = submit_tag "Update Selected Grade Statuses", :class => "button disabled", disabled: true, data: { behavior: "selected-individual-grades-command" }
 
   .clear

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -67,4 +67,4 @@
       %td
         .center
           - if grade.is_graded?
-            = check_box_tag "grade_ids[]", grade.id
+            = check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-individual-grades-command']" }

--- a/app/views/info/_in_progress_grades_table.haml
+++ b/app/views/info/_in_progress_grades_table.haml
@@ -44,10 +44,10 @@
                     %ul.button-bar
                       %li= link_to raw("<i class='fa fa-eye fa-fw'></i> See Grade"), assignment_grade_path(g.assignment, :student_id => g.student_id), :class => "button"
                       %li= link_to raw("<i class='fa fa-edit fa-fw'></i> Edit Grade"), edit_assignment_grade_path(:assignment_id => assignment.id, :student_id => student.try(:id)), :class => "button"
-                %td.center= check_box_tag "grade_ids[]", g.id
+                %td.center= check_box_tag "grade_ids[]", g.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-in-progress-grades-command']" }
       .submit-buttons
         .right
-          = submit_tag "Update Selected Grade Statuses", :class => "button"
+          = submit_tag "Update Selected Grade Statuses", :class => "button disabled", disabled: true, data: { behavior: "selected-in-progress-grades-command" }
 
 
 

--- a/app/views/info/_unreleased_grades_table.haml
+++ b/app/views/info/_unreleased_grades_table.haml
@@ -61,12 +61,12 @@
               %td
                 .center
                   %label
-                    = check_box_tag "grade_ids[]", g.id
+                    = check_box_tag "grade_ids[]", g.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-grades-command']" }
                     .sr-only
                       Check/Uncheck #{first_name} #{last_name}
 
       .submit-buttons
         .right
-          = submit_tag "Update Selected Grade Statuses", :class => "button"
+          = submit_tag "Update Selected Grade Statuses", :class => "button disabled", disabled: true, data: { behavior: "selected-grades-command" }
 
   %hr.dotted

--- a/app/views/info/_unreleased_grades_table.haml
+++ b/app/views/info/_unreleased_grades_table.haml
@@ -61,12 +61,12 @@
               %td
                 .center
                   %label
-                    = check_box_tag "grade_ids[]", g.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-grades-command']" }
+                    = check_box_tag "grade_ids[]", g.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-unreleased-grades-command']" }
                     .sr-only
                       Check/Uncheck #{first_name} #{last_name}
 
       .submit-buttons
         .right
-          = submit_tag "Update Selected Grade Statuses", :class => "button disabled", disabled: true, data: { behavior: "selected-grades-command" }
+          = submit_tag "Update Selected Grade Statuses", :class => "button disabled", disabled: true, data: { behavior: "selected-unreleased-grades-command" }
 
   %hr.dotted


### PR DESCRIPTION
Disables the command for list of checkboxes where the command should not be enabled until there are some selected checkboxes. This behavior is generic and can be attached to multiple areas of the application.

This adds the behavior to the grade lists for in progress grades, unreleased grades, and individual assignment show grade list.

Closes #1371 