### PR TITLE
Adds a has submission icon to Predictor

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -120,7 +120,7 @@
       # use raw score to keep weighting calculation on assignment type level
       if assignment.grade.raw_score != null
         total += assignment.grade.raw_score
-      else if ! assignment.pass_fail && !$scope.closed_for_prediction(assignment) && includePredicted
+      else if ! assignment.pass_fail && ! assignment.closed_without_sumbission && includePredicted
         total += assignment.grade.predicted_score
     )
     total

--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -120,7 +120,7 @@
       # use raw score to keep weighting calculation on assignment type level
       if assignment.grade.raw_score != null
         total += assignment.grade.raw_score
-      else if ! assignment.pass_fail && ! assignment.has_closed && includePredicted
+      else if ! assignment.pass_fail && !$scope.closed_for_prediction(assignment) && includePredicted
         total += assignment.grade.predicted_score
     )
     total
@@ -232,6 +232,14 @@
 
   $scope.badgeCompleted = (badge)->
     if (badge.point_total == badge.total_earned_points && ! badge.can_earn_multiple_times)
+      return true
+    else
+      return false
+
+  # We keep the predictor open on closed assignments IF the student has a
+  # a submission
+  $scope.closed_for_prediction = (assignment)->
+    if assignment.has_closed && !assignment.has_submission
       return true
     else
       return false

--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -46,7 +46,7 @@
           tooltip: 'This ' + scope.targetTerm() + ' is late!'
           icon: "fa-exclamation-triangle"
         }
-        has_closed: {
+        closed_without_sumbission: {
           tooltip: 'This ' + scope.targetTerm() + ' is no longer open for submissions'
           icon: "fa-ban"
         }
@@ -62,12 +62,12 @@
           tooltip: 'This ' + scope.targetTerm() + ' is rubric graded'
           icon: "fa-th"
         }
-        accepts_submissions: {
+        accepting_submissions: {
           tooltip: 'This ' + scope.targetTerm() + ' accepts submissions'
           icon: "fa-paperclip"
         }
         has_submission: {
-          tooltip: 'You have made a submission for this ' + scope.targetTerm()
+          tooltip: 'You have submitted this ' + scope.targetTerm()
           icon: "fa-file"
         }
         is_locked: {

--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -46,7 +46,7 @@
           tooltip: 'This ' + scope.targetTerm() + ' is late!'
           icon: "fa-exclamation-triangle"
         }
-        closed_without_sumbission: {
+        closed_without_submission: {
           tooltip: 'This ' + scope.targetTerm() + ' is no longer open for submissions'
           icon: "fa-ban"
         }

--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -66,6 +66,10 @@
           tooltip: 'This ' + scope.targetTerm() + ' accepts submissions'
           icon: "fa-paperclip"
         }
+        has_submission: {
+          tooltip: 'You have made a submission for this ' + scope.targetTerm()
+          icon: "fa-file"
+        }
         is_locked: {
           tooltip: scope.conditions()
           icon: "fa-lock"

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["is_required", "is_late", "has_closed", "has_info", "has_rubric", "accepts_submissions", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
+    icons = ["has_info", "is_required", "has_rubric", "accepts_submissions", "has_submission", "is_late", "has_closed", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "is_late", "closed_without_sumbission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
+    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "is_late", "closed_without_submission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["has_info", "is_required", "has_rubric", "accepts_submissions", "has_submission", "is_late", "has_closed", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
+    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "is_late", "closed_without_sumbission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -37,7 +37,7 @@
       %div{'ng-if' => 'assignment.predictor_display_type == "checkbox" && assignment.pass_fail == true'}
         .predictor-binary-switch{'target'=>'assignment','target-type'=>'assignment','off-value'=>'0','on-value'=>'1'}
 
-      %div{'ng-if' => 'assignment.predictor_display_type == "checkbox"'}
+      %div{'ng-if' => 'assignment.predictor_display_type == "checkbox" && !assignment.pass_fail == true'}
         .predictor-binary-switch{'target'=>'assignment','target-type'=>'assignment','off-value'=>'0','on-value'=>'assignment.point_total'}
 
 

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -1,4 +1,4 @@
-%article.predictor-article{'ng-repeat' => 'assignment in assignments | filter:{assignment_type_id: assignmentType.id}:true','ng-class'=>'{"status-graded" : articleGraded(assignment),"status-no-points":articleNoPoints(assignment), "status-locked" : assignment.locked}'}
+%article.predictor-article{'ng-repeat' => 'assignment in assignments | filter:{assignment_type_id: assignmentType.id}:true','ng-class'=>'{"status-graded" : articleGraded(assignment),"status-no-points":articleNoPoints(assignment), "status-locked" : assignment.is_locked, "status-late" : assignment.is_late}'}
 
   .predictor-article-title{'title' => '{{assignment.name}}'}
     {{assignment.name | limitTo:50}}

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -263,10 +263,8 @@ article.predictor-article
 .predictor-article-main
   padding-top: 8px
 
-article.predictor-article.status-locked
+article.predictor-article.status-late
   background-color: $color-yellow-1
-  border: 1px solid $color-red-1
-  border-bottom: .25rem solid $color-red-1
   .predictor-article-title
     background-color: $color-red-1
   .predictor-article-icons
@@ -276,7 +274,9 @@ article.predictor-article.status-locked
   .ui-slider .ui-slider-range
     background-color: $color-orange-1
   .slider.ui-widget-content
-    background-color: $color-orange-1
+    background-color: $color-yellow-1
+  .slider.ui-widget-content
+    border: 1px solid $color-red-1
   .predictor-counter-switch
     .switch-socket
       background-color: $color-orange-1
@@ -294,6 +294,14 @@ article.predictor-article.status-locked
     .switch-socket.on
       background-color: $color-orange-1
 
+article.predictor-article.status-locked
+  // background-color: $color-yellow-1
+  .predictor-article-title
+    background-color: $color-purple-2
+  .predictor-article-icons
+    background-color: lighten( $color-purple-2, 15%)
+
+
 article.predictor-article.status-graded
   background-color: lighten($color-green-2, 30%)
   .predictor-article-title
@@ -303,8 +311,6 @@ article.predictor-article.status-graded
 
 article.predictor-article.status-graded.status-no-points
   background-color: $color-grey-6
-  border: 1px solid $color-grey-5
-  border-bottom: .25rem solid $color-grey-5
   .predictor-article-title
     background-color: $color-grey-4
   .predictor-article-icons

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -62,7 +62,7 @@ class NullGrade
   end
 
   def student
-    nil
+    NullStudent.new
   end
 end
 

--- a/app/models/null_student.rb
+++ b/app/models/null_student.rb
@@ -11,7 +11,7 @@ class NullStudent
   end
 
   def submission_for_assignment(*)
-    self
+    nil
   end
 
   def weight_for_assignment_type(*)

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -71,12 +71,12 @@ class PredictedAssignmentSerializer < SimpleDelegator
       is_required: is_required?,
       has_info: has_info?,
       has_rubric: has_rubric?,
-      accepts_submissions: accepts_submissions?,
+      accepting_submissions: accepting_submissions?,
       has_submission: has_submission?,
       is_a_condition: is_a_condition?,
       is_earned_by_group: is_earned_by_group?,
       is_late: is_late?,
-      has_closed: has_closed?,
+      closed_without_sumbission: closed_without_sumbission?,
       is_locked: is_locked?,
       has_been_unlocked: has_been_unlocked?,
     }
@@ -94,15 +94,6 @@ class PredictedAssignmentSerializer < SimpleDelegator
     !!assignment.has_rubric?
   end
 
-  def accepts_submissions?
-    !!assignment.accepts_submissions?
-  end
-
-  def has_submission?
-    !!assignment.accepts_submissions? && \
-      student.submission_for_assignment(assignment).present?
-  end
-
   def is_earned_by_group?
     assignment.grade_scope == "Group"
   end
@@ -112,9 +103,20 @@ class PredictedAssignmentSerializer < SimpleDelegator
       !student.submission_for_assignment(assignment).present?
   end
 
-  # TODO: update when closed? method added to assignments
-  def has_closed?
-    assignment.submissions_have_closed?
+  def accepting_submissions?
+    !!assignment.accepts_submissions? && \
+    !assignment.submissions_have_closed? && \
+    !student.submission_for_assignment(assignment).present?
+  end
+
+  def has_submission?
+    !!assignment.accepts_submissions? && \
+      student.submission_for_assignment(assignment).present?
+  end
+
+  def closed_without_sumbission?
+    assignment.submissions_have_closed? && \
+     !student.submission_for_assignment(assignment).present?
   end
 
   def is_locked?

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -15,7 +15,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
   def grade
     if @grade.nil?
       grade = student.present? ? Grade.find_or_create(assignment.id, student.id) : NullGrade.new
-      @grade = PredictedGradeSerializer.new(grade, current_user)
+      @grade = PredictedGradeSerializer.new(assignment, grade, current_user)
     end
     @grade
   end
@@ -76,7 +76,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
       is_a_condition: is_a_condition?,
       is_earned_by_group: is_earned_by_group?,
       is_late: is_late?,
-      closed_without_sumbission: closed_without_sumbission?,
+      closed_without_submission: closed_without_sumbission?,
       is_locked: is_locked?,
       has_been_unlocked: has_been_unlocked?,
     }

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -72,6 +72,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
       has_info: has_info?,
       has_rubric: has_rubric?,
       accepts_submissions: accepts_submissions?,
+      has_submission: has_submission?,
       is_a_condition: is_a_condition?,
       is_earned_by_group: is_earned_by_group?,
       is_late: is_late?,
@@ -97,13 +98,18 @@ class PredictedAssignmentSerializer < SimpleDelegator
     !!assignment.accepts_submissions?
   end
 
+  def has_submission?
+    !!assignment.accepts_submissions? && \
+      student.submission_for_assignment(assignment).present?
+  end
+
   def is_earned_by_group?
     assignment.grade_scope == "Group"
   end
 
   def is_late?
     assignment.overdue? && assignment.accepts_submissions && \
-    !student.submission_for_assignment(assignment).present?
+      !student.submission_for_assignment(assignment).present?
   end
 
   # TODO: update when closed? method added to assignments

--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -30,7 +30,8 @@ class PredictedGradeSerializer
     grade.score if grade.is_student_visible?
   end
 
-  def initialize(grade, current_user)
+  def initialize(assignment, grade, current_user)
+    @assignment = assignment
     @grade = grade
     @current_user = current_user
   end
@@ -48,11 +49,11 @@ class PredictedGradeSerializer
 
   def show_zero_in_predictor(score)
     score.nil? &&
-    grade.assignment.accepts_submissions? &&
-    grade.assignment.submissions_have_closed? &&
+    assignment.accepts_submissions? &&
+    assignment.submissions_have_closed? &&
     grade.student.submission_for_assignment(grade.assignment).nil?
   end
 
-  attr_reader :grade
+  attr_reader :assignment, :grade
 end
 

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -44,10 +44,10 @@
   grades: false,
   # only used if :grades is true:
   grade_attributes: {
-    raw_score: Proc.new { rand(5000) },
-    instructor_modified: true,
-    status: "Graded",
-    predicted_score: Proc.new { 0 },
+    raw_score: -> { rand(5000) },
+    instructor_modified: false,
+    status: nil,
+    predicted_score: -> { 0 },
     feedback: nil
   },
   assignment_score_levels: false,
@@ -62,6 +62,9 @@
 }
 
 #------------------------------------------------------------------------------#
+
+#                        Grading Assignment Types
+
 #------------------------------------------------------------------------------#
 
 @assignments = {}
@@ -109,6 +112,7 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -144,6 +148,7 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -178,6 +183,7 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -208,6 +214,7 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -284,7 +291,8 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
-    raw_score: Proc.new { 80000 },
+    instructor_modified: true,
+    raw_score: -> { 80000 },
     feedback: 'As Aristotle said, <strong>"The whole is greater than the sum of its parts."</strong>'
   },
   rubric: true,
@@ -336,6 +344,12 @@
   },
   rubric: true
 }
+
+#------------------------------------------------------------------------------#
+
+#                        Submission Assignment Types
+
+#------------------------------------------------------------------------------#
 
 @assignments[:no_submissions_assignment] = {
   quotes: {
@@ -429,14 +443,21 @@
   }
 }
 
+#------------------------------------------------------------------------------#
+
+#                        Predictor Assignment Types
+
+#------------------------------------------------------------------------------#
+
+
 @assignments[:predictor_with_graded_grade_assignment] = {
   quotes: {
     assignment_created: nil,
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Assignment is Past with Grade",
-    description: "Description should be present as icon",
+    name: "Past Assignment with Grade",
+    description: "Points displayed and info icon",
     due_at: 1.week.ago,
     point_total: 15000,
     points_predictor_display: "Slider",
@@ -444,8 +465,9 @@
   grades: true,
   grade_attributes: {
     instructor_modified: true,
-    predicted_score: Proc.new { rand(15000) },
-    status: "Graded"
+    predicted_score: -> { rand(15000) },
+    status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -455,11 +477,34 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Assignment is Past with no Grade",
-    description: "Description and late should be present as icon",
+    name: "Past Assignment no Grade",
+    description: "Displays a Slider. Displays the info icon with this text on hover",
     due_at: 1.week.ago,
     point_total: 15000,
     points_predictor_display: "Slider",
+  }
+}
+
+@assignments[:predictor_past_with_unreleased_grade_assignment] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :predictor,
+  attributes: {
+    name: "Past Assignment Unreleased Grade",
+    description: "Should have a prediction slider, should have a prediction, should not have a visible grade",
+    due_at: 1.week.ago,
+    point_total: 15000,
+    points_predictor_display: "Slider",
+    release_necessary: true,
+  },
+  grades: true,
+  grade_attributes: {
+    instructor_modified: true,
+    predicted_score: -> { rand(15000) },
+    raw_score: -> { rand(15000) },
+    status: "Graded",
+    instructor_modified: true
   }
 }
 
@@ -469,12 +514,17 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Submissions Late",
-    description: "Should have a late icon, should still accept predictions.",
+    name: "Not Submitted, Late",
+    description: "Should have a submission and late icon, should still accept predictions.",
     due_at: 1.week.ago,
     accepts_submissions_until: 3.week.from_now,
     point_total: 15000,
     points_predictor_display: "Slider",
+    accepts_submissions: true,
+    resubmissions_allowed: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
   }
 }
 
@@ -484,18 +534,24 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Submissions Past Acceptance",
-    description: "Should not have a prediction slider, should be predicted at 0 points.",
+    name: "Not Submitted, Closed",
+    description: "Fixed at 0 points, displays 'Accepts Submissions', 'Closed' and 'Late' icons.",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     point_total: 15000,
     points_predictor_display: "Slider",
+    accepts_submissions: true,
+    resubmissions_allowed: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
   },
   grades: true,
   grade_attributes: {
     instructor_modified: false,
-    predicted_score: Proc.new { rand(15000) },
-    point_total: Proc.new { nil },
+    raw_score: -> { nil },
+    status: nil,
+    predicted_score: -> { rand(15000) },
   }
 }
 
@@ -505,36 +561,40 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Has Submissions Past Acceptance No Grades",
-    description: "Should not have a late icon, should still accept predictions.",
+    name: "Has Submissions, Closed",
+    description: "Displays 'Accepts Submissions', 'Has Submission', and 'Closed' icon but no 'Late' icon, has slider, accepts prediction.",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     point_total: 15000,
     points_predictor_display: "Slider",
+    accepts_submissions: true,
+    resubmissions_allowed: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
   },
   student_submissions: true
 }
 
-@assignments[:predictor_past_with_unreleased_grade_assignment] = {
+@assignments[:predictor_open_assignment_with_submissions] = {
   quotes: {
     assignment_created: nil,
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Assignment is Past with Unreleased Grade",
-    description: "Should have a prediction slider, should have a prediction, should not have released grade",
-    due_at: 1.week.ago,
+    name: "Has Submission, Open",
+    description: "Displays 'Accepts Submissions' and 'Has Submission' icons, has slider, accepts prediction.",
+    due_at: 5.weeks.from_now,
+    accepts_submissions_until: 5.weeks.from_now,
     point_total: 15000,
     points_predictor_display: "Slider",
-    release_necessary: true,
+    accepts_submissions: true,
+    resubmissions_allowed: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
   },
-  grades: true,
-  grade_attributes: {
-    instructor_modified: true,
-    predicted_score: Proc.new { rand(15000) },
-    point_total: Proc.new { rand(15000) },
-    status: "Graded"
-  }
+  student_submissions: true
 }
 
 @assignments[:predictor_fixed_assignment] = {
@@ -543,7 +603,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Assignment Shows Switch in Predictor",
+    name: "Fixed no Prediction",
+    description: "Should have a binary predictor switch with zero prediction",
     due_at: 1.week.from_now,
     point_total: 15000,
     points_predictor_display: "Fixed",
@@ -556,7 +617,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Assignment Shows Predicted Full Points with a Binary Switch",
+    name: "Fixed with Prediction",
+    description: "Should have a binary predictor switch with zero prediction",
     due_at: 1.week.from_now,
     point_total: 15000,
     points_predictor_display: "Fixed",
@@ -564,8 +626,30 @@
   grades: true,
   grade_attributes: {
     instructor_modified: false,
-    raw_score: Proc.new { nil },
-    predicted_score: Proc.new { rand(15000) },
+    raw_score: -> { nil },
+    status: nil,
+    predicted_score: -> { 15000 }
+  }
+}
+
+@assignments[:predictor_fixed_assignment_graded_predicted] = {
+  quotes: {
+    assignment_created: "The whole educational and professional training system is a very elaborate filter, which just weeds out people who are too independent, and who think for themselves, and who don't know how to be submissive, and so on -- because they're dysfunctional to the institutions. ― Noam Chomsky",
+  },
+  assignment_type: :predictor,
+  attributes: {
+    name: "Graded Fixed Assignment",
+    description: "Should have full points",
+    due_at: 1.week.from_now,
+    point_total: 15000,
+    points_predictor_display: "Fixed",
+  },
+  grades: true,
+  grade_attributes: {
+    instructor_modified: true,
+    raw_score: -> { 15000 },
+    predicted_score: -> { rand(15000) },
+    status: "Graded"
   }
 }
 
@@ -575,7 +659,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Slider No Levels [Not Graded]",
+    name: "Slider No Prediction",
+    description: "Should have a continuous slider with zero prediction",
     due_at: 1.week.from_now,
     point_total: 15000,
     points_predictor_display: "Slider"
@@ -588,7 +673,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Slider No Levels [Predicted, Not Graded]",
+    name: "Slider with Prediction",
+    description: "Should have a continuous slider with random prediction",
     due_at: 1.week.from_now,
     point_total: 15000,
     points_predictor_display: "Slider",
@@ -596,8 +682,9 @@
   grades: true,
   grade_attributes: {
     instructor_modified: false,
-    raw_score: Proc.new { nil },
-    predicted_score: Proc.new { rand(15000) },
+    raw_score: -> { nil },
+    status: nil,
+    predicted_score: -> { rand(15000) }
   }
 }
 
@@ -607,7 +694,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Slider with Levels [Not Predicted,Not Graded]",
+    name: "Level Slider no Prediction",
+    description: "Should have a slider with levels with zero prediction",
     due_at: 1.week.from_now,
     point_total: 25000,
     points_predictor_display: "Slider",
@@ -621,7 +709,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Slider with Levels [Predicted,Not Graded]",
+    name: "Level Slider with Prediction",
+    description: "Should have a slider with levels with random prediction",
     due_at: 1.week.from_now,
     point_total: 25000,
     points_predictor_display: "Slider",
@@ -630,10 +719,17 @@
   grades: true,
   grade_attributes: {
     instructor_modified: false,
-    raw_score: Proc.new { nil },
-    predicted_score: Proc.new { rand(25000) },
+    raw_score: -> { nil },
+    status: nil,
+    predicted_score: -> { rand(25000) }
   }
 }
+
+#------------------------------------------------------------------------------#
+
+#                        Visibility Assignment Types
+
+#------------------------------------------------------------------------------#
 
 @assignments[:invisible_assignment] = {
   quotes: {
@@ -904,7 +1000,8 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
-    raw_score: Proc.new { 180000 },
+    instructor_modified: true,
+    raw_score: -> { 180000 },
     feedback: 'As George Washington Carver said, <strong>"Education is the key to unlock the golden door of freedom."</strong>'
   }
 }
@@ -941,7 +1038,8 @@
   grades: true,
   grade_attributes: {
     status: "Graded",
-    raw_score: Proc.new { 180000 },
+    instructor_modified: true,
+    raw_score: -> { 180000 },
     feedback: 'As Winston Churchill said, <strong>"Continuous effort - not strength or intelligence - is the key to unlocking our potential."</strong>'
   }
 }

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -118,10 +118,7 @@
 
 @assignments[:standard_edit_quick_grade_checkbox] = {
   quotes: {
-    assignment_created: "For me, I am driven by two main philosophies: "\
-      "know more today about the world than I knew yesterday and lessen "\
-      "the suffering of others. You'd be surprised how far that gets you. "\
-      "― Neil deGrasse Tyson"
+    assignment_created: "For me, I am driven by two main philosophies: know more today about the world than I knew yesterday and lessen the suffering of others. You'd be surprised how far that gets you. ― Neil deGrasse Tyson"
   },
   assignment_type: :grading,
   attributes: {
@@ -134,9 +131,7 @@
 
 @assignments[:standard_edit_quick_grade_checkbox_graded] = {
   quotes: {
-    assignment_created: "I hope you're pleased with yourselves. "\
-      "We could all have been killed - or worse, expelled. "\
-      "Now if you don't mind, I'm going to bed. ― J.K. Rowling"
+    assignment_created: "I hope you're pleased with yourselves. We could all have been killed - or worse, expelled. Now if you don't mind, I'm going to bed. ― J.K. Rowling"
   },
   assignment_type: :grading,
   attributes: {
@@ -514,8 +509,28 @@
   },
   assignment_type: :predictor,
   attributes: {
+    name: "Not Submitted, On Time",
+    description: "Displays 'Accepts Submissions' icon. Still accepts predictions.",
+    due_at: 3.week.from_now,
+    accepts_submissions_until: 3.week.from_now,
+    point_total: 15000,
+    points_predictor_display: "Slider",
+    accepts_submissions: true,
+    resubmissions_allowed: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
+  }
+}
+
+@assignments[:predictor_past_assignment_submission_open] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :predictor,
+  attributes: {
     name: "Not Submitted, Late",
-    description: "Should have a submission and late icon, should still accept predictions.",
+    description: "Displays 'Accepts Submissions' and 'Late' icons. Still accepts predictions.",
     due_at: 1.week.ago,
     accepts_submissions_until: 3.week.from_now,
     point_total: 15000,
@@ -535,7 +550,7 @@
   assignment_type: :predictor,
   attributes: {
     name: "Not Submitted, Closed",
-    description: "Fixed at 0 points, displays 'Accepts Submissions', 'Closed' and 'Late' icons.",
+    description: "Fixed at 0 points, displays 'Closed' and 'Late' icons.",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     point_total: 15000,
@@ -561,8 +576,8 @@
   },
   assignment_type: :predictor,
   attributes: {
-    name: "Has Submissions, Closed",
-    description: "Displays 'Accepts Submissions', 'Has Submission', and 'Closed' icon but no 'Late' icon, has slider, accepts prediction.",
+    name: "Has Submission, Closed",
+    description: "Displays 'Has Submission' icon. Has slider, accepts prediction.",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     point_total: 15000,
@@ -583,7 +598,7 @@
   assignment_type: :predictor,
   attributes: {
     name: "Has Submission, Open",
-    description: "Displays 'Accepts Submissions' and 'Has Submission' icons, has slider, accepts prediction.",
+    description: "Displays 'Has Submission' icons, has slider, accepts prediction.",
     due_at: 5.weeks.from_now,
     accepts_submissions_until: 5.weeks.from_now,
     point_total: 15000,

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -577,7 +577,7 @@
   assignment_type: :predictor,
   attributes: {
     name: "Has Submission, Closed",
-    description: "Displays 'Has Submission' icon. Has slider, accepts prediction.",
+    description: "Displays 'Has Submission' icon. Has slider, accepts prediction. Faculty generic predictor is closed",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     point_total: 15000,

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -656,6 +656,7 @@ describe GradesController do
           controller.instance_eval { enqueue_predictor_event_job }
         end
 
+        # intermittent failure?
         it "adds an additional pageview record to mongo" do
           expect {
             controller.instance_eval { enqueue_predictor_event_job }

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -64,4 +64,8 @@ describe NullGrade do
   it "handles queries for assignments accepting submissions" do
     expect(subject.assignment.accepts_submissions?).to be_falsey
   end
+
+  it "returns a null student for student" do
+    expect(subject.student.class).to eq(NullStudent)
+  end
 end

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -116,19 +116,39 @@ describe PredictedAssignmentSerializer do
       end
 
       describe "accepts_submissions" do
-        it "is true when assignment accepts submissions" do
-          allow(assignment).to receive(:accepts_submissions?).and_return true
-          expect(subject[:accepts_submissions]).to eq(true)
-        end
-
         it "is false if assignment doesn't accept submissions" do
           allow(assignment).to receive(:accepts_submissions?).and_return false
-          expect(subject[:accepts_submissions]).to eq(false)
+          allow(assignment).to receive(:submissions_closed?).and_return false
+          allow(user).to receive(:submission_for_assignment).and_return nil
+          expect(subject[:accepting_submissions]).to eq(false)
         end
 
         it "is false if accept submission field is nil" do
           allow(assignment).to receive(:accepts_submissions?).and_return nil
-          expect(subject[:accepts_submissions]).to eq(false)
+          allow(assignment).to receive(:submissions_closed?).and_return false
+          allow(user).to receive(:submission_for_assignment).and_return nil
+          expect(subject[:accepting_submissions]).to eq(false)
+        end
+
+        it "is false if the submissions have closed" do
+          allow(assignment).to receive(:accepts_submissions?).and_return false
+          allow(assignment).to receive(:submissions_closed?).and_return true
+          allow(user).to receive(:submission_for_assignment).and_return nil
+          expect(subject[:accepting_submissions]).to eq(false)
+        end
+
+        it "is false if the student has already submitted" do
+          allow(assignment).to receive(:accepts_submissions?).and_return false
+          allow(assignment).to receive(:submissions_closed?).and_return true
+          allow(user).to receive(:submission_for_assignment).and_return "submission"
+          expect(subject[:accepting_submissions]).to eq(false)
+        end
+
+        it "is true when assignment currently accepts submissions and the student hasn't sumbitted" do
+          allow(assignment).to receive(:accepts_submissions?).and_return true
+          allow(assignment).to receive(:submissions_closed?).and_return false
+          allow(user).to receive(:submission_for_assignment).and_return nil
+          expect(subject[:accepting_submissions]).to eq(true)
         end
       end
 
@@ -187,15 +207,21 @@ describe PredictedAssignmentSerializer do
         end
       end
 
-      describe "has_closed" do
+      describe "closed_without_submission" do
         it "is true when the submissions for the assignment have closed" do
           allow(assignment).to receive(:submissions_have_closed?).and_return true
-          expect(subject[:has_closed]).to eq(true)
+          expect(subject[:closed_without_submission]).to eq(true)
         end
 
         it "is false if the assignment accepts_submissions in the future" do
           allow(assignment).to receive(:submissions_have_closed?).and_return false
-          expect(subject[:has_closed]).to eq(false)
+          expect(subject[:closed_without_submission]).to eq(false)
+        end
+
+        it "is always false if the student has already submitted" do
+          allow(assignment).to receive(:submissions_have_closed?).and_return true
+          allow(user).to receive(:submission_for_assignment).and_return "submission"
+          expect(subject[:closed_without_submission]).to eq(false)
         end
       end
 

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -77,7 +77,7 @@ describe PredictedAssignmentSerializer do
       expect(exposed_attributes & subject.attributes.keys).to eq(exposed_attributes)
     end
 
-    describe "#boolean flags" do
+    describe "boolean flags" do
       subject { described_class.new( assignment, user, user).attributes }
 
       describe "is_required" do

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -77,7 +77,7 @@ describe PredictedAssignmentSerializer do
       expect(exposed_attributes & subject.attributes.keys).to eq(exposed_attributes)
     end
 
-    describe "additional boolean flags" do
+    describe "#boolean flags" do
       subject { described_class.new( assignment, user, user).attributes }
 
       describe "is_required" do
@@ -116,14 +116,39 @@ describe PredictedAssignmentSerializer do
       end
 
       describe "accepts_submissions" do
-        it "is true when assignment has a rubric" do
+        it "is true when assignment accepts submissions" do
           allow(assignment).to receive(:accepts_submissions?).and_return true
           expect(subject[:accepts_submissions]).to eq(true)
         end
 
-        it "is false if assignment has no rubric" do
+        it "is false if assignment doesn't accept submissions" do
           allow(assignment).to receive(:accepts_submissions?).and_return false
           expect(subject[:accepts_submissions]).to eq(false)
+        end
+
+        it "is false if accept submission field is nil" do
+          allow(assignment).to receive(:accepts_submissions?).and_return nil
+          expect(subject[:accepts_submissions]).to eq(false)
+        end
+      end
+
+      describe "has_submission" do
+        it "is false whenever the assignment doesn't accept submissions" do
+          allow(assignment).to receive(:accepts_submissions?).and_return false
+          allow(user).to receive(:submission_for_assignment).and_return "submission"
+          expect(subject[:has_submission]).to eq(false)
+        end
+
+        it "is true when the student has a submission for the assignment" do
+          allow(assignment).to receive(:accepts_submissions?).and_return true
+          allow(user).to receive(:submission_for_assignment).and_return "submission"
+          expect(subject[:has_submission]).to eq(true)
+        end
+
+        it "is false when the student has no submission for the assignment" do
+          allow(assignment).to receive(:accepts_submissions?).and_return true
+          allow(user).to receive(:submission_for_assignment).and_return nil
+          expect(subject[:has_submission]).to eq(false)
         end
       end
 

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -7,7 +7,7 @@ describe PredictedGradeSerializer do
   let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, raw_score: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
   let(:user) { double(:user, submission_for_assignment: "sumbission") }
   let(:other_user) { double(:other_user) }
-  subject { described_class.new grade, user }
+  subject { described_class.new assignment, grade, user }
 
   describe "#id" do
     it "returns the grade's id" do
@@ -46,6 +46,10 @@ describe PredictedGradeSerializer do
       allow(user).to receive(:submission_for_assignment).and_return nil
       expect(subject.score).to eq(grade.score)
     end
+
+    it "always returns 0 for Null Student if the assignment sumbission has closed" do
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).raw_score).to eq(0)
+    end
   end
 
   describe "#raw_score" do
@@ -64,9 +68,13 @@ describe PredictedGradeSerializer do
       expect(subject.raw_score).to eq(0)
     end
 
-    it "doesn't override the raw score is present regardless of submission status" do
+    it "doesn't override the raw score if present regardless of submission status" do
       allow(user).to receive(:submission_for_assignment).and_return nil
       expect(subject.raw_score).to eq(grade.raw_score)
+    end
+
+    it "always returns 0 for Null Student if the assignment sumbission has closed" do
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).raw_score).to eq(0)
     end
   end
 
@@ -78,7 +86,7 @@ describe PredictedGradeSerializer do
     end
 
     it "returns 0 predicted_score if user is not same as student for grade" do
-      expect((described_class.new grade, other_user).predicted_score).to eq 0
+      expect((described_class.new assignment, grade, other_user).predicted_score).to eq 0
     end
 
     it "returns predicted score for student even if it's not visible" do


### PR DESCRIPTION
This addresses a bug where we were not summing predicted points for any closed assignments,
even if we had enabled the slider. This happened because we were not passing information
about the student's submissions to the front end.

This adds a file icon in the predictor icon bar if the student has made a submission for
the assignment, and only discounts predicted points for closed assignments without
a student submission.

Additionally, this updates the sample data to more explicitly test all areas of concern
in the predictor, and to better describe what is being tested within the assignment title
and description. It also fixes a number of bugs which prohibited predicted data from
accurately representing model states found in the real world.

![screen shot 2016-02-29 at 2 56 33 pm](https://cloud.githubusercontent.com/assets/1138350/13407165/019a6642-def5-11e5-9774-a93c8079fc84.png)


### To Test:

  1. Run sample data
  2. Sign in as a student and check all assignments in the Predictor "Predictor Settings" section.
  3. Check that the :information_source:  description matches both the exisiting and desired state (visible icons, slider type / points display)
  4. Check that the prediction sliders influence the top graph in the expected manner.