### PR TITLE
Enable duplication with a ruby threashold of 20

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,11 +9,12 @@ engines:
   coffeelint:
     enabled: false
   duplication:
-    enabled: false
+    enabled: true
     config:
       languages:
-      - ruby
-      - javascript
+        ruby:
+          mass_threshold: 20
+        javascript:
   eslint:
     enabled: false
   fixme:


### PR DESCRIPTION
Enables duplication analysis on CodeClimate.

This uses a threshold of `20` since the default is `18` and the default was too finicky before.