### PR TITLE
Fix bug where individually awarded badges do not get set to student visible

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -30,6 +30,7 @@ class EarnedBadgesController < ApplicationController
     @earned_badge = current_course.earned_badges.new(params[:earned_badge])
     @earned_badge.badge =  current_course.badges.find_by_id(params[:badge_id])
     @earned_badge.student =  current_course.students.find_by_id(params[:student_id])
+    @earned_badge.student_visible = true
 
     if @earned_badge.save
       if @badge.point_total?

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -60,8 +60,8 @@ describe EarnedBadgesController do
         params = attributes_for(:earned_badge)
         params[:badge_id] = @badge.id
         params[:student_id] = @student.id
-        expect{ post :create, :badge_id => @badge.id, :student_id => @student.id, :earned_badge => params }.to change(EarnedBadge, :count).by(1) 
-        expect(response).to redirect_to badge_path(@badge)   
+        expect{ post :create, :badge_id => @badge.id, :student_id => @student.id, :earned_badge => params }.to change(EarnedBadge.student_visible, :count).by(1)
+        expect(response).to redirect_to badge_path(@badge)
       end
 
       it "doesn't create earned badges with invalid attributes" do
@@ -204,11 +204,11 @@ describe EarnedBadgesController do
           expect(assigns(:earned_badges)[0].student_id).to eq(student2.id)
           expect(assigns(:earned_badges)[1].student_id).to eq(@student.id)
         end
-        
+
       end
 
-      describe "when badges can only be earned once" do 
-        it "builds a new one if it hasn't been earned" do 
+      describe "when badges can only be earned once" do
+        it "builds a new one if it hasn't been earned" do
           @badge.can_earn_multiple_times = false
           @badge.save
 


### PR DESCRIPTION
This fixes a bug where instructors awarding badges one at a time would award a badge, but the student would not be able to see it, and any points earned would not be added to the student's score. 