### PR TITLE
1605 Upgrade File Upload Removal to AWS SDK v2

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -16,10 +16,10 @@ class UploadsController < ApplicationController
   protected
 
   def fetch_upload_with_model
-    @upload = upload_klass.find params[:upload_id].to_i
+    @upload = upload_class.find params[:upload_id].to_i
   end
 
-  def upload_klass
+  def upload_class
     params[:model].classify.constantize
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,16 +1,19 @@
 class UploadsController < ApplicationController
+  before_filter :fetch_upload, only: :remove
+
   def remove
-    upload = params[:model].classify.constantize.find params[:upload_id]
-    s3 = AWS::S3.new
-    bucket = s3.buckets["gradecraft-#{Rails.env}"]
-    if Rails.env == "staging" || Rails.env == "production"
-      if upload.filepath.present?
-        bucket.objects[CGI::unescape(upload.filepath)].delete
-      else
-        bucket.objects[CGI::unescape(upload.file.path)].delete
-      end
+    if upload.remove # delete from s3
+      upload.destroy # destroy the actual persisted active record object resource
+    else
+      flash[:error] = "File could not be deleted from the server."
     end
-    upload.destroy
+
     redirect_to :back
+  end
+
+  protected
+
+  def fetch_upload
+    @upload = params[:model].classify.constantize.find params[:upload_id]
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,11 +1,12 @@
 class UploadsController < ApplicationController
-  before_filter :fetch_upload, only: :remove
-
   def remove
-    if upload.remove # delete from s3
-      upload.destroy # destroy the actual persisted active record object resource
+    fetch_upload
+    @upload.delete_from_s3
+
+    if @upload.exists_on_s3?
+      flash[:alert] = "File was not successfully deleted from the server."
     else
-      flash[:error] = "File could not be deleted from the server."
+      destroy_upload_with_flash
     end
 
     redirect_to :back
@@ -15,5 +16,13 @@ class UploadsController < ApplicationController
 
   def fetch_upload
     @upload = params[:model].classify.constantize.find params[:upload_id]
+  end
+
+  def destroy_upload_with_flash
+    if @upload.destroy # destroy the actual persisted active record object resource
+      flash[:success] = "File was successfully removed from the server and deleted."
+    else
+      flash[:alert] = "File was deleted from the server but the corresponding record could not be destroyed."
+    end
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,10 +1,11 @@
 class UploadsController < ApplicationController
+  before_filter :fetch_upload_with_model, only: :remove
+
   def remove
-    @upload = upload_klass.find params[:upload_id]
     @upload.delete_from_s3
 
     if @upload.exists_on_s3?
-      flash[:alert] = "File was not successfully deleted from the server."
+      flash[:alert] = "File failed to delete from the server."
     else
       destroy_upload_with_flash
     end
@@ -13,6 +14,10 @@ class UploadsController < ApplicationController
   end
 
   protected
+
+  def fetch_upload_with_model
+    @upload = upload_klass.find params[:upload_id].to_i
+  end
 
   def upload_klass
     params[:model].classify.constantize

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,6 +1,6 @@
 class UploadsController < ApplicationController
   def remove
-    fetch_upload
+    @upload = upload_klass.find params[:upload_id]
     @upload.delete_from_s3
 
     if @upload.exists_on_s3?
@@ -14,8 +14,8 @@ class UploadsController < ApplicationController
 
   protected
 
-  def fetch_upload
-    @upload = params[:model].classify.constantize.find params[:upload_id]
+  def upload_klass
+    params[:model].classify.constantize
   end
 
   def destroy_upload_with_flash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ GradeCraft::Application.routes.draw do
   #15. Uploads
   resource :uploads do
     get :remove
+    get :stuff
     get :remove_submission_file
   end
 

--- a/lib/s3_file.rb
+++ b/lib/s3_file.rb
@@ -29,8 +29,12 @@ module S3File
     filepath.present? ? CGI::unescape(filepath) : file.path
   end
 
-  def remove
-    bucket.object(s3_object_file_key).delete
+  def delete_from_s3
+    s3_object.delete
+  end
+
+  def exists_on_s3?
+    s3_object.exists?
   end
 
   private

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_spec_helper'
+
+RSpec.describe UploadsController do
+  let(:controller_instance) { UploadsController.new }
+
+  describe "#remove" do
+    subject { get :remove }
+    it "fetches the upload" do
+      expect(controller).to receive(:fetch_upload)
+    end
+  end
+
+  describe "#upload_klass" do
+    subject { controller_instance.instance_eval { upload_klass } }
+    before { allow(controller_instance).to receive(:params) { model_params }}
+
+    context "model is passed in camelcased format" do
+      let(:model_params) { ActionController::Parameters.new model: "SubmissionFile" }
+      it "returns the upload klass" do
+        expect(subject).to eq(SubmissionFile)
+      end
+    end
+
+    context "model is passed in underscored format" do
+      let(:model_params) { ActionController::Parameters.new model: "submission_file" }
+      it "still returns the upload klass" do
+        expect(subject).to eq(SubmissionFile)
+      end
+    end
+  end
+
+  describe "#destroy_upload_with_flash" do
+  end
+end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -3,28 +3,28 @@ require 'rails_spec_helper'
 RSpec.describe UploadsController do
   let(:controller_instance) { UploadsController.new }
   let(:submission_file) { create(:submission_file) }
-
-  before(:all) do
-    @professor = create(:user)
-    CourseMembership.create user: @professor, course: create(:course), role: "professor"
-  end
+  let(:course) { create(:course) }
+  let(:student) { create(:user) }
+  let(:create_student_course_membership) { CourseMembership.create user: student, course: create(:course), role: "student" }
+  let(:stub_submission_file) { allow(SubmissionFile).to receive(:find).with(submission_file.id) { submission_file }}
 
   before(:each) do
-    login_user(@professor)
+    create_student_course_membership
+    login_user(student)
+    stub_submission_file
   end
 
   describe "#remove" do
-    subject { get :remove, model: "submission_file", upload_id: submission_file.id }
+    subject { get :remove, model: "SubmissionFile", upload_id: submission_file.id }
     before(:each) { request.env['HTTP_REFERER'] = 'localhost:8000' }
 
     it "fetches the upload" do
-      allow(SubmissionFile).to receive(:find) { submission_file }
-      expect(SubmissionFile).to receive(:find).with(submission_file.id.to_s)
+      controller.instance_variable_set(:@upload, submission_file)
+      expect(controller).to receive(:fetch_upload_with_model)
       subject
     end
 
     it "deletes the upload from s3" do
-      allow(SubmissionFile).to receive(:find) { submission_file }
       expect(submission_file).to receive(:delete_from_s3)
       subject
     end
@@ -37,6 +37,22 @@ RSpec.describe UploadsController do
     it "redirects back to where you were" do
       subject
       expect(response).to redirect_to("localhost:8000")
+    end
+
+    context "upload was successfully deleted from s3" do
+      before { allow(submission_file).to receive(:exists_on_s3?) { false }}
+      it "destroys the upload" do
+        expect(submission_file).to receive(:destroy)
+        subject
+      end
+    end
+
+    context "upload failed to delete from s3" do
+      before { allow(submission_file).to receive(:exists_on_s3?) { true }}
+      it "sets a flash alert" do
+        subject
+        expect(flash[:alert]).to match(/File failed to delete from the server/)
+      end
     end
   end
 
@@ -86,6 +102,28 @@ RSpec.describe UploadsController do
         subject
         expect(controller_instance.flash[:alert]).to match(/File was deleted/)
       end
+    end
+  end
+
+  describe "#fetch_upload_with_model" do
+    let(:upload_params) { ActionController::Parameters.new upload_id: submission_file.id }
+
+    subject { controller_instance.instance_eval { fetch_upload_with_model } }
+
+    before(:each) do
+      controller_instance.instance_variable_set(:@upload, submission_file)
+      allow(controller_instance).to receive(:upload_klass) { SubmissionFile }
+      allow(controller_instance).to receive(:params) { upload_params }
+    end
+
+    it "fetches the upload" do
+      expect(SubmissionFile).to receive(:find).with(submission_file.id)
+      subject
+    end
+
+    it "sets an @upload ivar" do
+      subject
+      expect(controller_instance.instance_variable_get(:@upload)).to eq(submission_file)
     end
   end
 end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe UploadsController do
         expect(submission_file).to receive(:destroy)
         subject
       end
+
+      it "destroys the upload with flash" do
+        expect(controller).to receive(:destroy_upload_with_flash)
+        subject
+      end
     end
 
     context "upload failed to delete from s3" do

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe UploadsController do
   describe "#remove" do
     subject { get :remove }
     it "fetches the upload" do
-      expect(controller).to receive(:fetch_upload)
+      # expect(controller).to receive(:fetch_upload)
+      skip
     end
   end
 

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -30,5 +30,33 @@ RSpec.describe UploadsController do
   end
 
   describe "#destroy_upload_with_flash" do
+    subject { controller_instance.instance_eval { destroy_upload_with_flash } }
+    let(:submission_file) { create(:submission_file) }
+
+    before(:each) do
+      controller_instance.request = ActionDispatch::Request.new('rack.input' => [])
+      controller_instance.instance_variable_set(:@upload, submission_file)
+    end
+
+    it "destroys the upload" do
+      expect(submission_file).to receive(:destroy)
+      subject
+    end
+
+    context "upload destroys successfully" do
+      before { allow(submission_file).to receive(:destroy) { true }}
+      it "sets a success message" do
+        subject
+        expect(controller_instance.flash[:success]).to match(/File was successfully removed/)
+      end
+    end
+
+    context "upload fails to destroy" do
+      before { allow(submission_file).to receive(:destroy) { false }}
+      it "sets an alert message" do
+        subject
+        expect(controller_instance.flash[:alert]).to match(/File was deleted/)
+      end
+    end
   end
 end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -135,63 +135,59 @@ RSpec.describe UploadsController do
     end
   end
 
-  context ":model param is GradeFile" do
-    let(:grade_file) { create(:grade_file) }
-    subject { get :remove, model: "GradeFile", upload_id: grade_file.id }
+  describe "all possible upload file classes" do
+    before(:each) { subject }
 
-    it "returns a GradeFile object" do
-      subject
-      expect(assigns(:upload).class).to eq(GradeFile)
+    context ":model param is GradeFile" do
+      let(:grade_file) { create(:grade_file) }
+      subject { get :remove, model: "GradeFile", upload_id: grade_file.id }
+
+      it "returns a GradeFile object" do
+        expect(assigns(:upload).class).to eq(GradeFile)
+      end
+
+      it "returns the correct GradeFile" do
+        expect(assigns(:upload).id).to eq(grade_file.id)
+      end
     end
 
-    it "returns the correct GradeFile" do
-      subject
-      expect(assigns(:upload).id).to eq(grade_file.id)
-    end
-  end
+    context ":model param is ChallengeFile" do
+      let(:challenge_file) { create(:challenge_file) }
+      subject { get :remove, model: "ChallengeFile", upload_id: challenge_file.id }
 
-  context ":model param is ChallengeFile" do
-    let(:challenge_file) { create(:challenge_file) }
-    subject { get :remove, model: "ChallengeFile", upload_id: challenge_file.id }
+      it "returns a ChallengeFile object" do
+        expect(assigns(:upload).class).to eq(ChallengeFile)
+      end
 
-    it "returns a ChallengeFile object" do
-      subject
-      expect(assigns(:upload).class).to eq(ChallengeFile)
+      it "returns the correct ChallengeFile" do
+        expect(assigns(:upload).id).to eq(challenge_file.id)
+      end
     end
 
-    it "returns the correct ChallengeFile" do
-      subject
-      expect(assigns(:upload).id).to eq(challenge_file.id)
-    end
-  end
+    context ":model param is BadgeFile" do
+      let(:badge_file) { create(:badge_file) }
+      subject { get :remove, model: "BadgeFile", upload_id: badge_file.id }
 
-  context ":model param is BadgeFile" do
-    let(:badge_file) { create(:badge_file) }
-    subject { get :remove, model: "BadgeFile", upload_id: badge_file.id }
+      it "returns a BadgeFile object" do
+        expect(assigns(:upload).class).to eq(BadgeFile)
+      end
 
-    it "returns a BadgeFile object" do
-      subject
-      expect(assigns(:upload).class).to eq(BadgeFile)
+      it "returns the correct BadgeFile" do
+        expect(assigns(:upload).id).to eq(badge_file.id)
+      end
     end
 
-    it "returns the correct BadgeFile" do
-      subject
-      expect(assigns(:upload).id).to eq(badge_file.id)
-    end
-  end
+    context ":model param is AssignmentFile" do
+      let(:assignment_file) { create(:assignment_file) }
+      subject { get :remove, model: "AssignmentFile", upload_id: assignment_file.id }
 
-  context ":model param is AssignmentFile" do
-    let(:assignment_file) { create(:assignment_file) }
-    subject { get :remove, model: "AssignmentFile", upload_id: assignment_file.id }
+      it "returns a AssignmentFile object" do
+        expect(assigns(:upload).class).to eq(AssignmentFile)
+      end
 
-    it "returns a AssignmentFile object" do
-      subject
-      expect(assigns(:upload).class).to eq(AssignmentFile)
-    end
-
-    it "returns the correct AssignmentFile" do
-      subject
-      expect(assigns(:upload).id).to eq(assignment_file.id)
+      it "returns the correct AssignmentFile" do
+        expect(assigns(:upload).id).to eq(assignment_file.id)
+      end
     end
   end
 end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UploadsController do
       subject
       expect(assigns(:upload)).to eq(submission_file)
     end
-    
+
     it "redirects back to where you were" do
       subject
       expect(response).to redirect_to("localhost:8000")
@@ -64,8 +64,8 @@ RSpec.describe UploadsController do
     end
   end
 
-  describe "#upload_klass" do
-    subject { controller_instance.instance_eval { upload_klass } }
+  describe "#upload_class" do
+    subject { controller_instance.instance_eval { upload_class } }
     before { allow(controller_instance).to receive(:params) { model_params }}
 
     context "model is passed in camelcased format" do
@@ -120,7 +120,7 @@ RSpec.describe UploadsController do
 
     before(:each) do
       controller_instance.instance_variable_set(:@upload, submission_file)
-      allow(controller_instance).to receive(:upload_klass) { SubmissionFile }
+      allow(controller_instance).to receive(:upload_class) { SubmissionFile }
       allow(controller_instance).to receive(:params) { upload_params }
     end
 

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -11,12 +11,11 @@ RSpec.describe UploadsController do
   before(:each) do
     create_student_course_membership
     login_user(student)
-    stub_submission_file
+    request.env['HTTP_REFERER'] = 'localhost:8000'
   end
 
   describe "#remove" do
     subject { get :remove, model: "SubmissionFile", upload_id: submission_file.id }
-    before(:each) { request.env['HTTP_REFERER'] = 'localhost:8000' }
 
     it "fetches the upload" do
       controller.instance_variable_set(:@upload, submission_file)
@@ -25,6 +24,7 @@ RSpec.describe UploadsController do
     end
 
     it "deletes the upload from s3" do
+      stub_submission_file
       expect(submission_file).to receive(:delete_from_s3)
       subject
     end
@@ -41,7 +41,9 @@ RSpec.describe UploadsController do
 
     context "upload was successfully deleted from s3" do
       before { allow(submission_file).to receive(:exists_on_s3?) { false }}
+
       it "destroys the upload" do
+        stub_submission_file
         expect(submission_file).to receive(:destroy)
         subject
       end
@@ -55,6 +57,7 @@ RSpec.describe UploadsController do
     context "upload failed to delete from s3" do
       before { allow(submission_file).to receive(:exists_on_s3?) { true }}
       it "sets a flash alert" do
+        stub_submission_file
         subject
         expect(flash[:alert]).to match(/File failed to delete from the server/)
       end
@@ -129,6 +132,66 @@ RSpec.describe UploadsController do
     it "sets an @upload ivar" do
       subject
       expect(controller_instance.instance_variable_get(:@upload)).to eq(submission_file)
+    end
+  end
+
+  context ":model param is GradeFile" do
+    let(:grade_file) { create(:grade_file) }
+    subject { get :remove, model: "GradeFile", upload_id: grade_file.id }
+
+    it "returns a GradeFile object" do
+      subject
+      expect(assigns(:upload).class).to eq(GradeFile)
+    end
+
+    it "returns the correct GradeFile" do
+      subject
+      expect(assigns(:upload).id).to eq(grade_file.id)
+    end
+  end
+
+  context ":model param is ChallengeFile" do
+    let(:challenge_file) { create(:challenge_file) }
+    subject { get :remove, model: "ChallengeFile", upload_id: challenge_file.id }
+
+    it "returns a ChallengeFile object" do
+      subject
+      expect(assigns(:upload).class).to eq(ChallengeFile)
+    end
+
+    it "returns the correct ChallengeFile" do
+      subject
+      expect(assigns(:upload).id).to eq(challenge_file.id)
+    end
+  end
+
+  context ":model param is BadgeFile" do
+    let(:badge_file) { create(:badge_file) }
+    subject { get :remove, model: "BadgeFile", upload_id: badge_file.id }
+
+    it "returns a BadgeFile object" do
+      subject
+      expect(assigns(:upload).class).to eq(BadgeFile)
+    end
+
+    it "returns the correct BadgeFile" do
+      subject
+      expect(assigns(:upload).id).to eq(badge_file.id)
+    end
+  end
+
+  context ":model param is AssignmentFile" do
+    let(:assignment_file) { create(:assignment_file) }
+    subject { get :remove, model: "AssignmentFile", upload_id: assignment_file.id }
+
+    it "returns a AssignmentFile object" do
+      subject
+      expect(assigns(:upload).class).to eq(AssignmentFile)
+    end
+
+    it "returns the correct AssignmentFile" do
+      subject
+      expect(assigns(:upload).id).to eq(assignment_file.id)
     end
   end
 end

--- a/spec/lib/s3_file_spec.rb
+++ b/spec/lib/s3_file_spec.rb
@@ -127,4 +127,26 @@ RSpec.describe "An S3File inheritor" do
 
     after(:each) { subject }
   end
+
+  describe "actually removing the object" do
+    subject { s3_file_cylon.remove }
+    let(:s3_manager) { S3Manager::Manager.new }
+    let(:source_object) { Tempfile.new('walter-srsly') }
+    let(:s3_object_key) { "lets-see-what-happens.txt" }
+    let(:object_summary) { S3Manager::Manager::ObjectSummary.new(s3_object_key, s3_manager) }
+
+    before(:each) do
+      s3_manager.put_object(s3_object_key, source_object)
+    end
+
+    it "should actually be operating on a file that's present to begin with" do
+      expect(object_summary.exists?).to be_truthy
+    end
+
+    it "actually removes the object from the server" do
+      allow(s3_file_cylon).to receive(:s3_object_file_key) { s3_object_key }
+      subject
+      expect(object_summary.exists?).to be_falsey
+    end
+  end
 end

--- a/spec/models/assignment_file_spec.rb
+++ b/spec/models/assignment_file_spec.rb
@@ -58,4 +58,16 @@ describe AssignmentFile do
       expect(subject.course).to eq(course)
     end
   end
+
+  describe "S3File inclusion" do
+    let(:assignment_file) { build(:assignment_file) }
+
+    it "can be deleted from s3" do
+      expect(assignment_file.respond_to?(:delete_from_s3)).to be_truthy
+    end
+
+    it "can check whether it exists on s3" do
+      expect(assignment_file.respond_to?(:exists_on_s3?)).to be_truthy
+    end
+  end
 end

--- a/spec/models/badge_file_spec.rb
+++ b/spec/models/badge_file_spec.rb
@@ -58,4 +58,16 @@ describe BadgeFile do
       expect(subject.course).to eq(course)
     end
   end
+
+  describe "S3File inclusion" do
+    let(:badge_file) { build(:badge_file) }
+
+    it "can be deleted from s3" do
+      expect(badge_file.respond_to?(:delete_from_s3)).to be_truthy
+    end
+
+    it "can check whether it exists on s3" do
+      expect(badge_file.respond_to?(:exists_on_s3?)).to be_truthy
+    end
+  end
 end

--- a/spec/models/challenge_file_spec.rb
+++ b/spec/models/challenge_file_spec.rb
@@ -50,4 +50,16 @@ describe ChallengeFile do
     subject.challenge.save!
     expect expect(subject.url).to match(/.*\/uploads\/challenge_file\/file\/#{subject.id}\/\d+_too_long__strange_characters__and_spaces_\.jpg/)
   end
+
+  describe "S3File inclusion" do
+    let(:challenge_file) { build(:challenge_file) }
+
+    it "can be deleted from s3" do
+      expect(challenge_file.respond_to?(:delete_from_s3)).to be_truthy
+    end
+
+    it "can check whether it exists on s3" do
+      expect(challenge_file.respond_to?(:exists_on_s3?)).to be_truthy
+    end
+  end
 end

--- a/spec/models/grade_file_spec.rb
+++ b/spec/models/grade_file_spec.rb
@@ -65,4 +65,15 @@ describe GradeFile do
     end
   end
 
+  describe "S3File inclusion" do
+    let(:grade_file) { build(:grade_file) }
+
+    it "can be deleted from s3" do
+      expect(grade_file.respond_to?(:delete_from_s3)).to be_truthy
+    end
+
+    it "can check whether it exists on s3" do
+      expect(grade_file.respond_to?(:exists_on_s3?)).to be_truthy
+    end
+  end
 end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -175,4 +175,16 @@ describe SubmissionFile do
     subject.submission.save!
     expect(subject.url).to match(/.*\/uploads\/submission_file\/file\/#{submission_file.id}\/\d+_too_long__strange_characters__and_spaces_\.jpg/)
   end
+
+  describe "S3File inclusion" do
+    let(:submission_file) { build(:submission_file) }
+
+    it "can be deleted from s3" do
+      expect(submission_file.respond_to?(:delete_from_s3)).to be_truthy
+    end
+
+    it "can check whether it exists on s3" do
+      expect(submission_file.respond_to?(:exists_on_s3?)).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
File removal for all classes of file attachments (GradeFile, AssignmentFile, SubmissionFile) etc were previously using AWS v1. Those have been upgraded to v2 and specs have been added for the entire workflow (there weren't any previously). Additionally I've added some spec examples in each of the corresponding model classes to test that the S3File library is included and therefore each KlassFile class can interact with the same S3 methods in the controller. 

@jwright @acousticrobot, can one of you guys review this for me? Danke.