### PR TITLE
1641 track submission file changes

### DIFF
--- a/app/assets/stylesheets/_history_timeline.sass
+++ b/app/assets/stylesheets/_history_timeline.sass
@@ -98,7 +98,7 @@ $color-timeline-vertical-line: $color-blue-5
   &.timeline-grade
     background: $color-timeline-grade
 
-  &.timeline-submission
+  &.timeline-submission, &.timeline-attachment
     background: $color-timeline-submission
 
 @media only screen and (min-width: $media-medium-max)

--- a/app/assets/stylesheets/_icons.sass
+++ b/app/assets/stylesheets/_icons.sass
@@ -12,6 +12,11 @@ i.fa-slack
 i.fa-group, i.fa-key, i.fa-lock, i.fa-group, i.fa-exclamation-circle
   clear: both
 
+i.icon-attachment
+  /* Same as fa-paperclip */
+  &::before
+    content: "\f0c6"
+
 i.icon-grade
   /* Same as fa-check */
   &::before

--- a/app/models/concerns/historical.rb
+++ b/app/models/concerns/historical.rb
@@ -41,6 +41,13 @@ module Historical
     self
   end
 
+  def historical_collection_merge(historical_collection)
+    return self if historical_collection.nil? || historical_collection.empty?
+
+    historical_collection.each { |historical_model| historical_merge(historical_model) }
+    self
+  end
+
   private
 
   def history=(history)

--- a/app/models/concerns/historical.rb
+++ b/app/models/concerns/historical.rb
@@ -22,7 +22,7 @@ module Historical
   end
 
   def history
-    self.versions.reverse.map do |version|
+    @history ||= self.versions.reverse.map do |version|
       history = HistoryItem.new(version)
       history.changeset.merge!("object" => self.class.name,
                                "event" => version.event,
@@ -33,10 +33,17 @@ module Historical
   end
 
   def historical_merge(historical_model)
-    return self.history if historical_model.nil?
+    return self if historical_model.nil?
 
-    CollectionMerger.new(self.history, historical_model.history)
+    self.history = CollectionMerger.new(self.history, historical_model.history)
       .merge(field: ->(history) { history.changeset["recorded_at"] },
              order: :desc)
+    self
+  end
+
+  private
+
+  def history=(history)
+    @history = history
   end
 end

--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -44,6 +44,17 @@ class HistoryFilter
     self
   end
 
+  def rename(options)
+    object_key = options.keys.first
+    object_value = options.values.first
+
+    history.map(&:changeset).each do |changeset|
+      object = changeset["object"]
+      changeset["object"] = object_value if object == object_key
+    end
+    self
+  end
+
   def empty_changeset?(set)
     set.values.none? { |value| value.is_a? Array }
   end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -8,6 +8,7 @@ class SubmissionFile < ActiveRecord::Base
 
   mount_uploader :file, AttachmentUploader
   process_in_background :file
+  has_paper_trail ignore: [:file_missing, :file_processing, :last_confirmed_at]
 
   validates :filename, presence: true, length: { maximum: 60 }
   validates :file, file_size: { maximum: 40.megabytes.to_i }

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -1,5 +1,6 @@
 class SubmissionFile < ActiveRecord::Base
   include S3Manager::Carrierwave
+  include Historical
 
   attr_accessible :file, :filename, :filepath, :submission_id, :file_missing, :last_confirmed_at
 
@@ -7,8 +8,6 @@ class SubmissionFile < ActiveRecord::Base
 
   mount_uploader :file, AttachmentUploader
   process_in_background :file
-
-  has_paper_trail
 
   validates :filename, presence: true, length: { maximum: 60 }
   validates :file, file_size: { maximum: 40.megabytes.to_i }

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -1,6 +1,7 @@
 module SubmissionGradeHistory
   def submission_grade_filtered_history(submission, grade, only_student_visible_grades=true)
-    HistoryFilter.new(submission.historical_merge(grade).history)
+    HistoryFilter.new(submission.historical_collection_merge(submission.submission_files)
+      .historical_merge(grade).history)
       .remove("name" => "admin_notes")
       .remove("name" => "feedback_read")
       .remove("name" => "feedback_read_at")

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -1,6 +1,6 @@
 module SubmissionGradeHistory
   def submission_grade_filtered_history(submission, grade, only_student_visible_grades=true)
-    HistoryFilter.new(submission.historical_merge(grade))
+    HistoryFilter.new(submission.historical_merge(grade).history)
       .remove("name" => "admin_notes")
       .remove("name" => "feedback_read")
       .remove("name" => "feedback_read_at")

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -15,6 +15,7 @@ module SubmissionGradeHistory
       .remove("name" => "submission_id")
       .remove("name" => "submitted_at")
       .remove("name" => "updated_at")
+      .rename("SubmissionFile" => "Attachment")
       .include { |history|
         if (history.changeset["object"] == "Grade" && only_student_visible_grades)
           grade = history.version.reify

--- a/lib/human_history/default_change_description_formatter.rb
+++ b/lib/human_history/default_change_description_formatter.rb
@@ -21,7 +21,7 @@ module HumanHistory
     protected
 
     def attribute_name
-      type.classify.constantize.human_attribute_name(attribute).downcase
+      attribute.humanize(capitalize: false)
     end
 
     def format_change(change)

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -96,4 +96,15 @@ describe HistoryFilter do
       expect(result).to eq [{ "attr" => ["value1", "value2"] }]
     end
   end
+
+  describe "#rename" do
+    it "changes the object value in the changeset" do
+      history = [OpenStruct.new(changeset: { "event" => "blah", "object" => "Grade",
+                                             "change" => ["before", "after"] }),
+                 OpenStruct.new(changeset: { "event" => "bleh", "change" => ["before", "after"] }),
+                 OpenStruct.new(changeset: {})]
+      result = described_class.new(history).rename("Grade" => "BLAH").changesets
+      expect(result.first["object"]).to eq "BLAH"
+    end
+  end
 end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -1,5 +1,6 @@
 require "active_record_spec_helper"
-require_relative '../toolkits/models/shared/files'
+require "toolkits/models/shared/files"
+require "toolkits/historical_toolkit"
 
 describe SubmissionFile do
   let(:course) { build(:course) }
@@ -23,6 +24,8 @@ describe SubmissionFile do
       expect(subject.errors[:filename]).to include "can't be blank"
     end
   end
+
+  it_behaves_like "a historical model", :submission_file, filename: "my_submission.doc"
 
   describe "scopes" do
     let(:unconfirmed_file) { create(:submission_file, last_confirmed_at: nil) }
@@ -86,6 +89,21 @@ describe SubmissionFile do
 
     it "is versioned" do
       expect(subject).to be_versioned
+    end
+  end
+
+  describe "#public_url" do
+    it "uses the Rails root" do
+      expect(subject.public_url).to match(/#{Rails.root}/)
+    end
+
+    it "uses the public directory" do
+      expect(subject.public_url).to match("public")
+    end
+
+    it "uses the submission file url" do
+      allow(subject).to receive(:url) { "/great/scott.jpg" }
+      expect(subject.public_url).to match("/great/scott.jpg")
     end
   end
 

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -92,21 +92,6 @@ describe SubmissionFile do
     end
   end
 
-  describe "#public_url" do
-    it "uses the Rails root" do
-      expect(subject.public_url).to match(/#{Rails.root}/)
-    end
-
-    it "uses the public directory" do
-      expect(subject.public_url).to match("public")
-    end
-
-    it "uses the submission file url" do
-      allow(subject).to receive(:url) { "/great/scott.jpg" }
-      expect(subject.public_url).to match("/great/scott.jpg")
-    end
-  end
-
   describe "#course" do
     it "returns the course associated with the submission" do
       expect(subject.course).to eq(course)

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -38,6 +38,8 @@ end
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'paper_trail'
+require 'paper_trail/frameworks/rspec'
 require 'capybara/rspec'
 
 # ResqueSpec libraries

--- a/spec/toolkits/historical_toolkit.rb
+++ b/spec/toolkits/historical_toolkit.rb
@@ -112,7 +112,7 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
   describe "#historical_merge", versioning: true do
     let(:another_model) { build fixture }
 
-    it "returns new history with 2 histories for 2 creation events" do
+    it "merges history with 2 histories for 2 creation events" do
       model.save
       another_model.save
 
@@ -121,6 +121,19 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
       expect(history.length).to eq 2
       expect(history.first.changeset["id"].last).to eq another_model.id
       expect(history.last.changeset["id"].last).to eq model.id
+    end
+  end
+
+  describe "#historical_collection_merge", versioning: true do
+    let(:historical_collection) { [build(fixture), build(fixture)] }
+
+    it "merges history for all the historical models in the collection" do
+      model.save
+      historical_collection.each(&:save)
+
+      history = model.historical_collection_merge(historical_collection).history
+
+      expect(history.length).to eq 3
     end
   end
 end

--- a/spec/toolkits/historical_toolkit.rb
+++ b/spec/toolkits/historical_toolkit.rb
@@ -64,6 +64,7 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
     end
 
     context "with an updated changeset" do
+      let!(:changes) { model.previous_changes }
       subject { model.history }
 
       before { model.update_attributes updated_attributes }
@@ -77,7 +78,8 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
 
         it "returns the changesets for an updated #{fixture}" do
           updated_attributes.each do |key, value|
-            expect(subject).to include({ key.to_s => [nil, value] })
+            change = changes[key].nil? ? nil : changes[key].last
+            expect(subject).to include({ key.to_s => [change, value] })
           end
         end
 

--- a/spec/toolkits/historical_toolkit.rb
+++ b/spec/toolkits/historical_toolkit.rb
@@ -116,7 +116,7 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
       model.save
       another_model.save
 
-      history = model.historical_merge(another_model)
+      history = model.historical_merge(another_model).history
 
       expect(history.length).to eq 2
       expect(history.first.changeset["id"].last).to eq another_model.id


### PR DESCRIPTION
Adds submission files to the submission history. 

Since a `SubmissionFile` is an association, it has it's own version set in [PaperTrail](https://github.com/airblade/paper_trail). This PR merges that in with the submission history (submissions and grades) in order to display the history of the submission file.

Since "Submission file" is not the [preferred nomenclature dude](https://www.youtube.com/watch?v=OYOzUHnPJvU), this PR has the added ability to rename the object for display purposes. We use this to rename "Submission file" to "Attachment".

![screen shot 2016-02-10 at 4 02 42 pm](https://cloud.githubusercontent.com/assets/35017/12961965/35f9ea4a-d011-11e5-8638-0b527a52413f.png)

NOTE: There is a better way to display this data as it should be displayed within the "Submission" history changes themselves. This is a future issue that will be created.

Closes #1641 