### PR TITLE
Add AWS_S3_DEVELOPER_TAG to .env.sample with comments on its usage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,3 +23,8 @@ ISSUER=http://localhost:5000/saml/metadata
 IDP_CERT="/Users/prabode/venturit/gradecraft/IDP_CERT.key"
 SAML_CERT="/Users/prabode/venturit/gradecraft/gc.crt"
 SAML_PR_KEY="/Users/prabode/venturit/gradecraft/gc.key"
+
+# AWS_S3_DEVELOPER_TAG is a development-only environment variable
+# This SHOULD NOT be added for staging or production
+# FORMAT: developer's firstname-lastname, entirely in lowercase 
+AWS_S3_DEVELOPER_TAG=firstname-lastname


### PR DESCRIPTION
This PR simply adds the AWS_S3_DEVELOPER_TAG to .env.sample and comments on its usage.

References #1658.