### PR TITLE
hotfix predictor preview, sandardize on falsey

### DIFF
--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -70,4 +70,8 @@ class NullAssignment
   def submissions_have_closed?
     false
   end
+
+  def accepts_submissions?
+    false
+  end
 end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -171,7 +171,7 @@ describe AssignmentsController do
             expect(assigns(:assignments).assignments[0][attr]).to \
               eq(@assignment[attr])
           end
-          expect(assigns(:assignments).permission_to_update?).to be_falsy
+          expect(assigns(:assignments).permission_to_update?).to be_falsey
           expect(response).to render_template(:predictor_data)
         end
 
@@ -207,7 +207,7 @@ describe AssignmentsController do
           get :predictor_data, format: :json
           expect(assigns(:assignments).current_user).to eq(@professor)
           expect(assigns(:assignments).student.class).to eq(NullStudent)
-          expect(assigns(:assignments).permission_to_update?).to be_falsy
+          expect(assigns(:assignments).permission_to_update?).to be_falsey
         end
       end
     end

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -169,7 +169,7 @@ describe BadgesController do
           predictor_badge_attributes do |attr|
             expect(assigns(:badges)[0][attr]).to eq(@badge[attr])
           end
-          expect(assigns(:update_badges)).to be_falsy
+          expect(assigns(:update_badges)).to be_falsey
           expect(response).to render_template(:predictor_data)
         end
       end
@@ -178,7 +178,7 @@ describe BadgesController do
         it "assigns student as null student and no call to update" do
           get :predictor_data, format: :json
           expect(assigns(:student).class).to eq(NullStudent)
-          expect(assigns(:update_badges)).to be_falsy
+          expect(assigns(:update_badges)).to be_falsey
         end
       end
     end

--- a/spec/controllers/challenges_controller_spec.rb
+++ b/spec/controllers/challenges_controller_spec.rb
@@ -92,7 +92,7 @@ describe ChallengesController do
         expect(@challenge_2.reload.name).to eq("new name")
       end
 
-      it "redirects to the edit form if the update fails" do 
+      it "redirects to the edit form if the update fails" do
         params = { name: nil }
         post :update, id: @challenge_2.id, :challenge => params
         expect(response).to render_template(:edit)
@@ -140,7 +140,7 @@ describe ChallengesController do
           predictor_challenge_attributes do |attr|
             expect(assigns(:challenges)[0][attr]).to eq(@challenge[attr])
           end
-          expect(assigns(:update_challenges)).to be_falsy
+          expect(assigns(:update_challenges)).to be_falsey
           expect(response).to render_template(:predictor_data)
         end
       end
@@ -149,7 +149,7 @@ describe ChallengesController do
         it "assigns student as null student and no call to update" do
           get :predictor_data, format: :json
           expect(assigns(:student).class).to eq(NullStudent)
-          expect(assigns(:update_challenges)).to be_falsy
+          expect(assigns(:update_challenges)).to be_falsey
         end
       end
     end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -398,7 +398,7 @@ describe GradesController do
         expect(@grade.feedback).to eq("")
         [ :raw_score,:status,:feedback_read_at,:feedback_reviewed_at,
           :feedback_read,:feedback_reviewed,:instructor_modified,:graded_at].each do |attr|
-          expect(@grade[attr]).to be_falsy
+          expect(@grade[attr]).to be_falsey
         end
       end
 

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -58,6 +58,10 @@ describe NullGrade do
   end
 
   it "handles queries for assignments with closed submissions" do
-    expect(subject.assignment.submissions_have_closed?).to be_falsy
+    expect(subject.assignment.submissions_have_closed?).to be_falsey
+  end
+
+  it "handles queries for assignments accepting submissions" do
+    expect(subject.assignment.accepts_submissions?).to be_falsey
   end
 end

--- a/spec/serializers/predicted_assignment_collection_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_collection_serializer_spec.rb
@@ -65,7 +65,7 @@ describe PredictedAssignmentCollectionSerializer do
 
     it "doens't allow updates when current user is other than student" do
       subject = described_class.new assignments, other_user, user
-      expect(subject.permission_to_update?).to be_falsy
+      expect(subject.permission_to_update?).to be_falsey
     end
   end
 end

--- a/spec/services/creates_grade/saves_grade_spec.rb
+++ b/spec/services/creates_grade/saves_grade_spec.rb
@@ -28,7 +28,7 @@ describe Services::Actions::SavesGrade do
 
   it "sets the student visible status to nil when grade not visible" do
     result = described_class.execute grade: grade
-    expect(result[:student_visible_status]).to be_falsy
+    expect(result[:student_visible_status]).to be_falsey
   end
 
   it "sets the student visible status to true when grade is visible" do


### PR DESCRIPTION
Quick fix for predictor preview to handle new zero grade logic with null grades. Adds a spec, and changes all specs calling 'be_falsy' to 'be_falsey'