### PR TITLE
earned badges no points return 0 not null

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -17,7 +17,8 @@ module UsersHelper
                   name: assignment_type.name }
     end
 
-    earned_badge_score = user.earned_badges.where(course: course).pluck('score').sum
+    # Earned badges pre 2016 have nil scores cached on the model, must convert to integer
+    earned_badge_score = user.earned_badges.where(course: course).pluck('score').sum {|s| s.to_i}
     if earned_badge_score > 0
       scores << { :data => [earned_badge_score], :name => "#{course.badge_term.pluralize}" }
     end

--- a/app/models/earned_badge.rb
+++ b/app/models/earned_badge.rb
@@ -44,7 +44,7 @@ class EarnedBadge < ActiveRecord::Base
 
   def cache_associations
     self.course_id ||= badge.try(:course_id)
-    self.score ||= badge.try(:point_total)
+    self.score ||= badge.try(:point_total) || 0
   end
 
   def multiple_allowed

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -20,4 +20,14 @@ describe UsersHelper do
       helper.cancel_course_memberships user
     end
   end
+
+  describe "#total_scores_for_chart" do
+    it "handles the summing of earned badges, including old badges cached with nil points" do
+      course = double(:course, assignment_types: [], badge_term: "Badgeinskies", total_points: 0)
+      pluck = double(:pluck, pluck: [1000,nil])
+      earned_badges = double(:earned_badges, where: pluck)
+      user = double(:user, earned_badges: earned_badges)
+      expect(helper.total_scores_for_chart(user,course)).to eq({:scores=>[{:data=>[1000], :name=>"Badgeinskies"}], :course_total=>1000})
+    end
+  end
 end

--- a/spec/models/earned_badge_spec.rb
+++ b/spec/models/earned_badge_spec.rb
@@ -30,15 +30,15 @@ describe EarnedBadge do
     end
   end
 
-  describe "#multiple_allowed" do 
-    it "allows a student to earn a badge if they haven't earned it yet" do 
+  describe "#multiple_allowed" do
+    it "allows a student to earn a badge if they haven't earned it yet" do
       badge = create(:badge)
       student = create(:user)
       earned_badge = create(:earned_badge, badge: badge, student: student)
       expect(earned_badge).to be_valid
     end
 
-    it "allows a student to earn a badge multiple times if multiple_allowed" do 
+    it "allows a student to earn a badge multiple times if multiple_allowed" do
       badge = create(:badge, can_earn_multiple_times: true)
       student = create(:user)
       earned_badge = create(:earned_badge, badge: badge, student: student, student_visible: true)
@@ -47,7 +47,7 @@ describe EarnedBadge do
       expect(badge.earned_badge_count_for_student(student)).to eq(3)
     end
 
-    it "prevents a student from earning a badge if multiple_times not allowed" do 
+    it "prevents a student from earning a badge if multiple_times not allowed" do
       badge = create(:badge, can_earn_multiple_times: false)
       student = create(:user)
       EarnedBadge.create(badge_id: badge.id, student_id: student.id, student_visible: true)
@@ -56,7 +56,16 @@ describe EarnedBadge do
     end
   end
 
-  describe "#check_unlockables" do 
+  describe "#check_unlockables" do
     skip "implement"
+  end
+
+  describe "score" do
+    it "caches 0 for a badge with nil points" do
+      badge = create(:badge, point_total: nil)
+      student = create(:user)
+      earned_badge = EarnedBadge.create(badge_id: badge.id, student_id: student.id, student_visible: true)
+      expect(earned_badge.score).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Earned Badges associated with a Badge with a null point total will no longer just punk out when you need them to stand shoulder to shoulder with their more valuable peers.

 * caching on EarnedBadge score defaults to a 0, not null
 * user_helper converts older earned badges cached with a null score to 0  before summing them