### PR TITLE
1624 group graded assignments bug

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -221,6 +221,7 @@ class GradesController < ApplicationController
   def group_edit
     @assignment = current_course.assignments.find(params[:id])
     @group = @assignment.groups.find(params[:group_id])
+    @submission_id = @assignment.submissions.where(group_id: @group.id).first.try(:id)
     @title = "Grading #{@group.name}'s #{@assignment.name}"
     @assignment_score_levels = @assignment.assignment_score_levels
   end

--- a/app/views/grades/group_edit.html.haml
+++ b/app/views/grades/group_edit.html.haml
@@ -4,7 +4,7 @@
 
 .pageContent
   = render 'layouts/alerts'
-  
+
   .bold #{term_for :students}
   %ul
     - @group.students.each do |s|
@@ -18,6 +18,7 @@
     = hidden_field_tag "group_id", @group.id
     = f.hidden_field :graded_by_id, :value => current_user.id
     = f.hidden_field :instructor_modified, :value => true
+    = f.hidden_field :submission_id, value: @submission_id
 
     Score:
     = label_tag do

--- a/app/views/groups/_proposal_section.haml
+++ b/app/views/groups/_proposal_section.haml
@@ -10,7 +10,7 @@
         %fieldset.proposal.panel
           %span.columns
             %h6= "Created: #{proposal.created_at}"
-            %p= proposal.proposal
+            %p= raw proposal.proposal
             - i += 1
             = f.hidden_field :id
     - else

--- a/spec/features/grading_a_group_assignment_spec.rb
+++ b/spec/features/grading_a_group_assignment_spec.rb
@@ -11,6 +11,7 @@ feature "grading a group assignment" do
     let!(:group) { create :group, course: course, name: "Group Name", approved: "Approved" }
     let!(:assignment_group) { create :assignment_group, group: group, assignment: assignment }
     let!(:group_membership) { create :group_membership, student: student, group: group }
+    let!(:submission) { create :submission, course: course, assignment: assignment, group: group }
 
     before(:each) do
       login_as professor
@@ -41,6 +42,9 @@ feature "grading a group assignment" do
         click_button "Submit Grades"
       end
       expect(page).to have_notification_message('notice', "Group Name's Group Assignment was successfully updated")
+      grade = Grade.where(assignment_id: assignment.id).last
+      expect(grade.group_id).to eq group.id
+      expect(grade.submission_id).to eq submission.id
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where a group graded assignment would still appear in the ungraded assignment list.

The assignment did not come off of the ungraded submissions list because the `#submission_id` was not being assigned for group grades.

This PR fixes that and a feature integration was modified to check that a submission was assigned to the grade.

Closes #1624 