### PR TITLE
Resolve nil#last_login_at Error in LoginEventLogger, Speed Up Workflow (Issue 1720)

### DIFF
--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -51,11 +51,13 @@ class LoginEventLogger < ApplicationEventLogger
     end
 
     def update_last_login
-      course_membership.update_attributes(last_login_at: @cached_data[:created_at])
+      course_membership
+        .update_attributes(last_login_at: @cached_data[:created_at])
     end
 
     def course_membership
-      @course_membership ||= CourseMembership.where(course_membership_attrs).first
+      @course_membership ||= CourseMembership.where(course_membership_attrs)
+        .first
     end
 
     # let's make sure that we've got the necessary attributes present in order

--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -56,7 +56,8 @@ class LoginEventLogger < ApplicationEventLogger
     end
 
     def course_membership
-      @course_membership ||= CourseMembership.where(course_membership_attrs)
+      @course_membership ||= CourseMembership
+        .where(course_membership_attrs)
         .first
     end
 

--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -56,9 +56,8 @@ class LoginEventLogger < ApplicationEventLogger
     end
 
     def course_membership
-      @course_membership ||= CourseMembership
-        .where(course_membership_attrs)
-        .first
+      @course_membership ||= \
+        CourseMembership.where(course_membership_attrs).first
     end
 
     # let's make sure that we've got the necessary attributes present in order

--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -38,7 +38,9 @@ class LoginEventLogger < ApplicationEventLogger
   end
 
   def self.previous_last_login_at
-    course_membership.last_login_at.to_i if course_membership.last_login_at
+    if course_membership && course_membership.last_login_at
+      course_membership.last_login_at.to_i
+    end
   end
 
   def self.update_last_login

--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -31,10 +31,11 @@ class LoginEventLogger < ApplicationEventLogger
 
   # perform block that is ultimately called by Resque
   def self.perform(event_type, data = {})
-    @data = data
+    logger.info "Starting #{@queue} with data #{data}"
+    @cached_data = data
     data[:last_login_at] = previous_last_login_at
     super
-    update_last_login
+    update_last_login if course_membership
   end
 
   def self.previous_last_login_at
@@ -44,7 +45,7 @@ class LoginEventLogger < ApplicationEventLogger
   end
 
   def self.update_last_login
-    course_membership.update_attributes(last_login_at: @data[:created_at])
+    course_membership.update_attributes(last_login_at: @cached_data[:created_at])
   end
 
   def self.course_membership
@@ -52,6 +53,6 @@ class LoginEventLogger < ApplicationEventLogger
   end
 
   def self.course_membership_attrs
-    { course_id: @data[:course_id], user_id: @data[:user_id] }
+    { course_id: @cached_data[:course_id], user_id: @cached_data[:user_id] }
   end
 end

--- a/app/event_loggers/login_event_logger.rb
+++ b/app/event_loggers/login_event_logger.rb
@@ -70,7 +70,7 @@ class LoginEventLogger < ApplicationEventLogger
     end
 
     def course_membership_attrs_present?
-      @cached_data[:course_id].present? && @cached_data[:user_id].present?
+      course_membership_attrs.values.all?(&:present?)
     end
 
     def course_membership_attrs

--- a/spec/event_loggers/login_event_logger_spec.rb
+++ b/spec/event_loggers/login_event_logger_spec.rb
@@ -118,24 +118,39 @@ RSpec.describe LoginEventLogger, type: :event_logger do
     end
 
     describe "self#previous_last_login_at" do
-      subject { class_instance.previous_last_login_at }
+      let(:result) { class_instance.previous_last_login_at }
 
-      before do
-        allow(class_instance).to receive(:course_membership) { course_membership }
-      end
+      context "a course membership is present" do
+        before do
+          allow(class_instance).to receive(:course_membership)
+            .and_return course_membership
+        end
 
-      context "course membership has a last_login_at value" do
-        it "returns the timestamp as an integer in seconds" do
-          allow(course_membership).to receive(:last_login_at) { last_login }
-          expect(subject).to eq(last_login.to_i)
+        context "course membership has a last_login_at value" do
+          it "returns the timestamp as an integer in seconds" do
+            allow(course_membership).to receive(:last_login_at) { last_login }
+            expect(result).to eq(last_login.to_i)
+          end
+        end
+
+        context "course membership has no last_login_at value" do
+          it "returns nil" do
+            allow(course_membership).to receive(:last_login_at) { nil }
+            expect(result).to be_nil
+          end
         end
       end
 
-      context "course membership has no last_login_at value" do
+      context "no course membership is found for the login data" do
+        before do
+          allow(class_instance).to receive(:course_membership) { nil }
+        end
+
         it "returns nil" do
           allow(course_membership).to receive(:last_login_at) { nil }
-          expect(subject).to be_nil
+          expect(result).to be_nil
         end
+
       end
     end
 

--- a/spec/event_loggers/login_event_logger_spec.rb
+++ b/spec/event_loggers/login_event_logger_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe LoginEventLogger, type: :event_logger do
 
       it "sets the course membership to @course_membership" do
         result
-        expect(subject.instance_variable_get(:@course_membership)).to eq(course_membership)
+        expect(subject.instance_variable_get(:@course_membership))
+          .to eq(course_membership)
       end
     end
 
@@ -121,6 +122,38 @@ RSpec.describe LoginEventLogger, type: :event_logger do
 
       it "returns the timestamp as an integer in seconds" do
         expect(result).to eq(data)
+      end
+    end
+
+    describe ".course_membership_present?" do
+      let(:result) { subject.course_membership_present? }
+
+      before(:each) do
+        allow(subject).to receive_messages(
+          course_membership: true,
+          course_membership_attrs_present?: true
+        )
+      end
+
+      context "course membership attrs exist but the resource is not found" do
+        it "returns true" do
+          expect(result).to be_truthy
+        end
+      end
+
+      context "course membership attributes are not present" do
+        it "returns false" do
+          allow(subject).to receive(:course_membership_attrs_present?)
+            .and_return false
+          expect(result).to be_falsey
+        end
+      end
+
+      context "course membership resource does not exist" do
+        it "returns false" do
+          allow(subject).to receive(:course_membership) { false }
+          expect(result).to be_falsey
+        end
       end
     end
 
@@ -140,14 +173,14 @@ RSpec.describe LoginEventLogger, type: :event_logger do
 
       context "course_id is not present" do
         let(:cached_data) { { course_id: nil, user_id: 6 } }
-        it "returns true" do
+        it "returns false" do
           expect(result).to be_falsey
         end
       end
 
       context "user_id is not present" do
         let(:cached_data) { { course_id: 20, user_id: nil } }
-        it "returns true" do
+        it "returns false" do
           expect(result).to be_falsey
         end
       end


### PR DESCRIPTION
The crux of this PR is that there are circumstances in which `nil` value for `session[:user_id]` or `session[:course_id]` are being passed into a LoginEventLogger object and breaking the job because it presumes that these have to be present if a login event is triggered. The problem is that this isn't always true, but because the job is breaking early in the perform block we also don't have good logging data to troubleshoot the circumstances under which this is happening. So for now this PR resolves the bug by checking `CourseMembership` before using it, and also by adding logging for these events prior to any other logic being performed. Here's the breakdown:

* Adds a `logger.info` call to the beginning of the `.perform` block with the event `data` being used. This will help us troubleshoot more complex circumstances surrounding these bugs.

* Adds checking for `course_membership_attrs_present?` in order to make sure that there is a `course_id` and `user_id` coming into the `session` before we bother searching the system for the `CourseMembership` that we'd like to work with.

* As per my discussion with @jwright re: the PR in which this code came in, I've replaced all instances in which `subject` was being used to test outcomes with a `let(:result) { some_behavior }` call instead so that the `subject` method can properly define the subject as is conventional in RSpec testing.

* I've also moved the class methods into a `class << self` block on `LoginEventLogger` since it seems more readable than calling `self.` when defining every class method.

* I've also renamed `@data` to `@cached_data` to avoid any confusion over whether the `data` method is an accessor rather than a method argument, and better clarify that workflow.

Again, I don't believe this will resolve the root of the problem, but it will at least move us closer to being able to identify Login scenarios in which either `course_id` or `user_id` aren't present in the `session` for whatever reason, and cleans up the errors that we're receiving in the meantime.

This PR addresses issues further detailed in Issue #1720.