### PR TITLE
rich text in rubric feedback

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -1,4 +1,4 @@
-@gradecraft.controller 'GradeCtrl', ['$timeout', '$rootScope', '$scope', 'Grade', 'AssignmentScoreLevel', '$window', '$http', 'Badge', 'EventHelper', ($timeout, $rootScope, $scope, Grade, AssignmentScoreLevel, $window, $http, Badge, EventHelper) -> 
+@gradecraft.controller 'GradeCtrl', ['$timeout', '$rootScope', '$scope', 'Grade', 'AssignmentScoreLevel', '$window', '$http', 'Badge', 'EventHelper', ($timeout, $rootScope, $scope, Grade, AssignmentScoreLevel, $window, $http, Badge, EventHelper) ->
 
   # setup the controller scope on initialize
   $scope.init = (initData)->
@@ -15,7 +15,7 @@
     $scope.rawScoreUpdating = false
     $scope.hasChanges = false
     $scope.gradeStatuses = ["In Progress", "Graded", "Released"]
-    
+
     # establish and populate all necessary collections for UI
     $scope.populateCollections(initData.badges, initData.assignment_score_levels)
 

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -62,18 +62,15 @@
     new Criterion(attrs, $scope)
 
   # count how many levels have been selected in the UI
-  $scope.levelsSelected = []
   $scope.selectedLevels = ()->
     levels = []
     angular.forEach($scope.criteria, (criterion, index)->
       if criterion.selectedLevel
         levels.push criterion.selectedLevel
     )
-    $scope.levelsSelected = levels
     levels
 
 
-  $scope.selectedLevelIds = []
   # count how many levels have been selected in the UI
   $scope.selectedLevelIds = ()->
     levelIds = []
@@ -81,17 +78,14 @@
       if criterion.selectedLevel
         levelIds.push criterion.selectedLevel.id
     )
-    $scope.selectedLevelIds = levelIds
     levelIds
 
-  $scope.allCriterionIds = []
   # ids of all the criteria in the rubric
   $scope.allCriterionIds = ()->
     criterionIds = []
     angular.forEach($scope.criteria, (criterion, index)->
       criterionIds.push criterion.id
     )
-    $scope.allCriterionIds = criterionIds
     criterionIds
 
   # count how many points have been given from those levels
@@ -213,14 +207,12 @@
     if confirm "Are you sure you want to submit the grade for this assignment?"
       # alert(self.gradedRubricParams().level_badges.length)
 
-      # store in a var because this call has side effects
-      # and can't be called twice! TODO: debug this
-      params = self.gradedRubricParams()
       # !!! Document any updates to this call in the specs: /spec/support/api_calls/rubric_grade_put.rb
-      $http.put("/assignments/#{$scope.assignmentId}/grade/submit_rubric", params).success(
-        window.location = $scope.returnURL
-      )
-      .error(
+      $http.put("/assignments/#{$scope.assignmentId}/grade/submit_rubric", self.gradedRubricParams()).success(
+        (data)->
+          console.log(data)
+          window.location = $scope.returnURL
+      ).error(
         (data)->
           console.log(data)
       )
@@ -245,4 +237,12 @@
     )
 
   $scope.existingCriteria = []
+
+
+  $scope.froalaOptions = {
+    inlineMode: false,
+    minHeight: 100,
+    buttons: [ "bold", "italic", "underline", "strikeThrough", "insertOrderedList",
+               "insertUnorderedList"],
+  }
 ]

--- a/app/views/grades/_criterion_grade_results.haml
+++ b/app/views/grades/_criterion_grade_results.haml
@@ -50,4 +50,4 @@
           %td.filler(colspan="#{presenter.rubric.max_level_count - criterion.levels.size}")
         %td.level.level-comments.comments-box
           - unless comments_by_criterion_id.empty?
-            = comments_by_criterion_id[criterion.id]
+            = raw comments_by_criterion_id[criterion.id]

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -63,7 +63,7 @@
               .clear
           %td.filler(ng-show="criterion.levels.length < #{@rubric.max_level_count}" colspan="{{#{@rubric.max_level_count} - criterion.levels.length}}")
           %td.comments-box
-            %textarea(ng-model="criterion.comments")
+            %textarea(ng-model="criterion.comments" froala="froalaOptions")
 
     %br
     .right


### PR DESCRIPTION
This feature adds rich text editing in the rubric feedback form and displays on grade show page, similar to grades without rubrics. It also removes reassignment of functions in Angular to arrays, to allow for multiple calls to gradedRubricParams() without error. This will make way for any better error handling on POST failure, and the ability to resubmit, which would currently always fail.

<img width="519" alt="screen shot 2016-01-21 at 5 07 49 pm" src="https://cloud.githubusercontent.com/assets/1138350/12496110/a51f7d96-c061-11e5-9de7-831f89aaf86c.png">

<img width="562" alt="screen shot 2016-01-21 at 5 08 21 pm" src="https://cloud.githubusercontent.com/assets/1138350/12496117/aa8f7042-c061-11e5-8395-bd9302bed0e7.png">

<img width="467" alt="screen shot 2016-01-21 at 5 26 02 pm" src="https://cloud.githubusercontent.com/assets/1138350/12496497/21b3d4b8-c064-11e5-981b-7a2c9fb2321f.png">