### PR TITLE
Attempt Fix on S3Manager::Carrierwave Spec Bug

### DIFF
--- a/spec/lib/s3_manager/carrierwave_spec.rb
+++ b/spec/lib/s3_manager/carrierwave_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe S3Manager::Carrierwave do
 
     context "file does not exist on server" do
       it "returns an Aws::S3::Types::DeleteObjectOutput object" do
+        s3_file_cylon.delete_from_s3 # make sure this doesn't exist
         expect(subject).to be_falsey
       end
     end


### PR DESCRIPTION
Submit a potential patch for an issue in S3Manager::Carrierwave spec example where sometimes the file isn't being deleted correctly before expecting that the file doesn't exist.

Spec example `returns an Aws::S3::Types::DeleteObjectOutput object` is the culprit. Having trouble reproducing because it won't trigger locally and only fails some of the time on Codeship, but this patch  expressly deletes the tested S3 file before running the expectation block, so it should certainly not be present if the specs run out of order and S3 isn't reached to delete the file before the spec runs.

This has been re-run on Codeship 3 times with no failures.

Should close #1661 for now. 