### PR TITLE
disable rubric submissions without grade status

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -196,7 +196,7 @@
   $scope.submitGrade = ()->
     self = this
     if !$scope.grade.status
-      return alert "You must pick a grade status before submission"
+      return alert "You must select a grade status before you can submit this grade"
     if confirm "Are you sure you want to submit the grade for this assignment?"
       # !!! Document any updates to this call in the specs: /spec/support/api_calls/rubric_grade_put.rb
       $http.put("/assignments/#{$scope.assignmentId}/grade/submit_rubric", self.gradedRubricParams()).success(

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -195,6 +195,8 @@
 
   $scope.submitGrade = ()->
     self = this
+    if !$scope.grade.status
+      return alert "You must pick a grade status before submission"
     if confirm "Are you sure you want to submit the grade for this assignment?"
       # !!! Document any updates to this call in the specs: /spec/support/api_calls/rubric_grade_put.rb
       $http.put("/assignments/#{$scope.assignmentId}/grade/submit_rubric", self.gradedRubricParams()).success(

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -75,11 +75,15 @@
           %h4.notice(ng-hide="pointsSatisfied() || pointsMissing()") You have not yet allocated any points
           %h4.notice(ng-show="pointsMissing()") {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} have not been assigned
           %h4.notice(ng-show="pointsSatisfied()") You have allocated all possible points
+
     .clear
 
     .summary_feedback
+      %h3.text-right Overall Feedback
       %textarea(ng-model="grade.feedback" froala="froalaSummaryOptions")
     .clear
+    %br
+
     .right
       - if !@assignment.release_necessary?
         %select(ng-model="grade.status" ng-options="status for status in noReleaseGradeStatuses")
@@ -89,7 +93,8 @@
         %select(ng-model="grade.status" ng-options="status for status in releaseNecessaryGradeStatuses")
           %option(value="" disabled) Select grade status for this submission...
         .align-right.form_label Can the student see this grade?
-
     .clear
+    %br
+
     .right
       %button#submit-grade(ng-click="submitGrade()" ng-class='{"disabled" : !grade.status}') Submit Grade

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -80,18 +80,16 @@
     .summary_feedback
       %textarea(ng-model="grade.feedback" froala="froalaSummaryOptions")
     .clear
-
-      .right
-      .row
-        - if !@assignment.release_necessary?
-          %select(ng-model="grade.status" ng-options="status for status in noReleaseGradeStatuses")
-            %option(value="" disabled) Select grade status for this submission...
-          .form_label Is this grade ready to be reviewed?
-        - else
-          %select(ng-model="grade.status" ng-options="status for status in releaseNecessaryGradeStatuses")
-            %option(value="" disabled) Select grade status for this submission...
-          .align-right.form_label Can the student see this grade?
+    .right
+      - if !@assignment.release_necessary?
+        %select(ng-model="grade.status" ng-options="status for status in noReleaseGradeStatuses")
+          %option(value="" disabled) Select grade status for this submission...
+        .form_label Is this grade ready to be reviewed?
+      - else
+        %select(ng-model="grade.status" ng-options="status for status in releaseNecessaryGradeStatuses")
+          %option(value="" disabled) Select grade status for this submission...
+        .align-right.form_label Can the student see this grade?
 
     .clear
     .right
-      %button#submit-grade(ng-click="submitGrade()") Submit Grade
+      %button#submit-grade(ng-click="submitGrade()" ng-class='{"disabled" : !grade.status}') Submit Grade


### PR DESCRIPTION
	This pull request cancels sumbission from the rubric grade form if a
        grade status has not been selected.  It issues an alert box instead.
	Minimal style change to align the selector with it's info text and
	submit button. Fixes #1669