### PR TITLE
Issue 1710: fix sporadic failure of ActorHistoryTokenSpec

### DIFF
--- a/spec/human_history/actor_history_token_spec.rb
+++ b/spec/human_history/actor_history_token_spec.rb
@@ -23,7 +23,7 @@ describe HumanHistory::ActorHistoryToken do
     end
 
     context "user is not found" do
-      let(:subject) { described_class.new "actor_id", 123, Object }
+      let(:subject) { described_class.new "actor_id", nil, Object }
 
       it "returns 'Someone'" do
         expect(subject.parse).to eq({ actor: "Someone" })


### PR DESCRIPTION
I noticed that this spec was failing on `master` so I fixed it. I haven't worked with the `HumanHistory` library at all, but in looking at it the spec was sending an id of `123` in order to try to deliberately return `nil` and have the `ActorHistoryToken` object send a `parse` response of `{ actor: "Someone" }`.

The problem was, I believe, that if the suite is large enough that the base user_id for a given spec suite could easily run to `123`, so instead of returning the default `{ actor: "Someone" }` response it was just returning the name of the user with an id of `123`.

This patch just sends `nil` to the `User.find()` call in the `HumanHistory::ActorHistoryToken` object to guarantee that no user will be found. If @jwright prefers that this use an impossibly large integer such as `1_000_000_000` instead of nil to guarantee that this will fail while still demonstrating that this should be a non-existent `id` value for a user that would be fine, but it seems like `nil` better demonstrates a situation in which the `User` will not be found by the `ActorHistoryToken`.

This PR resolves issue #1710.