### PR TITLE
1384 refactor timeline

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -21,7 +21,7 @@ class InfoController < ApplicationController
   end
 
   def timeline_events
-    @events = current_course.timeline_events
+    @events = Timeline.new(current_course).events
     render(:partial => 'info/timeline', :handlers => [:jbuilder], :formats => [:js])
   end
 

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -43,7 +43,7 @@ class StudentsController < ApplicationController
     if current_user_is_student?
       redirect_to dashboard_path
     end
-    @events = current_course.timeline_events
+    @events = Timeline.new(current_course).events
   end
 
   #Displaying student profile to instructors

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -253,14 +253,6 @@ class Course < ActiveRecord::Base
     point_total || assignments.sum('point_total')
   end
 
-  def timeline_events
-    if team_challenges?
-      assignments.timelineable.with_dates.to_a + challenges.with_dates.to_a + events.with_dates.to_a
-    else
-      assignments.timelineable.with_dates.to_a + events.with_dates.to_a
-    end
-  end
-
   def active?
     status == true
   end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -4,4 +4,24 @@ class Timeline
   def initialize(course)
     @course = course
   end
+
+  def assignment_events
+    course.assignments.timelineable.with_dates
+  end
+
+  def event_events
+    course.events.with_dates
+  end
+
+  def challenge_events
+    course.challenges.with_dates if course.has_team_challenges?
+  end
+
+  def events
+    @events ||= [
+      assignment_events.to_a,
+      challenge_events.to_a,
+      event_events.to_a
+    ].flatten
+  end
 end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -1,0 +1,7 @@
+class Timeline
+  attr_reader :course
+
+  def initialize(course)
+    @course = course
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -536,24 +536,6 @@ describe Course do
     end
   end
 
-  describe "#timeline_events" do
-    it "returns all assignments with dates and events" do
-      course = create(:course)
-      @assignment = create(:assignment, course: course, due_at: Date.today)
-      @event = create(:event, course: course, due_at: Date.today)
-      @assignment_no_date = create(:assignment, course: course)
-      expect(course.timeline_events).to eq([@assignment, @event])
-    end
-
-    it "includes challenges with dates" do
-      course = create(:course, team_challenges: true)
-      @assignment = create(:assignment, course: course, due_at: Date.today)
-      @challenge = create(:challenge, course: course, due_at: Date.today)
-      @challenge_no_date = create(:challenge, course: course)
-      expect(course.timeline_events).to eq([@assignment, @challenge])
-    end
-  end
-
   describe "#student_weighted?" do
     it "returns false if no weights are set" do
       subject.total_assignment_weight = nil

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -11,29 +11,41 @@ describe Timeline do
   end
 
   describe "#events" do
-    it "includes assignments that have due dates or open dates" do
-      assignment = create(:assignment, course: course, due_at: Date.today)
-      assignment_no_date = create(:assignment, course: course, due_at: nil)
-      expect(subject.events).to eq [assignment]
+    context "with assignments for the course" do
+      let!(:assignment) { create :assignment, course: course, due_at: Date.today }
+      let!(:assignment_not_due) { create :assignment, course: course, due_at: nil }
+
+      it "includes the assignments" do
+        expect(subject.events).to eq [assignment]
+      end
     end
 
-    it "includes events that have due dates or open dates" do
-      event = create(:event, course: course, due_at: Date.today)
-      event_no_date = create(:event, course: course, due_at: nil)
-      expect(subject.events).to eq [event]
+    context "with events for the course" do
+      let!(:event) { create :event, course: course, due_at: Date.today }
+      let!(:event_not_due) { create :event, course: course, due_at: nil }
+
+      it "includes the events" do
+        expect(subject.events).to eq [event]
+      end
     end
 
-    it "includes challenge that have due dates or open dates if the course allows it" do
-      course.update_attributes team_challenges: true
-      challenge = create(:challenge, course: course, due_at: Date.today)
-      challenge_no_date = create(:challenge, course: course, due_at: nil)
-      expect(subject.events).to eq [challenge]
-    end
+    context "with challenges for the course" do
+      let!(:challenge) { create :challenge, course: course, due_at: Date.today }
+      let!(:challenge_not_due) { create :challenge, course: course, due_at: nil }
 
-    it "does not include challenge that have due dates or open dates if the course does not allows it" do
-      challenge = create(:challenge, course: course, due_at: Date.today)
-      challenge_no_date = create(:challenge, course: course, due_at: nil)
-      expect(subject.events).to eq []
+      context "that accepts team challenges" do
+        before { course.update_attributes team_challenges: true }
+
+        it "includes the challenges" do
+          expect(subject.events).to eq [challenge]
+        end
+      end
+
+      context "that does not accept team challenges" do
+        it "does not include the challenges" do
+          expect(subject.events).to eq []
+        end
+      end
     end
   end
 end

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -2,16 +2,15 @@ require "active_record_spec_helper"
 
 describe Timeline do
   let(:course) { create :course }
+  subject { described_class.new(course) }
 
   describe "#initialize" do
     it "is initialized with a course" do
-      expect(described_class.new(course).course).to eq course
+      expect(subject.course).to eq course
     end
   end
 
   describe "#events" do
-    subject { described_class.new(course) }
-
     it "includes assignments that have due dates or open dates" do
       assignment = create(:assignment, course: course, due_at: Date.today)
       assignment_no_date = create(:assignment, course: course, due_at: nil)

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -1,0 +1,11 @@
+require "active_record_spec_helper"
+
+describe Timeline do
+  let(:course) { create :course }
+
+  describe "#initialize" do
+    it "is initialized with a course" do
+      expect(described_class.new(course).course).to eq course
+    end
+  end
+end

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -8,4 +8,33 @@ describe Timeline do
       expect(described_class.new(course).course).to eq course
     end
   end
+
+  describe "#events" do
+    subject { described_class.new(course) }
+
+    it "includes assignments that have due dates or open dates" do
+      assignment = create(:assignment, course: course, due_at: Date.today)
+      assignment_no_date = create(:assignment, course: course, due_at: nil)
+      expect(subject.events).to eq [assignment]
+    end
+
+    it "includes events that have due dates or open dates" do
+      event = create(:event, course: course, due_at: Date.today)
+      event_no_date = create(:event, course: course, due_at: nil)
+      expect(subject.events).to eq [event]
+    end
+
+    it "includes challenge that have due dates or open dates if the course allows it" do
+      course.update_attributes team_challenges: true
+      challenge = create(:challenge, course: course, due_at: Date.today)
+      challenge_no_date = create(:challenge, course: course, due_at: nil)
+      expect(subject.events).to eq [challenge]
+    end
+
+    it "does not include challenge that have due dates or open dates if the course does not allows it" do
+      challenge = create(:challenge, course: course, due_at: Date.today)
+      challenge_no_date = create(:challenge, course: course, due_at: nil)
+      expect(subject.events).to eq []
+    end
+  end
 end


### PR DESCRIPTION
Refactors the `Course` object by removing the complex method `#timeline_events` into a `Timeline` object.

The `Timeline` object gathers all of the events for a specifc `Course`.

References #1384 