### PR TITLE
1610 badges not awarding

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -134,14 +134,10 @@
     unless badge.creating
       badge.setCreating()
       badge.earnBadgeForStudent({earned_badge: $scope.earnedBadgePostParams(badge)}).then ((response)->
-        if response.earned_badge
-          # earned badge promise returned successfully,
-          # so add the badge and remove the hold on creation
-          thisBadge.earnBadge(response.earned_badge)
-          thisBadge.doneCreating()
-        else
-          #indicate that badge was not created
-          thisBadge.doneCreating()
+        # earned badge promise returned successfully,
+        # so add the badge and remove the hold on creation
+        thisBadge.earnBadge(response)
+        thisBadge.doneCreating()
         return
       ), (error) ->
         # promise rejected, could log the error with: console.log('error', error);

--- a/app/models/earned_badge.rb
+++ b/app/models/earned_badge.rb
@@ -5,6 +5,8 @@ class EarnedBadge < ActiveRecord::Base
 
   STATUSES= ["Predicted", "Earned"]
 
+  before_validation :cache_associations
+
   belongs_to :course, touch: true
   belongs_to :badge
   belongs_to :student, :class_name => "User", touch: true
@@ -13,8 +15,6 @@ class EarnedBadge < ActiveRecord::Base
   belongs_to :grade # Optional
   belongs_to :group, :polymorphic => true # Optional
   has_many :badge_files, :through => :badge
-
-  before_validation :cache_associations
 
   validates_presence_of :badge, :course, :student
 
@@ -45,6 +45,8 @@ class EarnedBadge < ActiveRecord::Base
   def cache_associations
     self.course_id ||= badge.try(:course_id)
     self.score ||= badge.try(:point_total) || 0
+    self.student_visible = grade.is_student_visible? if grade.present?
+    true
   end
 
   def multiple_allowed

--- a/spec/models/earned_badge_spec.rb
+++ b/spec/models/earned_badge_spec.rb
@@ -56,16 +56,31 @@ describe EarnedBadge do
     end
   end
 
-  describe "#check_unlockables" do
-    skip "implement"
-  end
-
-  describe "score" do
+  describe "#score" do
     it "caches 0 for a badge with nil points" do
       badge = create(:badge, point_total: nil)
       student = create(:user)
       earned_badge = EarnedBadge.create(badge_id: badge.id, student_id: student.id, student_visible: true)
       expect(earned_badge.score).to eq(0)
+    end
+  end
+
+  describe "#student_visible" do
+    it "is not visible if the grade is not visible" do
+      grade = create(:grade, status: "In Progress")
+      subject = create(:earned_badge, grade: grade)
+      expect(subject).to_not be_student_visible
+    end
+
+    it "is visible if the grade is visible" do
+      grade = create(:grade, status: "Released")
+      subject = create(:earned_badge, grade: grade)
+      expect(subject).to be_student_visible
+    end
+
+    it "can be overriden by passing in a value" do
+      subject = create(:earned_badge, student_visible: true)
+      expect(subject).to be_student_visible
     end
   end
 end


### PR DESCRIPTION
This PR solves 2 things. For earned badges that are awared, they default the `student_visible` to the value on the `Grade` if the `Grade` is present.

In addition, the response for earning a badge changed but the front end logic did not reflect that change. This changes the response inspection.

Closes #1610 