### PR TITLE
More efficient Rake tasks to update resubmissions

### DIFF
--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -11,7 +11,7 @@ namespace :grades do
 
   desc "Update all of the graded_at dates to the updated_at for the grades"
   task :update_graded_at => :environment do
-    Grade.all.each { |g| g.update_attributes(graded_at: g.graded_at) }
+    Grade.find_each(batch_size: 500) { |g| g.update_column(:graded_at, g.graded_at) }
   end
 
 end

--- a/lib/tasks/submissions.rake
+++ b/lib/tasks/submissions.rake
@@ -1,6 +1,6 @@
 namespace :submissions do
   desc "Update all of the submitted_at dates to the updated_at for the submissions"
   task :update_submitted_at => :environment do
-    Submission.all.each { |s| s.update_attributes(submitted_at: s.updated_at) }
+    Submission.find_each(batch_size: 500) { |s| s.update_column(:submitted_at, s.updated_at) }
   end
 end


### PR DESCRIPTION
Updates the rake tasks for grades and submissions so they are more efficient and do not trigger callbacks.

In order to not trigger callbacks, the new Rails 4 `update_column` method is used.
In order to make the query more memory efficient, the `find_each` method is used to find the objects in batches of 500.

### DEPLOYMENT NOTES:

run `bundle exec rake submissions:update_submitted_at` on staging and production
run `bundle exec rake grades:update_graded_at` on staging and production

For #1532 