### PR TITLE
1597 dont strip links

### DIFF
--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -23,10 +23,17 @@ $( "#tabs" ).tabs({
   }
 });
 
- $('.froala').editable(
-    {inlineMode: false,
-      minHeight: 280
-    })
+ $('.froala').editable({
+  inlineMode: false,
+  minHeight: 280,
+  buttons: [
+    'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough', 'subscript',
+    'superscript', 'fontFamily', 'fontSize', 'sep', 'inlineStyle', 'blockStyle',
+    'sep', 'formatBlock', 'align', 'insertOrderedList', 'insertUnorderedList',
+    'outdent', 'indent', 'insertHorizontalRule', 'createLink', 'undo', 'redo',
+    'removeFormat', 'selectAll'
+  ]
+})
 
 // handle 'select all' buttons, used on release grade forms
 $(".select-all").click(function(e){

--- a/app/models/concerns/sanitizable.rb
+++ b/app/models/concerns/sanitizable.rb
@@ -1,0 +1,20 @@
+require "sanitize"
+
+module Sanitizable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def clean_html(attributes=[])
+      attributes = [attributes].flatten
+      attributes.each do |attribute|
+        clean_html_before_save attribute
+      end
+    end
+
+    def clean_html_before_save(attribute)
+      before_save do
+        self.send("#{attribute}=", Sanitize.clean(self.send(attribute), Sanitize::Config::BASIC))
+      end
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,5 @@
 class Group < ActiveRecord::Base
+  include Sanitizable
 
   APPROVED_STATUSES = ['Pending', 'Approved', 'Rejected']
 
@@ -26,7 +27,6 @@ class Group < ActiveRecord::Base
 
   has_many :earned_badges, :as => :group
 
-  before_save :clean_html
   before_validation :cache_associations
 
   validates_presence_of :name, :approved
@@ -36,6 +36,8 @@ class Group < ActiveRecord::Base
   scope :approved, -> { where approved: "Approved" }
   scope :rejected, -> { where approved: "Rejected" }
   scope :pending, -> { where approved: "Pending" }
+
+  clean_html :text_proposal
 
   #Instructors need to approve a group before the group is allowed to proceed
   def approved?
@@ -56,10 +58,6 @@ class Group < ActiveRecord::Base
   end
 
   private
-
-  def clean_html
-    self.text_proposal = Sanitize.clean(text_proposal, Sanitize::Config::BASIC)
-  end
 
   #Checking to make sure any constraints the instructor has set up around min/max group members are honored
   def min_group_number_met

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -7,6 +7,7 @@ class Submission < ActiveRecord::Base
   include Canable::Ables
   include Historical
   include MultipleFileAttributes
+  include Sanitizable
 
   belongs_to :task, touch: true
   belongs_to :assignment, touch: true
@@ -15,7 +16,7 @@ class Submission < ActiveRecord::Base
   belongs_to :group, touch: true
   belongs_to :course, touch: true
 
-  before_save :clean_html, :submit_something
+  before_save :submit_something
   after_save :check_unlockables
 
   has_one :grade
@@ -39,6 +40,7 @@ class Submission < ActiveRecord::Base
   validates :link, :format => URI::regexp(%w(http https)) , :allow_blank => true
   validates :assignment, presence: true
 
+  clean_html :text_comment
   multiple_files :submission_files
 
   #Canable permissions#
@@ -134,10 +136,6 @@ class Submission < ActiveRecord::Base
     elsif assignment.has_groups?
       group_id == user.group_for_assignment(assignment).id
     end
-  end
-
-  def clean_html
-    self.text_comment = Sanitize.clean(text_comment, Sanitize::Config::BASIC)
   end
 
   def submit_something

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -16,7 +16,6 @@ class Submission < ActiveRecord::Base
   belongs_to :group, touch: true
   belongs_to :course, touch: true
 
-  before_save :submit_something
   after_save :check_unlockables
 
   has_one :grade
@@ -39,6 +38,7 @@ class Submission < ActiveRecord::Base
   validates_uniqueness_of :task, :scope => :student, :allow_nil => true
   validates :link, :format => URI::regexp(%w(http https)) , :allow_blank => true
   validates :assignment, presence: true
+  validates_with SubmissionValidator
 
   clean_html :text_comment
   multiple_files :submission_files
@@ -136,10 +136,6 @@ class Submission < ActiveRecord::Base
     elsif assignment.has_groups?
       group_id == user.group_for_assignment(assignment).id
     end
-  end
-
-  def submit_something
-    link.present? || text_comment.present? || submission_files.present?
   end
 
   def cache_associations

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -137,7 +137,7 @@ class Submission < ActiveRecord::Base
   end
 
   def clean_html
-    self.text_comment = Sanitize.clean(text_comment, Sanitize::Config::RESTRICTED)
+    self.text_comment = Sanitize.clean(text_comment, Sanitize::Config::BASIC)
   end
 
   def submit_something

--- a/app/validators/submission_validator.rb
+++ b/app/validators/submission_validator.rb
@@ -1,0 +1,8 @@
+class SubmissionValidator < ActiveModel::Validator
+  def validate(record)
+    if record.link.blank? && record.text_comment.blank? &&
+        record.submission_files.empty?
+      record.errors[:base] << "Submission cannot be empty"
+    end
+  end
+end

--- a/lib/s3_file.rb
+++ b/lib/s3_file.rb
@@ -1,3 +1,5 @@
+require_relative "s3_manager"
+
 module S3File
 
   # Legacy submission files were handled by S3 direct upload and we stored their
@@ -11,7 +13,7 @@ module S3File
 
   def url
     if Rails.env.development?
-      file.url 
+      file.url
     else
       if s3_object
         s3_object.presigned_url(:get, expires_in: 900).to_s

--- a/lib/s3_manager.rb
+++ b/lib/s3_manager.rb
@@ -1,0 +1,6 @@
+require_relative "s3_manager/basics"
+require_relative "s3_manager/common"
+require_relative "s3_manager/encryption"
+require_relative "s3_manager/kms"
+require_relative "s3_manager/object_summary"
+require_relative "s3_manager/manager"

--- a/lib/s3_manager/manager.rb
+++ b/lib/s3_manager/manager.rb
@@ -1,8 +1,3 @@
-require_relative 'basics'
-require_relative 'encryption'
-require_relative 'kms'
-require_relative 'object_summary'
-
 module S3Manager
   class Manager
     include S3Manager::Basics

--- a/lib/s3_manager/s3_manager.rb
+++ b/lib/s3_manager/s3_manager.rb
@@ -1,2 +1,0 @@
-module S3Manager
-end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,5 +1,6 @@
 require "active_record_spec_helper"
 require "toolkits/sanitization_toolkit"
+require "toolkits/models/assignments_toolkit"
 
 describe Assignment do
   include Toolkits::Models::AssignmentsToolkit

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,5 +1,5 @@
 require "active_record_spec_helper"
-require "toolkits/sanitation_toolkit"
+require "toolkits/sanitization_toolkit"
 
 describe Assignment do
   include Toolkits::Models::AssignmentsToolkit
@@ -7,7 +7,7 @@ describe Assignment do
   subject { build(:assignment) }
   let(:assignment) { build :assignment }
 
-  it_behaves_like "a model that needs sanitation", :description
+  it_behaves_like "a model that needs sanitization", :description
 
   context "validations" do
     it "is valid with a name and assignment type" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1,10 +1,13 @@
-require "rails_spec_helper"
+require "active_record_spec_helper"
+require "toolkits/sanitation_toolkit"
 
 describe Assignment do
   include Toolkits::Models::AssignmentsToolkit
 
   subject { build(:assignment) }
   let(:assignment) { build :assignment }
+
+  it_behaves_like "a model that needs sanitation", :description
 
   context "validations" do
     it "is valid with a name and assignment type" do
@@ -794,7 +797,7 @@ describe Assignment do
       expect(subject).to be_open
     end
   end
- 
+
   describe "#to_json" do
     it "returns a json representation" do
       json = subject.to_json

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -1,5 +1,6 @@
 require "active_record_spec_helper"
 require "toolkits/historical_toolkit"
+require "toolkits/sanitation_toolkit"
 
 describe Grade do
   subject { build(:grade) }
@@ -42,6 +43,7 @@ describe Grade do
   end
 
   it_behaves_like "a historical model", :grade, raw_score: 1234
+  it_behaves_like "a model that needs sanitation", :feedback
 
   describe "versioning", versioning: true do
     it "ignores changes to predicted_score" do

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -1,6 +1,6 @@
 require "active_record_spec_helper"
 require "toolkits/historical_toolkit"
-require "toolkits/sanitation_toolkit"
+require "toolkits/sanitization_toolkit"
 
 describe Grade do
   subject { build(:grade) }
@@ -43,7 +43,7 @@ describe Grade do
   end
 
   it_behaves_like "a historical model", :grade, raw_score: 1234
-  it_behaves_like "a model that needs sanitation", :feedback
+  it_behaves_like "a model that needs sanitization", :feedback
 
   describe "versioning", versioning: true do
     it "ignores changes to predicted_score" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,11 +1,11 @@
 require "active_record_spec_helper"
-require "toolkits/sanitation_toolkit"
+require "toolkits/sanitization_toolkit"
 
 describe Group do
   let!(:course) { create :course, max_group_size: 4 }
   subject { create(:group, course: course ) }
 
-  it_behaves_like "a model that needs sanitation", :text_proposal
+  it_behaves_like "a model that needs sanitization", :text_proposal
 
   describe "validations" do
     it "is valid with a name and an approval state" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,8 +1,11 @@
 require "active_record_spec_helper"
+require "toolkits/sanitation_toolkit"
 
 describe Group do
   let!(:course) { create :course, max_group_size: 4 }
   subject { create(:group, course: course ) }
+
+  it_behaves_like "a model that needs sanitation", :text_proposal
 
   describe "validations" do
     it "is valid with a name and an approval state" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -39,6 +39,29 @@ describe Submission do
     end
   end
 
+  describe "basic html sanitization" do
+    describe "#text_comment" do
+      it "does not allow images before saving" do
+        subject.text_comment = "This is an image <img src='test.jpg' />, ok."
+        subject.save
+        expect(subject.text_comment).to eq "This is an image , ok."
+      end
+
+      it "does not allow tables before saving" do
+        subject.text_comment = "This is a table <table></table>, ok."
+        subject.save
+        expect(subject.text_comment).to eq "This is a table , ok."
+      end
+
+      it "adds a no-follow attribute to links" do
+        subject.text_comment = "This is a link <a href=\"gradecraft.com\">GradeCraft</a>, ok."
+        subject.save
+        expect(subject.text_comment).to \
+          eq "This is a link <a href=\"gradecraft.com\" rel=\"nofollow\">GradeCraft</a>, ok."
+      end
+    end
+  end
+
   it "can't be saved without any information" do
     subject.link = nil
     subject.text_comment = nil

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,5 +1,6 @@
 require "active_record_spec_helper"
 require "toolkits/historical_toolkit"
+require "toolkits/sanitation_toolkit"
 
 describe Submission do
   subject { build(:submission) }
@@ -15,6 +16,7 @@ describe Submission do
   end
 
   it_behaves_like "a historical model", :submission, link: "http://example.org"
+  it_behaves_like "a model that needs sanitation", :text_comment
 
   describe "versioning", versioning: true do
     before { subject.save }
@@ -36,29 +38,6 @@ describe Submission do
       previous_comment = subject.text_comment
       subject.update_attributes text_comment: "This was updated"
       expect(subject).to have_a_version_with text_comment: previous_comment
-    end
-  end
-
-  describe "basic html sanitization" do
-    describe "#text_comment" do
-      it "does not allow images before saving" do
-        subject.text_comment = "This is an image <img src='test.jpg' />, ok."
-        subject.save
-        expect(subject.text_comment).to eq "This is an image , ok."
-      end
-
-      it "does not allow tables before saving" do
-        subject.text_comment = "This is a table <table></table>, ok."
-        subject.save
-        expect(subject.text_comment).to eq "This is a table , ok."
-      end
-
-      it "adds a no-follow attribute to links" do
-        subject.text_comment = "This is a link <a href=\"gradecraft.com\">GradeCraft</a>, ok."
-        subject.save
-        expect(subject.text_comment).to \
-          eq "This is a link <a href=\"gradecraft.com\" rel=\"nofollow\">GradeCraft</a>, ok."
-      end
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,6 +1,6 @@
 require "active_record_spec_helper"
 require "toolkits/historical_toolkit"
-require "toolkits/sanitation_toolkit"
+require "toolkits/sanitization_toolkit"
 
 describe Submission do
   subject { build(:submission) }
@@ -16,7 +16,7 @@ describe Submission do
   end
 
   it_behaves_like "a historical model", :submission, link: "http://example.org"
-  it_behaves_like "a model that needs sanitation", :text_comment
+  it_behaves_like "a model that needs sanitization", :text_comment
 
   describe "versioning", versioning: true do
     before { subject.save }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -13,6 +13,14 @@ describe Submission do
       expect(subject).to_not be_valid
       expect(subject.errors[:link]).to include "is invalid"
     end
+
+    it "requires something to have been submitted" do
+      subject.link = nil
+      subject.text_comment = nil
+      subject.submission_files.clear
+      expect(subject).to_not be_valid
+      expect(subject.errors[:base]).to include "Submission cannot be empty"
+    end
   end
 
   it_behaves_like "a historical model", :submission, link: "http://example.org"
@@ -39,12 +47,6 @@ describe Submission do
       subject.update_attributes text_comment: "This was updated"
       expect(subject).to have_a_version_with text_comment: previous_comment
     end
-  end
-
-  it "can't be saved without any information" do
-    subject.link = nil
-    subject.text_comment = nil
-    expect { subject.save! }.to raise_error(ActiveRecord::RecordNotSaved)
   end
 
   it "can be saved with only a text comment" do

--- a/spec/toolkits/sanitation_toolkit.rb
+++ b/spec/toolkits/sanitation_toolkit.rb
@@ -1,0 +1,32 @@
+RSpec.shared_examples "a model that needs sanitation" do |attribute|
+  describe "basic html sanitization" do
+    describe "##{attribute}" do
+      def get(attribute)
+        subject.send attribute
+      end
+
+      def set(attribute, value)
+        subject.send "#{attribute}=", value
+      end
+
+      it "does not allow images before saving" do
+        set attribute, "This is an image <img src='test.jpg' />, ok."
+        subject.save
+        expect(get attribute).to eq "This is an image , ok."
+      end
+
+      it "does not allow tables before saving" do
+        set attribute, "This is a table <table></table>, ok."
+        subject.save
+        expect(get attribute).to eq "This is a table , ok."
+      end
+
+      it "adds a no-follow attribute to links" do
+        set attribute, "This is a link <a href=\"gradecraft.com\">GradeCraft</a>, ok."
+        subject.save
+        expect(get attribute).to \
+          eq "This is a link <a href=\"gradecraft.com\" rel=\"nofollow\">GradeCraft</a>, ok."
+      end
+    end
+  end
+end

--- a/spec/toolkits/sanitization_toolkit.rb
+++ b/spec/toolkits/sanitization_toolkit.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "a model that needs sanitation" do |attribute|
+RSpec.shared_examples "a model that needs sanitization" do |attribute|
   describe "basic html sanitization" do
     describe "##{attribute}" do
       def get(attribute)


### PR DESCRIPTION
This removes the ability for submission text comments to have links stripped from their descriptions. This was because it was using the `RESTRICTED` config method from [Santitize](https://github.com/rgrove/sanitize).

In order to reduce the duplication of code, the cleaning of the html was moved into a Sanitize concern and used for the following:

- `Assignment#description`
- `Grade#feedback`
- `Group#text_proposal`
- `Submission#text_comment`

In addition, since images nor tables are allowed for the methods, the froala editor options were updated to take away those buttons.

Closes #1597 