### PR TITLE
1413 Update Resque method for handling errors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,7 @@ RAILS_TOKEN=gradecraft
 RAILS_SECRET=changeme
 REDIS_URL=redis://localhost:6379
 REDIS_PORT=6379
+TERM_CHILD=1
 S3_BUCKET_NAME=<s3 bucket - used in production and staging>
 AWS_ACCESS_KEY_ID=abc
 AWS_SECRET_ACCESS_KEY=abc


### PR DESCRIPTION
Resque changed the way that they are handling signal termination errors. This article explains the technical details: http://hone.herokuapp.com/resque/2012/08/21/resque-signals.html

In order to remove the warning, you simply need to add the following line to the environment variables:

```
TERM_CHILD=1
```

This will remove the warning and enable the new termination handling.

This can be done locally on development by adjusting your local `.env` file. This needs to occur on staging and production appropriately.

This PR just simply adds the `TERM_CHILD` variable to the `Vagrantfile`.

Closes #1413