### PR TITLE
Bugfix/unlock condition group check

### DIFF
--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -143,10 +143,10 @@ class UnlockCondition < ActiveRecord::Base
 
   def check_submission_condition(student)
     assignment = Assignment.find(condition_id)
-    if assignment.has_groups?
+    if student.has_group_for_assignment? assignment
       group = student.group_for_assignment(assignment)
       submission = group.submission_for_assignment(assignment)
-    else
+    elsif assignment.is_individual?
       submission = student.submission_for_assignment(assignment)
     end
     if submission.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -525,6 +525,9 @@ class User < ActiveRecord::Base
     assignment_groups.where(assignment: assignment).first.try(:group)
   end
 
+  def has_group_for_assignment?(assignment)
+    assignment.has_groups? && group_for_assignment(assignment).present?
+  end
 
   private
 

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1,11 +1,12 @@
-#----------------------------------------------------------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
 
-#                                          ASSIGNMENT DEFAULT CONFIGURATION                                            #
+#                  ASSIGNMENT DEFAULT CONFIGURATION                            #
 
-#----------------------------------------------------------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
 
-# Add all attributes that will be passed on any assignment creation here, with a default value
-# All assignments will use defaults when individual attributes aren't supplied
+# Add all attributes that will be passed on any assignment creation here
+# with a default value.  All assignments will use defaults when individual
+# attributes aren't supplied.
 
 @assignment_default_config = {
   quotes: {
@@ -50,7 +51,7 @@
   },
   assignment_score_levels: false,
   rubric: false,
-  student_submissions: true,
+  student_submissions: true, # adds submissions for students
   unlock_condition: false,
   unlock_attributes: {
     condition: :nil,
@@ -59,8 +60,8 @@
   }
 }
 
-#----------------------------------------------------------------------------------------------------------------------#
-#----------------------------------------------------------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
+#------------------------------------------------------------------------------#
 
 @assignments = {}
 
@@ -98,7 +99,10 @@
 
 @assignments[:standard_edit_quick_grade_checkbox] = {
   quotes: {
-    assignment_created: "For me, I am driven by two main philosophies: know more today about the world than I knew yesterday and lessen the suffering of others. You'd be surprised how far that gets you. ― Neil deGrasse Tyson"
+    assignment_created: "For me, I am driven by two main philosophies: "\
+      "know more today about the world than I knew yesterday and lessen "\
+      "the suffering of others. You'd be surprised how far that gets you. "\
+      "― Neil deGrasse Tyson"
   },
   assignment_type: :grading,
   attributes: {
@@ -111,7 +115,9 @@
 
 @assignments[:standard_edit_quick_grade_checkbox_graded] = {
   quotes: {
-    assignment_created: "I hope you're pleased with yourselves. We could all have been killed - or worse, expelled. Now if you don't mind, I'm going to bed. ― J.K. Rowling"
+    assignment_created: "I hope you're pleased with yourselves. "\
+      "We could all have been killed - or worse, expelled. "\
+      "Now if you don't mind, I'm going to bed. ― J.K. Rowling"
   },
   assignment_type: :grading,
   attributes: {
@@ -442,7 +448,7 @@
   }
 }
 
-@assignments[:predictor_past_assignment_submission_closed] = {
+@assignments[:predictor_past_assignment_submission_open] = {
   quotes: {
     assignment_created: nil,
   },
@@ -476,6 +482,22 @@
     predicted_score: Proc.new { rand(15000) },
     point_total: Proc.new { nil },
   }
+}
+
+@assignments[:predictor_past_assignment_with_submissions] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :predictor,
+  attributes: {
+    name: "Has Submissions Past Acceptance No Grades",
+    description: "Should not have a late icon, should still accept predictions.",
+    due_at: 1.week.ago,
+    accepts_submissions_until: 1.week.ago,
+    point_total: 15000,
+    points_predictor_display: "Slider",
+  },
+  student_submissions: true
 }
 
 @assignments[:predictor_past_with_unreleased_grade_assignment] = {

--- a/spec/controllers/api/criterion_grades_controller_spec.rb
+++ b/spec/controllers/api/criterion_grades_controller_spec.rb
@@ -18,7 +18,6 @@ describe API::CriterionGradesController do
     describe "GET group_index" do
       before(:each) do
         world.create_group
-        world.assignment.groups << world.group
         world.group.students.each do |student|
           world.create_criterion_grade(assignment_id: world.assignment.id, student_id: student.id)
         end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -128,7 +128,7 @@ describe Grade do
   end
 
   describe ".find_or_create_grades" do
-    let(:world) { World.create.with(:course, :group, :assignment) }
+    let(:world) { World.create.with(:course, :assignment, :group) }
     let(:ids) { world.group.students.pluck(:id) }
 
     it "finds and existing grade for assignment and student" do

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -1,14 +1,21 @@
 require "active_record_spec_helper"
 
 describe UnlockCondition do
-
   let(:badge) { create :badge, name: "fancy name" }
   let(:unlockable_badge) { create :badge, name: "unlockable badge" }
   let(:assignment) { create :assignment, name: "fancier name" }
-  let(:unlockable_assignment) { create :assignment, name: "unlockable assignment" }
+  let :unlockable_assignment do
+    create :assignment, name: "unlockable assignment"
+  end
 
   subject do
-    UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
+    UnlockCondition.new(
+      condition_id: badge.id,
+      condition_type: "Badge",
+      condition_state: "Earned",
+      unlockable_id: unlockable_assignment.id,
+      unlockable_type: "Assignment"
+    )
   end
 
   describe "validations" do
@@ -37,304 +44,492 @@ describe UnlockCondition do
     end
 
     it "returns the name of an assignment condition" do
-      assignment_condition_unlock = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted"
+      assignment_condition_unlock = UnlockCondition.new(
+        condition_id: assignment.id,
+        condition_type: "Assignment",
+        condition_state: "Submitted"
+      )
       expect(assignment_condition_unlock.name).to eq "fancier name"
     end
   end
 
   describe "#unlockable_name" do
     it "returns the name of a badge to be unlocked" do
-      unlockable_badge_subject = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", unlockable_id: unlockable_badge.id, unlockable_type: "Badge"
+      unlockable_badge_subject = UnlockCondition.new(
+        condition_id: badge.id,
+        condition_type: "Badge",
+        condition_state: "Earned",
+        unlockable_id: unlockable_badge.id,
+        unlockable_type: "Badge"
+      )
       expect(unlockable_badge_subject.unlockable_name).to eq "unlockable badge"
     end
 
     it "returns the name of an assignment to be unlocked" do
-      unlockable_assignment_subject = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted", unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlockable_assignment_subject .unlockable_name).to eq "unlockable assignment"
+      unlockable_assignment_subject = UnlockCondition.new(
+        condition_id: assignment.id,
+        condition_type: "Assignment",
+        condition_state: "Submitted",
+        unlockable_id: unlockable_assignment.id,
+        unlockable_type: "Assignment"
+      )
+      expect(unlockable_assignment_subject .unlockable_name).to \
+        eq "unlockable assignment"
     end
   end
 
-  describe "#is_complete?" do
+  describe "#is_complete? badge conditions" do
+    describe "with a condition state of 'Earned'" do
+      it "returns true if the badge has been earned once" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        expect(subject.is_complete?(student)).to eq(true)
+      end
 
-    #badge conditions as an unlock
+      it "returns false if the badge has not been earned" do
+        student = create(:user)
+        expect(subject.is_complete?(student)).to eq(false)
+      end
 
-    it "returns true if the badge has been earned once" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      expect(subject.is_complete?(student)).to eq(true)
+      it "returns true if the badge has been earned enough times" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        create(:earned_badge, badge: badge, student: student)
+        unlock_condition = UnlockCondition.new(
+          condition_id: badge.id, condition_type: "Badge",
+          condition_state: "Earned", condition_value: 2,
+          unlockable_id: unlockable_assignment.id,
+          unlockable_type: "Assignment"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if the badge has been earned enough times" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        create(:earned_badge, badge: badge, student: student)
+        unlock_condition = UnlockCondition.new(
+          condition_id: badge.id, condition_type: "Badge",
+          condition_state: "Earned", condition_value: 3,
+          unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns true if the badge has been earned enough times and on time" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        create(:earned_badge, badge: badge, student: student)
+        unlock_condition = UnlockCondition.new(
+          condition_id: badge.id, condition_type: "Badge",
+          condition_state: "Earned", condition_value: 2,
+          condition_date: (Date.today + 1),
+          unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if the badge has been earned on time but not enough" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        create(:earned_badge, badge: badge, student: student)
+        unlock_condition = UnlockCondition.new(
+          condition_id: badge.id, condition_type: "Badge",
+          condition_state: "Earned", condition_value: 3,
+          condition_date: (Date.today + 1),
+          unlockable_id: unlockable_assignment.id,
+          unlockable_type: "Assignment"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns false for badge earned enough but not on time" do
+        student = create(:user)
+        create(:earned_badge, badge: badge, student: student)
+        create(:earned_badge, badge: badge, student: student)
+        unlock_condition = UnlockCondition.new(
+          condition_id: badge.id,
+          condition_type: "Badge",
+          condition_state: "Earned",
+          condition_value: 3, condition_date: (Date.today - 1),
+          unlockable_id: unlockable_assignment.id,
+          unlockable_type: "Assignment"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+    end
+  end
+
+  describe "#is_complete? assignment conditions" do
+    describe "with a condition state of 'Submitted'" do
+      let(:student) { create :user }
+      let :unlock_condition do
+        UnlockCondition.new(
+          condition_id: assignment.id,
+          condition_type: "Assignment",
+          condition_state: "Submitted"
+        )
+      end
+
+      it "return false for group assignmens if student is not in a group" do
+        assignment.update(grade_scope: "Group")
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns false if the assignment has not been submitted" do
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      describe "with submission" do
+        before do
+          create(:submission, assignment: assignment,
+                              student: student,
+                              submitted_at: DateTime.now
+                )
+        end
+
+        it "returns true if the assignment has been submitted" do
+          expect(unlock_condition.is_complete?(student)).to eq(true)
+        end
+
+        it "returns false when assignment has been submitted late" do
+          unlock_condition.update(condition_date: (Date.today - 1))
+          expect(unlock_condition.is_complete?(student)).to eq(false)
+        end
+
+        it "returns true if the assignment has been submitted on time" do
+          unlock_condition.update(condition_date: (Date.today + 1))
+          expect(unlock_condition.is_complete?(student)).to eq(true)
+        end
+      end
     end
 
-    it "returns false if the badge has not been earned" do
-      student = create(:user)
-      expect(subject.is_complete?(student)).to eq(false)
+    describe "with a condition state of 'Grade Earned'" do
+      it "returns true if the grade earned is present and student visible" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: "Released"
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if the grade earned is not student visible" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: nil
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns true if the grade earned meets the condition value" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: "Released")
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if the grade earned is less than the condition value" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 99, status: "Released")
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100)
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns false if condition is met but not student visible" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: nil, instructor_modified: false,
+                  graded_at: DateTime.now
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100)
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns true if the grade earned meets the condition date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: "Graded", instructor_modified:
+                  true, graded_at: DateTime.now
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_date: (Date.today + 1)
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if the grade earned did not meet the condition date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 100, status: "Graded", instructor_modified: true,
+                  graded_at: DateTime.now
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_date: (Date.today - 1)
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns true if the grade earned meets condition value and date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, raw_score: 100,
+                  status: "Graded", instructor_modified: true,
+                  graded_at: DateTime.now
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100,
+          condition_date: (Date.today + 1)
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
+
+      it "returns false if grade earned meets condition date but not value" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student,
+                  raw_score: 90, status: "Graded", instructor_modified: true
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100,
+          condition_date: (Date.today + 1)
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
+
+      it "returns false if grade earned meets condition value but not date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, raw_score: 100,
+                  status: "Graded", instructor_modified: true,
+                  graded_at: DateTime.now
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Grade Earned", condition_value: 100,
+          condition_date: (Date.today - 1)
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
     end
 
-    it "returns true if the badge has been earned enough times" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      student_earned_badge_2 = create(:earned_badge, badge: badge, student: student)
-      unlock_condition = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", condition_value: 2, unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
+    describe "with a condition state of 'Feedback Read'" do
+      it "returns true if the grade feedback is read" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, status: "Graded",
+                  instructor_modified: true, feedback_read: true
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Feedback Read"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
 
-    it "returns false if the badge has been earned enough times" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      student_earned_badge_2 = create(:earned_badge, badge: badge, student: student)
-      unlock_condition = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", condition_value: 3, unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
+      it "returns false if the grade feedback is not read" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, status: "Graded",
+                  instructor_modified: true, feedback_read: false
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Feedback Read"
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
 
-    it "returns true if the badge has been earned enough times by a specific date" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      student_earned_badge_2 = create(:earned_badge, badge: badge, student: student)
-      unlock_condition = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", condition_value: 2, condition_date: (Date.today + 1), unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
+      it "returns true if the grade feedback is read by specified date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, status: "Graded",
+                  instructor_modified: true, feedback_read: true,
+                  feedback_read_at: Date.today
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Feedback Read", condition_date: Date.today + 1
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(true)
+      end
 
-    it "returns false if the badge has been earned by a specific date but not enough times" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      student_earned_badge_2 = create(:earned_badge, badge: badge, student: student)
-      unlock_condition = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", condition_value: 3, condition_date: (Date.today + 1), unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns false if the badge has been earned enough times but not by a specific date" do
-      student = create(:user)
-      student_earned_badge = create(:earned_badge, badge: badge, student: student)
-      student_earned_badge_2 = create(:earned_badge, badge: badge, student: student)
-      unlock_condition = UnlockCondition.new condition_id: badge.id, condition_type: "Badge", condition_state: "Earned", condition_value: 3, condition_date: (Date.today - 1), unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the assignment has been submitted" do
-      student = create(:user)
-      student_submission = create(:submission, assignment: assignment, student: student)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted"
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the assignment has not been submitted" do
-      student = create(:user)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the assignment has been submitted by a specific date" do
-      student = create(:user)
-      student_submission = create(:submission, assignment: assignment, student: student, submitted_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted", condition_date: (Date.today + 1)
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the assignment has been submitted but not by the specified date" do
-      student = create(:user)
-      student_submission = create(:submission, assignment: assignment, student: student, submitted_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted", condition_date: (Date.today - 1)
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade earned is present and student visible" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Released")
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned"
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade earned is present but not student visible" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: nil)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade earned meets the condition value" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Released")
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade earned does not meet the condition value" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 99, status: "Released")
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns false if the grade earned meets the condition value but is not student visible" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: nil, instructor_modified: false, graded_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade earned meets the condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_date: (Date.today + 1)
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade earned did not meet the condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_date: (Date.today - 1)
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade earned meets condition value and the condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100, condition_date: (Date.today + 1)
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade earned does not meet the condition value but does meet the condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 90, status: "Graded", instructor_modified: true)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100, condition_date: (Date.today + 1)
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns false if the grade earned does meet the condition value but does not meet the condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, raw_score: 100, status: "Graded", instructor_modified: true, graded_at: DateTime.now)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned", condition_value: 100, condition_date: (Date.today - 1)
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade feedback is read" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, status: "Graded", instructor_modified: true, feedback_read: true)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Feedback Read"
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade feedback is not read" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, status: "Graded", instructor_modified: true, feedback_read: false)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Feedback Read"
-      expect(unlock_condition.is_complete?(student)).to eq(false)
-    end
-
-    it "returns true if the grade feedback is read by specified condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, status: "Graded", instructor_modified: true, feedback_read: true, feedback_read_at: Date.today)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Feedback Read", condition_date: Date.today + 1
-      expect(unlock_condition.is_complete?(student)).to eq(true)
-    end
-
-    it "returns false if the grade feedback is read but not by the specified condition date" do
-      student = create(:user)
-      grade = create(:grade, assignment: assignment, student: student, status: "Graded", instructor_modified: true, feedback_read: true, feedback_read_at: Date.today)
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Feedback Read", condition_date: Date.today - 1
-      expect(unlock_condition.is_complete?(student)).to eq(false)
+      it "returns false if feedback read but not by the date" do
+        student = create(:user)
+        create(
+          :grade, assignment: assignment, student: student, status: "Graded",
+                  instructor_modified: true, feedback_read: true,
+                  feedback_read_at: Date.today
+        )
+        unlock_condition = UnlockCondition.new(
+          condition_id: assignment.id, condition_type: "Assignment",
+          condition_state: "Feedback Read", condition_date: Date.today - 1
+        )
+        expect(unlock_condition.is_complete?(student)).to eq(false)
+      end
     end
   end
 
   describe "#is_complete_for_group(group)" do
+    let(:course) { create(:course) }
+    let(:student) { create(:user) }
+    let(:student_2) { create(:user) }
+    let(:student_3) { create(:user) }
+    let(:group) { create(:group, course: course) }
+    let :assignment do
+      create(:assignment, grade_scope: "Group", course: course)
+    end
+    let :membership do
+      create(:group_membership, group: group, student: student)
+    end
+    let :membership_2 do
+      create(:group_membership, group: group, student: student_2)
+    end
+    let :membership_3 do
+      create(:group_membership, group: group, student: student_3)
+    end
+    let :assignment_group do
+      create(:assignment_group, group: group, assignment: assignment)
+    end
+    let(:new_badge) { create(:badge, course: course) }
 
-    it "returns false if the students in the group have not earned the badge" do
-      course = create(:course)
-      student = create(:user)
-      student_2 = create(:user)
-      student_3 = create(:user)
-      group = create(:group, course: course)
-      group_assignment = create(:assignment, grade_scope: "Group", course: course)
-      group_membership = create(:group_membership, group: group, student: student)
-      group_membership_2 = create(:group_membership, group: group, student: student_2)
-      group_membership_3 = create(:group_membership, group: group, student: student_3)
-      assignment_group = create(:assignment_group, group: group, assignment: group_assignment)
-      new_badge = create(:badge, course: course)
-      unlock_condition = UnlockCondition.new unlockable_id: group_assignment.id, unlockable_type: "Assignment", condition_id: new_badge.id, condition_type: "Badge", condition_state: "Earned"
+    it "returns false if students in the group have not earned the badge" do
+      unlock_condition = UnlockCondition.new(
+        unlockable_id: assignment.id, unlockable_type: "Assignment",
+        condition_id: new_badge.id, condition_type: "Badge",
+        condition_state: "Earned"
+      )
       expect(unlock_condition.is_complete_for_group?(group)).to eq(false)
     end
 
-    it "returns false if one of the students in the group has not earned the badge" do
-      course = create(:course)
-      student = create(:user)
-      student_2 = create(:user)
-      student_3 = create(:user)
-      group = create(:group, course: course)
-      group_assignment = create(:assignment, grade_scope: "Group", course: course)
-      group_membership = create(:group_membership, group: group, student: student)
-      group_membership_2 = create(:group_membership, group: group, student: student_2)
-      group_membership_3 = create(:group_membership, group: group, student: student_3)
-      assignment_group = create(:assignment_group, group: group, assignment: group_assignment)
-      new_badge = create(:badge, course: course)
-      unlock_condition = UnlockCondition.new unlockable_id: group_assignment.id, unlockable_type: "Assignment", condition_id: new_badge.id, condition_type: "Badge", condition_state: "Earned"
-      earned_badge = create(:earned_badge, badge: new_badge, student: student, student_visible: true)
+    it "returns false if one student in the group has not earned the badge" do
+      unlock_condition = UnlockCondition.new(
+        unlockable_id: assignment.id, unlockable_type: "Assignment",
+        condition_id: new_badge.id, condition_type: "Badge",
+        condition_state: "Earned"
+      )
+      create(
+        :earned_badge, badge: new_badge, student: student, student_visible: true
+      )
       expect(unlock_condition.is_complete_for_group?(group)).to eq(false)
     end
 
-    it "returns true if all of the students in the group have earned the badge" do
+    it "returns true if all students in the group have earned the badge" do
       skip "pending"
-      course = create(:course)
-      student = create(:user)
-      student_2 = create(:user)
-      student_3 = create(:user)
       student.courses << course
       student_2.courses << course
       student_3.courses << course
-      group = build(:group, course: course)
-      group_membership = create(:group_membership, group: group, student: student)
-      group_membership_2 = create(:group_membership, group: group, student: student_2)
-      group_membership_3 = create(:group_membership, group: group, student: student_3)
-      group_assignment = create(:assignment, grade_scope: "Group")
-      assignment_group = create(:assignment_group, group: group, assignment: group_assignment)
+      create(
+        :assignment_group, group: group, assignment: assignment
+      )
       new_badge = create(:badge, course: course)
-      unlock_condition = UnlockCondition.create unlockable_id: group_assignment.id, unlockable_type: "Assignment", condition_id: new_badge.id, condition_type: "Badge", condition_state: "Earned"
-      earned_badge = create(:earned_badge, badge: new_badge, student: student, student_visible: true)
-      earned_badge_2 = create(:earned_badge, badge: new_badge, student: student_2, student_visible: true)
-      earned_badge_3 = create(:earned_badge, badge: new_badge, student: student_3, student_visible: true)
+      unlock_condition = UnlockCondition.create(
+        unlockable_id: assignment.id, unlockable_type: "Assignment",
+        condition_id: new_badge.id, condition_type: "Badge",
+        condition_state: "Earned"
+      )
+      create(
+        :earned_badge, badge: new_badge, student: student,
+                       student_visible: true
+      )
+      create(
+        :earned_badge, badge: new_badge, student: student_2,
+                       student_visible: true
+      )
+      create(
+        :earned_badge, badge: new_badge, student: student_3,
+                       student_visible: true
+      )
       expect(group.group_memberships.count).to eq 3
-      #expect(unlock_condition.is_complete_for_group?(@group)).to eq(true)
+      expect(unlock_condition.is_complete_for_group?(@group)).to eq(true)
     end
-
   end
 
   describe "#requirements_description_sentence" do
     it "returns a sentence summarizing a badge unlock condition" do
-      expect(subject.requirements_description_sentence).to eq("Earn the #{badge.name} Badge")
+      expect(subject.requirements_description_sentence).to \
+        eq("Earn the #{badge.name} Badge")
     end
 
-    it "returns a sentence summarizing an assignment feedback read unlock condition" do
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Feedback Read"
-      expect(unlock_condition.requirements_description_sentence).to eq("Read the feedback for the #{assignment.name} Assignment")
+    it "returns a summary of an assignment feedback read unlock condition" do
+      unlock_condition = UnlockCondition.new(
+        condition_id: assignment.id, condition_type: "Assignment",
+        condition_state: "Feedback Read"
+      )
+      expect(unlock_condition.requirements_description_sentence).to \
+        eq("Read the feedback for the #{assignment.name} Assignment")
     end
 
-    it "returns a sentence summarizing an assignment submission unlock condition" do
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Submitted"
-      expect(unlock_condition.requirements_description_sentence).to eq("Submit the #{assignment.name} Assignment")
+    it "returns a summary of an assignment submission unlock condition" do
+      unlock_condition = UnlockCondition.new(
+        condition_id: assignment.id, condition_type: "Assignment",
+        condition_state: "Submitted"
+      )
+      expect(unlock_condition.requirements_description_sentence).to \
+        eq("Submit the #{assignment.name} Assignment")
     end
 
-    it "returns a sentence summarizing an grade earned unlock condition" do
-      unlock_condition = UnlockCondition.new condition_id: assignment.id, condition_type: "Assignment", condition_state: "Grade Earned"
-      expect(unlock_condition.requirements_description_sentence).to eq("Earn a grade for the #{assignment.name} Assignment")
+    it "returns a summary of an grade earned unlock condition" do
+      unlock_condition = UnlockCondition.new(
+        condition_id: assignment.id, condition_type: "Assignment",
+        condition_state: "Grade Earned"
+      )
+      expect(unlock_condition.requirements_description_sentence).to \
+        eq("Earn a grade for the #{assignment.name} Assignment")
     end
   end
 
   describe "#key_description_sentence" do
     it "returns a sentence summarizing the badge as an unlock key" do
-      expect(subject.key_description_sentence).to eq("Earning it unlocks the #{unlockable_assignment.name} Assignment")
+      expect(subject.key_description_sentence).to \
+        eq("Earning it unlocks the #{unlockable_assignment.name} Assignment")
     end
 
-    it "returns a sentence summarizing an assignment feedback read unlock condition" do
+    it "returns a summary of an assignment feedback read unlock condition" do
       subject.condition_state = "Feedback Read"
-      expect(subject.key_description_sentence).to eq("Reading the feedback for it unlocks the #{unlockable_assignment.name} Assignment")
+      expect(subject.key_description_sentence).to \
+        eq("Reading the feedback for it unlocks the "\
+          "#{unlockable_assignment.name} Assignment")
     end
 
-    it "returns a sentence summarizing an assignment submission unlock condition" do
+    it "returns a summary of an assignment submission unlock condition" do
       subject.condition_state = "Submitted"
-      expect(subject.key_description_sentence).to eq("Submitting it unlocks the #{unlockable_assignment.name} Assignment")
+      expect(subject.key_description_sentence).to \
+        eq("Submitting it unlocks the #{unlockable_assignment.name} Assignment")
     end
 
-    it "returns a sentence summarizing an grade earned unlock condition" do
+    it "returns a summary of an grade earned unlock condition" do
       subject.condition_state = "Grade Earned"
-      expect(subject.key_description_sentence).to eq("Earning a grade for it unlocks the #{unlockable_assignment.name} Assignment")
+      expect(subject.key_description_sentence).to \
+        eq("Earning a grade for it unlocks the "\
+          "#{unlockable_assignment.name} Assignment")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -658,15 +658,23 @@ describe User do
   end
 
   describe "#group_for_assignment(assignment)" do
+    let!(:create_group) { world.create_group }
+    let(:group) { world.group }
+
     it "returns a student's group for a particular assignment if present" do
-      world.create_group
+      FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
+      FactoryGirl.create(:group_membership, student: student, group: group)
       expect(student.group_for_assignment(assignment)).to eq(world.group)
     end
   end
 
   describe "#has_group_for_assignment?" do
+    let!(:create_group) { world.create_group }
+    let(:group) { world.group }
+
     it "returns false for individual assignments" do
-      world.create_group
+      FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
+      FactoryGirl.create(:group_membership, student: student, group: group)
       assignment.update(grade_scope: "Individual")
       expect(student.has_group_for_assignment?(assignment)).to be_falsey
     end
@@ -678,7 +686,8 @@ describe User do
 
     it "returns true if the student is in a group" do
       assignment.update(grade_scope: "Group")
-      world.create_group
+      FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
+      FactoryGirl.create(:group_membership, student: student, group: group)
       expect(student.has_group_for_assignment?(assignment)).to be_truthy
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,12 +2,12 @@ require "active_record_spec_helper"
 
 describe User do
   let!(:world) do
-    World.create
-      .create_course
-      .create_student
-      .create_assignment
-      .create_grade
+    World.create.with(:course, :student, :assignment, :grade)
   end
+  let(:course) { world.course }
+  let(:student) { world.student }
+  let(:assignment) { world.assignment }
+  let(:grade) { world.grade }
 
   describe "validations" do
     it "requires the password confirmation to match" do
@@ -17,9 +17,9 @@ describe User do
     end
 
     it "requires that there is a password confirmation" do
-      world.student.password = "test"
-      expect(world.student).to_not be_valid
-      expect(world.student.errors[:password_confirmation]).to include "can't be blank"
+      student.password = "test"
+      expect(student).to_not be_valid
+      expect(student.errors[:password_confirmation]).to include "can't be blank"
     end
   end
 
@@ -34,19 +34,19 @@ describe User do
 
   describe ".find_by_insensitive_email" do
     it "should return the user no matter what the case the email address is in" do
-      expect(User.find_by_insensitive_email(world.student.email.upcase)).to eq world.student
+      expect(User.find_by_insensitive_email(student.email.upcase)).to eq student
     end
   end
 
   describe ".find_by_insensitive_username" do
     it "should return the user no matter what the case the username is in" do
-      expect(User.find_by_insensitive_username(world.student.username.upcase)).to eq world.student
+      expect(User.find_by_insensitive_username(student.username.upcase)).to eq student
     end
   end
 
   describe ".email_exists?" do
     it "should return true if the email already exists" do
-      expect(User.email_exists?(world.student.email.upcase)).to eq true
+      expect(User.email_exists?(student.email.upcase)).to eq true
     end
 
     it "should return false if the email does not exist" do
@@ -110,24 +110,24 @@ describe User do
   describe ".students_being_graded" do
     let(:student_not_being_graded) { create(:user) }
     before do
-      create(:course_membership, course: world.course, user: student_not_being_graded, auditing: true)
+      create(:course_membership, course: course, user: student_not_being_graded, auditing: true)
     end
 
     it "returns all the students that are being graded" do
-      result = User.students_being_graded(world.course)
-      expect(result.pluck(:id)).to eq [world.student.id]
+      result = User.students_being_graded(course)
+      expect(result.pluck(:id)).to eq [student.id]
     end
 
     context "with a team" do
       let(:student_in_team) { create :user }
-      let(:team) { create :team, course: world.course }
+      let(:team) { create :team, course: course }
       before do
-        create(:course_membership, course: world.course, user: student_in_team)
+        create(:course_membership, course: course, user: student_in_team)
         team.students << student_in_team
       end
 
       it "returns only students in the team that are being graded" do
-        result = User.students_being_graded(world.course, team)
+        result = User.students_being_graded(course, team)
         expect(result.pluck(:id)).to eq [student_in_team.id]
       end
     end
@@ -137,9 +137,9 @@ describe User do
     let(:team) { world.create_team.team }
 
     it "returns only students in the team" do
-      team.students << world.student
-      result = User.students_by_team(world.course, team)
-      expect(result.pluck(:id)).to eq [world.student.id]
+      team.students << student
+      result = User.students_by_team(course, team)
+      expect(result.pluck(:id)).to eq [student.id]
     end
   end
 
@@ -173,40 +173,40 @@ describe User do
     let(:student) { create :user }
 
     it "returns true if the student is auditing" do
-      create(:course_membership, course: world.course, user: student, auditing: true)
-      expect(student.auditing_course?(world.course)).to eq(true)
+      create(:course_membership, course: course, user: student, auditing: true)
+      expect(student.auditing_course?(course)).to eq(true)
     end
 
     it "returns false if the student is being graded" do
-      membership = create(:course_membership, course: world.course, user: student, auditing: false)
-      expect(student.auditing_course?(world.course)).to eq(false)
+      membership = create(:course_membership, course: course, user: student, auditing: false)
+      expect(student.auditing_course?(course)).to eq(false)
     end
   end
 
   describe "#self_reported_done?" do
     it "is not self reported if there are no grades" do
-      expect(world.student).to_not be_self_reported_done(world.assignment)
+      expect(student).to_not be_self_reported_done(world.assignment)
     end
 
     it "is self reported if there is at least one graded grade" do
       world.grade.update_attribute :status, "Graded"
-      expect(world.student).to be_self_reported_done(world.assignment)
+      expect(student).to be_self_reported_done(world.assignment)
     end
   end
 
   describe "#role" do
     it "returns the first role found from the course membership" do
-      expect(world.student.role(world.course)).to eq "student"
+      expect(student.role(course)).to eq "student"
     end
 
     it "returns nil if the course membership is not found" do
-      expect(world.student.role(Course.new)).to eq nil
+      expect(student.role(Course.new)).to eq nil
     end
 
     it "returns admin if the user is an admin" do
-      world.student.admin = true
-      world.student.save
-      expect(world.student.role(world.course)).to eq "admin"
+      student.admin = true
+      student.save
+      expect(student.role(course)).to eq "admin"
     end
   end
 
@@ -225,91 +225,90 @@ describe User do
   describe "#is_staff?(course)" do
     let(:user) { create :user }
     it "returns true if the user is a professor in the course" do
-      membership = create(:course_membership, course: world.course, user: user, role: "professor")
-      expect(user.is_staff?(world.course)).to eq(true)
+      membership = create(:course_membership, course: course, user: user, role: "professor")
+      expect(user.is_staff?(course)).to eq(true)
     end
     it "returns true if the user is a GSI in the course" do
-      membership = create(:course_membership, course: world.course, user: user, role: "gsi")
-      expect(user.is_staff?(world.course)).to eq(true)
+      membership = create(:course_membership, course: course, user: user, role: "gsi")
+      expect(user.is_staff?(course)).to eq(true)
     end
     it "returns true if the user is an admin in the course" do
-      membership = create(:course_membership, course: world.course, user: user, role: "admin")
-      expect(user.is_staff?(world.course)).to eq(true)
+      membership = create(:course_membership, course: course, user: user, role: "admin")
+      expect(user.is_staff?(course)).to eq(true)
     end
 
     it "returns false if the user is a student in the course" do
-      membership = create(:course_membership, course: world.course, user: user, role: "student")
-      expect(user.is_staff?(world.course)).to eq(false)
+      membership = create(:course_membership, course: course, user: user, role: "student")
+      expect(user.is_staff?(course)).to eq(false)
     end
 
     it "requires an email to end with umich if an internal user" do
-      world.student.internal = true
-      world.student.email = "blah@example.com"
-      expect(world.student).to_not be_valid
-      expect(world.student.errors[:email]).to include "must be a University of Michigan email"
+      student.internal = true
+      student.email = "blah@example.com"
+      expect(student).to_not be_valid
+      expect(student.errors[:email]).to include "must be a University of Michigan email"
     end
 
     it "requires an email to end with umich if it was saved with a umich email" do
-      world.student.email = "blah@umich.edu"
-      world.student.save
-      world.student.email = "blah@example.com"
-      expect(world.student).to_not be_valid
-      expect(world.student.errors[:email]).to include "must be a University of Michigan email"
+      student.email = "blah@umich.edu"
+      student.save
+      student.email = "blah@example.com"
+      expect(student).to_not be_valid
+      expect(student.errors[:email]).to include "must be a University of Michigan email"
     end
   end
 
   describe "#team_for_course(course)" do
     let(:student) { create :user }
-    let(:team) { create :team, course: world.course }
+    let(:team) { create :team, course: course }
 
     before do
-      create(:course_membership, course: world.course, user: student)
+      create(:course_membership, course: course, user: student)
     end
 
     it "returns the student's team for the course" do
       create(:team_membership, team: team, student: student)
-      expect(student.team_for_course(world.course)).to eq(team)
+      expect(student.team_for_course(course)).to eq(team)
     end
 
     it "returns nil if the student doesn't have a team" do
-      expect(student.team_for_course(world.course)).to eq(nil)
+      expect(student.team_for_course(course)).to eq(nil)
     end
-
   end
 
   describe "#team_leaders(course)" do
     let(:student) { create :user }
     let(:team_leader) { create :user }
-    let(:team) { create :team, course: world.course }
+    let(:team) { create :team, course: course }
 
     before do
-      create(:course_membership, course: world.course, user: student)
+      create(:course_membership, course: course, user: student)
     end
 
     it "returns the students team leaders if they're present" do
       create(:team_leadership, team: team, leader: team_leader)
       create(:team_membership, team: team, student: student)
-      expect(student.team_leaders(world.course)).to eq([team_leader])
+      expect(student.team_leaders(course)).to eq([team_leader])
 
     end
 
     it "returns nil if there are no team leaders present" do
       create(:team_membership, team: team, student: student)
-      expect(student.team_leaders(world.course)).to eq([])
+      expect(student.team_leaders(course)).to eq([])
     end
   end
 
   describe "#team_leaderships_for_course(course)" do
     let(:team_leader) { create :user }
-    let(:team) { create :team, course: world.course }
+    let(:team) { create :team, course: course }
 
     it "returns the team leaderships if they're present" do
       leadership = create(:team_leadership, team: team, leader: team_leader)
-      expect(team_leader.team_leaderships(world.course)).to eq([leadership])
+      expect(team_leader.team_leaderships(course)).to eq([leadership])
     end
 
     it "returns nil if there are no team leaderships present" do
-      expect(team_leader.team_leaderships(world.course)).to eq([])
+      expect(team_leader.team_leaderships(course)).to eq([])
     end
   end
 
@@ -317,11 +316,11 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, course: world.course, user: student, character_profile: "The six-fingered man.")
+      create(:course_membership, course: course, user: student, character_profile: "The six-fingered man.")
     end
 
     it "returns the student's character profile if it's present" do
-      expect(student.character_profile(world.course)).to eq("The six-fingered man.")
+      expect(student.character_profile(course)).to eq("The six-fingered man.")
     end
   end
 
@@ -329,7 +328,7 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, course: world.course, user: student)
+      create(:course_membership, course: course, user: student)
     end
 
     it "returns all archived courses for a student" do
@@ -343,13 +342,13 @@ describe User do
     let(:student) { create :user }
 
     it "returns the student's score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      expect(student.cached_score_for_course(world.course)).to eq(100000)
+      create(:course_membership, course: course, user: student, score: 100000)
+      expect(student.cached_score_for_course(course)).to eq(100000)
     end
 
     it "returns 0 if the student has no score" do
-      create(:course_membership, course: world.course, user: student)
-      expect(student.cached_score_for_course(world.course)).to eq(0)
+      create(:course_membership, course: course, user: student)
+      expect(student.cached_score_for_course(course)).to eq(0)
     end
   end
 
@@ -361,9 +360,9 @@ describe User do
     let(:student) { create :user }
 
     it "returns the grade scheme element that matches the students score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: world.course, low_range: 80000, high_range: 120000)
-      expect(student.grade_for_course(world.course)).to eq(gse)
+      create(:course_membership, course: course, user: student, score: 100000)
+      gse = create(:grade_scheme_element, course: course, low_range: 80000, high_range: 120000)
+      expect(student.grade_for_course(course)).to eq(gse)
     end
   end
 
@@ -371,9 +370,9 @@ describe User do
     let(:student) { create :user }
 
     it "returns the grade scheme level name that matches the student's score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: world.course, low_range: 80000, high_range: 120000, level: "Meh")
-      expect(student.grade_level_for_course(world.course)).to eq("Meh")
+      create(:course_membership, course: course, user: student, score: 100000)
+      gse = create(:grade_scheme_element, course: course, low_range: 80000, high_range: 120000, level: "Meh")
+      expect(student.grade_level_for_course(course)).to eq("Meh")
     end
   end
 
@@ -381,9 +380,9 @@ describe User do
     let(:student) { create :user }
 
     it "returns the grade scheme letter name that matches the student's score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: world.course, low_range: 80000, high_range: 120000, letter: "Q")
-      expect(student.grade_letter_for_course(world.course)).to eq("Q")
+      create(:course_membership, course: course, user: student, score: 100000)
+      gse = create(:grade_scheme_element, course: course, low_range: 80000, high_range: 120000, letter: "Q")
+      expect(student.grade_letter_for_course(course)).to eq("Q")
     end
   end
 
@@ -391,11 +390,11 @@ describe User do
     let(:student) { create :user }
 
     it "returns the next level above a student's current score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: world.course, low_range: 80000, high_range: 120000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: world.course, low_range: 120001, high_range: 150000, letter: "R")
-      gse_2 = create(:grade_scheme_element, course: world.course, low_range: 150001, high_range: 180000, letter: "S")
-      expect(student.next_element_level(world.course)).to eq(gse_1)
+      create(:course_membership, course: course, user: student, score: 100000)
+      gse = create(:grade_scheme_element, course: course, low_range: 80000, high_range: 120000, letter: "Q")
+      gse_1 = create(:grade_scheme_element, course: course, low_range: 120001, high_range: 150000, letter: "R")
+      gse_2 = create(:grade_scheme_element, course: course, low_range: 150001, high_range: 180000, letter: "S")
+      expect(student.next_element_level(course)).to eq(gse_1)
     end
   end
 
@@ -403,10 +402,10 @@ describe User do
     let(:student) { create :user }
 
     it "returns the next level above a student's current score for the course" do
-      create(:course_membership, course: world.course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: world.course, low_range: 80000, high_range: 120000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: world.course, low_range: 120001, high_range: 150000, letter: "R")
-      expect(student.points_to_next_level(world.course)).to eq(20001)
+      create(:course_membership, course: course, user: student, score: 100000)
+      gse = create(:grade_scheme_element, course: course, low_range: 80000, high_range: 120000, letter: "Q")
+      gse_1 = create(:grade_scheme_element, course: course, low_range: 120001, high_range: 150000, letter: "R")
+      expect(student.points_to_next_level(course)).to eq(20001)
     end
   end
 
@@ -476,18 +475,18 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
-      create(:earned_badge, score: 100, student: student, course: world.course, student_visible: true)
-      create(:earned_badge, score: 300, student: student, course: world.course, student_visible: true)
+      create(:course_membership, user: student, course: course)
+      create(:earned_badge, score: 100, student: student, course: course, student_visible: true)
+      create(:earned_badge, score: 300, student: student, course: course, student_visible: true)
     end
 
     it "returns the sum of the badge score for a student" do
-      expect(student.earned_badge_score_for_course(world.course)).to eq(400)
+      expect(student.earned_badge_score_for_course(course)).to eq(400)
     end
 
     it "does not include earned badges that have not yet been made student visible" do
-      create(:earned_badge, score: 155, student: student, course: world.course, student_visible: false)
-      expect(student.earned_badge_score_for_course(world.course)).to eq(400)
+      create(:earned_badge, score: 155, student: student, course: course, student_visible: false)
+      expect(student.earned_badge_score_for_course(course)).to eq(400)
     end
   end
 
@@ -495,41 +494,41 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "returns the students' earned_badges for a course" do
-      earned_badge_1 = create(:earned_badge, score: 100, student: student, course: world.course, student_visible: true)
-      earned_badge_2 = create(:earned_badge, score: 300, student: student, course: world.course, student_visible: true)
-      expect(student.earned_badges_for_course(world.course)).to eq([earned_badge_1, earned_badge_2])
+      earned_badge_1 = create(:earned_badge, score: 100, student: student, course: course, student_visible: true)
+      earned_badge_2 = create(:earned_badge, score: 300, student: student, course: course, student_visible: true)
+      expect(student.earned_badges_for_course(course)).to eq([earned_badge_1, earned_badge_2])
     end
   end
 
   describe "#earned_badge_for_badge(badge)" do
     let(:student) { create :user }
-    let(:badge) { create :badge, course: world.course }
+    let(:badge) { create :badge, course: course }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "returns the students' earned_badges for a particular badge" do
-      earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: world.course, student_visible: true)
+      earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: course, student_visible: true)
       expect(student.earned_badge_for_badge(badge)).to eq([earned_badge_1])
     end
   end
 
   describe "#earned_badges_for_badge_count(badge)" do
     let(:student) { create :user }
-    let(:badge) { create :badge, course: world.course }
+    let(:badge) { create :badge, course: course }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "returns the students' earned_badges for a course" do
-      earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: world.course, student_visible: true)
-      earned_badge_2 = create(:earned_badge, badge: badge, student: student, course: world.course, student_visible: true)
+      earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: course, student_visible: true)
+      earned_badge_2 = create(:earned_badge, badge: badge, student: student, course: course, student_visible: true)
       expect(student.earned_badges_for_badge_count(badge)).to eq(2)
     end
   end
@@ -555,13 +554,13 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "should return a student's assigned weight for an assignment" do
-      assignment_type = create(:assignment_type, course: world.course)
-      assignment = create(:assignment, assignment_type: assignment_type, course: world.course)
-      create(:assignment_weight, student: student, course: world.course, assignment: assignment, weight: 3)
+      assignment_type = create(:assignment_type, course: course)
+      assignment = create(:assignment, assignment_type: assignment_type, course: course)
+      create(:assignment_weight, student: student, course: course, assignment: assignment, weight: 3)
       expect(student.weight_for_assignment(assignment)).to eq(3)
     end
   end
@@ -570,13 +569,13 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "should return a student's assigned weight for an assignment type" do
-      assignment_type = create(:assignment_type, course: world.course)
-      assignment = create(:assignment, assignment_type: assignment_type, course: world.course)
-      create(:assignment_weight, student: student, course: world.course, assignment: assignment, weight: 3)
+      assignment_type = create(:assignment_type, course: course)
+      assignment = create(:assignment, assignment_type: assignment_type, course: course)
+      create(:assignment_weight, student: student, course: course, assignment: assignment, weight: 3)
       expect(student.weight_for_assignment_type(assignment_type)).to eq(3)
     end
   end
@@ -585,20 +584,20 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "should return the summed weight count for a course, for a student" do
-      world.course.total_assignment_weight = 6
-      world.course.max_assignment_weight = 4
-      world.course.max_assignment_types_weighted = 3
-      assignment_type = create(:assignment_type, course: world.course, student_weightable: true)
-      assignment_type_2 = create(:assignment_type, course: world.course, student_weightable: true)
-      assignment = create(:assignment, course: world.course, assignment_type: assignment_type)
-      assignment_2 = create(:assignment, course: world.course, assignment_type: assignment_type_2)
-      create(:assignment_weight, student: student, course: world.course, assignment: assignment, weight: 4)
-      create(:assignment_weight, student: student, course: world.course, assignment: assignment_2, weight: 2)
-      expect(student.weight_spent?(world.course)).to eq(true)
+      course.total_assignment_weight = 6
+      course.max_assignment_weight = 4
+      course.max_assignment_types_weighted = 3
+      assignment_type = create(:assignment_type, course: course, student_weightable: true)
+      assignment_type_2 = create(:assignment_type, course: course, student_weightable: true)
+      assignment = create(:assignment, course: course, assignment_type: assignment_type)
+      assignment_2 = create(:assignment, course: course, assignment_type: assignment_type_2)
+      create(:assignment_weight, student: student, course: course, assignment: assignment, weight: 4)
+      create(:assignment_weight, student: student, course: course, assignment: assignment_2, weight: 2)
+      expect(student.weight_spent?(course)).to eq(true)
     end
   end
 
@@ -606,23 +605,23 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "should return the summed weight count for a course, for a student" do
-      world.course.total_assignment_weight = 6
-      world.course.max_assignment_weight = 4
-      world.course.max_assignment_types_weighted = 3
-      assignment_type = create(:assignment_type, course: world.course, student_weightable: true)
-      assignment_type_2 = create(:assignment_type, course: world.course, student_weightable: true)
-      assignment_type_3 = create(:assignment_type, course: world.course, student_weightable: true)
-      assignment = create(:assignment, course: world.course, assignment_type: assignment_type)
-      assignment_2 = create(:assignment, course: world.course, assignment_type: assignment_type_2)
-      assignment_3 = create(:assignment, course: world.course, assignment_type: assignment_type_3)
+      course.total_assignment_weight = 6
+      course.max_assignment_weight = 4
+      course.max_assignment_types_weighted = 3
+      assignment_type = create(:assignment_type, course: course, student_weightable: true)
+      assignment_type_2 = create(:assignment_type, course: course, student_weightable: true)
+      assignment_type_3 = create(:assignment_type, course: course, student_weightable: true)
+      assignment = create(:assignment, course: course, assignment_type: assignment_type)
+      assignment_2 = create(:assignment, course: course, assignment_type: assignment_type_2)
+      assignment_3 = create(:assignment, course: course, assignment_type: assignment_type_3)
       assignment_weight_1 = create(:assignment_weight, student: student, assignment: assignment, weight: 2)
       assignment_weight_2 = create(:assignment_weight, student: student, assignment: assignment_2, weight: 2)
       assignment_weight_3 = create(:assignment_weight, student: student, assignment: assignment_3, weight: 2)
-      expect(student.total_weight_spent(world.course)).to eq(6)
+      expect(student.total_weight_spent(course)).to eq(6)
     end
   end
 
@@ -630,16 +629,16 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
+      create(:course_membership, user: student, course: course)
     end
 
     it "should return true if the student has weighted assignments" do
-      create(:assignment_weight, student: student, course: world.course)
-      expect(student.weighted_assignments?(world.course)).to eq(true)
+      create(:assignment_weight, student: student, course: course)
+      expect(student.weighted_assignments?(course)).to eq(true)
     end
 
     it "should return false if the student has not weighted any assignments" do
-      expect(student.weighted_assignments?(world.course)).to eq(false)
+      expect(student.weighted_assignments?(course)).to eq(false)
     end
   end
 
@@ -647,87 +646,97 @@ describe User do
     let(:student) { create :user }
 
     before do
-      create(:course_membership, user: student, course: world.course)
-      create(:assignment_weight, student: student, course: world.course)
-      create(:assignment_weight, student: student, course: world.course)
-      create(:assignment_weight, student: student, course: world.course)
+      create(:course_membership, user: student, course: course)
+      create(:assignment_weight, student: student, course: course)
+      create(:assignment_weight, student: student, course: course)
+      create(:assignment_weight, student: student, course: course)
     end
 
     it "should return the summed weight count for a course, for a student" do
-      expect(student.weight_count(world.course)).to eq(3)
+      expect(student.weight_count(course)).to eq(3)
     end
   end
 
   describe "#group_for_assignment(assignment)" do
-    let(:student) { create :user }
-    let(:assignment) {create :assignment, grade_scope: "Group"}
+    it "returns a student's group for a particular assignment if present" do
+      world.create_group
+      expect(student.group_for_assignment(assignment)).to eq(world.group)
+    end
+  end
 
-    before do
-      create(:course_membership, user: student, course: world.course)
+  describe "#has_group_for_assignment?" do
+    it "returns false for individual assignments" do
+      world.create_group
+      assignment.update(grade_scope: "Individual")
+      expect(student.has_group_for_assignment?(assignment)).to be_falsey
     end
 
-    it "returns a student's group for a particular assignment if present" do
-      group = create(:group)
-      create(:assignment_group, group: group, assignment: assignment)
-      create(:group_membership, student: student, group: group)
-      expect(student.group_for_assignment(assignment)).to eq(group)
+    it "returns false if the student has no group membership" do
+      assignment.update(grade_scope: "Group")
+      expect(student.has_group_for_assignment?(assignment)).to be_falsey
+    end
+
+    it "returns true if the student is in a group" do
+      assignment.update(grade_scope: "Group")
+      world.create_group
+      expect(student.has_group_for_assignment?(assignment)).to be_truthy
     end
   end
 
   context "earn_badges" do
     it "should be able to earn badges" do
-      badges = create_list(:badge, 2, course: world.course)
-      world.student.earn_badges(badges)
-      badges_earned = world.student.earned_badges.collect {|e| e.badge }.sort_by(&:id)
+      badges = create_list(:badge, 2, course: course)
+      student.earn_badges(badges)
+      badges_earned = student.earned_badges.collect {|e| e.badge }.sort_by(&:id)
       expect(badges_earned).to eq(badges.sort_by(&:id))
     end
   end
 
   context "student_visible_earned_badges" do
     it "should know which badges a student has earned" do
-      earned_badges = create_list(:earned_badge, 3, course: world.course, student: world.student, student_visible: true)
-      expect(world.student.student_visible_earned_badges(world.course)).to eq(earned_badges)
+      earned_badges = create_list(:earned_badge, 3, course: course, student: student, student_visible: true)
+      expect(student.student_visible_earned_badges(course)).to eq(earned_badges)
     end
 
     it "should not select non-visible student badges" do
-      earned_badges = create_list(:earned_badge, 3, course: world.course, student: world.student, student_visible: false)
-      expect(world.student.student_visible_earned_badges(world.course)).to be_empty
+      earned_badges = create_list(:earned_badge, 3, course: course, student: student, student_visible: false)
+      expect(student.student_visible_earned_badges(course)).to be_empty
     end
 
     it "should not return unearned badges as earned badges" do
-      unearned_badges = create_list(:badge, 2, course: world.course)
-      visible_earned_badges = create_list(:earned_badge, 3, course: world.course, student: world.student)
-      unique_earned_badges = world.student.student_visible_earned_badges(world.course)
+      unearned_badges = create_list(:badge, 2, course: course)
+      visible_earned_badges = create_list(:earned_badge, 3, course: course, student: student)
+      unique_earned_badges = student.student_visible_earned_badges(course)
       expect(unique_earned_badges).not_to include(*unearned_badges)
     end
   end
 
   context "unique_student_earned_badges" do
     before(:each) do
-      create_list(:earned_badge, 3, course: world.course, student: world.student, student_visible: true)
+      create_list(:earned_badge, 3, course: course, student: student, student_visible: true)
     end
 
     # Intermittent failure?
     it "should know which badges are unique to those student earned badges" do
-      sorted_badges = world.student.earned_badges.collect(&:badge).sort_by(&:id).flatten
-      expect(world.student.unique_student_earned_badges(world.course)).to eq(sorted_badges)
+      sorted_badges = student.earned_badges.collect(&:badge).sort_by(&:id).flatten
+      expect(student.unique_student_earned_badges(course)).to eq(sorted_badges)
     end
 
     it "should not return badges associated with student-unearned badges" do
-      badges_unearned = create_list(:badge, 2, course: world.course)
-      expect(world.student.unique_student_earned_badges(world.course)).not_to include(*badges_unearned)
+      badges_unearned = create_list(:badge, 2, course: course)
+      expect(student.unique_student_earned_badges(course)).not_to include(*badges_unearned)
     end
   end
 
   context "student_visible_unearned_badges" do
     it "should know which badges a student has yet to earn" do
-      badges = create_list(:badge, 2, course: world.course, visible: true)
-      expect(world.student.student_visible_unearned_badges(world.course)).to eq(badges)
+      badges = create_list(:badge, 2, course: course, visible: true)
+      expect(student.student_visible_unearned_badges(course)).to eq(badges)
     end
 
     it "should not return earned badges as unearned ones" do
-      earned_badges = create_list(:earned_badge, 2, course: world.course, student: world.student)
-      expect(world.student.student_visible_unearned_badges(world.course)).not_to include(*earned_badges)
+      earned_badges = create_list(:earned_badge, 2, course: course, student: student)
+      expect(student.student_visible_unearned_badges(course)).not_to include(*earned_badges)
     end
   end
 
@@ -741,74 +750,66 @@ describe User do
     end
 
     it "should not see badges that aren't included in the current course" do
-      some_other_course = create(:course)
-      some_other_assignment = create(:assignment, course: some_other_course)
-      some_other_grade = create(:grade, assignment: some_other_assignment, assignment_type: some_other_assignment.assignment_type, course: some_other_course, student: world.student)
-      some_other_badge = create(:badge, course: some_other_course)
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).not_to include(some_other_badge)
+      bizarro = World.create.with(:course, :student, :assignment, :grade, :badge)
+      expect(student.earnable_course_badges_for_grade(world.grade)).not_to include(bizarro.badge)
     end
 
     it "should see badges for the current course" do
-      EarnedBadge.destroy_all course_id: world.course[:id]
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge, @multi_badge)
+      EarnedBadge.destroy_all course_id: course[:id]
+      expect(student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge, @multi_badge)
     end
 
     it "should show course badges that the student has yet to earn", broken: true do
-      EarnedBadge.destroy_all course_id: world.course[:id]
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge, @multi_badge)
+      EarnedBadge.destroy_all course_id: course[:id]
+      expect(student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge, @multi_badge)
     end
 
     it "should not show badges that the student has earned for other grades, and can't be earned multiple times" do
-      world.student.earn_badge_for_grade(@single_badge, @another_grade) # earn the badge on another grade
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).not_to include(@single_badge)
+      student.earn_badge_for_grade(@single_badge, @another_grade) # earn the badge on another grade
+      expect(student.earnable_course_badges_for_grade(world.grade)).not_to include(@single_badge)
     end
 
     it "should show badges that the student has earned but CAN be earned multiple times", broken: true do
-      world.student.earn_badge_for_grade(@multi_badge, world.grade)
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).to include(@multi_badge)
+      student.earn_badge_for_grade(@multi_badge, world.grade)
+      expect(student.earnable_course_badges_for_grade(world.grade)).to include(@multi_badge)
     end
 
     it "should show badges that the student has earned for the current grade, even if it can't be earned multiple times" do
-      world.student.earn_badge_for_grade(@single_badge, world.grade)
-      expect(world.student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge)
+      student.earn_badge_for_grade(@single_badge, world.grade)
+      expect(student.earnable_course_badges_for_grade(world.grade)).to include(@single_badge)
     end
   end
 
   context "user earns just one badge" do
-    before(:each) do
-      world
-        .create_course
-        .create_assignment(course: world.courses.last)
-        .create_grade(assignment: world.assignments.last, course: world.courses.last)
-      @current_badge = world.create_badge(course: world.courses.last).badges.last
-    end
+    let!(:create_badge) { world.create_badge }
+    let(:current_badge) { world.badge }
 
     it "should create a valid earned badge" do
-      expect(world.student.earn_badge(@current_badge).class).to eq(EarnedBadge)
-      expect(world.student.earn_badge(@current_badge).valid?).to be true
+      expect(student.earn_badge(current_badge).class).to eq(EarnedBadge)
+      expect(student.earn_badge(current_badge).valid?).to be true
     end
 
     it "should not error out when earning one badge" do
-      expect { world.student.earn_badge(@current_badge) }.to_not raise_error
+      expect { student.earn_badge(current_badge) }.to_not raise_error
     end
 
     it "should choke on an array of badges" do
-      expect { world.student.earn_badge([@current_badge])}.to raise_error(TypeError)
+      expect { student.earn_badge([current_badge])}.to raise_error(TypeError)
     end
   end
 
   context "student_invisible_badges" do
     it "should return invisible badges for which the student has earned a badge" do
-      invisible_badges = create_list(:badge, 2, course: world.course, visible: false)
-      world.student.earn_badges(invisible_badges)
-      badges_earned_by_id = world.student.student_invisible_badges(world.course)
+      invisible_badges = create_list(:badge, 2, course: course, visible: false)
+      student.earn_badges(invisible_badges)
+      badges_earned_by_id = student.student_invisible_badges(course)
       expect(badges_earned_by_id).to eq(invisible_badges)
     end
 
     it "should not return visible badges for which the student has earned a badge" do
-      visible_badges = create_list(:badge, 2, course: world.course, visible: true)
-      world.student.earn_badges(visible_badges)
-      badges_earned_by_id = world.student.student_invisible_badges(world.course).sort_by(&:id)
+      visible_badges = create_list(:badge, 2, course: course, visible: true)
+      student.earn_badges(visible_badges)
+      badges_earned_by_id = student.student_invisible_badges(course).sort_by(&:id)
       expect(badges_earned_by_id).not_to eq(visible_badges.sort_by(&:id))
     end
   end

--- a/spec/support/world.rb
+++ b/spec/support/world.rb
@@ -27,10 +27,6 @@ class World
       criterion_grades.first
     end
 
-    def course_membership
-      course_memberships.first
-    end
-
     def grade
       grades.first
     end
@@ -109,12 +105,9 @@ class World
       self
     end
 
-    # creates a group and adds the current student to the group
     def create_group(attributes={})
       course = attributes.delete(:course) || self.course
       groups << FactoryGirl.create(:group, attributes.merge(course: course, approved: "Approved"))
-      FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
-      FactoryGirl.create(:group_membership, student: student, group: group)
     end
 
     def create_rubric(attributes={})

--- a/spec/support/world.rb
+++ b/spec/support/world.rb
@@ -27,6 +27,10 @@ class World
       criterion_grades.first
     end
 
+    def course_membership
+      course_memberships.first
+    end
+
     def grade
       grades.first
     end
@@ -105,9 +109,12 @@ class World
       self
     end
 
+    # creates a group and adds the current student to the group
     def create_group(attributes={})
       course = attributes.delete(:course) || self.course
       groups << FactoryGirl.create(:group, attributes.merge(course: course, approved: "Approved"))
+      FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
+      FactoryGirl.create(:group_membership, student: student, group: group)
     end
 
     def create_rubric(attributes={})


### PR DESCRIPTION
  * fix unlock_condition group error
  * adds `student.in_group_for_assignment?`
  * lint `unlock_condition_spec`
    * all lines under 80 characters
    * nest #is_complete? section in describe blocks
    * reduce duplicate model assignments
  * some linting in `user_spec`
  * minor changes to samples in advance of predictor bugfix