### PR TITLE
1652 Group Assignment Syllabus Bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -536,7 +536,7 @@ class User < ActiveRecord::Base
   ### GROUPS
 
   def group_for_assignment(assignment)
-    @group_for_assignment ||= assignment_groups.where(assignment: assignment).first.try(:group)
+    assignment_groups.where(assignment: assignment).first.try(:group)
   end
 
 


### PR DESCRIPTION
This PR fixes an issue where the ability to submit for a group where the student did not have access to the assignment.

This was a result of a caching issue with the `User#grade_for_assignment` method. The method use to cache the result of finding the group for an assignment where the user belonged to.

```
def group_for_assignment(assignment)
  @group_for_assignment ||= assignment_groups.where(assignment: assignment).first.try(:group)
end
```

The `@group_for_assignment` variable should vary for the `assignment` passed in and when looping through the assignments but passing in the same current student, it would always use the first group. The syllabus page would return the same group and therefore cause issues.

Fixes #1652 