### PR TITLE
1503 refactor course copy

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,96 +29,18 @@ class CoursesController < ApplicationController
     @course = Course.find(params[:id])
   end
 
-  # Important for instructors to be able to copy one course's structure into a new one - does not copy students or grades
   def copy
-    @course = Course.find(params[:id])
-    new_course = @course.dup
-    new_course.name.prepend("Copy of ")
-    new_course.save
-    if @course.badges.present?
-      @course.badges.each do |b|
-        nb = b.dup
-        nb.course_id = new_course.id
-        nb.save
+    course = Course.find(params[:id])
+    duplicated = course.copy
+    if duplicated.save
+      if !current_user_is_admin?
+        duplicated.course_memberships.create(user: current_user, role: current_role)
       end
+      session[:course_id] = duplicated.id
+      redirect_to course_path(duplicated.id), notice: "#{course.name} successfully copied"
+    else
+      redirect_to courses_path, alert: "#{course.name} was not successfully copied"
     end
-    if @course.assignment_types.present?
-      @course.assignment_types.each do |at|
-        nat = at.dup
-        nat.course_id = new_course.id
-        nat.save
-        at.assignments.each do |a|
-          na = a.dup
-          na.assignment_type_id = nat.id
-          na.course_id = new_course.id
-          na.save
-          if a.assignment_score_levels.present?
-            a.assignment_score_levels.each do |asl|
-              nasl = asl.dup
-              nasl.assignment_id = na.id
-              nasl.save
-            end
-          end
-          if a.rubric.present?
-            new_rubric = a.rubric.dup
-            new_rubric.assignment_id = na.id
-            new_rubric.save
-            if a.rubric.metrics.present?
-              a.rubric.metrics.each do |metric|
-                new_metric = metric.dup
-                new_metric.rubric_id = new_rubric.id
-                new_metric.add_default_tiers = false
-                new_metric.save
-                if metric.tiers.present?
-                  metric.tiers.each do |tier|
-                    new_tier = tier.dup
-                    new_tier.metric_id = new_metric.id
-                    new_tier.save
-                    if tier.tier_badges.present?
-                      tier.tier_badges.each do |tier_badge|
-                        new_tier_badge = tier_badge.dup
-                        new_tier_badge.tier_id = new_tier.id
-                        badge = tier_badge.badge
-                        new_badge = new_course.badges.where(:name => badge.name).first
-                        new_tier_badge.badge_id = new_badge.id
-                        new_tier_badge.save
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-    if @course.challenges.present?
-      @course.challenges.each do |c|
-        nc = c.dup
-        nc.course_id = new_course.id
-        nc.save
-      end
-    end
-    if @course.grade_scheme_elements.present?
-      @course.grade_scheme_elements.each do |gse|
-        ngse = gse.dup
-        ngse.course_id = new_course.id
-        ngse.save
-      end
-    end
-    respond_to do |format|
-      if new_course.save
-        if ! current_user_is_admin?
-          new_course.course_memberships.create(:user_id => current_user.id,
-                                                :role => current_user.role(current_course))
-        end
-        session[:course_id] = new_course.id
-        format.html { redirect_to course_path(new_course.id), notice: "#{@course.name} successfully copied" }
-      else
-        format.html { redirect_to courses_path, alert: "#{@course.name} was not successfully copied" }
-      end
-    end
-
   end
 
   def create

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -115,7 +115,7 @@ class CoursesController < ApplicationController
         session[:course_id] = new_course.id
         format.html { redirect_to course_path(new_course.id), notice: "#{@course.name} successfully copied" }
       else
-        redirect_to courses_path, alert: "#{@course.name} was not successfully copied"
+        format.html { redirect_to courses_path, alert: "#{@course.name} was not successfully copied" }
       end
     end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,7 @@
 require_relative "concerns/multiple_file_attributes"
 
 class Assignment < ActiveRecord::Base
+  include Copyable
   include Gradable
   include MultipleFileAttibutes
   include ScoreLevelable
@@ -82,7 +83,7 @@ class Assignment < ActiveRecord::Base
   def copy(attributes={})
     copy = self.dup
     copy.name.prepend "Copy of "
-    copy.assign_attributes(attributes)
+    copy.copy_attributes(attributes)
     copy.save unless self.new_record?
     copy.assignment_score_levels << self.assignment_score_levels.map(&:copy)
     copy.rubric = self.rubric.copy if self.rubric.present?

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -17,7 +17,7 @@ class Assignment < ActiveRecord::Base
     :mass_grade_type, :include_in_timeline, :include_in_predictor,
     :include_in_to_do, :assignment_file_ids,
     :assignment_files_attributes, :assignment_file,
-    :assignment_score_levels_attributes, :assignment_score_level, :course
+    :assignment_score_levels_attributes, :assignment_score_level, :course, :course_id
 
   attr_accessor :current_student_grade
 
@@ -79,9 +79,10 @@ class Assignment < ActiveRecord::Base
 
   delegate :student_weightable?, to: :assignment_type
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
     copy.name.prepend "Copy of "
+    copy.assign_attributes(attributes)
     copy.save unless self.new_record?
     copy.assignment_score_levels << self.assignment_score_levels.map(&:copy)
     copy.rubric = self.rubric.copy if self.rubric.present?

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -17,6 +17,13 @@ class AssignmentType < ActiveRecord::Base
 
   default_scope { order 'position' }
 
+  def copy
+    copy = self.dup
+    copy.save unless self.new_record?
+    copy.assignments << self.assignments.map(&:copy)
+    copy
+  end
+
   def weight_for_student(student)
     #return a standard multiplier of 1 if the assignment type is not student weightable
     return 1 unless student_weightable?

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -1,4 +1,6 @@
 class AssignmentType < ActiveRecord::Base
+  include Copyable
+
   acts_as_list scope: :course
 
   attr_accessible :max_points, :name, :description, :student_weightable, :position
@@ -19,7 +21,7 @@ class AssignmentType < ActiveRecord::Base
 
   def copy(attributes={})
     copy = self.dup
-    copy.assign_attributes(attributes)
+    copy.copy_attributes(attributes)
     copy.save unless self.new_record?
     copy.assignments << self.assignments.map { |a| a.copy(attributes) }
     copy

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -17,10 +17,11 @@ class AssignmentType < ActiveRecord::Base
 
   default_scope { order 'position' }
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
+    copy.assign_attributes(attributes)
     copy.save unless self.new_record?
-    copy.assignments << self.assignments.map(&:copy)
+    copy.assignments << self.assignments.map { |a| a.copy(attributes) }
     copy
   end
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -1,9 +1,9 @@
 class Badge < ActiveRecord::Base
   include UnlockableCondition
 
-  attr_accessible :name, :description, :icon, :visible, :can_earn_multiple_times, 
-    :point_total, :earned_badges, :earned_badges_attributes, :badge_file_ids, 
-    :badge_files_attributes, :badge_file, :position, :visible_when_locked, 
+  attr_accessible :name, :description, :icon, :visible, :can_earn_multiple_times,
+    :point_total, :earned_badges, :earned_badges_attributes, :badge_file_ids,
+    :badge_files_attributes, :badge_file, :position, :visible_when_locked,
     :course_id, :course
 
   # grade points available to the predictor from the assignment controller
@@ -37,6 +37,10 @@ class Badge < ActiveRecord::Base
   #indexed badges
   def awarded_count
     earned_badges.student_visible.count
+  end
+
+  def copy
+    self.dup
   end
 
   #badges per role

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -1,4 +1,5 @@
 class Badge < ActiveRecord::Base
+  include Copyable
   include UnlockableCondition
 
   attr_accessible :name, :description, :icon, :visible, :can_earn_multiple_times,
@@ -37,10 +38,6 @@ class Badge < ActiveRecord::Base
   #indexed badges
   def awarded_count
     earned_badges.student_visible.count
-  end
-
-  def copy
-    self.dup
   end
 
   #badges per role

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -33,6 +33,10 @@ class Challenge < ActiveRecord::Base
   validates_presence_of :course, :name
   validate :positive_points, :open_before_close
 
+  def copy
+    self.dup
+  end
+
   def has_levels?
     challenge_score_levels.present?
   end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,4 +1,5 @@
 class Challenge < ActiveRecord::Base
+  include Copyable
   include ScoreLevelable
   include UploadsMedia
   include UploadsThumbnails
@@ -32,10 +33,6 @@ class Challenge < ActiveRecord::Base
 
   validates_presence_of :course, :name
   validate :positive_points, :open_before_close
-
-  def copy
-    self.dup
-  end
 
   def has_levels?
     challenge_score_levels.present?

--- a/app/models/concerns/copyable.rb
+++ b/app/models/concerns/copyable.rb
@@ -1,0 +1,18 @@
+module Copyable
+  extend ActiveSupport::Concern
+
+  def copy(attributes={})
+    copy = self.dup
+    copy.copy_attributes(attributes)
+    copy
+  end
+
+  def copy_attributes(attributes)
+    attributes.each do |name, value|
+      method = "#{name}="
+      if self.respond_to? method
+        self.send method, value
+      end
+    end
+  end
+end

--- a/app/models/concerns/score_level.rb
+++ b/app/models/concerns/score_level.rb
@@ -1,5 +1,6 @@
 module ScoreLevel
   extend ActiveSupport::Concern
+  include Copyable
 
   included do
     attr_accessible :name, :value
@@ -9,14 +10,9 @@ module ScoreLevel
     validates :name, presence: true
     validates :value, presence: true
   end
-  
+
   #Displaying the name and the point value together in grading lists
   def formatted_name
     "#{name} (#{value} points)"
   end
-
-  def copy
-    self.dup
-  end
-
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,7 @@
 require_relative "role"
 
 class Course < ActiveRecord::Base
+  include Copyable
   include UploadsMedia
 
   after_create :create_admin_memberships
@@ -183,7 +184,7 @@ class Course < ActiveRecord::Base
     super.presence || 'Player'
   end
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
     copy.name.prepend "Copy of "
     copy.save unless self.new_record?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -188,7 +188,7 @@ class Course < ActiveRecord::Base
     copy.name.prepend "Copy of "
     copy.save unless self.new_record?
     copy.badges << self.badges.map(&:copy)
-    copy.assignment_types << self.assignment_types.map(&:copy)
+    copy.assignment_types << self.assignment_types.map { |at| at.copy(course_id: copy.id) }
     copy.challenges << self.challenges.map(&:copy)
     copy.grade_scheme_elements << self.grade_scheme_elements.map(&:copy)
     copy

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -188,6 +188,9 @@ class Course < ActiveRecord::Base
     copy.name.prepend "Copy of "
     copy.save unless self.new_record?
     copy.badges << self.badges.map(&:copy)
+    copy.assignment_types << self.assignment_types.map(&:copy)
+    copy.challenges << self.challenges.map(&:copy)
+    copy.grade_scheme_elements << self.grade_scheme_elements.map(&:copy)
     copy
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -183,6 +183,14 @@ class Course < ActiveRecord::Base
     super.presence || 'Player'
   end
 
+  def copy
+    copy = self.dup
+    copy.name.prepend "Copy of "
+    copy.save unless self.new_record?
+    copy.badges << self.badges.map(&:copy)
+    copy
+  end
+
   def has_teams?
     team_setting == true
   end

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -10,6 +10,10 @@ class GradeSchemeElement < ActiveRecord::Base
 
   scope :order_by_low_range, -> { order 'low_range ASC' }
 
+  def copy
+    self.dup
+  end
+
   # Getting the name of the Grade Scheme Element - the Level if it's present, the Letter if not
   def name
     if level? && letter?

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -1,4 +1,5 @@
 class GradeSchemeElement < ActiveRecord::Base
+  include Copyable
   attr_accessible :letter, :low_range, :high_range, :level, :description, :course_id, :course, :updated_at
 
   belongs_to :course, touch: true
@@ -9,10 +10,6 @@ class GradeSchemeElement < ActiveRecord::Base
   default_scope { order 'high_range DESC' }
 
   scope :order_by_low_range, -> { order 'low_range ASC' }
-
-  def copy
-    self.dup
-  end
 
   # Getting the name of the Grade Scheme Element - the Level if it's present, the Letter if not
   def name

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,4 +1,6 @@
 class Metric < ActiveRecord::Base
+  include Copyable
+
   belongs_to :rubric
   has_many :tiers, dependent: :destroy
 
@@ -20,7 +22,7 @@ class Metric < ActiveRecord::Base
 
   scope :ordered, lambda { order(:order) }
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
     copy.add_default_tiers = false
     copy.save unless self.new_record?

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -1,4 +1,6 @@
 class Rubric < ActiveRecord::Base
+  include Copyable
+
   belongs_to :assignment
   has_many :metrics
   has_many :rubric_grades
@@ -17,7 +19,7 @@ class Rubric < ActiveRecord::Base
     metrics.count > 0
   end
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
     copy.save unless self.new_record?
     copy.metrics << self.metrics.map(&:copy)

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -1,4 +1,6 @@
 class Tier < ActiveRecord::Base
+  include Copyable
+
   belongs_to :metric
   has_many :tier_badges
   has_many :badges, through: :tier_badges
@@ -13,7 +15,7 @@ class Tier < ActiveRecord::Base
 
   include DisplayHelpers
 
-  def copy
+  def copy(attributes={})
     copy = self.dup
     copy.save unless self.new_record?
     copy.badges << self.badges.map(&:dup)

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -73,33 +73,33 @@ describe CoursesController do
       end
     end
 
-    describe "POST copy" do 
-      it "creates a duplicate course" do 
+    describe "POST copy" do
+      it "creates a duplicate course" do
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
       end
 
-      it "duplicates badges if present" do 
+      it "duplicates badges if present" do
         create(:badge, course: @course)
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
         course_2 = Course.last
         expect(course_2.badges.present?).to eq(true)
       end
 
-      it "duplicates challenges if present" do 
+      it "duplicates challenges if present" do
         create(:challenge, course: @course)
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
         course_2 = Course.last
         expect(course_2.challenges.present?).to eq(true)
       end
 
-      it "duplicates grade_scheme_elements if present" do 
+      it "duplicates grade_scheme_elements if present" do
         create(:grade_scheme_element, course: @course)
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
         course_2 = Course.last
         expect(course_2.grade_scheme_elements.present?).to eq(true)
       end
 
-      it "duplicates assignment_types and assignments if present" do 
+      it "duplicates assignment_types and assignments if present" do
         assignment_type = create(:assignment_type, course: @course)
         create(:assignment, assignment_type: assignment_type, course: @course)
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
@@ -108,7 +108,7 @@ describe CoursesController do
         expect(course_2.assignments.present?).to eq(true)
       end
 
-      it "duplicates score levels if present" do         
+      it "duplicates score levels if present" do
         assignment_type = create(:assignment_type, course: @course)
         assignment = create(:assignment, assignment_type: assignment_type, course: @course)
         score_level = create(:assignment_score_level, assignment: assignment)
@@ -118,7 +118,7 @@ describe CoursesController do
         expect(assignment_2.assignment_score_levels.present?).to eq(true)
       end
 
-      it "duplicates rubrics if present" do 
+      it "duplicates rubrics if present" do
         assignment_type = create(:assignment_type, course: @course)
         badge = create(:badge, course: @course, name: "First")
         assignment = create(:assignment, assignment_type: assignment_type, course: @course)
@@ -129,7 +129,7 @@ describe CoursesController do
         course_2 = Course.last
         assignment_2 = course_2.assignments.first
         rubric_2 = assignment_2.rubric
-        metric_2 = rubric_2.metrics.first 
+        metric_2 = rubric_2.metrics.first
         tier_2 = metric_2.tiers.last
         expect{ post :copy, :id => @course.id }.to change(Course, :count).by(1)
         expect(assignment_2.rubric.present?).to eq(true)
@@ -138,8 +138,11 @@ describe CoursesController do
         expect(tier_2.tier_badges.present?).to eq(true)
       end
 
-      it "redirects to the courses path if the copy fails" do 
-        skip "pending"
+      it "redirects to the courses path if the copy fails" do
+        @course.update_attribute :max_group_size, 0
+        post :copy, id: @course.id
+        expect(response).to redirect_to courses_path
+        expect(flash[:alert]).to eq "#{@course.name} was not successfully copied"
       end
     end
 
@@ -151,7 +154,7 @@ describe CoursesController do
         expect(@course.reload.name).to eq("new name")
       end
 
-      it "redirects to the edit path if the course fails to update" do 
+      it "redirects to the edit path if the course fails to update" do
         params = { name: "" }
         post :update, id: @course.id, :course => params
         expect(response).to render_template(:edit)
@@ -164,8 +167,8 @@ describe CoursesController do
       end
     end
 
-    describe "GET timeline settings" do 
-      it "displays a list of all assignments for the course and their timeline info " do 
+    describe "GET timeline settings" do
+      it "displays a list of all assignments for the course and their timeline info " do
         get :timeline_settings, :id => @course.id
         expect(assigns(:title)).to eq("Timeline Settings")
         expect(assigns(:course)).to eq(@course)
@@ -173,9 +176,9 @@ describe CoursesController do
       end
     end
 
-    describe "POST timeline settings update" do 
+    describe "POST timeline settings update" do
 
-      it "changes the list of all assignments for the course and their timeline info " do 
+      it "changes the list of all assignments for the course and their timeline info " do
         @assignment = create(:assignment, course: @course)
         params = { "course" => { "assignments_attributes" => { "0" => { "media"=>"", "thumbnail"=>"", "media_credit"=>"", "media_caption"=>"Testing", "id"=> @assignment.id } } }, :id => @course.id}
         post :timeline_settings_update, params
@@ -183,7 +186,7 @@ describe CoursesController do
         expect(response).to redirect_to dashboard_path
       end
 
-      it "redirects to the edit timeline settings page if it fails" do 
+      it "redirects to the edit timeline settings page if it fails" do
         @assignment = create(:assignment, course: @course)
         params = { "course" => { "assignments_attributes" => { "0" => { "media"=>"", "thumbnail"=>"", "media_credit"=>"", "media_caption"=>"Testing", "id"=> nil} } }, :id => @course.id}
         post :timeline_settings_update, params
@@ -192,8 +195,8 @@ describe CoursesController do
       end
     end
 
-    describe "GET predictor settings" do 
-      it "displays a list of all assignments for the course and their predictor info " do 
+    describe "GET predictor settings" do
+      it "displays a list of all assignments for the course and their predictor info " do
         get :predictor_settings, :id => @course.id
         expect(assigns(:title)).to eq("Grade Predictor Settings")
         expect(assigns(:course)).to eq(@course)
@@ -201,8 +204,8 @@ describe CoursesController do
       end
     end
 
-    describe "POST predictor settings update" do 
-      it "changes the predictor settings for all assignments for the course" do 
+    describe "POST predictor settings update" do
+      it "changes the predictor settings for all assignments for the course" do
         @assignment = create(:assignment, course: @course)
         params = { "course" => { "assignments_attributes" => { "0" => {"include_in_predictor"=>"1", "points_predictor_display"=>"Fixed", "id"=> @assignment.id } } }, :id => @course.id}
         post :predictor_settings_update, params
@@ -210,7 +213,7 @@ describe CoursesController do
         expect(response).to redirect_to @course
       end
 
-      it "redirects to the edit predictor settings page if it fails" do 
+      it "redirects to the edit predictor settings page if it fails" do
         @assignment = create(:assignment, course: @course)
         params = { "course" => { "assignments_attributes" => { "0" => {"include_in_predictor"=>"1", "points_predictor_display"=>"Fixed", "id"=> nil } } }, :id => @course.id}
         post :predictor_settings_update, params
@@ -247,7 +250,7 @@ describe CoursesController do
         :destroy,
         :timeline_settings,
         :timeline_settings_update,
-        :predictor_settings, 
+        :predictor_settings,
         :predictor_settings_update
       ].each do |route|
         it "#{route} redirects to root" do

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -48,6 +48,15 @@ describe Badge do
     end
   end
 
+  describe "#copy" do
+    let(:badge) { build :badge }
+    subject { badge.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq badge
+    end
+  end
+
   describe "#is_a_condition?" do
     it "returns true if the badge is an unlock condition" do
       badge = create(:badge)

--- a/spec/models/challenge_spec.rb
+++ b/spec/models/challenge_spec.rb
@@ -4,7 +4,7 @@ describe Challenge do
   subject { build(:challenge) }
 
   describe "validations" do
-    it "is valid" do 
+    it "is valid" do
       expect(subject).to be_valid
     end
     it "is invalid without a name" do
@@ -19,25 +19,34 @@ describe Challenge do
       expect(subject.errors[:course]).to include "can't be blank"
     end
 
-    it "is valid only with positive_points" do 
+    it "is valid only with positive_points" do
       subject.point_total = -100
       expect(subject).to be_invalid
     end
 
-    it "is valid only if the open date is before the close date" do 
+    it "is valid only if the open date is before the close date" do
       subject.due_at = Date.today -1
       subject.open_at = Date.today + 1
       expect(subject).to be_invalid
     end
   end
 
-  describe "#has_levels?" do 
-    it "returns true if challenge score levels are present" do 
+  describe "#copy" do
+    let(:challenge) { build :challenge }
+    subject { challenge.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq challenge
+    end
+  end
+
+  describe "#has_levels?" do
+    it "returns true if challenge score levels are present" do
       create(:challenge_score_level, challenge: subject)
       expect(subject.has_levels?).to be(true)
     end
 
-    it "returns false if score levels are not present" do 
+    it "returns false if score levels are not present" do
       expect(subject.has_levels?).to be(false)
     end
   end
@@ -48,20 +57,20 @@ describe Challenge do
       expect(subject.mass_grade?).to be(true)
     end
 
-    it 'returns false if the mass grade is off' do 
+    it 'returns false if the mass grade is off' do
       subject.mass_grade = false
       expect(subject.mass_grade?).to be(true)
     end
   end
 
   describe "#challenge_grade_for_team(team)" do
-    it "returns the grade for team if present" do 
+    it "returns the grade for team if present" do
       team = create(:team)
       challenge_grade = create(:challenge_grade, challenge: subject, team: team)
       expect(subject.challenge_grade_for_team(team)).to eq(challenge_grade)
     end
 
-    it "returns nil if not grade present" do 
+    it "returns nil if not grade present" do
       team = create(:team)
       expect(subject.challenge_grade_for_team(team)).to eq(nil)
     end
@@ -73,36 +82,36 @@ describe Challenge do
       expect(subject.future?).to be(true)
     end
 
-    it 'returns false if there is no due date' do 
+    it 'returns false if there is no due date' do
       subject.due_at = nil
       expect(subject.future?).to be(false)
-    end 
+    end
 
-    it 'returns false if the due date is in the past' do 
+    it 'returns false if the due date is in the past' do
       subject.due_at = Date.today - 1
       expect(subject.future?).to be(false)
-    end 
+    end
 
   end
 
   describe "#graded?" do
-    it 'returns true if challenge grades are present' do 
+    it 'returns true if challenge grades are present' do
       create(:challenge_grade, challenge: subject)
       expect(subject.graded?).to be(true)
     end
 
-    it 'returns false if no challenge grades are present' do 
+    it 'returns false if no challenge grades are present' do
       expect(subject.graded?).to be(false)
     end
   end
 
   describe "#visible_for_student?(student)" do
-    it 'returns true if challenge is visible' do 
+    it 'returns true if challenge is visible' do
       subject.visible = true
       expect(subject.visible?).to be(true)
     end
 
-    it 'returns false if the challenge is invisible' do 
+    it 'returns false if the challenge is invisible' do
       subject.visible = false
       expect(subject.visible?).to be(false)
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -48,8 +48,38 @@ describe Course do
     end
   end
 
-  describe "#staff" do 
-    it "returns an alphabetical list of the staff in the course" do 
+  describe "#copy", focus: true do
+    let(:course) { build :course }
+    subject { course.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq course
+    end
+
+    it "prepends the name with 'Copy of'" do
+      course.name = "Important Course"
+      expect(subject.name).to eq "Copy of Important Course"
+    end
+
+    it "saves the copy if the course is saved" do
+      course.save
+      expect(subject).to_not be_new_record
+    end
+
+    it "copies the badges" do
+      course.save
+      create :badge, course: course
+      expect(subject.badges.size).to eq 1
+      expect(subject.badges.map(&:course_id)).to eq [subject.id]
+    end
+
+    xit "copies the assignment types"
+    xit "copies the challenges"
+    xit "copies the grade scheme elements"
+  end
+
+  describe "#staff" do
+    it "returns an alphabetical list of the staff in the course" do
       course = create(:course)
       staff_1 = create(:user, last_name: 'Zeto')
       staff_2 = create(:user, last_name: 'Able')
@@ -79,7 +109,7 @@ describe Course do
       student3 = create(:user, last_name: 'Mr. Green')
       student3.courses << subject
       team = create(:team, course: subject)
-      team.students << [ student, student2] 
+      team.students << [ student, student2]
       expect(subject.students_being_graded_by_team(team)).to eq([student2,student])
     end
   end
@@ -104,12 +134,12 @@ describe Course do
       student3 = create(:user, last_name: 'Mr. Green')
       course_membership_2 = create(:auditing_membership, user: student3, course: subject)
       team = create(:team, course: subject)
-      team.students << [ student, student2] 
+      team.students << [ student, student2]
       expect(subject.students_auditing_by_team(team)).to eq([student])
     end
   end
 
-  describe "#students_by_team(team)" do 
+  describe "#students_by_team(team)" do
     it "returns an alphabetical list of all students in a team" do
       student = create(:user, last_name: 'Zed')
       course_membership = create(:auditing_membership, user: student, course: subject)
@@ -118,7 +148,7 @@ describe Course do
       student3 = create(:user, last_name: 'Mr. Green')
       course_membership_2 = create(:auditing_membership, user: student3, course: subject)
       team = create(:team, course: subject)
-      team.students << [ student, student2] 
+      team.students << [ student, student2]
       expect(subject.students_by_team(team)).to eq([student2, student])
     end
   end
@@ -173,245 +203,245 @@ describe Course do
     expect(CourseMembership.where(user_id: admin.id, course_id: course.id, role: "admin")).to be_exist
   end
 
-  describe "#assignment_term" do 
-    it "returns the set assignment_term if present" do 
-      subject.assignment_term = 'Quest'  
+  describe "#assignment_term" do
+    it "returns the set assignment_term if present" do
+      subject.assignment_term = 'Quest'
       expect(subject.assignment_term).to eq("Quest")
     end
 
-    it "returns Assignment if no assignment_term is present" do 
+    it "returns Assignment if no assignment_term is present" do
       expect(subject.assignment_term).to eq("Assignment")
     end
   end
 
-  describe "#badge_term" do 
-    it "returns the set badge_term if present" do 
-      subject.badge_term = 'Achievement'  
+  describe "#badge_term" do
+    it "returns the set badge_term if present" do
+      subject.badge_term = 'Achievement'
       expect(subject.badge_term).to eq("Achievement")
     end
 
-    it "returns Badge if no badge_term is present" do 
+    it "returns Badge if no badge_term is present" do
       expect(subject.badge_term).to eq("Badge")
     end
   end
 
-  describe "#challenge_term" do 
-    it "returns the set challenge_term if present" do 
-      subject.challenge_term = 'Boss Battle'  
+  describe "#challenge_term" do
+    it "returns the set challenge_term if present" do
+      subject.challenge_term = 'Boss Battle'
       expect(subject.challenge_term).to eq("Boss Battle")
     end
 
-    it "returns Challenge if no challenge_term is present" do 
+    it "returns Challenge if no challenge_term is present" do
       expect(subject.challenge_term).to eq("Challenge")
     end
   end
 
-  describe "#fail_term" do 
-    it "returns the set fail_term if present" do 
-      subject.fail_term = 'Miss'  
+  describe "#fail_term" do
+    it "returns the set fail_term if present" do
+      subject.fail_term = 'Miss'
       expect(subject.fail_term).to eq("Miss")
     end
 
-    it "returns Fail if no fail_term is present" do 
+    it "returns Fail if no fail_term is present" do
       expect(subject.fail_term).to eq("Fail")
     end
   end
 
-  describe "#group_term" do 
-    it "returns the set group_term if present" do 
-      subject.group_term = 'Flange'  
+  describe "#group_term" do
+    it "returns the set group_term if present" do
+      subject.group_term = 'Flange'
       expect(subject.group_term).to eq("Flange")
     end
 
-    it "returns Group if no group_term is present" do 
+    it "returns Group if no group_term is present" do
       expect(subject.group_term).to eq("Group")
     end
   end
 
-  describe "#pass_term" do 
-    it "returns the set pass_term if present" do  
-      subject.pass_term = 'Win'  
+  describe "#pass_term" do
+    it "returns the set pass_term if present" do
+      subject.pass_term = 'Win'
       expect(subject.pass_term).to eq("Win")
     end
 
-    it "returns Pass if no pass_term is present" do 
+    it "returns Pass if no pass_term is present" do
       expect(subject.pass_term).to eq("Pass")
     end
   end
 
-  describe "#team_term" do 
-    it "returns the set team_term if present" do 
-      subject.team_term = 'Horde'  
+  describe "#team_term" do
+    it "returns the set team_term if present" do
+      subject.team_term = 'Horde'
       expect(subject.team_term).to eq("Horde")
     end
 
-    it "returns Team if no team_term is present" do 
+    it "returns Team if no team_term is present" do
       expect(subject.team_term).to eq("Team")
     end
   end
 
-  describe "#team_leader_term" do 
-    it "returns the set team_leader_term if present" do 
-      subject.team_leader_term = 'Captain'  
+  describe "#team_leader_term" do
+    it "returns the set team_leader_term if present" do
+      subject.team_leader_term = 'Captain'
       expect(subject.team_leader_term).to eq("Captain")
     end
 
-    it "returns Team Leader if no team_leader_term is present" do 
+    it "returns Team Leader if no team_leader_term is present" do
       expect(subject.team_leader_term).to eq("Team Leader")
     end
   end
 
-  describe "#weight_term" do 
-    it "returns the set weight_term if present" do 
-      subject.weight_term = 'Kapital'  
+  describe "#weight_term" do
+    it "returns the set weight_term if present" do
+      subject.weight_term = 'Kapital'
       expect(subject.weight_term).to eq("Kapital")
     end
 
-    it "returns Weight if no weight_term is present" do 
+    it "returns Weight if no weight_term is present" do
       expect(subject.weight_term).to eq("Multiplier")
     end
   end
 
-  describe "#user_term" do 
-    it "returns the set user_term if present" do 
-      subject.user_term = 'User'  
+  describe "#user_term" do
+    it "returns the set user_term if present" do
+      subject.user_term = 'User'
       expect(subject.user_term).to eq("User")
     end
 
-    it "returns User if no user_term is present" do 
+    it "returns User if no user_term is present" do
       expect(subject.user_term).to eq("Player")
     end
   end
 
-  describe "#has_teams?" do 
-    it "does not have teams by default" do 
+  describe "#has_teams?" do
+    it "does not have teams by default" do
       expect(subject.has_teams?).to eq(false)
     end
 
-    it "has teams if they're turned on" do 
+    it "has teams if they're turned on" do
       subject.team_setting = true
       expect(subject.has_teams?).to eq(true)
-    end    
+    end
   end
 
-  describe "#has_team_challenges?" do 
-    it "does not have team challenges by default" do 
+  describe "#has_team_challenges?" do
+    it "does not have team challenges by default" do
       expect(subject.has_team_challenges?).to eq(false)
     end
 
-    it "has team challenges if they're turned on" do 
+    it "has team challenges if they're turned on" do
       subject.team_challenges = true
       expect(subject.has_team_challenges?).to eq(true)
     end
   end
 
-  describe "#teams_visible?" do 
-    it "does not have team visible by default" do 
+  describe "#teams_visible?" do
+    it "does not have team visible by default" do
       expect(subject.teams_visible?).to eq(false)
     end
 
-    it "has team visible if it's turned on" do 
+    it "has team visible if it's turned on" do
       subject.teams_visible = true
       expect(subject.teams_visible?).to eq(true)
     end
   end
 
-  describe "#in_team_leaderboard?" do 
-    it "does not have in-team leaderboards turned on by default" do 
+  describe "#in_team_leaderboard?" do
+    it "does not have in-team leaderboards turned on by default" do
       expect(subject.in_team_leaderboard?).to eq(false)
     end
 
-    it "has in-team leaderboards if they're turned on" do 
+    it "has in-team leaderboards if they're turned on" do
       subject.in_team_leaderboard = true
       expect(subject.in_team_leaderboard?).to eq(true)
     end
   end
 
-  describe "#active?" do 
-    it "returns true if the course status equals true" do 
+  describe "#active?" do
+    it "returns true if the course status equals true" do
       subject.status = true
       expect(subject.active?).to eq(true)
     end
 
-    it "returns false if the course status equals false" do 
+    it "returns false if the course status equals false" do
       subject.status = false
       expect(subject.active?).to eq(false)
     end
   end
 
-  describe "#has_badges?" do 
-    it "does not have badges turned on by default" do 
+  describe "#has_badges?" do
+    it "does not have badges turned on by default" do
       expect(subject.has_badges?).to eq(false)
     end
 
-    it "has badges if they're turned on" do 
+    it "has badges if they're turned on" do
       subject.badge_setting = true
       expect(subject.has_badges?).to eq(true)
     end
   end
 
-  describe "#valuable_badges?" do 
-    it "does not have badge with points by default" do 
+  describe "#valuable_badges?" do
+    it "does not have badge with points by default" do
       expect(subject.valuable_badges?).to eq(false)
     end
 
-    it "registers as having valuable has badges with points if they exist" do 
+    it "registers as having valuable has badges with points if they exist" do
       badge = create(:badge, point_total: 1000, course: subject)
       expect(subject.valuable_badges?).to eq(true)
     end
   end
 
-  describe "#has_groups?" do 
-    it "does not have badges turned on by default" do 
+  describe "#has_groups?" do
+    it "does not have badges turned on by default" do
       expect(subject.has_groups?).to eq(false)
     end
 
-    it "has badges if they're turned on" do 
+    it "has badges if they're turned on" do
       subject.group_setting = true
       expect(subject.has_groups?).to eq(true)
     end
 
   end
 
-  describe "#min_group_size" do 
-    it "sets the default min group size at 2" do 
+  describe "#min_group_size" do
+    it "sets the default min group size at 2" do
       expect(subject.min_group_size).to eq(2)
     end
 
-    it "accepts the instructor's setting here if it exists" do 
+    it "accepts the instructor's setting here if it exists" do
       subject.min_group_size = 3
       expect(subject.min_group_size).to eq(3)
     end
   end
 
-  describe "#max_group_size" do 
-    it "sets the default max group size at 6" do 
+  describe "#max_group_size" do
+    it "sets the default max group size at 6" do
       expect(subject.max_group_size).to eq(6)
     end
 
-    it "accepts the instructor's setting here if it exists" do 
+    it "accepts the instructor's setting here if it exists" do
       subject.max_group_size = 8
       expect(subject.max_group_size).to eq(8)
     end
   end
 
-  describe "#formatted_tagline" do 
-    it "returns an empty string if no tagline is present" do 
+  describe "#formatted_tagline" do
+    it "returns an empty string if no tagline is present" do
       expect(subject.formatted_tagline).to eq(" ")
     end
 
-    it "returns a tagline if present" do 
+    it "returns a tagline if present" do
       subject.tagline = "Good night, Westley. Good work. Sleep well. I'll most likely kill you in the morning."
       expect(subject.formatted_tagline).to eq("Good night, Westley. Good work. Sleep well. I'll most likely kill you in the morning.")
     end
   end
 
-  describe "#formatted_short_name" do 
-    it "uses the course number if that's all that's present" do 
+  describe "#formatted_short_name" do
+    it "uses the course number if that's all that's present" do
       expect(subject.formatted_short_name).to eq(subject.courseno)
     end
 
-    it "creates a formatted short name that includes the course number, semester, and year if they're present" do 
+    it "creates a formatted short name that includes the course number, semester, and year if they're present" do
       subject.semester = "Fall"
       subject.year = "2015"
 
@@ -420,13 +450,13 @@ describe Course do
 
   end
 
-  describe "#total_points" do 
-    it "returns the total points available if they're set by the instructor" do 
+  describe "#total_points" do
+    it "returns the total points available if they're set by the instructor" do
       subject.point_total = 100000
       expect(subject.total_points).to eq(subject.point_total)
     end
 
-    it "sums up the available points in the assignments if there's no point total set" do 
+    it "sums up the available points in the assignments if there's no point total set" do
       course = create(:course)
       course.point_total = nil
       assignment = create(:assignment, course_id: course.id, point_total: 101)
@@ -435,107 +465,107 @@ describe Course do
     end
   end
 
-  describe "#timeline_events" do 
-    it "returns all assignments with dates and events" do  
+  describe "#timeline_events" do
+    it "returns all assignments with dates and events" do
       course = create(:course)
-      @assignment = create(:assignment, course: course, due_at: Date.today) 
+      @assignment = create(:assignment, course: course, due_at: Date.today)
       @event = create(:event, course: course, due_at: Date.today)
       @assignment_no_date = create(:assignment, course: course)
       expect(course.timeline_events).to eq([@assignment, @event])
     end
 
-    it "includes challenges with dates" do 
+    it "includes challenges with dates" do
       course = create(:course, team_challenges: true)
-      @assignment = create(:assignment, course: course, due_at: Date.today) 
+      @assignment = create(:assignment, course: course, due_at: Date.today)
       @challenge = create(:challenge, course: course, due_at: Date.today)
       @challenge_no_date = create(:challenge, course: course)
       expect(course.timeline_events).to eq([@assignment, @challenge])
     end
   end
 
-  describe "#student_weighted?" do 
-    it "returns false if no weights are set" do 
+  describe "#student_weighted?" do
+    it "returns false if no weights are set" do
       subject.total_assignment_weight = nil
       expect(subject.student_weighted?).to eq(false)
     end
 
-    it "returns true if weights have been set by the instructor" do 
+    it "returns true if weights have been set by the instructor" do
       subject.total_assignment_weight = 5
       expect(subject.student_weighted?).to eq(true)
     end
   end
 
-  describe "#assignment_weight_open?" do 
-    it "returns false if the assignment_weight_close_at_date is past" do 
+  describe "#assignment_weight_open?" do
+    it "returns false if the assignment_weight_close_at_date is past" do
       subject.assignment_weight_close_at = Date.today - 1
       expect(subject.assignment_weight_open?).to eq(false)
     end
 
-    it "returns true if there is no close at date" do 
+    it "returns true if there is no close at date" do
       expect(subject.assignment_weight_open?).to eq(true)
     end
 
-    it "returns true if the close date is in the future" do 
+    it "returns true if the close date is in the future" do
       subject.assignment_weight_close_at = Date.today + 1
       expect(subject.assignment_weight_open?).to eq(true)
     end
   end
 
-  describe "#team_roles?" do 
-    it "turns team roles for students in their profile settings to true if the instructor turns them on" do 
+  describe "#team_roles?" do
+    it "turns team roles for students in their profile settings to true if the instructor turns them on" do
       subject.team_roles = true
       expect(subject.team_roles?).to eq(true)
     end
-    it "returns false for team roles if the instructor has not turned them on" do 
+    it "returns false for team roles if the instructor has not turned them on" do
       subject.team_roles = false
       expect(subject.team_roles?).to eq(false)
     end
   end
 
   describe "#has_submissions?" do
-    it "returns true if the instructor has turned submissions on" do 
+    it "returns true if the instructor has turned submissions on" do
       subject.accepts_submissions = true
       expect(subject.has_submissions?).to eq(true)
     end
-    it "returns false for submissions if the instructor has not turned them on" do 
+    it "returns false for submissions if the instructor has not turned them on" do
       subject.accepts_submissions = false
       expect(subject.has_submissions?).to eq(false)
     end
   end
 
-  describe "#grade_level_for_score(score)" do  
-    it "returns the grade level that matches the score" do 
+  describe "#grade_level_for_score(score)" do
+    it "returns the grade level that matches the score" do
       low_grade_scheme_element = create(:grade_scheme_element_low, course:subject)
       high_grade_scheme_element = create(:grade_scheme_element_high, course:subject)
       expect(subject.grade_level_for_score(9990)).to eq("Awful")
     end
   end
 
-  describe "#grade_letter_for_score(score)" do  
-    it "returns the grade letter that matches the score" do 
+  describe "#grade_letter_for_score(score)" do
+    it "returns the grade letter that matches the score" do
       low_grade_scheme_element = create(:grade_scheme_element_low, course:subject)
       high_grade_scheme_element = create(:grade_scheme_element_high, course:subject)
       expect(subject.grade_letter_for_score(9990)).to eq("F")
     end
   end
 
-  describe "#element_for_score(score)" do  
-    it "returns the level that matches the score" do 
+  describe "#element_for_score(score)" do
+    it "returns the level that matches the score" do
       low_grade_scheme_element = create(:grade_scheme_element_low, course:subject)
       high_grade_scheme_element = create(:grade_scheme_element_high, course:subject)
       expect(subject.element_for_score(10000)).to eq(high_grade_scheme_element)
     end
   end
 
-  describe "#membership_for_student(student)" do 
-    it "returns the membership relationship for a student" do 
+  describe "#membership_for_student(student)" do
+    it "returns the membership relationship for a student" do
       student = create(:user)
       course_membership = create(:course_membership, user: student, course: subject)
-      expect(subject.membership_for_student(student)).to eq(course_membership) 
+      expect(subject.membership_for_student(student)).to eq(course_membership)
     end
   end
 
-  describe "#assignment_weight_for_student(student)" do  
+  describe "#assignment_weight_for_student(student)" do
     it "sums the assignment weights the student has spent" do
       student = create(:user)
       student.courses << subject
@@ -545,8 +575,8 @@ describe Course do
     end
   end
 
-  describe "#assignment_weight_spent_for_student(student)" do  
-    it "returns false if the student has not yet spent enough weights" do 
+  describe "#assignment_weight_spent_for_student(student)" do
+    it "returns false if the student has not yet spent enough weights" do
       subject.total_assignment_weight = 4
       student = create(:user)
       student.courses << subject
@@ -554,7 +584,7 @@ describe Course do
       expect(subject.assignment_weight_spent_for_student(student)).to eq(false)
     end
 
-    it "returns true if the student has spent enough weights" do 
+    it "returns true if the student has spent enough weights" do
       subject.total_assignment_weight = 4
       student = create(:user)
       student.courses << subject
@@ -564,16 +594,16 @@ describe Course do
     end
   end
 
-  describe "#score_for_student(student)" do  
-    it "returns a student's score for a specific course" do 
+  describe "#score_for_student(student)" do
+    it "returns a student's score for a specific course" do
       student = create(:user)
       course_membership = create(:student_course_membership, score: 101, user: student, course: subject)
       expect(subject.score_for_student(student)).to eq(101)
     end
   end
 
-  describe "#minimum_course_score" do 
-    it "returns the lowest student score in the course" do 
+  describe "#minimum_course_score" do
+    it "returns the lowest student score in the course" do
       student = create(:user)
       course_membership = create(:student_course_membership, course: subject, user: student, score: 100)
       student_2 = create(:user)
@@ -584,8 +614,8 @@ describe Course do
     end
   end
 
-  describe "#maximum_course_score" do  
-    it "returns the highest student score in the course" do 
+  describe "#maximum_course_score" do
+    it "returns the highest student score in the course" do
       student = create(:user)
       course_membership = create(:student_course_membership, course: subject, user: student, score: 100)
       student_2 = create(:user)
@@ -596,8 +626,8 @@ describe Course do
     end
   end
 
-  describe "#average_course_score" do  
-    it "returns the average student score in the course" do 
+  describe "#average_course_score" do
+    it "returns the average student score in the course" do
       student = create(:user)
       course_membership = create(:student_course_membership, course: subject, user: student, score: 100)
       student_2 = create(:user)
@@ -608,8 +638,8 @@ describe Course do
     end
   end
 
-  describe "#student_count" do  
-    it "counts the number of students in a course" do 
+  describe "#student_count" do
+    it "counts the number of students in a course" do
       student = create(:user)
       student.courses << subject
       student2 = create(:user)
@@ -621,8 +651,8 @@ describe Course do
     end
   end
 
-  describe "#graded_student_count" do  
-    it "returns the number of student who are being graded in the course" do 
+  describe "#graded_student_count" do
+    it "returns the number of student who are being graded in the course" do
       student = create(:user, last_name: 'Zed')
       student2 = create(:user, last_name: 'Alpha')
       student3 = create(:user)
@@ -633,16 +663,16 @@ describe Course do
     end
   end
 
-  describe "#point_total_for_challenges" do  
-    it "sums up the total number of points in the challenges" do 
+  describe "#point_total_for_challenges" do
+    it "sums up the total number of points in the challenges" do
       challenge = create(:challenge, course: subject, point_total: 101)
       challenge_2 = create(:challenge, course: subject, point_total: 1000)
       expect(subject.point_total_for_challenges).to eq(1101)
     end
   end
 
-  describe "#ordered_student_ids" do  
-    it "returns an ordered array of student ids" do 
+  describe "#ordered_student_ids" do
+    it "returns an ordered array of student ids" do
       student_2 = create(:user)
       student_2.courses << subject
       student_1 = create(:user)
@@ -653,35 +683,35 @@ describe Course do
     end
   end
 
-  describe "#self.csv_summary_data" do  
+  describe "#self.csv_summary_data" do
     skip "implement"
   end
 
-  describe "#self.csv_roster" do  
+  describe "#self.csv_roster" do
     skip "implement"
   end
 
-  describe "#self.csv_assignments" do  
+  describe "#self.csv_assignments" do
     skip "implement"
   end
 
-  describe "#csv_gradebook" do  
+  describe "#csv_gradebook" do
     skip "implement"
   end
 
-  describe "#csv_multiplied_gradebook" do  
+  describe "#csv_multiplied_gradebook" do
     skip "implement"
   end
 
-  describe "#research_grades_csv(options = {})" do  
+  describe "#research_grades_csv(options = {})" do
     skip "implement"
   end
 
-  describe "#earned_badges_for_course" do  
+  describe "#earned_badges_for_course" do
     skip "implement"
   end
 
-  describe "#course_badge_count" do 
+  describe "#course_badge_count" do
     it "tallies the number of badges in a course" do
       badge = create(:badge, course: subject)
       badge1 = create(:badge, course: subject)
@@ -691,8 +721,8 @@ describe Course do
     end
   end
 
-  describe "#awarded_course_badge_count" do 
-    it "tallies the number of earned badges in a course" do 
+  describe "#awarded_course_badge_count" do
+    it "tallies the number of earned badges in a course" do
       badge = create(:badge, course: subject)
       student = create(:user)
       earned_badge = create(:earned_badge, badge: badge, student: student, course: subject, student_visible: true)
@@ -702,16 +732,16 @@ describe Course do
     end
   end
 
-  describe "#max_more_than_min" do  
-    it "errors out if the max group size is smaller than the minimum" do 
+  describe "#max_more_than_min" do
+    it "errors out if the max group size is smaller than the minimum" do
       subject.max_group_size = 2
       subject.min_group_size = 5
-      expect !subject.valid?  
+      expect !subject.valid?
     end
   end
 
-  describe "#create_admin_memberships" do  
-    it "creates admin memberships for all courses automatically on creation of new courses" do 
+  describe "#create_admin_memberships" do
+    it "creates admin memberships for all courses automatically on creation of new courses" do
       admin = create(:user, admin: true)
       course = create(:course)
       new_course = create(:course)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -48,7 +48,7 @@ describe Course do
     end
   end
 
-  describe "#copy", focus: true do
+  describe "#copy" do
     let(:course) { build :course }
     subject { course.copy }
 
@@ -73,9 +73,26 @@ describe Course do
       expect(subject.badges.map(&:course_id)).to eq [subject.id]
     end
 
-    xit "copies the assignment types"
-    xit "copies the challenges"
-    xit "copies the grade scheme elements"
+    it "copies the assignment types" do
+      course.save
+      create :assignment_type, course: course
+      expect(subject.assignment_types.size).to eq 1
+      expect(subject.assignment_types.map(&:course_id)).to eq [subject.id]
+    end
+
+    it "copies the challenges" do
+      course.save
+      create :challenge, course: course
+      expect(subject.challenges.size).to eq 1
+      expect(subject.challenges.map(&:course_id)).to eq [subject.id]
+    end
+
+    it "copies the grade scheme elements" do
+      course.save
+      create :grade_scheme_element, course: course
+      expect(subject.grade_scheme_elements.size).to eq 1
+      expect(subject.grade_scheme_elements.map(&:course_id)).to eq [subject.id]
+    end
   end
 
   describe "#staff" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -75,9 +75,11 @@ describe Course do
 
     it "copies the assignment types" do
       course.save
-      create :assignment_type, course: course
+      assignment_type = create :assignment_type, course: course
+      create :assignment, assignment_type: assignment_type
       expect(subject.assignment_types.size).to eq 1
       expect(subject.assignment_types.map(&:course_id)).to eq [subject.id]
+      expect(subject.assignments.map(&:course_id)).to eq [subject.id]
     end
 
     it "copies the challenges" do

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -1,7 +1,7 @@
 require "active_record_spec_helper"
 
-describe GradeSchemeElement do 
-  
+describe GradeSchemeElement do
+
   subject { build(:grade_scheme_element) }
 
   context "validations" do
@@ -9,78 +9,87 @@ describe GradeSchemeElement do
       expect(subject).to be_valid
     end
 
-    it "is invalid without a low range" do 
+    it "is invalid without a low range" do
       subject.low_range = nil
       expect(subject).to be_invalid
     end
 
-    it "is invalid without a high range" do 
+    it "is invalid without a high range" do
       subject.high_range = nil
       expect(subject).to be_invalid
     end
 
-    it "is invalid without a course" do 
+    it "is invalid without a course" do
       subject.course = nil
       expect(subject).to be_invalid
     end
   end
 
-  describe "#name" do 
-    it 'returns the name as the level and letter if both are present' do 
+  describe "#copy" do
+    let(:grade_scheme_element) { build :grade_scheme_element }
+    subject { grade_scheme_element.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq grade_scheme_element
+    end
+  end
+
+  describe "#name" do
+    it 'returns the name as the level and letter if both are present' do
       subject.level = "Kvothe Kingkiller"
       subject.letter = "B+"
       expect(subject.name).to eq("B+ / Kvothe Kingkiller")
     end
 
-    it 'returns the name as just the level if present' do 
+    it 'returns the name as just the level if present' do
       subject.level = "Kvothe Kingkiller"
       expect(subject.name).to eq("Kvothe Kingkiller")
     end
 
-    it 'returns the name as just the letter if present' do 
+    it 'returns the name as just the letter if present' do
       subject.letter = "B+"
       expect(subject.name).to eq("B+")
     end
 
-    it "returns nil if no aspects are present" do 
+    it "returns nil if no aspects are present" do
       expect(subject.name).to eq(nil)
     end
   end
 
-  describe "#range" do 
-    it "returns the difference between the high range and the low range" do 
+  describe "#range" do
+    it "returns the difference between the high range and the low range" do
       subject.high_range = 100
       subject.low_range = 0
       expect(subject.range).to eq(100)
     end
   end
 
-  describe "#points_to_next_level(student, course)" do 
+  describe "#points_to_next_level(student, course)" do
     let(:student) { create :user }
     let(:course) { create :course}
 
-    before do 
+    before do
       create(:course_membership, user: student, course: course, score: 82 )
     end
 
-    it "returns the difference between the current level high range and the student's 
+    it "returns the difference between the current level high range and the student's
     total score + 1 point - the value to achieve the next level" do
-      subject.high_range = 100 
+      subject.high_range = 100
       subject.course = course
       expect(subject.points_to_next_level(student, course)).to eq(19)
     end
   end
 
-  describe "#progress_percent(student)" do 
+  describe "#progress_percent(student)" do
     let(:student) { create :user }
     let(:course) { create :course}
 
-    before do 
+    before do
       create(:course_membership, user: student, course: course, score: 82 )
     end
 
     it "returns the level's percent complete value for the student" do
-      subject.high_range = 100 
+      subject.high_range = 100
       subject.low_range = 0
       subject.course = course
       expect(subject.progress_percent(student)).to eq(82)


### PR DESCRIPTION
Refactors the `CoursesController#copy` action to move the `copy` functionality into the `Course` object and it's child objects.

The copy methods now allow for attributes to be sent down to the objects for deep copying.

Closes #1503 