### PR TITLE
bugfix - predictor displays zero grade only for select criteria

### DIFF
--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -21,12 +21,12 @@ class PredictedGradeSerializer
   end
 
   def raw_score
-    return 0 if grade.assignment.submissions_have_closed?
+    return 0 if show_zero_in_predictor grade.raw_score
     grade.raw_score if grade.is_student_visible?
   end
 
   def score
-    return 0 if grade.assignment.submissions_have_closed?
+    return 0 if show_zero_in_predictor grade.score
     grade.score if grade.is_student_visible?
   end
 
@@ -45,6 +45,13 @@ class PredictedGradeSerializer
  end
 
   private
+
+  def show_zero_in_predictor(score)
+    score.nil? and
+    grade.assignment.accepts_submissions? and
+    grade.assignment.submissions_have_closed? and
+    grade.student.submission_for_assignment(grade.assignment).nil?
+  end
 
   attr_reader :grade
 end

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -3,9 +3,9 @@ require "./app/serializers/predicted_grade_serializer"
 
 describe PredictedGradeSerializer do
   let(:course) { double(:course) }
-  let(:assignment) { double(:assignment, submissions_have_closed?: false)}
+  let(:assignment) { double(:assignment, accepts_submissions?: true, submissions_have_closed?: true, )}
   let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, raw_score: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
-  let(:user) { double(:user) }
+  let(:user) { double(:user, submission_for_assignment: "sumbission") }
   let(:other_user) { double(:other_user) }
   subject { described_class.new grade, user }
 
@@ -36,9 +36,15 @@ describe PredictedGradeSerializer do
       expect(subject.score).to be_nil
     end
 
-    it "returns 0 if the assignment submissions have closed" do
-      allow(assignment).to receive(:submissions_have_closed?).and_return true
+    it "returns 0 with no score and no sumbission if the assignment submissions have closed" do
+      allow(grade).to receive(:score).and_return nil
+      allow(user).to receive(:submission_for_assignment).and_return nil
       expect(subject.score).to eq(0)
+    end
+
+    it "doesn't override the score is present regardless of submission status" do
+      allow(user).to receive(:submission_for_assignment).and_return nil
+      expect(subject.score).to eq(grade.score)
     end
   end
 
@@ -52,9 +58,15 @@ describe PredictedGradeSerializer do
       expect(subject.raw_score).to be_nil
     end
 
-    it "returns 0 if the assignment submissions have closed" do
-      allow(assignment).to receive(:submissions_have_closed?).and_return true
-      expect(subject.score).to eq(0)
+    it "returns 0 with no raw score and no sumbission if the assignment submissions have closed" do
+      allow(grade).to receive(:raw_score).and_return nil
+      allow(user).to receive(:submission_for_assignment).and_return nil
+      expect(subject.raw_score).to eq(0)
+    end
+
+    it "doesn't override the raw score is present regardless of submission status" do
+      allow(user).to receive(:submission_for_assignment).and_return nil
+      expect(subject.raw_score).to eq(grade.raw_score)
     end
   end
 


### PR DESCRIPTION
  This PR addresses grades which are showing up in the predictor as zero,
  when the student actually has a real grade.  The predictor logic should
  now follow the following logic path:

    raw_score is nil -> false
      grade is student visible? -> true
        = show grade
      grade is student visible? -> false
        = show predictor-slider

    raw_score is nil -> true
      assignment accepts_submissions? -> false
        = show predictor-slider

      assignment accepts_submissions? -> true
        submissions_have_closed? -> false
          = show predictor-slider

        submissions_have_closed? -> true
          student has made a submission -> true
            = show predictor-slider
          student has made a submission -> false
            = show GRADE = 0