### PR TITLE
predictor coffescript rendering bugfix

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -118,9 +118,10 @@
     total = 0
     _.each(assignments, (assignment)->
       # use raw score to keep weighting calculation on assignment type level
+      debugger
       if assignment.grade.raw_score != null
         total += assignment.grade.raw_score
-      else if ! assignment.pass_fail && ! assignment.has_closed? && includePredicted
+      else if ! assignment.pass_fail && ! assignment.has_closed && includePredicted
         total += assignment.grade.predicted_score
     )
     total


### PR DESCRIPTION
Fixes a bug introduced in commit 591059595c71ba86c3a0349bdf0aaa5692fefaac where coffescript was compiling a `?` as an evaluation against null on `assignment.has_closed`