### PR TITLE
1532 resubmissions

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -93,6 +93,7 @@ class GradesController < ApplicationController
          instructor_modified: true,
          status: params[:status],
          updated_at: Time.now,
+         graded_at: DateTime.now,
          raw_score: params[:raw_score]
       }
     )

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -134,6 +134,8 @@ class GradesController < ApplicationController
 
   # PUT /assignments/:assignment_id/grade/submit_rubric
   def submit_rubric
+    @submission = Submission.where(current_assignment_and_student_ids).first
+
     @grade = Grade.where(student_id: current_student[:id], assignment_id: @assignment[:id]).first
 
     if @grade
@@ -141,8 +143,6 @@ class GradesController < ApplicationController
     else
       @grade = Grade.create(new_grade_from_criterion_grades_attributes)
     end
-
-    @submission = Submission.where(current_assignment_and_student_ids).first
 
     # delete existing rubric grades
     # TODO: Shouldn't require a second parameter of criterion_ids when already supplied.

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -57,7 +57,7 @@ class GradesController < ApplicationController
   # create a new grade if none exists, and otherwise update the existing grade
   # PUT /assignments/:assignment_id/grade
   def update
-    @grade = Grade.find_or_create(@assignment,current_student)
+    @grade = Grade.find_or_create(@assignment, current_student)
 
     # extract file attributes from grade params
     if params[:grade][:grade_files_attributes].present?
@@ -65,7 +65,8 @@ class GradesController < ApplicationController
       params[:grade].delete :grade_files_attributes
     end
 
-    if @grade.update_attributes params[:grade].merge(instructor_modified: true)
+    if @grade.update_attributes params[:grade].merge(graded_at: DateTime.now,
+        instructor_modified: true)
 
       # @mz TODO: ADD SPECS
       if @grade.is_released? || (@grade.is_graded? && ! @assignment.release_necessary)

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -134,10 +134,6 @@ class GradesController < ApplicationController
 
   # PUT /assignments/:assignment_id/grade/submit_rubric
   def submit_rubric
-    if @submission = Submission.where(current_assignment_and_student_ids).first
-      @submission.update_attributes(graded: true)
-    end
-
     @grade = Grade.where(student_id: current_student[:id], assignment_id: @assignment[:id]).first
 
     if @grade
@@ -145,6 +141,8 @@ class GradesController < ApplicationController
     else
       @grade = Grade.create(new_grade_from_criterion_grades_attributes)
     end
+
+    @submission = Submission.where(current_assignment_and_student_ids).first
 
     # delete existing rubric grades
     # TODO: Shouldn't require a second parameter of criterion_ids when already supplied.

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -188,7 +188,7 @@ class GradesController < ApplicationController
     @grade.feedback_reviewed = false
     @grade.feedback_reviewed_at = nil
     @grade.instructor_modified = false
-
+    @grade.graded_at = nil
 
     @grade.update_attributes(params[:grade])
 
@@ -230,6 +230,9 @@ class GradesController < ApplicationController
 
   # PUT /assignments/:id/mass_grade
   def mass_update
+    params[:assignment][:grades_attributes].each do |index, grade_params|
+      grade_params.merge!(graded_at: DateTime.now)
+    end
     @assignment = current_course.assignments.find(params[:id])
     if @assignment.update_attributes(params[:assignment])
 
@@ -268,7 +271,7 @@ class GradesController < ApplicationController
 
     grade_ids = []
     @grades = @grades.each do |grade|
-      grade.update_attributes(params[:grade])
+      grade.update_attributes(params[:grade].merge(graded_at: DateTime.now))
       grade_ids << grade.id
     end
 
@@ -525,7 +528,8 @@ class GradesController < ApplicationController
       # and not handled by front end logic
       point_total: params[:points_possible],
       status: params[:grade_status],
-      instructor_modified: true
+      instructor_modified: true,
+      graded_at: DateTime.now
     }
   end
 

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -233,7 +233,7 @@ class GradesController < ApplicationController
   def mass_update
     params[:assignment][:grades_attributes].each do |index, grade_params|
       grade_params.merge!(graded_at: DateTime.now)
-    end
+    end if params[:assignment][:grades_attributes].present?
     @assignment = current_course.assignments.find(params[:id])
     if @assignment.update_attributes(params[:assignment])
 

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -63,7 +63,7 @@ class InfoController < ApplicationController
 
   def ungraded_submissions
     @title = "Ungraded #{term_for :assignment} Submissions"
-    @ungraded_submissions = current_course.submissions.ungraded.date_submitted.includes(:assignment, :student, :submission_files)
+    @ungraded_submissions = current_course.submissions.ungraded.order_by_submitted.includes(:assignment, :student, :submission_files)
     @count_ungraded = @ungraded_submissions.count
   end
 

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -48,14 +48,11 @@ class InfoController < ApplicationController
   # Displaying all resubmisisons
   def resubmissions
     @title = "Resubmitted Assignments"
-    resubmissions = current_course.submissions.resubmitted
+    @resubmissions = current_course.submissions.resubmitted
 
     @teams = current_course.teams
     if @team
-      @students ||= @team.students.pluck(:id)
-      @resubmissions = resubmissions.where(student_id: @students)
-    else
-      @resubmissions = resubmissions
+      @resubmissions = @resubmissions.where(student_id: @team.students.pluck(:id))
     end
 
     @resubmission_count = @resubmissions.count

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -19,7 +19,7 @@ class SubmissionsController < ApplicationController
 
   def create
     assignment = current_course.assignments.find(params[:assignment_id])
-    submission = assignment.submissions.new(params[:submission])
+    submission = assignment.submissions.new(params[:submission].merge(submitted_at: DateTime.now))
     if submission.save
       redirect_to = (session.delete(:return_to) || assignment_path(assignment))
       if current_user_is_student?
@@ -49,7 +49,7 @@ class SubmissionsController < ApplicationController
     submission = assignment.submissions.find(params[:id])
 
     respond_to do |format|
-      if submission.update_attributes(params[:submission])
+      if submission.update_attributes(params[:submission].merge(submitted_at: DateTime.now))
         path = assignment.has_groups? ? { group_id: submission.group_id } :
           { student_id: submission.student_id }
         redirect_to = assignment_submission_path(assignment, submission, path)

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -27,7 +27,7 @@ class GradeExporter
                 grade.feedback || "",
                 grade.raw_score || "",
                 submission.try(:text_comment) || "",
-                grade.updated_at || ""]
+                grade.graded_at || ""]
       end
     end
   end

--- a/app/exporters/grades_for_research_exporter.rb
+++ b/app/exporters/grades_for_research_exporter.rb
@@ -36,7 +36,7 @@ class GradesForResearchExporter
       (grade.submission.try(:updated_at) || ""),
       (grade.graded_by_id || ""),
       grade.created_at,
-      grade.graded_at]
+      grade.graded_at || ""]
   end
 
 end

--- a/app/exporters/grades_for_research_exporter.rb
+++ b/app/exporters/grades_for_research_exporter.rb
@@ -36,7 +36,7 @@ class GradesForResearchExporter
       (grade.submission.try(:updated_at) || ""),
       (grade.graded_by_id || ""),
       grade.created_at,
-      grade.updated_at]
+      grade.graded_at]
   end
 
 end

--- a/app/importers/grade_importer.rb
+++ b/app/importers/grade_importer.rb
@@ -56,6 +56,7 @@ class GradeImporter
     grade.feedback = row.feedback
     grade.status = "Graded" if grade.status.nil?
     grade.instructor_modified = true
+    grade.graded_at = DateTime.now
   end
 
   def create_grade(row, assignment, student)

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -1,5 +1,3 @@
-require_relative "concerns/historical"
-
 class Grade < ActiveRecord::Base
   include Canable::Ables
   include Historical

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -12,7 +12,7 @@ class Grade < ActiveRecord::Base
     :predicted_score, :raw_score, :status, :student, :student_id, :submission,
     :_destroy, :submission_id, :task, :task_id, :team_id, :earned_badges,
     :earned_badges_attributes, :feedback_read, :feedback_read_at,
-    :feedback_reviewed, :feedback_reviewed_at, :is_custom_value
+    :feedback_reviewed, :feedback_reviewed_at, :is_custom_value, :graded_at
 
   STATUSES= ["In Progress", "Graded", "Released"]
 

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -2,6 +2,9 @@ class Grade < ActiveRecord::Base
   include Canable::Ables
   include Historical
 
+  has_paper_trail ignore: [:feedback_reviewed, :feedback_reviewed_at,
+                           :feedback_read, :feedback_read_at]
+
   attr_accessible :assignment, :assignments_attributes, :assignment_id,
     :assignment_type_id, :course_id, :feedback, :final_score, :grade_file,
     :grade_file_ids, :grade_files_attributes, :graded_by_id, :group, :group_id,

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -57,6 +57,10 @@ class NullGrade
     nil
   end
 
+  def graded_at
+    nil
+  end
+
   def student
     nil
   end

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -11,15 +11,16 @@ class Resubmission
     resubmissions = []
     grade = submission.grade
     if grade.present?
-      grade.versions.where(event: :update).each do |grade_revision|
-        submission_revision = submission.versions
-          .where(event: :update)
-          .where("created_at <= :created_at", created_at: grade_revision.created_at)
-          .last
-        if submission_revision.present?
-          resubmissions << Resubmission.new(submission: submission,
-                                            grade_revision: grade_revision,
-                                            submission_revision: submission_revision)
+      grade.versions.updates.each do |grade_revision|
+        if grade_revision.changeset.has_key?("raw_score")
+          submission_revision = submission.versions.updates
+            .preceding(grade_revision.created_at, true)
+            .last
+          if submission_revision.present?
+            resubmissions << Resubmission.new(submission: submission,
+                                              grade_revision: grade_revision,
+                                              submission_revision: submission_revision)
+          end
         end
       end
     end

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -1,5 +1,5 @@
 class Resubmission
-  attr_reader :grade, :submission
+  attr_reader :grade_revision, :submission, :submission_revision
 
   def initialize(attributes={})
     attributes.each do |name, value|
@@ -11,8 +11,16 @@ class Resubmission
     resubmissions = []
     grade = submission.grade
     if grade.present?
-      grade.versions.where(event: :update).each do |grade|
-        resubmissions << Resubmission.new(submission: submission, grade: grade)
+      submission.versions.where(event: :update).each do |submission_revision|
+        grade_revision = grade.versions
+          .where(event: :update)
+          .where("created_at >= :created_at", created_at: submission_revision.created_at)
+          .last
+        if grade_revision.present?
+          resubmissions << Resubmission.new(submission: submission,
+                                            grade_revision: grade_revision,
+                                            submission_revision: submission_revision)
+        end
       end
     end
     resubmissions

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -11,12 +11,12 @@ class Resubmission
     resubmissions = []
     grade = submission.grade
     if grade.present?
-      submission.versions.where(event: :update).each do |submission_revision|
-        grade_revision = grade.versions
+      grade.versions.where(event: :update).each do |grade_revision|
+        submission_revision = submission.versions
           .where(event: :update)
-          .where("created_at >= :created_at", created_at: submission_revision.created_at)
+          .where("created_at <= :created_at", created_at: grade_revision.created_at)
           .last
-        if grade_revision.present?
+        if submission_revision.present?
           resubmissions << Resubmission.new(submission: submission,
                                             grade_revision: grade_revision,
                                             submission_revision: submission_revision)

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -10,7 +10,7 @@ class Resubmission
   def self.find_for_submission(submission)
     resubmissions = []
     grade = submission.grade
-    if grade.present?
+    if grade.present? && grade.is_student_visible?
       grade.versions.updates.each do |grade_revision|
         if grade_revision.changeset.has_key?("raw_score")
           submission_revision = submission.versions.updates

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -26,6 +26,11 @@ class Resubmission
       resubmissions
     end
 
+    def future_resubmission?(submission)
+      grade = submission.grade
+      include_grade?(grade)
+    end
+
     private
 
     def include_grade?(grade)

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -32,7 +32,7 @@ class Resubmission
     private
 
     def grade_revision_for_submission(grade, submission_revision)
-      grade.versions.subsequent(submission_revision.created_at, true).last
+      grade.versions.preceding(submission_revision.created_at, true).last
     end
 
     def include_grade?(grade)
@@ -40,8 +40,9 @@ class Resubmission
     end
 
     def include_grade_revision?(grade_revision)
-      grade_revision.changeset.has_key?("raw_score") ||
-        grade_revision.event == "create"
+      grade_revision.present? &&
+        (grade_revision.changeset.has_key?("raw_score") ||
+         grade_revision.event == "create")
     end
   end
 end

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -1,0 +1,20 @@
+class Resubmission
+  attr_reader :grade, :submission
+
+  def initialize(attributes={})
+    attributes.each do |name, value|
+      instance_variable_set "@#{name}", value if respond_to?(name)
+    end
+  end
+
+  def self.find_for_submission(submission)
+    resubmissions = []
+    grade = submission.grade
+    if grade.present?
+      grade.versions.where(event: :update).each do |grade|
+        resubmissions << Resubmission.new(submission: submission, grade: grade)
+      end
+    end
+    resubmissions
+  end
+end

--- a/app/models/resubmission.rb
+++ b/app/models/resubmission.rb
@@ -24,11 +24,6 @@ class Resubmission
       resubmissions
     end
 
-    def future_resubmission?(submission)
-      grade = submission.grade
-      include_grade?(grade)
-    end
-
     private
 
     def grade_revision_for_submission(grade, submission_revision)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -56,7 +56,7 @@ class Submission < ActiveRecord::Base
   end
 
   def graded_at
-    grade.updated_at if graded?
+    grade.graded_at if graded?
   end
 
   def graded?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -30,7 +30,7 @@ class Submission < ActiveRecord::Base
   scope :graded, -> { where(:grade) }
   scope :resubmitted, -> { joins(:grade).where(grades: { status: ["Graded", "Released"] })
                                         .where("grades.graded_at < submitted_at") }
-  scope :date_submitted, -> { order('created_at ASC') }
+  scope :order_by_submitted, -> { order('submitted_at ASC') }
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -62,7 +62,11 @@ class Submission < ActiveRecord::Base
   end
 
   def resubmitted?
-    student.grade_for_assignment(assignment).present? && student.grade_for_assignment(assignment).updated_at < self.updated_at
+    !resubmissions.empty?
+  end
+
+  def resubmissions
+    @resubmissions ||= Resubmission.find_for_submission(self)
   end
 
   # Getting the name of the student who submitted the work

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -61,6 +61,10 @@ class Submission < ActiveRecord::Base
     ! grade || grade.status == nil
   end
 
+  def will_be_resubmission?
+    Resubmission.future_resubmission?(self)
+  end
+
   def resubmitted?
     !resubmissions.empty?
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,7 +2,7 @@ class Submission < ActiveRecord::Base
   attr_accessible :task, :task_id, :assignment, :assignment_id, :assignment_type_id,
     :group, :group_id, :link, :student, :student_id, :creator, :creator_id,
     :text_comment, :submission_file, :submission_files_attributes, :submission_files,
-    :course_id, :submission_file_ids, :updated_at
+    :course_id, :submission_file_ids, :updated_at, :submitted_at
 
   include Canable::Ables
   include Historical

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,7 +1,7 @@
 class Submission < ActiveRecord::Base
   attr_accessible :task, :task_id, :assignment, :assignment_id, :assignment_type_id,
     :group, :group_id, :link, :student, :student_id, :creator, :creator_id,
-    :text_comment, :graded, :submission_file, :submission_files_attributes, :submission_files,
+    :text_comment, :submission_file, :submission_files_attributes, :submission_files,
     :course_id, :submission_file_ids, :updated_at
 
   include Canable::Ables

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -55,6 +55,10 @@ class Submission < ActiveRecord::Base
     permissions_check(user)
   end
 
+  def graded_at
+    grade.updated_at if graded?
+  end
+
   def graded?
     !ungraded?
   end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,7 +28,8 @@ class Submission < ActiveRecord::Base
 
   scope :ungraded, -> { where('NOT EXISTS(SELECT 1 FROM grades WHERE submission_id = submissions.id OR (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (status = ? OR status = ?))', "Graded", "Released") }
   scope :graded, -> { where(:grade) }
-  scope :resubmitted, -> { where('EXISTS(SELECT 1 FROM grades WHERE (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (updated_at < submissions.updated_at) AND (status = ? OR status = ?))', "Graded", "Released") }
+  scope :resubmitted, -> { joins(:grade).where(grades: { status: ["Graded", "Released"] })
+                                        .where("grades.graded_at < submitted_at") }
   scope :date_submitted, -> { order('created_at ASC') }
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -55,6 +55,10 @@ class Submission < ActiveRecord::Base
     permissions_check(user)
   end
 
+  def graded?
+    !ungraded?
+  end
+
   # Grabbing any submission that has NO instructor-defined grade (if the student has predicted the grade,
   # it'll exist, but we still don't want to catch those here)
   def ungraded?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -70,7 +70,7 @@ class Submission < ActiveRecord::Base
   end
 
   def will_be_resubmission?
-    Resubmission.future_resubmission?(self)
+    graded?
   end
 
   def resubmitted?

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -184,11 +184,7 @@ class UnlockCondition < ActiveRecord::Base
   end
 
   def check_if_grade_earned_met_condition_date(grade)
-    if grade.present? && grade.is_student_visible? && grade.updated_at < condition_date
-      return true
-    else
-      return false
-    end
+    grade.present? && grade.is_student_visible? && grade.graded_at < condition_date
   end
 
   def check_feedback_read_condition(student)

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -152,11 +152,7 @@ class UnlockCondition < ActiveRecord::Base
   end
 
   def check_if_submitted_by_condition_date(submission)
-    if submission.updated_at < condition_date
-      return true
-    else
-      return false
-    end
+    submission.submitted_at < condition_date
   end
 
   def check_grade_earned_condition(student)

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -162,8 +162,7 @@ class AssignmentPresenter < Showtime::Presenter
   end
 
   def submission_date_for(student)
-    submission = submissions_for(student).first
-    submission.updated_at if submission
+    submission_updated_date_for(submissions_for(student))
   end
 
   def submission_for_assignment(student)

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -94,9 +94,7 @@ class AssignmentPresenter < Showtime::Presenter
 
   def submission_updated_date_for(submissions)
     submission = submissions.first
-    if submission
-      submission.updated_at if submission.updated_at != submission.created_at
-    end
+    submission.submitted_at if submission
   end
 
   def criteria

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -15,7 +15,7 @@
     %hr.dotted
     = simple_form_for @grade, url: assignment_grade_path(@assignment), method: :patch do |f|
       = hidden_field_tag :student_id, current_student.id
-      = hidden_field_tag :instructor_modified, true
+      = f.hidden_field :submission_id, value: @submission.try(:id)
 
       #grade(ng-controller="GradeCtrl" ng-init="init(#{@serialized_init_data})")
         .panel.splash(ng-cloak) Loading grade for #{@student.name}...

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -31,7 +31,7 @@
               = link_to submission.student.try(:name), student_path(submission.student)
             - elsif submission.assignment.has_groups?
               = link_to submission.group.try(:name), group_path(submission.group)
-          %td= submission.updated_at
+          %td= submission.submitted_at
           %td= raw submission.text_comment
           - if current_course.has_teams?
             %td

--- a/app/views/notification_mailer/successful_submission.html.haml
+++ b/app/views/notification_mailer/successful_submission.html.haml
@@ -48,7 +48,7 @@ border: 1px solid #f0f0f0;
 }
 
 table.footer-wrap {
-width: 100%;  
+width: 100%;
 clear: both!important;
 }
 
@@ -151,7 +151,7 @@ width: 100%;
 </p>
 <h2 align="center"><strong>Congratulations #{ @user.first_name }!</strong></h2>
 
-<h3 align="center">You successfully submitted your work for #{ @assignment.name } on #{ @submission.created_at }. </h3>
+<h3 align="center">You successfully submitted your work for #{ @assignment.name } on #{ @submission.submitted_at }. </h3>
 <p>
 <hr />
 </p>

--- a/app/views/notification_mailer/successful_submission.text.haml
+++ b/app/views/notification_mailer/successful_submission.text.haml
@@ -1,6 +1,6 @@
 Dear #{ @user.first_name },
 
-You successfully submitted your work for #{ @assignment.name } on #{ @submission.created_at }.
+You successfully submitted your work for #{ @assignment.name } on #{ @submission.submitted_at }.
 
 Check out what other #{ @course.assignment_term.pluralize.downcase } you can complete in #{ @course.name } here: https://www.gradecraft.com/predictor
 

--- a/app/views/notification_mailer/updated_submission.html.haml
+++ b/app/views/notification_mailer/updated_submission.html.haml
@@ -48,7 +48,7 @@ border: 1px solid #f0f0f0;
 }
 
 table.footer-wrap {
-width: 100%;  
+width: 100%;
 clear: both!important;
 }
 
@@ -151,7 +151,7 @@ width: 100%;
 </p>
 <h2 align="center"><strong>Congratulations #{ @user.first_name }!</strong></h2>
 
-<h3 align="center">You successfully updated your submission for #{ @assignment.name } on #{ @submission.created_at }. </h3>
+<h3 align="center">You successfully updated your submission for #{ @assignment.name } on #{ @submission.submitted_at }. </h3>
 <p>
 <hr />
 </p>

--- a/app/views/notification_mailer/updated_submission.text.haml
+++ b/app/views/notification_mailer/updated_submission.text.haml
@@ -1,6 +1,6 @@
 Dear #{ @user.first_name },
 
-You successfully updated your submission for #{ @assignment.name } on #{ @submission.created_at }.
+You successfully updated your submission for #{ @assignment.name } on #{ @submission.submitted_at }.
 
 Check out what other #{ @course.assignment_term.pluralize.downcase } you can complete in #{ @course.name } here: https://www.gradecraft.com/predictor
 

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -31,7 +31,7 @@
           %td= points grade.score
           %td= raw grade.feedback
           %td= grade.created_at
-          %td= grade.updated_at
+          %td= grade.graded_at
           %td
             %ul.button-bar
               %li= link_to raw('<i class="fa fa-edit fa-fw"> </i> Edit'), edit_assignment_grade_path(grade.assignment, :student_id => grade.student.id), :class => 'button'

--- a/app/views/submissions/_assignment_guidelines.haml
+++ b/app/views/submissions/_assignment_guidelines.haml
@@ -3,8 +3,12 @@
 - else
   .italic.not_bold= "#{points assignment.point_total} points possible"
 %br
-.italic.not_bold= "Opens: #{assignment.open_at}" if assignment.open_at?
-.italic.not_bold= "Due: #{assignment.due_at}" if assignment.due_at?
+- if assignment.open_at?
+  .italic.not_bold= "Opens: #{assignment.open_at}"
+
+- if assignment.due_at?
+  .italic.not_bold= "Due: #{assignment.due_at}"
+
 - if assignment.description.present?
   %hr.dotted
 

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -10,6 +10,11 @@
   - elsif presenter.assignment.is_individual?
     = f.input :student_id, :input_html => { :value => presenter.student.id }, :as => :hidden
 
+  - if presenter.submission.graded?
+    %section
+      .italic.not_bold= "Graded: #{presenter.submission.graded_at}"
+      %span.label.alert Resubmission!
+
   %section
     - if presenter.assignment.accepts_attachments
       %h4 Attachments

--- a/app/views/submissions/_instructor_show.haml
+++ b/app/views/submissions/_instructor_show.haml
@@ -8,6 +8,9 @@
     - if presenter.student.submission_for_assignment(presenter.assignment).late?
       %span.label.alert Late!
 
+    - if presenter.student.submission_for_assignment(presenter.assignment).resubmitted?
+      %span.label.alert Resubmission!
+
     // Checking to see if the submission was updated - if the update date is different from the creation date, displaying it
   - if presenter.student.submission_for_assignment(presenter.assignment).updated_at != presenter.student.submission_for_assignment(presenter.assignment).created_at
     %p

--- a/app/views/submissions/_student_show.haml
+++ b/app/views/submissions/_student_show.haml
@@ -14,6 +14,9 @@
     - if presenter.submission_for_assignment(current_student).late?
       %span.label.alert Late!
 
+    - if presenter.submission_for_assignment(current_student).resubmitted?
+      %span.label.alert Resubmission!
+
     // Checking to see if the submission was updated - if the update date is different from the creation date, displaying it
   - if presenter.submission_updated?(current_student)
     %p

--- a/db/migrate/20160111161343_remove_graded_from_submissions.rb
+++ b/db/migrate/20160111161343_remove_graded_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveGradedFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :graded
+  end
+end

--- a/db/migrate/20160111163552_remove_submitted_at_date_from_submissions.rb
+++ b/db/migrate/20160111163552_remove_submitted_at_date_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveSubmittedAtDateFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :submitted_at_date
+  end
+end

--- a/db/migrate/20160111164104_remove_attachment_fields_from_submissions.rb
+++ b/db/migrate/20160111164104_remove_attachment_fields_from_submissions.rb
@@ -1,0 +1,8 @@
+class RemoveAttachmentFieldsFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :attachment_content_type
+    remove_column :submissions, :attachment_file_name
+    remove_column :submissions, :attachment_file_size
+    remove_column :submissions, :attachment_updated_at
+  end
+end

--- a/db/migrate/20160111164938_remove_resubmission_from_submissions.rb
+++ b/db/migrate/20160111164938_remove_resubmission_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveResubmissionFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :resubmission
+  end
+end

--- a/db/migrate/20160111165205_remove_text_feedback_from_submissions.rb
+++ b/db/migrate/20160111165205_remove_text_feedback_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveTextFeedbackFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :text_feedback
+  end
+end

--- a/db/migrate/20160113164920_add_submitted_at_to_submissions.rb
+++ b/db/migrate/20160113164920_add_submitted_at_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToSubmissions < ActiveRecord::Migration
+  def change
+    add_column :submissions, :submitted_at, :datetime
+  end
+end

--- a/db/migrate/20160113195301_add_graded_at_to_grades.rb
+++ b/db/migrate/20160113195301_add_graded_at_to_grades.rb
@@ -1,0 +1,5 @@
+class AddGradedAtToGrades < ActiveRecord::Migration
+  def change
+    add_column :grades, :graded_at, :datetime
+  end
+end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -247,6 +247,8 @@ end
   puts_success :assignment_type, assignment_type_name, :assignment_type_created
 end
 
+PaperTrail.whodunnit = nil
+
 # Create Assignments!
 
 @assignments.each do |assignment_name,config|
@@ -304,6 +306,7 @@ end
 
       if config[:student_submissions]
         @students.each do |student|
+          PaperTrail.whodunnit = student.id
           submission = student.submissions.create! do |s|
             s.assignment = assignment
             s.text_comment = "Wingardium Leviosa"
@@ -357,6 +360,7 @@ end
                 g[attr] = grade_attributes[attr] || @assignment_default_config[:grade_attributes][attr]
               end
               g.graded_by_id = course_config[:staff_ids].sample
+              PaperTrail.whodunnit = g.graded_by_id
             end
             g.assignment = assignment
           end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -311,6 +311,7 @@ PaperTrail.whodunnit = nil
             s.assignment = assignment
             s.text_comment = "Wingardium Leviosa"
             s.link = "http://www.twitter.com"
+            s.submitted_at = DateTime.now
           end
           print "."
         end
@@ -359,6 +360,7 @@ PaperTrail.whodunnit = nil
               else
                 g[attr] = grade_attributes[attr] || @assignment_default_config[:grade_attributes][attr]
               end
+              g.graded_at = DateTime.now
               g.graded_by_id = course_config[:staff_ids].sample
               PaperTrail.whodunnit = g.graded_by_id
             end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -318,7 +318,7 @@ end
       if config[:rubric] and config[:grades]
         @students.each do |student|
           assignment.rubric.criteria.each do |criterion|
-            criterion.rubric_grades.create! do |rg|
+            criterion.criterion_grades.create! do |rg|
               rg.max_points = criterion.max_points
               rg.points = criterion.levels.first.points
               rg.level = criterion.levels.first

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160113164920) do
+ActiveRecord::Schema.define(version: 20160113195301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -552,6 +552,7 @@ ActiveRecord::Schema.define(version: 20160113164920) do
     t.boolean  "is_custom_value",                  default: false
     t.boolean  "feedback_reviewed",                default: false
     t.datetime "feedback_reviewed_at"
+    t.datetime "graded_at"
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -709,13 +709,15 @@ ActiveRecord::Schema.define(version: 20160111165205) do
   end
 
   create_table "submission_files", force: :cascade do |t|
-    t.string   "filename",        limit: 255,                 null: false
-    t.integer  "submission_id",                               null: false
-    t.string   "filepath",        limit: 255
-    t.string   "file",            limit: 255
-    t.boolean  "file_processing",             default: false, null: false
+    t.string   "filename",          limit: 255,                 null: false
+    t.integer  "submission_id",                                 null: false
+    t.string   "filepath",          limit: 255
+    t.string   "file",              limit: 255
+    t.boolean  "file_processing",               default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "last_confirmed_at"
+    t.boolean  "file_missing"
   end
 
   create_table "submission_files_duplicate", id: false, force: :cascade do |t|
@@ -747,6 +749,33 @@ ActiveRecord::Schema.define(version: 20160111165205) do
 
   add_index "submissions", ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree
   add_index "submissions", ["course_id"], name: "index_submissions_on_course_id", using: :btree
+
+  create_table "submissions_exports", force: :cascade do |t|
+    t.integer  "assignment_id"
+    t.integer  "course_id"
+    t.integer  "professor_id"
+    t.integer  "student_ids",                              default: [], null: false, array: true
+    t.integer  "team_id"
+    t.text     "export_filename"
+    t.text     "s3_object_key"
+    t.text     "s3_bucket_name"
+    t.text     "performer_error_log",                      default: [], null: false, array: true
+    t.hstore   "submissions_snapshot",                     default: {}, null: false
+    t.datetime "created_at",                                            null: false
+    t.datetime "updated_at",                                            null: false
+    t.datetime "last_export_started_at"
+    t.datetime "last_export_completed_at"
+    t.boolean  "generate_export_csv"
+    t.boolean  "export_csv_successful"
+    t.boolean  "create_student_directories"
+    t.boolean  "student_directories_created_successfully"
+    t.boolean  "create_submission_text_files"
+    t.boolean  "create_submission_binary_files"
+    t.boolean  "generate_error_log"
+    t.boolean  "archive_exported_files"
+    t.boolean  "upload_archive_to_s3"
+    t.boolean  "check_s3_upload_success"
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.integer  "assignment_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111164938) do
+ActiveRecord::Schema.define(version: 20160111165205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -735,7 +735,6 @@ ActiveRecord::Schema.define(version: 20160111164938) do
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.string   "link",               limit: 255
-    t.text     "text_feedback"
     t.text     "text_comment"
     t.integer  "creator_id"
     t.integer  "group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111163552) do
+ActiveRecord::Schema.define(version: 20160111164104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -730,15 +730,11 @@ ActiveRecord::Schema.define(version: 20160111163552) do
   create_table "submissions", force: :cascade do |t|
     t.integer  "assignment_id"
     t.integer  "student_id"
-    t.string   "feedback",                limit: 255
-    t.string   "comment",                 limit: 255
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.string   "attachment_file_name",    limit: 255
-    t.string   "attachment_content_type", limit: 255
-    t.integer  "attachment_file_size"
-    t.datetime "attachment_updated_at"
-    t.string   "link",                    limit: 255
+    t.string   "feedback",           limit: 255
+    t.string   "comment",            limit: 255
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.string   "link",               limit: 255
     t.text     "text_feedback"
     t.text     "text_comment"
     t.integer  "creator_id"
@@ -747,8 +743,8 @@ ActiveRecord::Schema.define(version: 20160111163552) do
     t.integer  "task_id"
     t.integer  "course_id"
     t.integer  "assignment_type_id"
-    t.string   "assignment_type",         limit: 255
-    t.boolean  "resubmission",                        default: false
+    t.string   "assignment_type",    limit: 255
+    t.boolean  "resubmission",                   default: false
   end
 
   add_index "submissions", ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111165205) do
+ActiveRecord::Schema.define(version: 20160113164920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -745,6 +745,7 @@ ActiveRecord::Schema.define(version: 20160111165205) do
     t.integer  "course_id"
     t.integer  "assignment_type_id"
     t.string   "assignment_type",    limit: 255
+    t.datetime "submitted_at"
   end
 
   add_index "submissions", ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -717,8 +717,6 @@ ActiveRecord::Schema.define(version: 20160113195301) do
     t.boolean  "file_processing",               default: false, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "last_confirmed_at"
-    t.boolean  "file_missing"
   end
 
   create_table "submission_files_duplicate", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -752,33 +752,6 @@ ActiveRecord::Schema.define(version: 20160113195301) do
   add_index "submissions", ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree
   add_index "submissions", ["course_id"], name: "index_submissions_on_course_id", using: :btree
 
-  create_table "submissions_exports", force: :cascade do |t|
-    t.integer  "assignment_id"
-    t.integer  "course_id"
-    t.integer  "professor_id"
-    t.integer  "student_ids",                              default: [], null: false, array: true
-    t.integer  "team_id"
-    t.text     "export_filename"
-    t.text     "s3_object_key"
-    t.text     "s3_bucket_name"
-    t.text     "performer_error_log",                      default: [], null: false, array: true
-    t.hstore   "submissions_snapshot",                     default: {}, null: false
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
-    t.datetime "last_export_started_at"
-    t.datetime "last_export_completed_at"
-    t.boolean  "generate_export_csv"
-    t.boolean  "export_csv_successful"
-    t.boolean  "create_student_directories"
-    t.boolean  "student_directories_created_successfully"
-    t.boolean  "create_submission_text_files"
-    t.boolean  "create_submission_binary_files"
-    t.boolean  "generate_error_log"
-    t.boolean  "archive_exported_files"
-    t.boolean  "upload_archive_to_s3"
-    t.boolean  "check_s3_upload_success"
-  end
-
   create_table "tasks", force: :cascade do |t|
     t.integer  "assignment_id"
     t.string   "name",                limit: 255

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111161343) do
+ActiveRecord::Schema.define(version: 20160111163552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -748,7 +748,6 @@ ActiveRecord::Schema.define(version: 20160111161343) do
     t.integer  "course_id"
     t.integer  "assignment_type_id"
     t.string   "assignment_type",         limit: 255
-    t.datetime "submitted_at_date"
     t.boolean  "resubmission",                        default: false
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111164104) do
+ActiveRecord::Schema.define(version: 20160111164938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -732,8 +732,8 @@ ActiveRecord::Schema.define(version: 20160111164104) do
     t.integer  "student_id"
     t.string   "feedback",           limit: 255
     t.string   "comment",            limit: 255
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.string   "link",               limit: 255
     t.text     "text_feedback"
     t.text     "text_comment"
@@ -744,7 +744,6 @@ ActiveRecord::Schema.define(version: 20160111164104) do
     t.integer  "course_id"
     t.integer  "assignment_type_id"
     t.string   "assignment_type",    limit: 255
-    t.boolean  "resubmission",                   default: false
   end
 
   add_index "submissions", ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160105155201) do
+ActiveRecord::Schema.define(version: 20160111161343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -743,7 +743,6 @@ ActiveRecord::Schema.define(version: 20160105155201) do
     t.text     "text_comment"
     t.integer  "creator_id"
     t.integer  "group_id"
-    t.boolean  "graded"
     t.datetime "released_at"
     t.integer  "task_id"
     t.integer  "course_id"

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -9,4 +9,9 @@ namespace :grades do
     puts "DONE"
   end
 
+  desc "Update all of the graded_at dates to the updated_at for the grades"
+  task :update_graded_at => :environment do
+    Grade.all.each { |g| g.update_attributes(graded_at: g.graded_at) }
+  end
+
 end

--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -1,0 +1,6 @@
+namespace :submissions do
+  desc "Update all of the submitted_at dates to the updated_at for the submissions"
+  task :update_submitted_at => :environment do
+    Submission.all.each { |s| s.update_attributes(submitted_at: s.updated_at) }
+  end
+end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -140,6 +140,17 @@ describe GradesController do
         expect(@grade.score).to eq(12345)
       end
 
+      it "attaches the student submission" do
+        submission = create :submission, assignment: @assignment, student: @student
+        grade_params = { raw_score: 12345,
+                         assignment_id: @assignment.id,
+                         submission_id: submission.id }
+        post :update, { assignment_id: @assignment.id,
+                        student_id: @student.id, grade: grade_params }
+        grade = Grade.last
+        expect(grade.submission).to eq submission
+      end
+
       it "handles a grade file upload" do
         grade_params = { raw_score: 12345, assignment_id: @assignment.id, "grade_files_attributes"=> {"0"=>{"file"=>[fixture_file('Too long, strange characters, and Spaces (In) Name.jpg', 'img/jpg')]}}}
         post :update, { :assignment_id => @assignment.id, :student_id => @student.id, :grade => grade_params}

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -293,11 +293,6 @@ describe GradesController do
         allow(controller).to receive(:current_student).and_return(@student)
       end
 
-      it "updates the submission grading status" do
-        submission = create(:submission, student: @student, assignment: @rubric_assignment)
-        expect{ post :submit_rubric, @params }.to change { CriterionGrade.count }.by(@rubric.criteria.count)
-      end
-
       describe "finds or creates the grade for the assignment and student" do
         it "finds and assigns the grade" do
           grade = create(:grade, assignment: @rubric_assignment, student: @student)

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -214,6 +214,12 @@ describe GradesController do
         expect(@grade.instructor_modified).to be_truthy
       end
 
+      it "timestamps the grade" do
+          current_time = DateTime.now
+          post :async_update, { id: @grade.id, raw_score: 20000, feedback: "good jorb!" }
+          expect(@grade.reload.graded_at).to be > current_time
+        end
+
       describe "manages update with model validations" do
         it "handles commas in raw score params" do
           post :async_update, { id: @grade.id, raw_score: "12,345", feedback: "good jorb!" }

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -300,10 +300,17 @@ describe GradesController do
           expect(assigns(:grade)).to eq(grade)
         end
 
-        it "cretes and assigns the grade" do
+        it "creates and assigns the grade" do
           expect{ post :submit_rubric, @params }.to change { Grade.count }.by(1)
           expect(assigns(:grade).assignment).to eq(@rubric_assignment)
           expect(assigns(:grade).student).to eq(@student)
+        end
+
+        it "assigns the grade to the submission" do
+          submission = create :submission, assignment: @rubric_assignment, student: @student
+          post :submit_rubric, @params
+          grade = Grade.unscoped.last
+          expect(grade.submission).to eq submission
         end
       end
 

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -66,11 +66,11 @@ describe GradeExporter do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return double(:grade, instructor_modified?: true, graded_or_released?: false,
-                              score: 123, raw_score: 789, feedback: nil, updated_at: updated_at)
+                              score: 123, raw_score: 789, feedback: nil, graded_at: updated_at)
       allow(students[1]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return double(:grade, instructor_modified?: false, graded_or_released?: true,
-                              score: 456, raw_score: 456, feedback: "Grrrrreat!", updated_at: updated_at)
+                              score: 456, raw_score: 456, feedback: "Grrrrreat!", graded_at: updated_at)
       allow(students[1]).to \
         receive(:submission_for_assignment).with(assignment)
           .and_return double(:submission, text_comment: "Hello there")

--- a/spec/exporters/grades_for_research_exporter_spec.rb
+++ b/spec/exporters/grades_for_research_exporter_spec.rb
@@ -16,7 +16,7 @@ describe GradesForResearchExporter do
       @student.courses << course
       @assignment_type = create(:assignment_type, course: course)
       @assignment = create(:assignment, course: course, assignment_type: @assignment_type, name: "Quiz")
-      @grade = create(:grade, raw_score: 100, course: course, student: @student, assignment: @assignment)
+      @grade = create(:grade, raw_score: 100, course: course, student: @student, assignment: @assignment, graded_at: Time.now)
 
       csv = CSV.new(subject.research_grades(course)).read
       expect(csv.length).to eq 2
@@ -39,7 +39,7 @@ describe GradesForResearchExporter do
       expect(csv[1][16]).to eq "#{@grade.submission.try(:updated_at)}"
       expect(csv[1][17]).to eq "#{@grade.graded_by_id}"
       expect(csv[1][18]).to eq "#{@grade.created_at}"
-      expect(csv[1][19]).to eq "#{@grade.updated_at}"
+      expect(csv[1][19]).to eq "#{@grade.graded_at.utc.strftime("%Y-%m-%d %H:%M:%S %Z")}"
     end
   end
 end

--- a/spec/exporters/grades_for_research_exporter_spec.rb
+++ b/spec/exporters/grades_for_research_exporter_spec.rb
@@ -16,7 +16,9 @@ describe GradesForResearchExporter do
       @student.courses << course
       @assignment_type = create(:assignment_type, course: course)
       @assignment = create(:assignment, course: course, assignment_type: @assignment_type, name: "Quiz")
-      @grade = create(:grade, raw_score: 100, course: course, student: @student, assignment: @assignment, graded_at: Time.now)
+      @grade = create(:grade, raw_score: 100, course: course, student: @student, assignment: @assignment)
+      graded_at = DateTime.now
+      allow_any_instance_of(Grade).to receive(:graded_at).and_return graded_at
 
       csv = CSV.new(subject.research_grades(course)).read
       expect(csv.length).to eq 2
@@ -39,7 +41,7 @@ describe GradesForResearchExporter do
       expect(csv[1][16]).to eq "#{@grade.submission.try(:updated_at)}"
       expect(csv[1][17]).to eq "#{@grade.graded_by_id}"
       expect(csv[1][18]).to eq "#{@grade.created_at}"
-      expect(csv[1][19]).to eq "#{@grade.graded_at.utc.strftime("%Y-%m-%d %H:%M:%S %Z")}"
+      expect(csv[1][19]).to eq "#{graded_at}"
     end
   end
 end

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -4,7 +4,6 @@ FactoryGirl.define do
     text_comment "needs a link, file, or text comment to be valid"
 
     factory :graded_submission do
-      # TODO, verify this method exists and works, or fails with no method error: submission.graded?
       association :grade, factory: :released_grade
     end
   end

--- a/spec/features/editing_submissions_spec.rb
+++ b/spec/features/editing_submissions_spec.rb
@@ -1,0 +1,25 @@
+require "rails_spec_helper"
+
+feature "editing submissions" do
+  context "as a student" do
+    let!(:submission) do
+      create :submission, course: membership.course, assignment: assignment, student: student
+    end
+
+    let(:assignment) { create :assignment, accepts_submissions: true, course: membership.course }
+    let(:membership) { create :student_course_membership, user: student }
+    let(:student) { create :user }
+
+    before { login_as student }
+
+    scenario "notification of a resubmission" do
+      create :grade, status: "Released", student: student, submission: submission,
+        assignment: assignment
+      visit edit_assignment_submission_path assignment, submission
+
+      within ".pageContent" do
+        expect(page).to have_content "Resubmission"
+      end
+    end
+  end
+end

--- a/spec/features/editing_submissions_spec.rb
+++ b/spec/features/editing_submissions_spec.rb
@@ -18,7 +18,7 @@ feature "editing submissions" do
       visit edit_assignment_submission_path assignment, submission
 
       within ".pageContent" do
-        expect(page).to have_content "Resubmission"
+        expect(page).to have_content "Resubmission!"
       end
     end
   end

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -1,22 +1,53 @@
 require "rails_spec_helper"
 
 feature "viewing submissions" do
-  context "as a student" do
-    let!(:submission) do
-      create :submission, course: membership.course, assignment: assignment, student: student
-    end
+  let(:assignment) { create :assignment, accepts_submissions: true, course: membership.course }
+  let!(:submission) do
+    create :submission, course: membership.course, assignment: assignment, student: student
+  end
+  let(:student) { create :user }
 
-    let(:assignment) { create :assignment, accepts_submissions: true, course: membership.course }
+  context "as a student" do
     let(:membership) { create :student_course_membership, user: student }
-    let(:student) { create :user }
 
     before do
       login_as student
-      visit assignment_path assignment
     end
 
     scenario "allows an editable submission if it's before the due date" do
+      visit assignment_path assignment
+
       expect(find_link("Edit My Submission")).to be_visible
+    end
+
+    scenario "displays a resubmitted alert for a resubmitted submission" do
+      grade = create :grade, submission: submission, assignment: assignment, student: student, raw_score: 10000, status: "Released"
+      submission.update_attributes link: "http://example.org"
+      grade.update_attributes raw_score: 1234 # TODO: Does a resubmission mean that it has a grade?
+      visit assignment_path assignment
+
+      within ".pageContent" do
+        expect(page).to have_content "Resubmission!"
+      end
+    end
+  end
+
+  context "as a professor", versioning: true do
+    let(:membership) { create :professor_course_membership, user: professor }
+    let(:professor) { create :user }
+
+    before do
+      login_as professor
+      grade = create :grade, submission: submission, assignment: assignment, student: student, raw_score: 10000, status: "Released"
+      submission.update_attributes link: "http://example.org"
+      grade.update_attributes raw_score: 1234 # TODO: Does a resubmission mean that it has a grade?
+      visit assignment_submission_path assignment, submission
+    end
+
+    scenario "displays a resubmitted alert for a resubmitted submission" do
+      within ".pageContent" do
+        expect(page).to have_content "Resubmission!"
+      end
     end
   end
 end

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -7,12 +7,10 @@ feature "viewing submissions" do
   end
   let(:student) { create :user }
 
-  context "as a student" do
+  context "as a student", versioning: true do
     let(:membership) { create :student_course_membership, user: student }
 
-    before do
-      login_as student
-    end
+    before { login_as student }
 
     scenario "allows an editable submission if it's before the due date" do
       visit assignment_path assignment
@@ -21,9 +19,9 @@ feature "viewing submissions" do
     end
 
     scenario "displays a resubmitted alert for a resubmitted submission" do
-      grade = create :grade, submission: submission, assignment: assignment, student: student, raw_score: 10000, status: "Released"
+      create :grade, submission: submission, assignment: assignment, student: student,
+        raw_score: 10000, status: "Released"
       submission.update_attributes link: "http://example.org"
-      grade.update_attributes raw_score: 1234 # TODO: Does a resubmission mean that it has a grade?
       visit assignment_path assignment
 
       within ".pageContent" do

--- a/spec/human_history/history_token_registry_spec.rb
+++ b/spec/human_history/history_token_registry_spec.rb
@@ -8,15 +8,15 @@ describe HumanHistory::HistoryTokenRegistry do
 
   describe ".register" do
     it "adds the token type to the registry" do
-      described_class.register HumanHistory::ActorHistoryToken, ->(key) { key == "actor_id" }
+      described_class.register HumanHistory::ActorHistoryToken, ->(key, _, _) { key == "actor_id" }
 
       expect(described_class.registered_tokens.length).to eq 1
       expect(described_class.registered_tokens.first.type).to eq HumanHistory::ActorHistoryToken
     end
 
     it "does not register the same token type twice" do
-      described_class.register HumanHistory::ActorHistoryToken, ->(key) { key == "actor_id" }
-      described_class.register HumanHistory::ActorHistoryToken, ->(key) { key == "actor_id" }
+      described_class.register HumanHistory::ActorHistoryToken, ->(key, _, _) { key == "actor_id" }
+      described_class.register HumanHistory::ActorHistoryToken, ->(key, _, _) { key == "actor_id" }
 
       expect(described_class.registered_tokens.length).to eq 1
     end
@@ -34,7 +34,7 @@ describe HumanHistory::HistoryTokenRegistry do
 
   describe ".unregister" do
     it "removes the token type from the registry" do
-      described_class.register HumanHistory::ActorHistoryToken, ->(key) { key == "actor_id" }
+      described_class.register HumanHistory::ActorHistoryToken, ->(key, _, _) { key == "actor_id" }
       described_class.unregister HumanHistory::ActorHistoryToken
 
       expect(described_class.registered_tokens).to be_empty

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -43,6 +43,36 @@ describe Grade do
 
   it_behaves_like "a historical model", :grade, raw_score: 1234
 
+  describe "versioning", versioning: true do
+    it "ignores changes to feedback_reviewed" do
+      subject.save!
+      subject.update_attributes feedback_reviewed: true
+      expect(subject.versions.count).to eq 1
+      expect(subject.versions.first.event).to eq "create"
+    end
+
+    it "ignores changes to feedback_reviewed_at" do
+      subject.save!
+      subject.update_attributes feedback_reviewed_at: DateTime.now
+      expect(subject.versions.count).to eq 1
+      expect(subject.versions.first.event).to eq "create"
+    end
+
+    it "ignores changes to feedback_read" do
+      subject.save!
+      subject.update_attributes feedback_read: true
+      expect(subject.versions.count).to eq 1
+      expect(subject.versions.first.event).to eq "create"
+    end
+
+    it "ignores changes to feedback_read_at" do
+      subject.save!
+      subject.update_attributes feedback_read_at: DateTime.now
+      expect(subject.versions.count).to eq 1
+      expect(subject.versions.first.event).to eq "create"
+    end
+  end
+
   describe "#raw_score" do
     it "converts raw_score from human readable strings" do
       subject.update(raw_score: "1,234")

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -31,6 +31,10 @@ describe NullGrade do
     expect(subject.updated_at).to eq(nil)
   end
 
+  it "has a nil graded at timestamp" do
+    expect(subject.graded_at).to eq(nil)
+  end
+
   it "has a team id of zero" do
     expect(subject.team_id).to eq(0)
   end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -56,7 +56,25 @@ describe Resubmission do
         end
       end
 
-      xit "with several submission changes and several grades"
+      context "with several submission changes and two grades changes" do
+        before do
+          grade.update_attributes raw_score: 1234
+          submission.update_attributes link: "http://google.com"
+          grade.update_attributes raw_score: 5678
+        end
+
+        it "returns two resubmissions for the each grade change" do
+          results = described_class.find_for_submission(submission)
+
+          expect(results.length).to eq 2
+          expect(results.first.submission_revision.reify.link).to eq nil
+          expect(results.first.grade_revision.reify.raw_score).to eq nil
+          expect(results.last.submission_revision.reify.link).to eq "http://example.org"
+          expect(results.last.grade_revision.reify.raw_score).to eq 1234
+        end
+      end
+
+      xit "with a grade that is updated for other reasons than the score"
       xit "with a grade that is not visible to the student"
       xit "with an assignment that no longer accepts submissions"
     end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -42,6 +42,20 @@ describe Resubmission do
         end
       end
 
+      context "with several submission changes and one grade change" do
+        before do
+          submission.update_attributes link: "http://google.com"
+          grade.update_attributes raw_score: 1234
+        end
+
+        it "returns one resubmission for the last submission change" do
+          results = described_class.find_for_submission(submission)
+
+          expect(results.length).to eq 1
+          expect(results.first.submission_revision.reify.link).to eq "http://example.org"
+        end
+      end
+
       xit "with several submission changes and several grades"
       xit "with a grade that is not visible to the student"
       xit "with an assignment that no longer accepts submissions"

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -111,20 +111,4 @@ describe Resubmission do
       end
     end
   end
-
-  describe ".future_resubmission?" do
-    it "returns false if the grade is not created" do
-      expect(described_class.future_resubmission?(submission)).to eq false
-    end
-
-    it "returns true if the grade has already been assigned" do
-      grade.touch
-      expect(described_class.future_resubmission?(submission)).to eq true
-    end
-
-    it "returns false if the grade is not visible to the student" do
-      grade.update_attributes status: nil
-      expect(described_class.future_resubmission?(submission)).to eq false
-    end
-  end
 end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -21,7 +21,7 @@ describe Resubmission do
     describe "it pairs up the grade revision with the submission revision" do
       before { submission.update_attributes link: "http://example.org" }
 
-      context "with a submission change and no grades" do
+      context "with a submission change and no grade" do
         it "returns no resubmissions" do
           expect(described_class.find_for_submission(submission)).to be_empty
         end
@@ -74,7 +74,14 @@ describe Resubmission do
         end
       end
 
-      xit "with a grade that is updated for other reasons than the score"
+      context "with a grade that is updated for other reasons than the score" do
+        before { grade.update_attributes feedback: "You rock!" }
+
+        it "returns no resubmissions" do
+          expect(described_class.find_for_submission(submission)).to be_empty
+        end
+      end
+
       xit "with a grade that is not visible to the student"
       xit "with an assignment that no longer accepts submissions"
     end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -29,6 +29,19 @@ describe Resubmission do
         end
       end
 
+      context "with a submission change after the grade is created" do
+        it "returns one ungraded resubmission" do
+          grade.touch
+          results = described_class.find_for_submission(submission)
+
+          expect(results.length).to eq 1
+          expect(results.first.submission).to eq submission
+          expect(results.first.submission_revision.event).to eq "update"
+          expect(results.first.submission_revision.reify.link).to eq nil
+          expect(results.first.grade_revision.event).to eq "create"
+        end
+      end
+
       context "with a submission change and one grade change" do
         before { grade.update_attributes raw_score: 1234 }
 
@@ -53,8 +66,8 @@ describe Resubmission do
         it "returns one resubmission for the last submission change" do
           results = described_class.find_for_submission(submission)
 
-          expect(results.length).to eq 1
-          expect(results.first.submission_revision.reify.link).to eq "http://example.org"
+          expect(results.length).to eq 2
+          expect(results.last.submission_revision.reify.link).to eq "http://example.org"
         end
       end
 
@@ -70,7 +83,7 @@ describe Resubmission do
 
           expect(results.length).to eq 2
           expect(results.first.submission_revision.reify.link).to eq nil
-          expect(results.first.grade_revision.reify.raw_score).to eq nil
+          expect(results.first.grade_revision.reify.raw_score).to eq 1234
           expect(results.last.submission_revision.reify.link).to eq "http://example.org"
           expect(results.last.grade_revision.reify.raw_score).to eq 1234
         end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -1,0 +1,40 @@
+require "active_record_spec_helper"
+
+describe Resubmission do
+  let(:submission) { create :submission }
+
+  describe "#initialize" do
+    it "initializes with attributes" do
+      subject = described_class.new submission: submission
+      expect(subject.submission).to eq submission
+    end
+
+    it "does not create an instance variable if there is no accessor" do
+      subject = described_class.new blah: "blah"
+      expect(subject.instance_variable_get("@blah")).to be_nil
+    end
+  end
+
+  describe ".find_for_submission" do
+    it "is empty if there are no grades for the submission" do
+      expect(described_class.find_for_submission(submission)).to be_empty
+    end
+
+    context "with one grade revision", versioning: true do
+      let(:grade) { create :grade, submission: submission, assignment: submission.assignment }
+
+      before do
+        grade.update_attributes raw_score: 1234
+      end
+
+      it "returns one resubmission" do
+        results = described_class.find_for_submission(submission)
+
+        expect(results.length).to eq 1
+        expect(results.first.submission).to eq submission
+        expect(results.first.grade.event).to eq "update"
+        expect(results.first.grade.reify.raw_score).to eq nil
+      end
+    end
+  end
+end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -16,7 +16,10 @@ describe Resubmission do
   end
 
   describe ".find_for_submission", versioning: true do
-    let(:grade) { create :grade, submission: submission, assignment: submission.assignment }
+    let(:grade) do
+      create :grade, status: "Released", submission: submission,
+        assignment: submission.assignment
+    end
 
     describe "it pairs up the grade revision with the submission revision" do
       before { submission.update_attributes link: "http://example.org" }
@@ -82,7 +85,14 @@ describe Resubmission do
         end
       end
 
-      xit "with a grade that is not visible to the student"
+      context "with a grade that is not visible to the student" do
+        before { grade.update_attributes status: nil, raw_score: 1234 }
+
+        it "returns no resubmissions" do
+          expect(described_class.find_for_submission(submission)).to be_empty
+        end
+      end
+
       xit "with an assignment that no longer accepts submissions"
     end
   end

--- a/spec/models/resubmission_spec.rb
+++ b/spec/models/resubmission_spec.rb
@@ -92,8 +92,6 @@ describe Resubmission do
           expect(described_class.find_for_submission(submission)).to be_empty
         end
       end
-
-      xit "with an assignment that no longer accepts submissions"
     end
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -240,41 +240,60 @@ describe Submission do
     end
   end
 
+  describe "#graded_at" do
+    it "returns when the grade was updated if it was graded" do
+      subject.save
+      grade = create(:grade, submission: subject, status: "Graded")
+      expect(subject.graded_at).to eq grade.updated_at
+    end
+
+    it "returns nil if there is no grade" do
+      subject.save
+      expect(subject.graded_at).to be_nil
+    end
+
+    it "returns nil if the grade is not released" do
+      subject.save
+      grade = create(:grade, submission: subject)
+      expect(subject.graded_at).to be_nil
+    end
+  end
+
   describe "#graded?" do
     it "returns false for a submission that has no grade" do
-      submission = create(:submission)
-      expect(submission).to_not be_graded
+      subject.save
+      expect(subject).to_not be_graded
     end
 
     it "returns false for a submission that has grade that is not student visible" do
-      submission = create(:submission)
-      grade = create(:grade, submission: submission)
-      expect(submission).to_not be_graded
+      subject.save
+      grade = create(:grade, submission: subject)
+      expect(subject).to_not be_graded
     end
 
     it "returns true for a submission that has grade that is student visible" do
-      submission = create(:submission)
-      grade = create(:grade, submission: submission, status: "Graded")
-      expect(submission).to be_graded
+      subject.save
+      grade = create(:grade, submission: subject, status: "Graded")
+      expect(subject).to be_graded
     end
   end
 
   describe "#ungraded?" do
     it "returns true for a submission that has no grade" do
-      submission = create(:submission)
-      expect(submission).to be_ungraded
+      subject.save
+      expect(subject).to be_ungraded
     end
 
     it "returns true for a submission that has grade that is not student visible" do
-      submission = create(:submission)
-      grade = create(:grade, submission: submission)
-      expect(submission).to be_ungraded
+      subject.save
+      grade = create(:grade, submission: subject)
+      expect(subject).to be_ungraded
     end
 
     it "returns false for a submission that has grade that is student visible" do
-      submission = create(:submission)
-      grade = create(:grade, submission: submission, status: "Graded")
-      expect(submission).to_not be_ungraded
+      subject.save
+      grade = create(:grade, submission: subject, status: "Graded")
+      expect(subject).to_not be_ungraded
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -298,6 +298,29 @@ describe Submission do
     end
   end
 
+  describe ".resubmitted" do
+    it "returns the submissions that have been submitted after they were graded" do
+      grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)
+      subject.submitted_at = DateTime.now
+      subject.save
+      expect(Submission.resubmitted).to eq [subject]
+    end
+
+    it "does not return non-graded or released grades" do
+      grade = create(:grade, submission: subject, graded_at: 1.day.ago)
+      subject.submitted_at = DateTime.now
+      subject.save
+      expect(Submission.resubmitted).to be_empty
+    end
+
+    it "does not return resubmissions that have been graded" do
+      grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)
+      subject.submitted_at = 2.days.ago
+      subject.save
+      expect(Submission.resubmitted).to be_empty
+    end
+  end
+
   describe "#will_be_resubmission?", versioning: true do
     before { subject.save }
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -323,6 +323,7 @@ describe Submission do
 
   describe ".order_by_submitted" do
     it "returns the submissions in the order they were submitted" do
+      Submission.delete_all
       submitted_yesterday = create(:submission, submitted_at: 1.day.ago)
       never_submitted = create(:submission)
       just_submitted = create(:submission, submitted_at: DateTime.now)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -321,6 +321,16 @@ describe Submission do
     end
   end
 
+  describe ".order_by_submitted" do
+    it "returns the submissions in the order they were submitted" do
+      submitted_yesterday = create(:submission, submitted_at: 1.day.ago)
+      never_submitted = create(:submission)
+      just_submitted = create(:submission, submitted_at: DateTime.now)
+
+      expect(Submission.order_by_submitted).to eq [submitted_yesterday, just_submitted, never_submitted]
+    end
+  end
+
   describe "#will_be_resubmission?", versioning: true do
     before { subject.save }
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -346,8 +346,8 @@ describe Submission do
 
       before do
         subject.save
-        subject.update_attributes link: "http://example.com"
         grade.update_attributes raw_score: 1234
+        subject.update_attributes link: "http://example.com"
       end
 
       it "returns an array of resubmissions" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -259,6 +259,20 @@ describe Submission do
     end
   end
 
+  describe "#will_be_resubmission?", versioning: true do
+    before { subject.save }
+
+    it "returns false if there is no grade" do
+      expect(subject).to_not be_will_be_resubmission
+    end
+
+    it "returns true if there is a grade" do
+      create :grade, status: "Graded", submission: subject, assignment: subject.assignment
+
+      expect(subject).to be_will_be_resubmission
+    end
+  end
+
   describe "#resubmitted?", versioning: true do
     it "returns false if there are no resubmissions" do
       expect(subject).to_not be_resubmitted

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -240,22 +240,41 @@ describe Submission do
     end
   end
 
+  describe "#graded?" do
+    it "returns false for a submission that has no grade" do
+      submission = create(:submission)
+      expect(submission).to_not be_graded
+    end
+
+    it "returns false for a submission that has grade that is not student visible" do
+      submission = create(:submission)
+      grade = create(:grade, submission: submission)
+      expect(submission).to_not be_graded
+    end
+
+    it "returns true for a submission that has grade that is student visible" do
+      submission = create(:submission)
+      grade = create(:grade, submission: submission, status: "Graded")
+      expect(submission).to be_graded
+    end
+  end
+
   describe "#ungraded?" do
     it "returns true for a submission that has no grade" do
       submission = create(:submission)
-      expect(submission.ungraded?).to eq(true)
+      expect(submission).to be_ungraded
     end
 
     it "returns true for a submission that has grade that is not student visible" do
       submission = create(:submission)
       grade = create(:grade, submission: submission)
-      expect(submission.ungraded?).to eq(true)
+      expect(submission).to be_ungraded
     end
 
     it "returns false for a submission that has grade that is student visible" do
       submission = create(:submission)
       grade = create(:grade, submission: submission, status: "Graded")
-      expect(submission.ungraded?).to eq(false)
+      expect(submission).to_not be_ungraded
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -241,10 +241,11 @@ describe Submission do
   end
 
   describe "#graded_at" do
-    it "returns when the grade was updated if it was graded" do
+    it "returns when the grade was graded if it was graded" do
       subject.save
-      grade = create(:grade, submission: subject, status: "Graded")
-      expect(subject.graded_at).to eq grade.updated_at
+      graded_at = DateTime.now
+      grade = create(:grade, submission: subject, status: "Graded", graded_at: graded_at)
+      expect(subject.graded_at).to eq graded_at
     end
 
     it "returns nil if there is no grade" do

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -166,28 +166,28 @@ describe UnlockCondition do
 
     it "returns false if the grade earned meets the condition value but is not student visible" do
       student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: nil, instructor_modified: false)
+      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: nil, instructor_modified: false, graded_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100
       expect(unlock_condition.is_complete?(student)).to eq(false)
     end
 
     it "returns true if the grade earned meets the condition date" do
       student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true)
+      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_date: (Date.today + 1)
       expect(unlock_condition.is_complete?(student)).to eq(true)
     end
 
     it "returns false if the grade earned did not meet the condition date" do
       student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true)
+      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_date: (Date.today - 1)
       expect(unlock_condition.is_complete?(student)).to eq(false)
     end
 
     it "returns true if the grade earned meets condition value and the condition date" do
       student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true)
+      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100, condition_date: (Date.today + 1)
       expect(unlock_condition.is_complete?(student)).to eq(true)
     end
@@ -201,7 +201,7 @@ describe UnlockCondition do
 
     it "returns false if the grade earned does meet the condition value but does not meet the condition date" do
       student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true)
+      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100, condition_date: (Date.today - 1)
       expect(unlock_condition.is_complete?(student)).to eq(false)
     end

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -124,14 +124,14 @@ describe UnlockCondition do
 
     it "returns true if the assignment has been submitted by a specific date" do
       student = create(:user)
-      student_submission = create(:submission, assignment: assignment, student: student)
+      student_submission = create(:submission, assignment: assignment, student: student, submitted_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted", condition_date: (Date.today + 1)
       expect(unlock_condition.is_complete?(student)).to eq(true)
     end
 
     it "returns false if the assignment has been submitted but not by the specified date" do
       student = create(:user)
-      student_submission = create(:submission, assignment: assignment, student: student)
+      student_submission = create(:submission, assignment: assignment, student: student, submitted_at: DateTime.now)
       unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted", condition_date: (Date.today - 1)
       expect(unlock_condition.is_complete?(student)).to eq(false)
     end

--- a/spec/presenters/assignment_presenter_spec.rb
+++ b/spec/presenters/assignment_presenter_spec.rb
@@ -118,6 +118,15 @@ describe AssignmentPresenter do
     end
   end
 
+  describe "#submission_date_for" do
+    it "returns the submitted at date for the students first submission" do
+      submitted_at = DateTime.now
+      submission = double(submission, submitted_at: submitted_at)
+      allow(subject).to receive(:submissions_for).and_return [submission]
+      expect(subject.submission_date_for(double(:user))).to eq submitted_at
+    end
+  end
+
   describe "#submission_updated_date_for" do
     it "returns the submitted at date for the first submission" do
       submitted_at = DateTime.now

--- a/spec/presenters/assignment_presenter_spec.rb
+++ b/spec/presenters/assignment_presenter_spec.rb
@@ -118,6 +118,18 @@ describe AssignmentPresenter do
     end
   end
 
+  describe "#submission_updated_date_for" do
+    it "returns the submitted at date for the first submission" do
+      submitted_at = DateTime.now
+      submission = double(submission, submitted_at: submitted_at)
+      expect(subject.submission_updated_date_for([submission])).to eq submitted_at
+    end
+
+    it "returns nil if there are no submissions" do
+      expect(subject.submission_updated_date_for([])).to be_nil
+    end
+  end
+
   describe "#students" do
     let(:student) { double(:user) }
 


### PR DESCRIPTION
This PR matches changes on `Submission`s with changes on `Grades` to see if a `Submission` change is a resubmission.

In addition, multiple unused fields for `Submissions` were removed via migrations.

The wiki for [Submissions](https://github.com/UM-USElab/gradecraft-development/wiki/Submissions) was updated on wiki branch `1532-resubmissions`.

### DEPLOYMENT NOTES:

run `bundle exec rake submissions:update_submitted_at` on staging and production
run `bundle exec rake grades:update_graded_at` on staging and production

Closes #1532 
Fixes #1572 