### PR TITLE
1647 incorporate submission files

### DIFF
--- a/app/helpers/history_helper.rb
+++ b/app/helpers/history_helper.rb
@@ -28,7 +28,7 @@ module HistoryHelper
     end
 
     content = content_tag(:div, nil, class: "timeline-content") do
-      concat content_tag(:h2, "#{changeset["object"].humanize} #{changeset["event"]}d")
+      concat content_tag(:h2, "#{changeset["object"].humanize} #{Gradecraft::String.new(changeset["event"]).past_tense}")
       concat history_timeline_list(changeset)
       concat content_tag(:span, changeset["recorded_at"], class: "timeline-date")
     end

--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -55,6 +55,11 @@ class HistoryFilter
     self
   end
 
+  def transform(&blk)
+    history.map(&blk)
+    self
+  end
+
   def empty_changeset?(set)
     set.values.none? { |value| value.is_a? Array }
   end

--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -18,7 +18,8 @@ class HistoryFilter
       end
       result &= !yield(history_item) if block_given?
       result
-    end.delete_if { |history_item| empty_changeset?(history_item.changeset) }
+    end
+    clear_empty_changesets
     self
   end
 
@@ -31,7 +32,8 @@ class HistoryFilter
       end
       result &= yield(history_item) if block_given?
       result
-    end.delete_if { |history_item| empty_changeset?(history_item.changeset) }
+    end
+    clear_empty_changesets
     self
   end
 
@@ -40,7 +42,8 @@ class HistoryFilter
 
     @history = history.select do |history_item|
       history_item.changeset.delete_if { |key, value| name == key } if name
-    end.delete_if { |history_item| empty_changeset?(history_item.changeset) }
+    end
+    clear_empty_changesets
     self
   end
 
@@ -48,7 +51,7 @@ class HistoryFilter
     object_key = options.keys.first
     object_value = options.values.first
 
-    history.map(&:changeset).each do |changeset|
+    changesets.each do |changeset|
       object = changeset["object"]
       changeset["object"] = object_value if object == object_key
     end
@@ -57,10 +60,17 @@ class HistoryFilter
 
   def transform(&blk)
     history.map(&blk)
+    clear_empty_changesets
     self
   end
 
   def empty_changeset?(set)
     set.values.none? { |value| value.is_a? Array }
+  end
+
+  private
+
+  def clear_empty_changesets
+    history.delete_if { |history_item| empty_changeset?(history_item.changeset) }
   end
 end

--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -37,6 +37,27 @@ class HistoryFilter
     self
   end
 
+  def merge(options)
+    from_versions = []
+    to_versions = []
+
+    options.each_pair do |from, to|
+      (from_versions << history.select { |h| h.version.item_type == from }).flatten!
+      (to_versions << history.select { |h| h.version.item_type == to }).flatten!
+    end
+
+    from_versions.each_with_index do |history_item, index|
+      history_item.changeset.each_pair do |key, value|
+        if !["created_at", "updated_at"].include?(key) && value.is_a?(Array)
+          to_versions[index].changeset.merge!({ "#{key}" => value })
+        end
+      end
+      exclude("object" => history_item.changeset["object"])
+    end
+
+    self
+  end
+
   def remove(options)
     name = options["name"]
 

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -15,6 +15,15 @@ module SubmissionGradeHistory
       .remove("name" => "submission_id")
       .remove("name" => "submitted_at")
       .remove("name" => "updated_at")
+      .remove("name" => "file")
+      .remove("name" => "store_dir")
+      .remove("name" => "id")
+      .merge("SubmissionFile" => "Submission")
+      .transform { |history|
+        if history.version.item_type == "SubmissionFile"
+          history.changeset["event"] = "upload"
+        end
+      }
       .rename("SubmissionFile" => "Attachment")
       .include { |history|
         if (history.changeset["object"] == "Grade" && only_student_visible_grades)

--- a/lib/human_history/event_history_token.rb
+++ b/lib/human_history/event_history_token.rb
@@ -1,3 +1,5 @@
+require_relative "../string"
+
 module HumanHistory
   class EventHistoryToken
     attr_reader :event
@@ -7,7 +9,8 @@ module HumanHistory
     end
 
     def parse(options={})
-      { self.class.token => event == "update" ? "changed" : "created" }
+      { self.class.token => event == "update" ? "changed" :
+        Gradecraft::String.new(event).past_tense }
     end
 
     class << self

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -4,6 +4,11 @@ module Gradecraft
       @string = string.to_s
     end
 
+    def past_tense
+      ending = string.end_with?("e") ? "d" : "ed"
+      "#{string}#{ending}"
+    end
+
     def to_s
       string
     end

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -1,0 +1,35 @@
+module Gradecraft
+  class String
+    def initialize(string)
+      @string = string.to_s
+    end
+
+    def to_s
+      string
+    end
+    alias_method :to_str,  :to_s
+
+    def ==(other)
+      to_s == other
+    end
+    alias_method :eql?, :==
+
+    def method_missing(m, *args, &blk)
+      if respond_to?(m)
+        s = string.__send__(m, *args, &blk)
+        s = self.class.new(s) if s.is_a? ::String
+        s
+      else
+        raise NoMethodError.new(%(undefined method `#{m}' for "#{string}":#{self.class}))
+      end
+    end
+
+    def respond_to_missing?(m, include_private=false)
+      string.respond_to?(m, include_private)
+    end
+
+    private
+
+    attr_reader :string
+  end
+end

--- a/spec/lib/string_spec.rb
+++ b/spec/lib/string_spec.rb
@@ -1,0 +1,51 @@
+require "./lib/string"
+
+describe Gradecraft::String do
+  describe "#past_tense" do
+    xit "adds a 'd' to the end of the string" do
+      subject = described_class.new("create")
+
+      expect(subject.past_tense).to eq "created"
+    end
+  end
+
+  describe "#to_s" do
+    it "returns a string representation" do
+      expect(described_class.new(123).to_s).to eq "123"
+    end
+  end
+
+  describe "#==" do
+    it "returns true for other strings" do
+      expect(described_class.new("blah") == "blah").to eq true
+    end
+
+    it "returns true for values that respond to to_s" do
+      expect(described_class.new(123) == "123").to eq true
+    end
+
+    it "returns true using eql method" do
+      expect(described_class.new("blah")).to eq "blah"
+    end
+  end
+
+  describe "#method_missing" do
+    it "returns the same thing a string would" do
+      expect(described_class.new("123").chars).to eq ["1", "2", "3"]
+    end
+
+    it "wraps the result in this string class for chaining" do
+      expect(described_class.new("blah").capitalize).to be_a_kind_of described_class
+    end
+
+    it "raises a NoMethodError if the method is not defined on string" do
+      expect { described_class.new("123").blah }.to raise_error NoMethodError
+    end
+  end
+
+  describe "#respond_to_missing?" do
+    it "responds to the string interface" do
+      expect(described_class.new("123").respond_to?(:chars)).to eq true
+    end
+  end
+end

--- a/spec/lib/string_spec.rb
+++ b/spec/lib/string_spec.rb
@@ -2,10 +2,12 @@ require "./lib/string"
 
 describe Gradecraft::String do
   describe "#past_tense" do
-    xit "adds a 'd' to the end of the string" do
-      subject = described_class.new("create")
+    it "adds a 'd' to the end of the string if it ends in an 'e'" do
+      expect(described_class.new("create").past_tense).to eq "created"
+    end
 
-      expect(subject.past_tense).to eq "created"
+    it "adds an 'ed' to the end of the string if it ends in a 'd'" do
+      expect(described_class.new("poop").past_tense).to eq "pooped"
     end
   end
 

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -83,21 +83,21 @@ describe HistoryFilter do
 
   describe "#merge" do
     it "merges the changeset from one object to another" do
-      history = [OpenStruct.new(version: OpenStruct.new(item_type: "SubmissionFile"),
+      history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
                                 changeset: { "event" => "create",
-                                             "object" => "SubmissionFile",
-                                             "filename" => [nil, "blah"]}),
-                 OpenStruct.new(version: OpenStruct.new(item_type: "Submission"),
+                                             "object" => "FromObject",
+                                             "attribute1" => [nil, "blah"]}),
+                 OpenStruct.new(version: OpenStruct.new(item_type: "ToObjectType"),
                                 changeset: { "event" => "create",
-                                             "object" => "Submission",
-                                             "link" => [nil, "http://example.org"]})
+                                             "object" => "ToObject",
+                                             "attribute2" => [nil, "http://example.org"]})
       ]
-      result = described_class.new(history).merge("SubmissionFile" => "Submission")
+      result = described_class.new(history).merge("FromObjectType" => "ToObjectType")
         .changesets
       expect(result).to eq [{ "event" => "create",
-                              "object" => "Submission",
-                              "link" => [nil, "http://example.org"],
-                              "filename" => [nil, "blah"]}]
+                              "object" => "ToObject",
+                              "attribute2" => [nil, "http://example.org"],
+                              "attribute1" => [nil, "blah"]}]
     end
   end
 

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -115,7 +115,6 @@ describe HistoryFilter do
                                              "filename" => [nil, "blah"]
       })]
       result = described_class.new(history).transform do |history_item|
-        puts history_item.inspect
         history_item.changeset["event"] = "upload"
       end.changesets
       expect(result.first["event"]).to eq "upload"

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -107,4 +107,18 @@ describe HistoryFilter do
       expect(result.first["object"]).to eq "BLAH"
     end
   end
+
+  describe "#transform" do
+    it "manipulates a single history item" do
+      history = [OpenStruct.new(changeset: { "event" => "create",
+                                             "object" => "SubmissionFile",
+                                             "filename" => [nil, "blah"]
+      })]
+      result = described_class.new(history).transform do |history_item|
+        puts history_item.inspect
+        history_item.changeset["event"] = "upload"
+      end.changesets
+      expect(result.first["event"]).to eq "upload"
+    end
+  end
 end

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -81,6 +81,26 @@ describe HistoryFilter do
     end
   end
 
+  describe "#merge" do
+    it "merges the changeset from one object to another" do
+      history = [OpenStruct.new(version: OpenStruct.new(item_type: "SubmissionFile"),
+                                changeset: { "event" => "create",
+                                             "object" => "SubmissionFile",
+                                             "filename" => [nil, "blah"]}),
+                 OpenStruct.new(version: OpenStruct.new(item_type: "Submission"),
+                                changeset: { "event" => "create",
+                                             "object" => "Submission",
+                                             "link" => [nil, "http://example.org"]})
+      ]
+      result = described_class.new(history).merge("SubmissionFile" => "Submission")
+        .changesets
+      expect(result).to eq [{ "event" => "create",
+                              "object" => "Submission",
+                              "link" => [nil, "http://example.org"],
+                              "filename" => [nil, "blah"]}]
+    end
+  end
+
   describe "#remove" do
     it "filters a changeset by the changes" do
       history = [OpenStruct.new(changeset: { "attr" => ["value1", "value2"],


### PR DESCRIPTION
Merges and transforms the history for `Submission`s and `SubmissionFile`s so that they are not treated as separate events.

Instead of this (separate submission file):

<img width="1246" alt="screen shot 2016-02-25 at 11 27 51 am" src="https://cloud.githubusercontent.com/assets/35017/13326271/3115430a-dbb3-11e5-9a1a-94c2873092fc.png">

It now displays the `SubmissionFile` changes with the `Submission`:

<img width="1253" alt="screen shot 2016-02-25 at 11 28 08 am" src="https://cloud.githubusercontent.com/assets/35017/13326280/35cd51ee-dbb3-11e5-802b-dad6a74fc8bf.png">

In addition, in order to create a "past tense" version of a string ("create" -> "created", "upload" -> "uploaded"), I created a custom string class that allows this. No 🐒patching.

Closes #1647 