### PR TITLE
1504 add item count to instructor nav bar

### DIFF
--- a/app/assets/stylesheets/_staff_sidebar.sass
+++ b/app/assets/stylesheets/_staff_sidebar.sass
@@ -70,6 +70,19 @@
       color: $color-white
       font-weight: normal
 
+    span.sidebar-nav
+      display: block
+      padding: 2.4px
+
+    .staff-notification-badge
+      background-color: $color-orange-1
+      color: $color-white
+      padding: .15rem .5rem
+      position: relative
+      top: -27px
+      margin: 0
+      left: 0px
+
   /* Spacing the list divider */
   hr
     margin: .75rem auto

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -40,9 +40,6 @@ class InfoController < ApplicationController
     @ungraded_submissions_by_assignment = @ungraded_submissions.group_by(&:assignment)
     @unreleased_grades_by_assignment = unrealeased_grades.group_by(&:assignment)
     @in_progress_grades_by_assignment = in_progress_grades.group_by(&:assignment)
-    @count_unreleased = unrealeased_grades.not_released.count
-    @count_ungraded = @ungraded_submissions.count
-    @count_in_progress = in_progress_grades.count
   end
 
   # Displaying all resubmisisons
@@ -61,7 +58,6 @@ class InfoController < ApplicationController
   def ungraded_submissions
     @title = "Ungraded #{term_for :assignment} Submissions"
     @ungraded_submissions = current_course.submissions.ungraded.order_by_submitted.includes(:assignment, :student, :submission_files)
-    @count_ungraded = @ungraded_submissions.count
   end
 
   # Displaying the top 10 and bottom 10 students for quick overview

--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -14,6 +14,7 @@ module GradesHelper
   end
 
   def in_progress_grades_count_cache_key(course)
+    # This cache key is busted when a grade is updated as a Grade touches a Course
     "#{course.cache_key}/in_progress_grades_count"
   end
 
@@ -24,6 +25,7 @@ module GradesHelper
   end
 
   def unreleased_grades_count_cache_key(course)
+    # This cache key is busted when a grade is updated as a Grade touches a Course
     "#{course.cache_key}/unreleased_grades_count"
   end
 end

--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -1,0 +1,29 @@
+module GradesHelper
+  extend SubmissionsHelper
+
+  def grading_status_count_for(course)
+    unreleased_grades_count_for(course) +
+      in_progress_grades_count_for(course) +
+      ungraded_submissions_count_for(course)
+  end
+
+  def in_progress_grades_count_for(course)
+    Rails.cache.fetch(in_progress_grades_count_cache_key(course)) do
+      course.grades.in_progress.count
+    end
+  end
+
+  def in_progress_grades_count_cache_key(course)
+    "#{course.cache_key}/in_progress_grades_count"
+  end
+
+  def unreleased_grades_count_for(course)
+    Rails.cache.fetch(unreleased_grades_count_cache_key(course)) do
+      course.grades.not_released.count
+    end
+  end
+
+  def unreleased_grades_count_cache_key(course)
+    "#{course.cache_key}/unreleased_grades_count"
+  end
+end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,0 +1,21 @@
+module SubmissionsHelper
+  def resubmission_count_for(course)
+    Rails.cache.fetch(resubmission_count_cache_key(course)) do
+      course.submissions.resubmitted.count
+    end
+  end
+
+  def resubmission_count_cache_key(course)
+    "#{course.cache_key}/resubmission_count"
+  end
+
+  def ungraded_submissions_count_for(course)
+    Rails.cache.fetch(ungraded_submissions_count_cache_key(course)) do
+      course.submissions.ungraded.count
+    end
+  end
+
+  def ungraded_submissions_count_cache_key(course)
+    "#{course.cache_key}/ungraded_submissions_count"
+  end
+end

--- a/app/views/info/_in_progress_grades_table.haml
+++ b/app/views/info/_in_progress_grades_table.haml
@@ -1,6 +1,6 @@
 %h4.subtitle#inProgressTableCaption
   = "In Progress Grades"
-  %span.label.alert= @count_in_progress
+  %span.label.alert= in_progress_grades_count_for(course)
 
 - @in_progress_grades_by_assignment.each do |assignment, grades|
   .assignment-in-progress

--- a/app/views/info/_ungraded_submissions_table.haml
+++ b/app/views/info/_ungraded_submissions_table.haml
@@ -1,6 +1,6 @@
 %h4.subtitle#ungradedTableCaption
   = "Ungraded #{term_for :assignment} Submissions"
-  %span.label.alert= @count_ungraded
+  %span.label.alert= ungraded_submissions_count_for(course)
 
 - @ungraded_submissions_by_assignment.each do |assignment, submissions|
   %h4.assignment_name

--- a/app/views/info/_unreleased_grades_table.haml
+++ b/app/views/info/_unreleased_grades_table.haml
@@ -1,6 +1,6 @@
 %h4.subtitle#unreleasedTableCaption
   = "Unreleased Grades"
-  %span.label.alert= @count_unreleased
+  %span.label.alert= unreleased_grades_count_for(course)
 
 - @unreleased_grades_by_assignment.each do |assignment, grades|
   .assignment-unreleased

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -5,7 +5,7 @@
 .pageContent
   = render 'layouts/alerts'
 
-  %span.label.alert= "You have #{@count_ungraded} ungraded #{term_for :assignments}"
+  %span.label.alert= "You have #{ungraded_submissions_count_for(current_course)} ungraded #{term_for :assignments}"
 
   %br
 

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -18,11 +18,18 @@
 %li
   = link_to_unless_current raw('<i class="fa fa-list-ol fa-fw"></i> Leaderboard'), leaderboard_path
 %li
-  = link_to_unless_current raw('<i class="fa fa-flag-checkered fa-fw"></i> Grading Status'), grading_status_path
+  = link_to_unless_current raw('<i class="fa fa-flag-checkered fa-fw"></i> Grading Status'), grading_status_path do |name|
+    = raw("<span class='sidebar-nav'>#{name}</span>")
+  %div.notification-badge.staff-notification-badge 123
 %li
-  = link_to_unless_current raw('<i class="fa fa-history fa-fw"></i> Resubmissions'), resubmissions_path
+  = link_to_unless_current raw('<i class="fa fa-history fa-fw"></i> Resubmissions'), resubmissions_path do |name|
+    = raw("<span class='sidebar-nav'>#{name}</span>")
+
+  %div.notification-badge.staff-notification-badge 12
 %li
-  = link_to_unless_current raw('<i class="fa fa-exclamation-triangle fa-fw"></i> Ungraded Submissions'), ungraded_submissions_path
+  = link_to_unless_current raw('<i class="fa fa-exclamation-triangle fa-fw"></i> Ungraded Submissions'), ungraded_submissions_path do |name|
+    = raw("<span class='sidebar-nav'>#{name}</span>")
+  %div.notification-badge.staff-notification-badge 6
 
 - if current_course.student_weighted?
   %li= link_to_unless_current raw("<i class='fa fa-cubes fa-fw'></i> #{term_for :weight} Choices"), multiplier_choices_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -18,18 +18,24 @@
 %li
   = link_to_unless_current raw('<i class="fa fa-list-ol fa-fw"></i> Leaderboard'), leaderboard_path
 %li
+  - grading_status_count = grading_status_count_for(current_course)
   = link_to_unless_current raw('<i class="fa fa-flag-checkered fa-fw"></i> Grading Status'), grading_status_path do |name|
     = raw("<span class='sidebar-nav'>#{name}</span>")
-  %div.notification-badge.staff-notification-badge 123
+  - if grading_status_count > 0
+    %div.notification-badge.staff-notification-badge= grading_status_count
 %li
+  - resubmission_count = resubmission_count_for(current_course)
   = link_to_unless_current raw('<i class="fa fa-history fa-fw"></i> Resubmissions'), resubmissions_path do |name|
     = raw("<span class='sidebar-nav'>#{name}</span>")
 
-  %div.notification-badge.staff-notification-badge 12
+  - if resubmission_count > 0
+    %div.notification-badge.staff-notification-badge= resubmission_count
 %li
+  - ungraded_submissions_count = ungraded_submissions_count_for(current_course)
   = link_to_unless_current raw('<i class="fa fa-exclamation-triangle fa-fw"></i> Ungraded Submissions'), ungraded_submissions_path do |name|
     = raw("<span class='sidebar-nav'>#{name}</span>")
-  %div.notification-badge.staff-notification-badge 6
+  - if ungraded_submissions_count > 0
+    %div.notification-badge.staff-notification-badge= ungraded_submissions_count
 
 - if current_course.student_weighted?
   %li= link_to_unless_current raw("<i class='fa fa-cubes fa-fw'></i> #{term_for :weight} Choices"), multiplier_choices_path

--- a/spec/helpers/grades_helper_spec.rb
+++ b/spec/helpers/grades_helper_spec.rb
@@ -1,0 +1,54 @@
+require "rails_spec_helper"
+require "./app/helpers/grades_helper"
+
+describe GradesHelper do
+  let(:course) { create :course }
+
+  describe "#in_progress_grades_count_for" do
+    let!(:grade) { create :grade, status: "In Progress", course: course }
+
+    it "returns the number of grades that are in progress" do
+      expect(in_progress_grades_count_for(course)).to eq 1
+    end
+
+    it "caches the result" do
+      expect(course).to receive(:grades).and_call_original.at_most(:twice)
+      in_progress_grades_count_for(course)
+      in_progress_grades_count_for(course)
+      Rails.cache.delete in_progress_grades_count_cache_key(course)
+      in_progress_grades_count_for(course)
+    end
+  end
+
+  describe "#unreleased_grades_count_for" do
+    let(:assignment) { create :assignment, course: course, release_necessary: true }
+    let!(:grade) { create :grade, status: "Graded", assignment: assignment, course: course }
+
+    it "returns the number of grades that are unreleased" do
+      expect(unreleased_grades_count_for(course)).to eq 1
+    end
+
+    it "caches the result" do
+      expect(course).to receive(:grades).and_call_original.at_most(:twice)
+      unreleased_grades_count_for(course)
+      unreleased_grades_count_for(course)
+      Rails.cache.delete unreleased_grades_count_cache_key(course)
+      unreleased_grades_count_for(course)
+    end
+  end
+
+  describe "#grading_status_count_for" do
+    class Helper
+      include GradesHelper
+    end
+
+    let(:helper) { Helper.new }
+
+    it "returns the sum of unreleased grades, in progress grades, and ungraded submissions" do
+      allow(helper).to receive(:ungraded_submissions_count_for).with(course).and_return 10
+      allow(helper).to receive(:unreleased_grades_count_for).with(course).and_return 20
+      allow(helper).to receive(:in_progress_grades_count_for).with(course).and_return 30
+      expect(helper.grading_status_count_for(course)).to eq 60
+    end
+  end
+end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,0 +1,40 @@
+require "rails_spec_helper"
+require "./app/helpers/submissions_helper"
+
+describe SubmissionsHelper do
+  let(:course) { create :course }
+
+  describe "#resubmission_count_for" do
+    let!(:grade) { create :grade, course: course, status: "Released", submission: submission,
+                   graded_at: 1.day.ago }
+    let(:submission) { create :submission, course: course, submitted_at: DateTime.now }
+
+    it "returns the number of resubmitted submissions" do
+      expect(resubmission_count_for(course)).to eq 1
+    end
+
+    it "caches the result" do
+      expect(course).to receive(:submissions).and_call_original.at_most(:twice)
+      resubmission_count_for(course)
+      resubmission_count_for(course)
+      Rails.cache.delete resubmission_count_cache_key(course)
+      resubmission_count_for(course)
+    end
+  end
+
+  describe "#ungraded_submissions_count_for" do
+    let!(:submission) { create :submission, course: course }
+
+    it "returns the number of ungraded submissions" do
+      expect(ungraded_submissions_count_for(course)).to eq 1
+    end
+
+    it "caches the result" do
+      expect(course).to receive(:submissions).and_call_original.at_most(:twice)
+      ungraded_submissions_count_for(course)
+      ungraded_submissions_count_for(course)
+      Rails.cache.delete ungraded_submissions_count_cache_key(course)
+      ungraded_submissions_count_for(course)
+    end
+  end
+end


### PR DESCRIPTION
Adds 3 "unread" indicators for the staff sidebar which indicate the number of resubmissions that need to be graded, the number of resubmissions, and a grading status number which is a sum of unreleased grades, ungraded submissions, and in progress grades.
  
![469c49d8-c4f4-11e5-9a8e-dbd75fc0e63c](https://cloud.githubusercontent.com/assets/35017/12651479/b9074f52-c5b4-11e5-8a74-81df4e240201.png)

This uses helpers to achieve these counts. The counts are cached using Rails caching since they are on the sidebar and we do not want to hit the database everytime we perform a request with a staff member. The caching was tested manually to make sure the numbers update when a grade updates. This works because a grade update touches the `Course` which is what the cache key is updated with.

These counts also replaced the instance variables on the respective controller/views.

Closes #1504 