### PR TITLE
1581 new course membership

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 require_relative "../services/cancels_course_membership"
-require_relative "../services/creates_new_user"
+require_relative "../services/creates_or_updates_user"
 
 class UsersController < ApplicationController
   include UsersHelper
@@ -39,7 +39,8 @@ class UsersController < ApplicationController
   end
 
   def create
-    result = Services::CreatesNewUser.create params[:user], params[:send_welcome] == "1"
+    result = Services::CreatesOrUpdatesUser.create_or_update params[:user], current_course,
+      params[:send_welcome] == "1"
     @user = result[:user]
 
     if result.success?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,10 @@ class User < ActiveRecord::Base
     where("LOWER(username) = :username", username: username.downcase).first
   end
 
+  def self.email_exists?(email)
+    !!find_by_insensitive_email(email)
+  end
+
   def activated?
     activation_state == "active"
   end

--- a/app/services/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user.rb
@@ -1,5 +1,5 @@
 require "light-service"
-require_relative "creates_or_updates_user/create_or_update_user"
+require_relative "creates_or_updates_user/creates_or_updates_user"
 
 module Services
   class CreatesOrUpdatesUser
@@ -8,7 +8,7 @@ module Services
     def self.create_or_update(attributes, course, send_welcome_email=false)
       with(attributes: attributes, course: course, send_welcome_email: send_welcome_email)
         .reduce(
-        Actions::CreateOrUpdateUser
+        Actions::CreatesOrUpdatesUser
       )
     end
   end

--- a/app/services/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user.rb
@@ -1,0 +1,15 @@
+require "light-service"
+require_relative "creates_or_updates_user/create_or_update_user"
+
+module Services
+  class CreatesOrUpdatesUser
+    extend LightService::Organizer
+
+    def self.create_or_update(attributes, course, send_welcome_email=false)
+      with(attributes: attributes, course: course, send_welcome_email: send_welcome_email)
+        .reduce(
+        Actions::CreateOrUpdateUser
+      )
+    end
+  end
+end

--- a/app/services/creates_or_updates_user/create_or_update_user.rb
+++ b/app/services/creates_or_updates_user/create_or_update_user.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class CreateOrUpdateUser
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -1,4 +1,5 @@
 require_relative "../creates_new_user"
+require_relative "../updates_user"
 
 module Services
   module Actions
@@ -9,9 +10,20 @@ module Services
 
       executed do |context|
         attributes = context[:attributes]
-        course = attributes[:course]
+        email = attributes[:email]
 
-        Services::CreatesNewUser.create attributes
+        if email.blank?
+          context.fail! "Email can't be blank", 422
+          next context
+        end
+
+        if User.email_exists? email
+          course = attributes[:course]
+          context.add_to_context Services::UpdatesUser.update(attributes, course)
+        else
+          send_welcome_email = attributes[:send_welcome_email]
+          context.add_to_context Services::CreatesNewUser.create(attributes, send_welcome_email)
+        end
       end
     end
   end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -1,7 +1,9 @@
 module Services
   module Actions
-    class CreateOrUpdateUser
+    class CreatesOrUpdatesUser
       extend LightService::Action
+
+      expects :attributes, :course
 
       executed do |context|
       end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -1,11 +1,17 @@
+require_relative "../creates_new_user"
+
 module Services
   module Actions
     class CreatesOrUpdatesUser
       extend LightService::Action
 
-      expects :attributes, :course
+      expects :attributes, :course, :send_welcome_email
 
       executed do |context|
+        attributes = context[:attributes]
+        course = attributes[:course]
+
+        Services::CreatesNewUser.create attributes
       end
     end
   end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -18,7 +18,7 @@ module Services
         end
 
         if User.email_exists? email
-          course = attributes[:course]
+          course = context[:course]
           context.add_to_context Services::UpdatesUser.update(attributes, course)
         else
           send_welcome_email = attributes[:send_welcome_email]

--- a/app/services/updates_user.rb
+++ b/app/services/updates_user.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "updates_user/creates_course_membership"
 require_relative "updates_user/updates_user"
 
 module Services
@@ -8,7 +9,8 @@ module Services
     def self.update(attributes, course)
       with(attributes: attributes, course: course)
         .reduce(
-        Actions::UpdatesUser
+        Actions::UpdatesUser,
+        Actions::CreatesCourseMembership
       )
     end
   end

--- a/app/services/updates_user.rb
+++ b/app/services/updates_user.rb
@@ -1,0 +1,15 @@
+require "light-service"
+require_relative "updates_user/updates_user"
+
+module Services
+  class UpdatesUser
+    extend LightService::Organizer
+
+    def self.update(attributes, course)
+      with(attributes: attributes, course: course)
+        .reduce(
+        Actions::UpdatesUser
+      )
+    end
+  end
+end

--- a/app/services/updates_user/creates_course_membership.rb
+++ b/app/services/updates_user/creates_course_membership.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class CreatesCourseMembership
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/updates_user/creates_course_membership.rb
+++ b/app/services/updates_user/creates_course_membership.rb
@@ -3,7 +3,15 @@ module Services
     class CreatesCourseMembership
       extend LightService::Action
 
+      expects :course, :user
+
       executed do |context|
+        course = context[:course]
+        user = context[:user]
+
+        unless user.course_memberships.map(&:course_id).include? course.id
+          user.course_memberships.create(course_id: course.id, role: :student)
+        end
       end
     end
   end

--- a/app/services/updates_user/updates_user.rb
+++ b/app/services/updates_user/updates_user.rb
@@ -7,13 +7,10 @@ module Services
 
       executed do |context|
         attributes = context[:attributes]
-        id = attributes[:id]
+        email = attributes[:email]
 
-        begin
-          user = User.find id
-        rescue ActiveRecord::RecordNotFound => e
-          context.fail_with_rollback!(e.message, error_code: 404)
-        end
+        user = User.find_by_insensitive_email email
+        context.fail_with_rollback!("User could not be found", error_code: 404) if user.nil?
 
         context.fail_with_rollback!("The user is invalid and cannot be saved", error_code: 422) \
           unless user.update_attributes attributes

--- a/app/services/updates_user/updates_user.rb
+++ b/app/services/updates_user/updates_user.rb
@@ -3,7 +3,21 @@ module Services
     class UpdatesUser
       extend LightService::Action
 
-      executed do |execute|
+      expects :attributes
+
+      executed do |context|
+        attributes = context[:attributes]
+        id = attributes[:id]
+
+        begin
+          user = User.find id
+        rescue ActiveRecord::RecordNotFound => e
+          context.fail_with_rollback!(e.message, error_code: 404)
+        end
+
+        context.fail_with_rollback!("The user is invalid and cannot be saved", error_code: 422) \
+          unless user.update_attributes attributes
+        context[:user] = user
       end
     end
   end

--- a/app/services/updates_user/updates_user.rb
+++ b/app/services/updates_user/updates_user.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class UpdatesUser
+      extend LightService::Action
+
+      executed do |execute|
+      end
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -71,6 +71,15 @@ describe UsersController do
         end
       end
 
+      it "updates an existing user" do
+        existing_user = create :user, email: "jimmy@example.com"
+        post :create, user: { first_name: "Jimmy",
+                              last_name: "Page",
+                              username: "jimmy",
+                              email: "jimmy@example.com" }
+        expect(user.first_name).to_not eq existing_user.first_name
+      end
+
       it "sends an activation email for the user" do
         expect {
           post :create, user: { first_name: "Jimmy",

--- a/spec/features/creating_a_new_user_spec.rb
+++ b/spec/features/creating_a_new_user_spec.rb
@@ -10,6 +10,24 @@ feature "creating a new user" do
       visit new_user_path
     end
 
+    context "for an existing GradeCraft student" do
+      scenario "successfully" do
+        user = create(:user)
+        within(".pageContent #tab1") do
+          NewUserPage.new(user)
+            .submit(courses: [course_membership.course])
+        end
+
+        expect(current_path).to eq students_path
+        expect(page).to have_notification_message "notice", "#{course_membership.course.user_term} #{user.name} was successfully created!"
+
+        result = user.reload
+        expect(result.course_memberships.count).to eq 1
+        expect(result.course_memberships.first.course).to eq course_membership.course
+        expect(result.course_memberships.first.role).to eq "student"
+      end
+    end
+
     context "for a UM student" do
       scenario "successfully" do
         username = Faker::Internet.user_name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,6 +44,16 @@ describe User do
     end
   end
 
+  describe ".email_exists?" do
+    it "should return true if the email already exists" do
+      expect(User.email_exists?(world.student.email.upcase)).to eq true
+    end
+
+    it "should return false if the email does not exist" do
+      expect(User.email_exists?("blah@somewhere-cool.biz")).to eq false
+    end
+  end
+
   describe ".students_auditing" do
     let(:student_being_audited) { create(:user) }
     before do

--- a/spec/services/creates_or_updates_user/creates_or_updates_user_spec.rb
+++ b/spec/services/creates_or_updates_user/creates_or_updates_user_spec.rb
@@ -7,13 +7,32 @@ describe Services::Actions::CreatesOrUpdatesUser do
   let(:user) { build :user }
   let(:attributes) { user.attributes }
 
+  before do
+    user_mailer = double(:user_mailer, activation_needed_email: double(:mailer, deliver_now: nil))
+    stub_const "UserMailer", user_mailer
+  end
+
   it "expects attributes to assign to the user" do
-    expect { described_class.execute course: course }.to \
+    expect { described_class.execute course: course, send_welcome_email: false }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
   it "expects course to assign to the user" do
-    expect { described_class.execute attributes: attributes }.to \
+    expect { described_class.execute attributes: attributes, send_welcome_email: false }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
+
+  it "expects the option to send the welcome email" do
+    expect { described_class.execute attributes: attributes, course: course }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "creates the user if they do not exist" do
+    expect(Services::CreatesNewUser).to receive(:create).and_call_original
+    described_class.execute attributes: attributes, course: course, send_welcome_email: false
+  end
+
+  xit "updates the user if they do not exist"
+  xit "fails if the attributes do not have an email address to check"
+  xit "promises the created or updated user"
 end

--- a/spec/services/creates_or_updates_user/creates_or_updates_user_spec.rb
+++ b/spec/services/creates_or_updates_user/creates_or_updates_user_spec.rb
@@ -1,0 +1,19 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_or_updates_user/creates_or_updates_user"
+
+describe Services::Actions::CreatesOrUpdatesUser do
+  let(:course) { create :course }
+  let(:user) { build :user }
+  let(:attributes) { user.attributes }
+
+  it "expects attributes to assign to the user" do
+    expect { described_class.execute course: course }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects course to assign to the user" do
+    expect { described_class.execute attributes: attributes }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+end

--- a/spec/services/creates_or_updates_user_spec.rb
+++ b/spec/services/creates_or_updates_user_spec.rb
@@ -1,0 +1,15 @@
+require "active_record_spec_helper"
+require "./app/services/creates_or_updates_user"
+
+describe Services::CreatesOrUpdatesUser do
+  let(:course) { create :course }
+  let(:user) { build :user }
+  let(:params) { user.attributes }
+
+  describe ".create_or_update" do
+    it "decides if a user gets created or updated" do
+      expect(Services::Actions::CreateOrUpdateUser).to receive(:execute).and_call_original
+      described_class.create_or_update params, course
+    end
+  end
+end

--- a/spec/services/creates_or_updates_user_spec.rb
+++ b/spec/services/creates_or_updates_user_spec.rb
@@ -11,5 +11,19 @@ describe Services::CreatesOrUpdatesUser do
       expect(Services::Actions::CreatesOrUpdatesUser).to receive(:execute).and_call_original
       described_class.create_or_update params, course
     end
+
+    it "fails the context if create user service fails" do
+      allow(Services::Actions::SavesUser).to receive(:execute).and_raise \
+        LightService::FailWithRollbackError
+      result = described_class.create_or_update params, course
+      expect(result).to be_failure
+    end
+
+    it "fails the context if update user service fails" do
+      allow(Services::Actions::UpdatesUser).to receive(:execute).and_raise \
+        LightService::FailWithRollbackError
+      result = described_class.create_or_update params, course
+      expect(result).to be_failure
+    end
   end
 end

--- a/spec/services/creates_or_updates_user_spec.rb
+++ b/spec/services/creates_or_updates_user_spec.rb
@@ -8,7 +8,7 @@ describe Services::CreatesOrUpdatesUser do
 
   describe ".create_or_update" do
     it "decides if a user gets created or updated" do
-      expect(Services::Actions::CreateOrUpdateUser).to receive(:execute).and_call_original
+      expect(Services::Actions::CreatesOrUpdatesUser).to receive(:execute).and_call_original
       described_class.create_or_update params, course
     end
   end

--- a/spec/services/updates_user/creates_course_membership_spec.rb
+++ b/spec/services/updates_user/creates_course_membership_spec.rb
@@ -1,0 +1,32 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/updates_user/creates_course_membership"
+
+describe Services::Actions::CreatesCourseMembership do
+  let(:course) { create :course }
+  let(:user) { create :user }
+
+  it "expects a user to create the course membership for" do
+    expect { described_class.execute course: course }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects a course to create the course membership for" do
+    expect { described_class.execute user: user }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "creates the course membership between the course and the user" do
+    described_class.execute course: course, user: user
+    result = CourseMembership.where(course: course, user: user).first
+    expect(result).to_not be_nil
+    expect(result.role).to eq "student"
+  end
+
+  it "does not create the course membership if it already exists" do
+    CourseMembership.create user: user, course: course, role: :professor
+
+    described_class.execute course: course, user: user
+    expect(CourseMembership.where(course: course, user: user).count).to eq 1
+  end
+end

--- a/spec/services/updates_user/updates_user_spec.rb
+++ b/spec/services/updates_user/updates_user_spec.rb
@@ -1,0 +1,31 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/updates_user/updates_user"
+
+describe Services::Actions::UpdatesUser do
+  let(:user) { create :user }
+  let(:attributes) { user.attributes.symbolize_keys }
+
+  it "expects attributes to assign to the user" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "updates the user with the new attributes" do
+    attributes.merge!(first_name: "Gary")
+    result = described_class.execute attributes: attributes
+    expect(result[:user].first_name).to eq "Gary"
+  end
+
+  it "halts if the user cannot be found" do
+    attributes.merge!(id: 0)
+    expect { described_class.execute attributes: attributes }.to \
+      raise_error LightService::FailWithRollbackError
+  end
+
+  it "halts if the user is invalid" do
+    attributes.merge!(first_name: nil)
+    expect { described_class.execute attributes: attributes }.to \
+      raise_error LightService::FailWithRollbackError
+  end
+end

--- a/spec/services/updates_user/updates_user_spec.rb
+++ b/spec/services/updates_user/updates_user_spec.rb
@@ -18,7 +18,7 @@ describe Services::Actions::UpdatesUser do
   end
 
   it "halts if the user cannot be found" do
-    attributes.merge!(id: 0)
+    attributes.merge!(email: "blah@somewhere.com")
     expect { described_class.execute attributes: attributes }.to \
       raise_error LightService::FailWithRollbackError
   end

--- a/spec/services/updates_user_spec.rb
+++ b/spec/services/updates_user_spec.rb
@@ -11,5 +11,10 @@ describe Services::UpdatesUser do
       expect(Services::Actions::UpdatesUser).to receive(:execute).and_call_original
       described_class.update params, course
     end
+
+    it "creates the course membership with the user and course" do
+      expect(Services::Actions::CreatesCourseMembership).to receive(:execute).and_call_original
+      described_class.update params, course
+    end
   end
 end

--- a/spec/services/updates_user_spec.rb
+++ b/spec/services/updates_user_spec.rb
@@ -1,0 +1,15 @@
+require "active_record_spec_helper"
+require "./app/services/updates_user"
+
+describe Services::UpdatesUser do
+  let(:course) { create :course }
+  let(:user) { create :user }
+  let(:params) { user.attributes }
+
+  describe ".update" do
+    it "updates the existing user" do
+      expect(Services::Actions::UpdatesUser).to receive(:execute).and_call_original
+      described_class.update params, course
+    end
+  end
+end

--- a/spec/services/updates_user_spec.rb
+++ b/spec/services/updates_user_spec.rb
@@ -4,7 +4,7 @@ require "./app/services/updates_user"
 describe Services::UpdatesUser do
   let(:course) { create :course }
   let(:user) { create :user }
-  let(:params) { user.attributes }
+  let(:params) { user.attributes.symbolize_keys }
 
   describe ".update" do
     it "updates the existing user" do


### PR DESCRIPTION
Updates the user information and adds them to the current course when a professor tries to create a new user with an email that already exists.

In order to do this, a new service was created to "create or update a user". This service just checks to see if the user already exists and then calls the appropriate service to create or update a user.

The `CreatesNewUser` service stays untouched and a new `UpdatesUser` service updates the user attributes and then creates a `CourseMembership` for the new user and the current course.

Closes #1581 