### PR TITLE
Feature/1704 override rubric total points

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -90,7 +90,7 @@
     )
     points
 
-  $scope.pointsGivenAfterAdjustment = ()->
+  $scope.finalPoints = ()->
     $scope.pointsGiven() + $scope.adjustmentPoints()
 
   $scope.gradedCriteria = ()->

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -185,7 +185,7 @@
 
   $scope.gradeParams = ()->
     {
-      raw_score: $scope.pointsGivenAfterAdjustment(),
+      raw_score: $scope.pointsGiven(),
       feedback: $scope.grade.feedback,
       status:   $scope.grade.status,
       points_adjustment: $scope.grade.points_adjustment,

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -31,11 +31,11 @@
     )
     points or 0
 
-  $scope.pointsAdjustment = ()->
-    parseInt($scope.grade.points_adjustment) || 0
+  $scope.adjustmentPoints = ()->
+    parseInt($scope.grade.adjustment_points) || 0
 
   $scope.pointsAdjusted = ()->
-    $scope.pointsAdjustment() != 0
+    $scope.adjustmentPoints() != 0
 
   $scope.pointsDifference = ()->
     $scope.pointsPossible() - $scope.pointsGiven()
@@ -91,7 +91,7 @@
     points
 
   $scope.pointsGivenAfterAdjustment = ()->
-    $scope.pointsGiven() + $scope.pointsAdjustment()
+    $scope.pointsGiven() + $scope.adjustmentPoints()
 
   $scope.gradedCriteria = ()->
     criteria = []
@@ -188,8 +188,8 @@
       raw_score: $scope.pointsGiven(),
       feedback: $scope.grade.feedback,
       status:   $scope.grade.status,
-      points_adjustment: $scope.grade.points_adjustment,
-      points_adjustment_feedback: $scope.grade.points_adjustment_feedback
+      adjustment_points: $scope.grade.adjustment_points,
+      adjustment_points_feedback: $scope.grade.adjustment_points_feedback
     }
 
   # Document any updates to this format in the specs: /spec/support/api_calls/rubric_grade_put.rb

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -31,6 +31,12 @@
     )
     points or 0
 
+  $scope.pointsAdjustment = ()->
+    parseInt($scope.grade.points_adjustment) || 0
+
+  $scope.pointsAdjusted = ()->
+    $scope.pointsAdjustment() != 0
+
   $scope.pointsDifference = ()->
     $scope.pointsPossible() - $scope.pointsGiven()
 
@@ -83,6 +89,9 @@
         points += criterion.selectedLevel.points
     )
     points
+
+  $scope.pointsGivenAfterAdjustment = ()->
+    $scope.pointsGiven() + $scope.pointsAdjustment()
 
   $scope.gradedCriteria = ()->
     criteria = []
@@ -176,29 +185,30 @@
 
   $scope.gradeParams = ()->
     {
+      raw_score: $scope.pointsGivenAfterAdjustment(),
       feedback: $scope.grade.feedback,
-      status:   $scope.grade.status
+      status:   $scope.grade.status,
+      points_adjustment: $scope.grade.points_adjustment,
+      points_adjustment_feedback: $scope.grade.points_adjustment_feedback
     }
 
   # Document any updates to this format in the specs: /spec/support/api_calls/rubric_grade_put.rb
   # student_id or group_id is now passed through the route, see RubricService.putRubricGradeSubmission
   $scope.gradedRubricParams = ()->
     {
-      points_given:     $scope.pointsGiven(),
       points_possible:  $scope.pointsPossible(),
       criterion_grades: $scope.criteriaParams(),
       level_badges:     $scope.levelBadgesParams(),
       level_ids:        $scope.selectedLevelIds(),
       criterion_ids:    $scope.allCriterionIds(),
       grade:            $scope.gradeParams(),
-  }
+    }
 
   $scope.submitGrade = (returnURL)->
-    self = this
     if !$scope.grade.status
       return alert "You must select a grade status before you can submit this grade"
     if confirm "Are you sure you want to submit the grade for this assignment?"
-      RubricService.putRubricGradeSubmission(self.assignment, self.gradedRubricParams(), returnURL)
+      RubricService.putRubricGradeSubmission($scope.assignment, $scope.gradedRubricParams(), returnURL)
 
   $scope.froalaOptions = {
     inlineMode: false,

--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -118,8 +118,8 @@
     total = 0
     _.each(assignments, (assignment)->
       # use raw score to keep weighting calculation on assignment type level
-      if assignment.grade.raw_score != null
-        total += assignment.grade.raw_score
+      if assignment.grade.final_score != null
+        total += assignment.grade.final_score
       else if ! assignment.pass_fail && ! assignment.closed_without_sumbission && includePredicted
         total += assignment.grade.predicted_score
     )

--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -118,8 +118,8 @@
     total = 0
     _.each(assignments, (assignment)->
       # use raw score to keep weighting calculation on assignment type level
-      if assignment.grade.final_score != null
-        total += assignment.grade.final_score
+      if assignment.grade.final_points != null
+        total += assignment.grade.final_points
       else if ! assignment.pass_fail && ! assignment.closed_without_sumbission && includePredicted
         total += assignment.grade.predicted_score
     )

--- a/app/assets/javascripts/angular/directives/smartNumber.js.coffee
+++ b/app/assets/javascripts/angular/directives/smartNumber.js.coffee
@@ -5,8 +5,8 @@ NumberModule.directive 'smartNumber',
 
     defaultOptions = smartNumberConfig.defaultOptions
 
-    # 0 = tab, 8 = backspace , 13 = enter, 46 = delete, 37 = left arrow, 39 = right arrow, 65 = A
-    controlKeys = [0,8,13, 46, 37, 39, 65]
+    # 0 = tab, 8 = backspace , 13 = enter, 46 = delete, 37 = left arrow, 39 = right arrow, 65 = A, 82 = R
+    controlKeys = [0,8,13, 46, 37, 39, 65, 82]
 
     # 37 = left arrow, 39 = right arrow, 9 = enter, 33 = page up, 34 = page down
     inertKeys = [37, 39, 9, 33, 34]
@@ -445,6 +445,7 @@ NumberModule.directive 'smartNumber',
                   negatedVal = -stripCommas(elem.val())
                   elem.val(numberWithCommas(negatedVal))
                   elem[0].setSelectionRange(1,1)
+                  triggerChange(elem)
 
             elem.on 'keypress', (event) ->
               killEvent(event)

--- a/app/assets/javascripts/angular/directives/smartNumber.js.coffee
+++ b/app/assets/javascripts/angular/directives/smartNumber.js.coffee
@@ -66,6 +66,9 @@ NumberModule.directive 'smartNumber',
     isNotDigit = (which) ->
         (which < 44 || which > 57 || which is 47)
 
+    isNegative = (which) ->
+      which == 109 || which == 189
+
     isTooLong = (val, maxDigits) ->
       val >= maxDigits
 
@@ -89,7 +92,7 @@ NumberModule.directive 'smartNumber',
 
     # invalid actions
     invalidKey = (event) ->
-      isNotDigit(event.which) && isNotControlKey(event.which)
+      isNotDigit(event.which) && isNotControlKey(event.which) && !isNegative(event.which)
 
     maxDigitsReached = (elem, maxDigits) ->
       elem.val().length >= maxDigits
@@ -235,9 +238,11 @@ NumberModule.directive 'smartNumber',
     numberWithCommas = (integer) ->
       integer.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
 
+    stripCommas = (val) ->
+      val.replace(/,/g, "")
+
     resetCommas = (val) ->
-      stripped = val.replace(/,/g, "")
-      numberWithCommas(stripped)
+      numberWithCommas(stripCommas(val))
 
     {
         restrict: 'A'
@@ -431,6 +436,15 @@ NumberModule.directive 'smartNumber',
 
                     # trigger final change event
                     triggerChange(elem)
+
+                if isNegative(event.which)
+                  return if initialPosition != 0
+                  # return the "-" character if no number present
+                  return elem.val("-") if elem.val() == ""
+
+                  negatedVal = -stripCommas(elem.val())
+                  elem.val(numberWithCommas(negatedVal))
+                  elem[0].setSelectionRange(1,1)
 
             elem.on 'keypress', (event) ->
               killEvent(event)

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -14,7 +14,7 @@
 
     .article-graded{'ng-if' => 'articleGraded(assignment)'}
       .grade{'ng-if' => 'assignment.pass_fail == false'}
-        {{assignment.grade.raw_score | number}} / {{assignment.point_total | number}}
+        {{assignment.grade.final_score | number}} / {{assignment.point_total | number}}
       .grade{'ng-if' => 'assignment.pass_fail == true'}
         .no-status{{'ng-if'=>'!assignment.grade.pass_fail_status'}}
           {{termFor["pass"]}} / {{termFor["fail"]}}

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -14,7 +14,7 @@
 
     .article-graded{'ng-if' => 'articleGraded(assignment)'}
       .grade{'ng-if' => 'assignment.pass_fail == false'}
-        {{assignment.grade.final_score | number}} / {{assignment.point_total | number}}
+        {{assignment.grade.final_points | number}} / {{assignment.point_total | number}}
       .grade{'ng-if' => 'assignment.pass_fail == true'}
         .no-status{{'ng-if'=>'!assignment.grade.pass_fail_status'}}
           {{termFor["pass"]}} / {{termFor["fail"]}}

--- a/app/assets/stylesheets/_grades.sass
+++ b/app/assets/stylesheets/_grades.sass
@@ -62,3 +62,6 @@ select#grade_raw_score[disabled], input[type=text]#grade_raw_score[disabled]
 .gradebox
   input
     border: none
+
+.points-adjustment-feedback
+  margin-right: 1rem;

--- a/app/assets/stylesheets/_grades.sass
+++ b/app/assets/stylesheets/_grades.sass
@@ -63,5 +63,5 @@ select#grade_raw_score[disabled], input[type=text]#grade_raw_score[disabled]
   input
     border: none
 
-.grade-points-adjustment
+.grade-adjustment-points
  border: 1pt $color-blue-4 solid

--- a/app/assets/stylesheets/_grades.sass
+++ b/app/assets/stylesheets/_grades.sass
@@ -63,5 +63,5 @@ select#grade_raw_score[disabled], input[type=text]#grade_raw_score[disabled]
   input
     border: none
 
-.points-adjustment-feedback
-  margin-right: 1rem;
+.grade-points-adjustment
+ border: 1pt $color-blue-4 solid

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -363,7 +363,7 @@ button.delete
     color: $color-green-2
 
 
-.points-adjustment-feedback
+.adjustment-points-feedback
   margin-right: 1rem;
 
 .total-points

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -362,6 +362,13 @@ button.delete
   h4.notice
     color: $color-green-2
 
+
+.points-adjustment-feedback
+  margin-right: 1rem;
+
+.total-points
+  margin-bottom: 1rem;
+
 #grade-rubric-table.edit
   .level:hover
     background-color: $color-green-2

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -41,7 +41,7 @@
   right: 28px
   z-index: 800
   padding: 1.5rem 1rem .5rem
-  height: 70px
+  height: 5rem
   border-bottom-left-radius: $global-radius
   border-bottom-right-radius: $global-radius
   background: $color-blue-2
@@ -68,6 +68,10 @@ h4.notice
   font-weight: normal
   color: $color-yellow-1
   text-transform: none
+  &.adjustment
+    color: $color-orange-1
+  &.adjustment.positive-adjustment
+    color: $color-green-2
 
 #rubric-column-heading
   margin-top: 1rem

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -10,7 +10,8 @@ class Grade < ActiveRecord::Base
     :assignment_type_id, :course_id, :feedback, :final_score, :grade_file,
     :grade_file_ids, :grade_files_attributes, :graded_by_id, :group, :group_id,
     :group_type, :instructor_modified, :pass_fail_status, :point_total,
-    :predicted_score, :raw_score, :status, :student, :student_id, :submission,
+    :points_adjustment, :points_adjustment_feedback, :predicted_score,
+    :raw_score, :status, :student, :student_id, :submission,
     :_destroy, :submission_id, :task, :task_id, :team_id, :earned_badges,
     :earned_badges_attributes, :feedback_read, :feedback_read_at,
     :feedback_reviewed, :feedback_reviewed_at, :is_custom_value, :graded_at
@@ -34,7 +35,7 @@ class Grade < ActiveRecord::Base
   accepts_nested_attributes_for :earned_badges, reject_if: proc { |a| (a["score"].blank?) }, allow_destroy: true
 
   before_validation :cache_associations
-  before_save :cache_point_total
+  before_save :calculate_points
   before_save :zero_points_for_pass_fail
   after_save :check_unlockables
 
@@ -106,25 +107,13 @@ class Grade < ActiveRecord::Base
   # Handle raw score attributes with commas (ex "300,000")
   def raw_score=(rs)
     if rs.class == String
-      rs.gsub!(",","").to_i
+      rs.delete!(",").to_i
     end
     write_attribute(:raw_score,rs)
   end
 
-  def score
-    if assignment_type.student_weightable?
-      final_score || ((raw_score * assignment_weight).round if raw_score.present?)  || nil
-    else
-      final_score || raw_score || nil
-    end
-  end
-
   def predicted_score
     self[:predicted_score] || 0
-  end
-
-  def point_total
-    assignment.point_total_for_student(student)
   end
 
   def assignment_weight
@@ -132,7 +121,7 @@ class Grade < ActiveRecord::Base
   end
 
   def has_feedback?
-    feedback != "" && feedback != nil
+    feedback.present?
   end
 
   def is_released?
@@ -183,25 +172,44 @@ class Grade < ActiveRecord::Base
 
   private
 
+  # full points (with student's weighting)
+  def calculate_point_total
+    assignment.point_total_for_student(student)
+  end
+
+  # totaled points (adds adjustment, without weighting)
+  def calculate_final_score
+    return nil unless raw_score.present?
+    raw_score + points_adjustment
+  end
+
+  # points with student's weighting
+  def calculate_score
+    return nil unless raw_score.present?
+    weighting = assignment_type.student_weightable? ? assignment_weight : 1
+    (final_score * weighting).round
+  end
+
+  # Calculate all stored points fields before save
+  def calculate_points
+    self.point_total = calculate_point_total
+    self.final_score = calculate_final_score
+    self.score = calculate_score
+  end
+
   def self.student_visible_sql
     ["status = 'Released' OR (status = 'Graded' AND assignments.release_necessary = ?)", false]
   end
 
   def save_student
-    if self.raw_score_changed? || self.status_changed?
-      student.save
-    end
+    return unless self.raw_score_changed? || self.status_changed?
+    student.save
   end
 
   def save_team
     if course.has_teams? && student.team_for_course(course).present?
       student.team_for_course(course).save
     end
-  end
-
-  def cache_point_total
-    self.score = score
-    self.point_total = point_total
   end
 
   def cache_associations
@@ -267,5 +275,4 @@ class Grade < ActiveRecord::Base
 
     failure_attrs
   end
-
 end

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -41,6 +41,10 @@ class NullGrade
     nil
   end
 
+  def final_points
+    nil
+  end
+
   def status
     nil
   end

--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -21,8 +21,8 @@ class PredictedGradeSerializer
   end
 
   def final_score
-    return 0 if show_zero_in_predictor grade.final_score
-    grade.final_score if grade.is_student_visible?
+    return 0 if show_zero_in_predictor grade.final_points
+    grade.final_points if grade.is_student_visible?
   end
 
   def score

--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -20,9 +20,9 @@ class PredictedGradeSerializer
     grade.student == current_user ? grade.predicted_score : 0
   end
 
-  def raw_score
-    return 0 if show_zero_in_predictor grade.raw_score
-    grade.raw_score if grade.is_student_visible?
+  def final_score
+    return 0 if show_zero_in_predictor grade.final_score
+    grade.final_score if grade.is_student_visible?
   end
 
   def score
@@ -41,7 +41,7 @@ class PredictedGradeSerializer
       id: id,
       predicted_score: predicted_score,
       score: score,
-      raw_score: raw_score,
+      final_score: final_score,
     }
  end
 

--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -20,7 +20,7 @@ class PredictedGradeSerializer
     grade.student == current_user ? grade.predicted_score : 0
   end
 
-  def final_score
+  def final_points
     return 0 if show_zero_in_predictor grade.final_points
     grade.final_points if grade.is_student_visible?
   end
@@ -41,7 +41,7 @@ class PredictedGradeSerializer
       id: id,
       predicted_score: predicted_score,
       score: score,
-      final_score: final_score,
+      final_points: final_points,
     }
  end
 

--- a/app/services/creates_grade/builds_grade.rb
+++ b/app/services/creates_grade/builds_grade.rb
@@ -15,11 +15,13 @@ module Services
         grade.raw_score = context[:attributes]["grade"]["raw_score"]
         grade.status = context[:attributes]["grade"]["status"]
         grade.feedback = context[:attributes]["grade"]["feedback"]
-        grade.points_adjustment = context[:attributes]["grade"]["points_adjustment"]
-        grade.points_adjustment_feedback = context[:attributes]["grade"]["points_adjustment_feedback"]
+        grade.adjustment_points = context[:attributes]["grade"]["adjustment_points"]
+        grade.adjustment_points_feedback = context[:attributes]["grade"]["adjustment_points_feedback"]
         grade.group_id = context[:attributes]["group_id"] if context[:attributes]["group_id"]
         context[:grade] = grade
       end
     end
   end
 end
+
+

--- a/app/services/creates_grade/builds_grade.rb
+++ b/app/services/creates_grade/builds_grade.rb
@@ -11,12 +11,13 @@ module Services
 
       executed do |context|
         grade = Grade.find_or_create(context[:assignment].id,context[:student].id)
-        grade.raw_score = context[:attributes]["points_given"]
         grade.point_total = context[:assignment].point_total
+        grade.raw_score = context[:attributes]["grade"]["raw_score"]
         grade.status = context[:attributes]["grade"]["status"]
         grade.feedback = context[:attributes]["grade"]["feedback"]
-        grade.group_id = context[:attributes]["group_id"] \
-          if context[:attributes]["group_id"]
+        grade.points_adjustment = context[:attributes]["grade"]["points_adjustment"]
+        grade.points_adjustment_feedback = context[:attributes]["grade"]["points_adjustment_feedback"]
+        grade.group_id = context[:attributes]["group_id"] if context[:attributes]["group_id"]
         context[:grade] = grade
       end
     end

--- a/app/views/api/grades/group_index.json.jbuilder
+++ b/app/views/api/grades/group_index.json.jbuilder
@@ -3,11 +3,13 @@ json.data @grades do |grade|
   json.id   grade.id.to_s
 
   json.attributes do
-    json.id            grade.id
-    json.assignment_id grade.assignment_id
-    json.student_id    grade.student_id
-    json.feedback      grade.feedback
-    json.status        grade.status
+    json.id                         grade.id
+    json.assignment_id              grade.assignment_id
+    json.student_id                 grade.student_id
+    json.feedback                   grade.feedback
+    json.status                     grade.status
+    json.points_adjustment          grade.points_adjustment
+    json.points_adjustment_feedback grade.points_adjustment_feedback
   end
 end
 

--- a/app/views/api/grades/group_index.json.jbuilder
+++ b/app/views/api/grades/group_index.json.jbuilder
@@ -8,8 +8,8 @@ json.data @grades do |grade|
     json.student_id                 grade.student_id
     json.feedback                   grade.feedback
     json.status                     grade.status
-    json.points_adjustment          grade.points_adjustment
-    json.points_adjustment_feedback grade.points_adjustment_feedback
+    json.adjustment_points          grade.adjustment_points
+    json.adjustment_points_feedback grade.adjustment_points_feedback
   end
 end
 

--- a/app/views/api/grades/show.json.jbuilder
+++ b/app/views/api/grades/show.json.jbuilder
@@ -8,8 +8,8 @@ json.data do
     json.student_id                 @grade.student_id
     json.feedback                   @grade.feedback
     json.status                     @grade.status
-    json.points_adjustment          @grade.points_adjustment
-    json.points_adjustment_feedback @grade.points_adjustment_feedback
+    json.adjustment_points          @grade.adjustment_points
+    json.adjustment_points_feedback @grade.adjustment_points_feedback
   end
 end
 

--- a/app/views/api/grades/show.json.jbuilder
+++ b/app/views/api/grades/show.json.jbuilder
@@ -3,11 +3,13 @@ json.data do
   json.id   @grade.id.to_s
 
   json.attributes do
-    json.id            @grade.id
-    json.assignment_id @grade.assignment_id
-    json.student_id    @grade.student_id
-    json.feedback      @grade.feedback
-    json.status        @grade.status
+    json.id                         @grade.id
+    json.assignment_id              @grade.assignment_id
+    json.student_id                 @grade.student_id
+    json.feedback                   @grade.feedback
+    json.status                     @grade.status
+    json.points_adjustment          @grade.points_adjustment
+    json.points_adjustment_feedback @grade.points_adjustment_feedback
   end
 end
 

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -39,7 +39,7 @@
               - grade = group_presenter.grade_for(student)
               %td
                 - if grade.present? && grade.instructor_modified?
-                  = points grade.final_score
+                  = points grade.final_points
               - if group_presenter.assignment.assignment_type.student_weightable?
                 %td
                   - if grade.present?

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -39,7 +39,7 @@
               - grade = group_presenter.grade_for(student)
               %td
                 - if grade.present? && grade.instructor_modified?
-                  = points grade.raw_score
+                  = points grade.final_score
               - if group_presenter.assignment.assignment_type.student_weightable?
                 %td
                   - if grade.present?

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -16,7 +16,7 @@
         - else
           No Grade
       - else
-        = points grade.final_score if grade.instructor_modified?
+        = points grade.final_points if grade.instructor_modified?
 
     // If the student can weight the assignment type
     - if presenter.assignment_type.student_weightable?

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -16,7 +16,7 @@
         - else
           No Grade
       - else
-        = points grade.raw_score if grade.instructor_modified?
+        = points grade.final_score if grade.instructor_modified?
 
     // If the student can weight the assignment type
     - if presenter.assignment_type.student_weightable?

--- a/app/views/grades/_group_show.html.haml
+++ b/app/views/grades/_group_show.html.haml
@@ -24,16 +24,16 @@
       %p.bold Your Results
       - grade = presenter.grade_for(current_student)
       %p
-        %span.bold= "#{points grade.final_score }"
+        %span.bold= "#{points grade.final_points }"
         %span=" / #{points presenter.assignment.point_total } possible points"
 
-      - if grade.points_adjustment != 0
-        %div.grade-points-adjustment
+      - if grade.adjustment_points != 0
+        %div.grade-adjustment-points
           %p
             %span Points Adjustment:
-            %span= grade.points_adjustment
-          - if grade.points_adjustment_feedback.present?
-            %p= raw grade.points_adjustment_feedback
+            %span= grade.adjustment_points
+          - if grade.adjustment_points_feedback.present?
+            %p= raw grade.adjustment_points_feedback
 
       - if grade.feedback.present?
         %p.bold Instructor Feedback:
@@ -51,7 +51,7 @@
 
           - grade = presenter.grade_for(student)
           %p
-            %span.bold= "#{points grade.final_score }"
+            %span.bold= "#{points grade.final_points }"
             %span=" / #{points presenter.assignment.point_total } possible points"
           - if presenter.grade_for(student).assignment.release_necessary?
             %p

--- a/app/views/grades/_group_show.html.haml
+++ b/app/views/grades/_group_show.html.haml
@@ -21,21 +21,20 @@
 
   - if current_user_is_student?
     - if presenter.grade_for(current_student).present?
-      - if current_user_is_student?
-        %p.bold Your Results
-      - else
-        %p.bold
-          #{current_student.first_name}'s Grade
-          %span= link_to "Edit", edit_assignment_grade_path(presenter.assignment, student_id: current_student.id), class: "button"
-
+      %p.bold Your Results
       - grade = presenter.grade_for(current_student)
       %p
-        %span.bold= "#{points grade.raw_score }"
+        %span.bold= "#{points grade.final_score }"
         %span=" / #{points presenter.assignment.point_total } possible points"
-      - if grade.assignment.release_necessary? && current_user_is_staff?
-        %p
-          Status:
-          %span.bold= grade.status
+
+      - if grade.points_adjustment != 0
+        %div.grade-points-adjustment
+          %p
+            %span Points Adjustment:
+            %span= grade.points_adjustment
+          - if grade.points_adjustment_feedback.present?
+            %p= raw grade.points_adjustment_feedback
+
       - if grade.feedback.present?
         %p.bold Instructor Feedback:
         %p= raw grade.feedback
@@ -52,7 +51,7 @@
 
           - grade = presenter.grade_for(student)
           %p
-            %span.bold= "#{points grade.raw_score }"
+            %span.bold= "#{points grade.final_score }"
             %span=" / #{points presenter.assignment.point_total } possible points"
           - if presenter.grade_for(student).assignment.release_necessary?
             %p

--- a/app/views/grades/_individual_show.html.haml
+++ b/app/views/grades/_individual_show.html.haml
@@ -17,16 +17,16 @@
         %span= "the #{term_for :assignment}."
       - elsif grade.score.present?
         %span You earned
-        %span.bold= "#{points grade.final_score }"
+        %span.bold= "#{points grade.final_points }"
         %span=" out of #{points presenter.assignment.point_total } possible points."
 
-  - if grade.points_adjustment != 0
+  - if grade.adjustment_points != 0
     %div.grade-points-adjustment
       %p
         %span Points Adjustment:
-        %span= grade.points_adjustment
-      - if grade.points_adjustment_feedback.present?
-        %p= raw grade.points_adjustment_feedback
+        %span= grade.adjustment_points
+      - if grade.adjustment_points_feedback.present?
+        %p= raw grade.adjustment_points_feedback
 
     - if presenter.assignment.release_necessary? && current_user_is_staff?
       %p

--- a/app/views/grades/_individual_show.html.haml
+++ b/app/views/grades/_individual_show.html.haml
@@ -21,12 +21,12 @@
         %span=" out of #{points presenter.assignment.point_total } possible points."
 
   - if grade.points_adjustment != 0
-    %p
-      %span Points Adjustment:
-      %span= grade.points_adjustment
-    - if grade.points_adjustment_feedback.present?
-      %p.small_uppercase Points Adjustment Feedback:
-      %p= raw grade.points_adjustment_feedback
+    %div.grade-points-adjustment
+      %p
+        %span Points Adjustment:
+        %span= grade.points_adjustment
+      - if grade.points_adjustment_feedback.present?
+        %p= raw grade.points_adjustment_feedback
 
 
     - if presenter.assignment.release_necessary? && current_user_is_staff?

--- a/app/views/grades/_individual_show.html.haml
+++ b/app/views/grades/_individual_show.html.haml
@@ -17,7 +17,7 @@
         %span= "the #{term_for :assignment}."
       - elsif grade.score.present?
         %span You earned
-        %span.bold= "#{points grade.raw_score }"
+        %span.bold= "#{points grade.final_score }"
         %span=" out of #{points presenter.assignment.point_total } possible points."
 
   - if grade.points_adjustment != 0
@@ -28,14 +28,15 @@
       - if grade.points_adjustment_feedback.present?
         %p= raw grade.points_adjustment_feedback
 
-
     - if presenter.assignment.release_necessary? && current_user_is_staff?
       %p
         %span.small_uppercase Status:
         %span.bold= grade.status
+
     - if grade.feedback.present?
       %span.small_uppercase Your Feedback:
       %p= raw grade.feedback
+
     - if grade.grade_files.present?
       %hr
       %h4.uppercase Attachments from Grader

--- a/app/views/grades/_individual_show.html.haml
+++ b/app/views/grades/_individual_show.html.haml
@@ -20,6 +20,15 @@
         %span.bold= "#{points grade.raw_score }"
         %span=" out of #{points presenter.assignment.point_total } possible points."
 
+  - if grade.points_adjustment != 0
+    %p
+      %span Points Adjustment:
+      %span= grade.points_adjustment
+    - if grade.points_adjustment_feedback.present?
+      %p.small_uppercase Points Adjustment Feedback:
+      %p= raw grade.points_adjustment_feedback
+
+
     - if presenter.assignment.release_necessary? && current_user_is_staff?
       %p
         %span.small_uppercase Status:

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -14,7 +14,7 @@
         %h4.notice(ng-hide="pointsSatisfied() || pointsMissing()") You have not yet allocated any points
         %h4.notice(ng-show="pointsMissing()") {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} have not been assigned
         %h4.notice(ng-show="pointsSatisfied()") You have allocated all possible points
-        %h4.notice.adjustment(ng-class="{'positive-adjustment' : pointsAdjustment() > 0}" ng-show="pointsAdjusted()") You have adjusted the total by {{pointsAdjustment()}} points
+        %h4.notice.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}" ng-show="pointsAdjusted()") You have adjusted the total by {{adjustmentPoints()}} points
 
       .clear
 
@@ -79,15 +79,15 @@
       %br
       .points-adjustment(ng-cloak)
         %h4 Points Adjustment
-        %input(type="text" placeholder="Enter points adjustment to calculated total" smart-number="" ng-model="grade.points_adjustment")
+        %input(type="text" placeholder="Enter points adjustment to calculated total" smart-number="" ng-model="grade.adjustment_points")
       %br
       .total-points(ng-cloak)
         %h3 {{pointsGivenAfterAdjustment() | number:0}} Total Points
 
     .right
-      .points-adjustment-feedback(ng-if="grade.points_adjustment != 0" ng-cloak)
+      .points-adjustment-feedback(ng-if="grade.adjustment_points != 0" ng-cloak)
         %h4.text-right Points Adjustment Feedback
-        %textarea(ng-model="grade.points_adjustment_feedback" froala="froalaOptions")
+        %textarea(ng-model="grade.adjustment_points_feedback" froala="froalaOptions")
     .clear
 
     .summary_feedback

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -80,16 +80,15 @@
       .points-adjustment(ng-cloak)
         %h4 Points Adjustment
         %input(type="text" placeholder="Enter points adjustment to calculated total" smart-number="" ng-model="grade.points_adjustment")
+      %br
+      .total-points(ng-cloak)
+        %h3 {{pointsGivenAfterAdjustment() | number:0}} Total Points
+
     .right
       .points-adjustment-feedback(ng-if="grade.points_adjustment != 0" ng-cloak)
         %h4.text-right Points Adjustment Feedback
         %textarea(ng-model="grade.points_adjustment_feedback" froala="froalaOptions")
     .clear
-
-    %br
-    .right
-      %h3 Total Points
-      %h4 {{pointsGivenAfterAdjustment() | number:0}}
 
     .summary_feedback
       %h3.text-right Overall Feedback

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -9,11 +9,12 @@
 
       #points-overview-floating(ng-cloak ng-hide="angular.element('#points-overview').isOnscreen()")
         %h4#points-legend
-          %span.points-assigned(ng-class="{'points-missing': pointsMissing(), 'points-satisfied': pointsSatisfied(), 'points-overage': pointsOverage()}") {{pointsGiven() | number:0}}
+          %span.points-assigned(ng-class="{'points-missing': pointsMissing(), 'points-satisfied': pointsSatisfied(), 'points-overage': pointsOverage()}") {{pointsGivenAfterAdjustment() | number:0}}
           \/{{pointsPossible() | number:0}} Points Allocated
         %h4.notice(ng-hide="pointsSatisfied() || pointsMissing()") You have not yet allocated any points
         %h4.notice(ng-show="pointsMissing()") {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} have not been assigned
         %h4.notice(ng-show="pointsSatisfied()") You have allocated all possible points
+        %h4.notice.adjustment(ng-class="{'positive-adjustment' : pointsAdjustment() > 0}" ng-show="pointsAdjusted()") You have adjusted the total by {{pointsAdjustment()}} points
 
       .clear
 
@@ -71,12 +72,24 @@
         .points-overview.bottom(ng-cloak)
           %h4.points-legend
             %span.points-assigned(ng-class="{'points-missing': pointsMissing(), 'points-satisfied': pointsSatisfied(), 'points-overage': pointsOverage()}") {{pointsGiven() | number:0}}
-            \/{{pointsPossible | number:0}} Points Allocated
+            \/{{pointsPossible() | number:0}} Points Allocated
           %h4.notice(ng-hide="pointsSatisfied() || pointsMissing()") You have not yet allocated any points
           %h4.notice(ng-show="pointsMissing()") {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} have not been assigned
           %h4.notice(ng-show="pointsSatisfied()") You have allocated all possible points
-
+      %br
+      .points-adjustment(ng-cloak)
+        %h4 Points Adjustment
+        %input(type="text" placeholder="Enter points adjustment to calculated total" smart-number="" ng-model="grade.points_adjustment")
+    .right
+      .points-adjustment-feedback(ng-if="grade.points_adjustment != 0" ng-cloak)
+        %h4.text-right Points Adjustment Feedback
+        %textarea(ng-model="grade.points_adjustment_feedback" froala="froalaOptions")
     .clear
+
+    %br
+    .right
+      %h3 Total Points
+      %h4 {{pointsGivenAfterAdjustment() | number:0}}
 
     .summary_feedback
       %h3.text-right Overall Feedback

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -9,7 +9,7 @@
 
       #points-overview-floating(ng-cloak ng-hide="angular.element('#points-overview').isOnscreen()")
         %h4#points-legend
-          %span.points-assigned(ng-class="{'points-missing': pointsMissing(), 'points-satisfied': pointsSatisfied(), 'points-overage': pointsOverage()}") {{pointsGivenAfterAdjustment() | number:0}}
+          %span.points-assigned(ng-class="{'points-missing': pointsMissing(), 'points-satisfied': pointsSatisfied(), 'points-overage': pointsOverage()}") {{finalPoints() | number:0}}
           \/{{pointsPossible() | number:0}} Points Allocated
         %h4.notice(ng-hide="pointsSatisfied() || pointsMissing()") You have not yet allocated any points
         %h4.notice(ng-show="pointsMissing()") {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} have not been assigned
@@ -82,7 +82,7 @@
         %input(type="text" placeholder="Enter points adjustment to calculated total" smart-number="" ng-model="grade.adjustment_points")
       %br
       .total-points(ng-cloak)
-        %h3 {{pointsGivenAfterAdjustment() | number:0}} Total Points
+        %h3 {{finalPoints() | number:0}} Total Points
 
     .right
       .points-adjustment-feedback(ng-if="grade.adjustment_points != 0" ng-cloak)

--- a/app/views/grades/edit_status.html.haml
+++ b/app/views/grades/edit_status.html.haml
@@ -15,7 +15,7 @@
       - for grade in @grades
         %tr
           %td= grade.student.name
-          %td= points grade.raw_score
+          %td= points grade.final_score
           %td= grade.status
 
   = simple_form_for :grade, :url => update_status_grades_assignment_path(@assignment), :html => { :method => :put} do |f|

--- a/app/views/grades/edit_status.html.haml
+++ b/app/views/grades/edit_status.html.haml
@@ -15,7 +15,7 @@
       - for grade in @grades
         %tr
           %td= grade.student.name
-          %td= points grade.final_score
+          %td= points grade.final_points
           %td= grade.status
 
   = simple_form_for :grade, :url => update_status_grades_assignment_path(@assignment), :html => { :method => :put} do |f|

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -25,7 +25,7 @@
           %td= "#{g.assignment_id} • #{g.assignment.try(:name)}"
           %td= g.task.name if g.task.present?
           %td= g.submission.id if g.submission.present?
-          %td= g.final_score
+          %td= g.final_points
           %td= g.try(:score)
           %td= g.predicted_score
           %td= g.feedback

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -10,8 +10,8 @@
         %th ID | Assignment
         %th Task
         %th Submission
-        %th Raw Score
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Final Score
+        %th{ "data-dynatable-sorts" => "numericScore" } Score With Weights
         %th Predicted Score
         %th Feedback
         %th Status
@@ -25,7 +25,7 @@
           %td= "#{g.assignment_id} • #{g.assignment.try(:name)}"
           %td= g.task.name if g.task.present?
           %td= g.submission.id if g.submission.present?
-          %td= g.raw_score
+          %td= g.final_score
           %td= g.try(:score)
           %td= g.predicted_score
           %td= g.feedback

--- a/app/views/students/syllabus/_instructor_table.haml
+++ b/app/views/students/syllabus/_instructor_table.haml
@@ -35,13 +35,13 @@
             // Checking to see if this student has weighted this assignment anything other than 1
             - if (@student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || @student.weight_for_assignment_type(assignment_type) > 1
               - if grade_modified
-                = "#{points grade.raw_score} / #{ points assignment.point_total } points (Raw)"
+                = "#{points grade.final_score} / #{ points assignment.point_total } points (Raw)"
                 .bold= "#{ points grade.score } / #{points grade.point_total} points (Multiplied)"
               - else
                 .italic= "#{points grade.point_total} points possible"
             - else
               - if grade_modified
-                .bold= "#{points grade.raw_score} / #{ points grade.point_total } points"
+                .bold= "#{points grade.final_score} / #{ points grade.point_total } points"
               - else
                 .italic= "#{points assignment.point_total} points possible"
           - else

--- a/app/views/students/syllabus/_instructor_table.haml
+++ b/app/views/students/syllabus/_instructor_table.haml
@@ -35,13 +35,13 @@
             // Checking to see if this student has weighted this assignment anything other than 1
             - if (@student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || @student.weight_for_assignment_type(assignment_type) > 1
               - if grade_modified
-                = "#{points grade.final_score} / #{ points assignment.point_total } points (Raw)"
+                = "#{points grade.final_points} / #{ points assignment.point_total } points (Raw)"
                 .bold= "#{ points grade.score } / #{points grade.point_total} points (Multiplied)"
               - else
                 .italic= "#{points grade.point_total} points possible"
             - else
               - if grade_modified
-                .bold= "#{points grade.final_score} / #{ points grade.point_total } points"
+                .bold= "#{points grade.final_points} / #{ points grade.point_total } points"
               - else
                 .italic= "#{points assignment.point_total} points possible"
           - else

--- a/app/views/students/syllabus/_student_table.haml
+++ b/app/views/students/syllabus/_student_table.haml
@@ -35,13 +35,13 @@
               // Checking to see if this student has weighted this assignment anything other than 1
               - if (@student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || @student.weight_for_assignment_type(assignment_type) > 1
                 - if grade_visible_for_assignment
-                  = "#{points grade.final_score} / #{ points assignment.point_total } points (Raw)"
+                  = "#{points grade.final_points} / #{ points assignment.point_total } points (Raw)"
                   .bold= "#{ points grade.score } / #{points grade.point_total} points (Multiplied)"
                 - else
                   .italic= "#{points grade.point_total} points possible"
               - else
                 - if grade_visible_for_assignment
-                  .bold= "#{points grade.final_score} / #{ points grade.point_total } points"
+                  .bold= "#{points grade.final_points} / #{ points grade.point_total } points"
                 - else
                   .italic= "#{points assignment.point_total} points possible"
             - else

--- a/app/views/students/syllabus/_student_table.haml
+++ b/app/views/students/syllabus/_student_table.haml
@@ -35,13 +35,13 @@
               // Checking to see if this student has weighted this assignment anything other than 1
               - if (@student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || @student.weight_for_assignment_type(assignment_type) > 1
                 - if grade_visible_for_assignment
-                  = "#{points grade.raw_score} / #{ points assignment.point_total } points (Raw)"
+                  = "#{points grade.final_score} / #{ points assignment.point_total } points (Raw)"
                   .bold= "#{ points grade.score } / #{points grade.point_total} points (Multiplied)"
                 - else
                   .italic= "#{points grade.point_total} points possible"
               - else
                 - if grade_visible_for_assignment
-                  .bold= "#{points grade.raw_score} / #{ points grade.point_total } points"
+                  .bold= "#{points grade.final_score} / #{ points grade.point_total } points"
                 - else
                   .italic= "#{points assignment.point_total} points possible"
             - else

--- a/db/migrate/20160302203209_add_points_adjustment_to_grades.rb
+++ b/db/migrate/20160302203209_add_points_adjustment_to_grades.rb
@@ -1,6 +1,6 @@
 class AddPointsAdjustmentToGrades < ActiveRecord::Migration
   def change
-    add_column :grades, :points_adjustment, :integer, default: 0, null: false
-    add_column :grades, :points_adjustment_feedback, :text
+    add_column :grades, :adjustment_points, :integer, default: 0, null: false
+    add_column :grades, :adjustment_points_feedback, :text
   end
 end

--- a/db/migrate/20160302203209_add_points_adjustment_to_grades.rb
+++ b/db/migrate/20160302203209_add_points_adjustment_to_grades.rb
@@ -1,0 +1,6 @@
+class AddPointsAdjustmentToGrades < ActiveRecord::Migration
+  def change
+    add_column :grades, :points_adjustment, :integer, default: 0, null: false
+    add_column :grades, :points_adjustment_feedback, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160207122312) do
+ActiveRecord::Schema.define(version: 20160302203209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -418,8 +418,8 @@ ActiveRecord::Schema.define(version: 20160207122312) do
     t.boolean  "complete"
     t.boolean  "semis"
     t.boolean  "finals"
-    t.string   "type",                 limit: 255
-    t.string   "status",               limit: 255
+    t.string   "type",                       limit: 255
+    t.string   "status",                     limit: 255
     t.boolean  "attempted"
     t.boolean  "substantial"
     t.integer  "final_score"
@@ -429,22 +429,24 @@ ActiveRecord::Schema.define(version: 20160207122312) do
     t.integer  "student_id"
     t.integer  "task_id"
     t.integer  "group_id"
-    t.string   "group_type",           limit: 255
+    t.string   "group_type",                 limit: 255
     t.integer  "score"
     t.integer  "assignment_type_id"
     t.integer  "point_total"
     t.text     "admin_notes"
     t.integer  "graded_by_id"
     t.integer  "team_id"
-    t.integer  "predicted_score",                  default: 0,     null: false
-    t.boolean  "instructor_modified",              default: false
+    t.integer  "predicted_score",                        default: 0,     null: false
+    t.boolean  "instructor_modified",                    default: false
     t.string   "pass_fail_status"
-    t.boolean  "is_custom_value",                  default: false
-    t.boolean  "feedback_read",                    default: false
+    t.boolean  "is_custom_value",                        default: false
+    t.boolean  "feedback_read",                          default: false
     t.datetime "feedback_read_at"
-    t.boolean  "feedback_reviewed",                default: false
+    t.boolean  "feedback_reviewed",                      default: false
     t.datetime "feedback_reviewed_at"
     t.datetime "graded_at"
+    t.integer  "points_adjustment",                      default: 0,     null: false
+    t.text     "points_adjustment_feedback"
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -445,8 +445,8 @@ ActiveRecord::Schema.define(version: 20160302203209) do
     t.boolean  "feedback_reviewed",                      default: false
     t.datetime "feedback_reviewed_at"
     t.datetime "graded_at"
-    t.integer  "points_adjustment",                      default: 0,     null: false
-    t.text     "points_adjustment_feedback"
+    t.integer  "adjustment_points",                      default: 0,     null: false
+    t.text     "adjustment_points_feedback"
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree

--- a/spec/controllers/api/criterion_grades_controller_spec.rb
+++ b/spec/controllers/api/criterion_grades_controller_spec.rb
@@ -107,7 +107,7 @@ describe API::CriterionGradesController do
       end
 
       it "updates the grade for all students in group" do
-        target = params["points_given"]
+        target = params["grade"]["raw_score"]
         put :group_update, params
         expect(Grade.where(
           student_id: world.group.students.pluck(:id), assignment_id: world.assignment.id

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -182,7 +182,7 @@ describe AssignmentsController do
           expect(assigns(:assignments).student).to eq(@student)
           assigns(:assignments)[0].grade.tap do |assigned_grade|
             expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.final_score).to eq(nil)
+            expect(assigned_grade.final_points).to eq(nil)
             expect(assigned_grade.score).to eq(nil)
             expect(assigned_grade.predicted_score).to eq(0)
           end
@@ -195,7 +195,7 @@ describe AssignmentsController do
           expect(assigns(:assignments).student).to eq(@student)
           assigns(:assignments)[0].grade.tap do |assigned_grade|
             expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.final_score).to eq(grade.raw_score)
+            expect(assigned_grade.final_points).to eq(grade.raw_score)
             expect(assigned_grade.score).to eq(grade.score)
             expect(assigned_grade.predicted_score).to eq(0)
           end
@@ -299,7 +299,7 @@ describe AssignmentsController do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id)
         get :predictor_data, format: :json, id: @student.id
         expect(assigns(:assignments)[0].grade.score).to eq(nil)
-        expect(assigns(:assignments)[0].grade.final_score).to eq(nil)
+        expect(assigns(:assignments)[0].grade.final_points).to eq(nil)
       end
 
       it "assigns a unreleased grade for the assignment with only predicted score data" do
@@ -309,7 +309,7 @@ describe AssignmentsController do
         expect(assigns(:assignments).student).to eq(@student)
         assigns(:assignments)[0].grade.tap do |assigned_grade|
           expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.final_score).to eq(nil)
+          expect(assigned_grade.final_points).to eq(nil)
           expect(assigned_grade.score).to eq(nil)
           expect(assigned_grade.predicted_score).to eq(500)
         end
@@ -322,7 +322,7 @@ describe AssignmentsController do
         expect(assigns(:assignments).student).to eq(@student)
         assigns(:assignments)[0].grade.tap do |assigned_grade|
           expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.final_score).to eq(grade.raw_score)
+          expect(assigned_grade.final_points).to eq(grade.raw_score)
           expect(assigned_grade.score).to eq(grade.score)
           expect(assigned_grade.predicted_score).to eq(500)
         end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -182,7 +182,7 @@ describe AssignmentsController do
           expect(assigns(:assignments).student).to eq(@student)
           assigns(:assignments)[0].grade.tap do |assigned_grade|
             expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.raw_score).to eq(nil)
+            expect(assigned_grade.final_score).to eq(nil)
             expect(assigned_grade.score).to eq(nil)
             expect(assigned_grade.predicted_score).to eq(0)
           end
@@ -195,7 +195,7 @@ describe AssignmentsController do
           expect(assigns(:assignments).student).to eq(@student)
           assigns(:assignments)[0].grade.tap do |assigned_grade|
             expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.raw_score).to eq(grade.raw_score)
+            expect(assigned_grade.final_score).to eq(grade.raw_score)
             expect(assigned_grade.score).to eq(grade.score)
             expect(assigned_grade.predicted_score).to eq(0)
           end
@@ -299,7 +299,7 @@ describe AssignmentsController do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id)
         get :predictor_data, format: :json, id: @student.id
         expect(assigns(:assignments)[0].grade.score).to eq(nil)
-        expect(assigns(:assignments)[0].grade.raw_score).to eq(nil)
+        expect(assigns(:assignments)[0].grade.final_score).to eq(nil)
       end
 
       it "assigns a unreleased grade for the assignment with only predicted score data" do
@@ -309,7 +309,7 @@ describe AssignmentsController do
         expect(assigns(:assignments).student).to eq(@student)
         assigns(:assignments)[0].grade.tap do |assigned_grade|
           expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.raw_score).to eq(nil)
+          expect(assigned_grade.final_score).to eq(nil)
           expect(assigned_grade.score).to eq(nil)
           expect(assigned_grade.predicted_score).to eq(500)
         end
@@ -322,7 +322,7 @@ describe AssignmentsController do
         expect(assigns(:assignments).student).to eq(@student)
         assigns(:assignments)[0].grade.tap do |assigned_grade|
           expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.raw_score).to eq(grade.raw_score)
+          expect(assigned_grade.final_score).to eq(grade.raw_score)
           expect(assigned_grade.score).to eq(grade.score)
           expect(assigned_grade.predicted_score).to eq(500)
         end

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -191,7 +191,7 @@ describe AssignmentType do
 
     it "returns the total score a student has earned for an assignment type and has a reduced final score" do
       assignment = create(:assignment, course: world.course, assignment_type: assignment_type, release_necessary: true)
-      grade = create(:grade, student: student, raw_score: 100, points_adjustment: -25, assignment: assignment, status: "Released")
+      grade = create(:grade, student: student, raw_score: 100, adjustment_points: -25, assignment: assignment, status: "Released")
       expect(assignment_type.score_for_student(student)).to eq(75)
     end
 

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -191,7 +191,7 @@ describe AssignmentType do
 
     it "returns the total score a student has earned for an assignment type and has a reduced final score" do
       assignment = create(:assignment, course: world.course, assignment_type: assignment_type, release_necessary: true)
-      grade = create(:grade, student: student, raw_score: 100, final_score: 75, assignment: assignment, status: "Released")
+      grade = create(:grade, student: student, raw_score: 100, points_adjustment: -25, assignment: assignment, status: "Released")
       expect(assignment_type.score_for_student(student)).to eq(75)
     end
 

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -81,8 +81,8 @@ describe Grade do
       expect(subject.final_score).to eq(nil)
     end
 
-    it "is the sum of raw_score and points_adjustment" do
-      subject.update(raw_score: "1234", points_adjustment: -234)
+    it "is the sum of raw_score and adjustment_points" do
+      subject.update(raw_score: "1234", adjustment_points: -234)
       expect(subject.final_score).to eq(1000)
     end
   end
@@ -94,14 +94,14 @@ describe Grade do
     end
 
     it "is the same as final score when assignment isn't weighted" do
-      subject.update(raw_score: "1234", points_adjustment: -234)
+      subject.update(raw_score: "1234", adjustment_points: -234)
       expect(subject.score).to eq(1000)
     end
 
     it "is the final score weighted by the students weight for the assignment" do
       subject.assignment.assignment_type.update(student_weightable: true)
       create(:assignment_weight, student: subject.student, assignment: subject.assignment, weight: 3 )
-      subject.update(raw_score: "1,234", points_adjustment: -234)
+      subject.update(raw_score: "1,234", adjustment_points: -234)
       expect(subject.score).to eq(3000)
     end
   end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -75,6 +75,37 @@ describe Grade do
     end
   end
 
+  describe "calculation of final_score" do
+    it "is nil when raw_score is nil" do
+      subject.update(raw_score: nil)
+      expect(subject.final_score).to eq(nil)
+    end
+
+    it "is the sum of raw_score and points_adjustment" do
+      subject.update(raw_score: "1234", points_adjustment: -234)
+      expect(subject.final_score).to eq(1000)
+    end
+  end
+
+  describe "calculating score" do
+    it "is nil when raw_score is nil" do
+      subject.update(raw_score: nil)
+      expect(subject.score).to eq(nil)
+    end
+
+    it "is the same as final score when assignment isn't weighted" do
+      subject.update(raw_score: "1234", points_adjustment: -234)
+      expect(subject.score).to eq(1000)
+    end
+
+    it "is the final score weighted by the students weight for the assignment" do
+      subject.assignment.assignment_type.update(student_weightable: true)
+      create(:assignment_weight, student: subject.student, assignment: subject.assignment, weight: 3 )
+      subject.update(raw_score: "1,234", points_adjustment: -234)
+      expect(subject.score).to eq(3000)
+    end
+  end
+
   describe "when assignment is pass-fail" do
     before do
       subject.assignment.update(pass_fail: true)

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -15,6 +15,10 @@ describe NullGrade do
     expect(subject.final_score).to eq(nil)
   end
 
+  it "has a nil final points" do
+    expect(subject.final_points).to eq(nil)
+  end
+
   it "has nil feedback" do
     expect(subject.feedback).to be_nil
   end

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -4,7 +4,7 @@ require "./app/serializers/predicted_grade_serializer"
 describe PredictedGradeSerializer do
   let(:course) { double(:course) }
   let(:assignment) { double(:assignment, accepts_submissions?: true, submissions_have_closed?: true )}
-  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, raw_score: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
+  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, final_score: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
   let(:user) { double(:user, submission_for_assignment: "sumbission") }
   let(:other_user) { double(:other_user) }
   subject { described_class.new assignment, grade, user }
@@ -48,33 +48,33 @@ describe PredictedGradeSerializer do
     end
 
     it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).raw_score).to eq(0)
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_score).to eq(0)
     end
   end
 
-  describe "#raw_score" do
-    it "returns the grade's raw score if it's visible" do
-      expect(subject.raw_score).to eq grade.raw_score
+  describe "#final_score" do
+    it "returns the grade's final score if it's visible" do
+      expect(subject.final_score).to eq grade.final_score
     end
 
     it "returns nil if it's not visible" do
       allow(grade).to receive(:is_student_visible?).and_return false
-      expect(subject.raw_score).to be_nil
+      expect(subject.final_score).to be_nil
     end
 
-    it "returns 0 with no raw score and no sumbission if the assignment submissions have closed" do
-      allow(grade).to receive(:raw_score).and_return nil
+    it "returns 0 with no final score and no sumbission if the assignment submissions have closed" do
+      allow(grade).to receive(:final_score).and_return nil
       allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.raw_score).to eq(0)
+      expect(subject.final_score).to eq(0)
     end
 
-    it "doesn't override the raw score if present regardless of submission status" do
+    it "doesn't override the final score if present regardless of submission status" do
       allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.raw_score).to eq(grade.raw_score)
+      expect(subject.final_score).to eq(grade.final_score)
     end
 
     it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).raw_score).to eq(0)
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_score).to eq(0)
     end
   end
 
@@ -101,7 +101,7 @@ describe PredictedGradeSerializer do
         id: subject.id,
         predicted_score: subject.predicted_score,
         score: subject.score,
-        raw_score: subject.raw_score
+        final_score: subject.final_score
       })
     end
   end

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -4,7 +4,7 @@ require "./app/serializers/predicted_grade_serializer"
 describe PredictedGradeSerializer do
   let(:course) { double(:course) }
   let(:assignment) { double(:assignment, accepts_submissions?: true, submissions_have_closed?: true )}
-  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, final_score: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
+  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, final_points: 84, student: user, course: course, assignment: assignment, is_student_visible?: true) }
   let(:user) { double(:user, submission_for_assignment: "sumbission") }
   let(:other_user) { double(:other_user) }
   subject { described_class.new assignment, grade, user }
@@ -54,7 +54,7 @@ describe PredictedGradeSerializer do
 
   describe "#final_score" do
     it "returns the grade's final score if it's visible" do
-      expect(subject.final_score).to eq grade.final_score
+      expect(subject.final_score).to eq grade.final_points
     end
 
     it "returns nil if it's not visible" do
@@ -63,14 +63,14 @@ describe PredictedGradeSerializer do
     end
 
     it "returns 0 with no final score and no sumbission if the assignment submissions have closed" do
-      allow(grade).to receive(:final_score).and_return nil
+      allow(grade).to receive(:final_points).and_return nil
       allow(user).to receive(:submission_for_assignment).and_return nil
       expect(subject.final_score).to eq(0)
     end
 
     it "doesn't override the final score if present regardless of submission status" do
       allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.final_score).to eq(grade.final_score)
+      expect(subject.final_score).to eq(grade.final_points)
     end
 
     it "always returns 0 for Null Student if the assignment sumbission has closed" do

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -48,33 +48,33 @@ describe PredictedGradeSerializer do
     end
 
     it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_score).to eq(0)
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_points).to eq(0)
     end
   end
 
-  describe "#final_score" do
+  describe "#final_points" do
     it "returns the grade's final score if it's visible" do
-      expect(subject.final_score).to eq grade.final_points
+      expect(subject.final_points).to eq grade.final_points
     end
 
     it "returns nil if it's not visible" do
       allow(grade).to receive(:is_student_visible?).and_return false
-      expect(subject.final_score).to be_nil
+      expect(subject.final_points).to be_nil
     end
 
     it "returns 0 with no final score and no sumbission if the assignment submissions have closed" do
       allow(grade).to receive(:final_points).and_return nil
       allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.final_score).to eq(0)
+      expect(subject.final_points).to eq(0)
     end
 
     it "doesn't override the final score if present regardless of submission status" do
       allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.final_score).to eq(grade.final_points)
+      expect(subject.final_points).to eq(grade.final_points)
     end
 
     it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_score).to eq(0)
+      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_points).to eq(0)
     end
   end
 
@@ -101,7 +101,7 @@ describe PredictedGradeSerializer do
         id: subject.id,
         predicted_score: subject.predicted_score,
         score: subject.score,
-        final_score: subject.final_score
+        final_points: subject.final_points
       })
     end
   end

--- a/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
+++ b/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
@@ -18,7 +18,7 @@ describe Services::Actions::VerifiesAssignmentStudent do
   end
 
   it "halts with error if assignment is not found" do
-    raw_params["assignment_id"] = 1000
+    raw_params["assignment_id"] = nil
     expect { described_class.execute raw_params: raw_params }.to \
       raise_error LightService::FailWithRollbackError
   end
@@ -29,7 +29,7 @@ describe Services::Actions::VerifiesAssignmentStudent do
   end
 
   it "halts with error if student is not found" do
-    raw_params["student_id"] = 1000
+    raw_params["student_id"] = nil
     expect { described_class.execute raw_params: raw_params }.to \
       raise_error LightService::FailWithRollbackError
   end

--- a/spec/services/creates_grade/builds_grade_spec.rb
+++ b/spec/services/creates_grade/builds_grade_spec.rb
@@ -40,9 +40,11 @@ describe Services::Actions::BuildsGrade do
     expect(result[:grade].assignment_id).to eq world.assignment.id
     expect(result[:grade].student_id).to eq world.student.id
     expect(result[:grade].point_total).to eq attributes["points_possible"]
-    expect(result[:grade].raw_score).to eq attributes["points_given"]
+    expect(result[:grade].raw_score).to eq world.assignment.point_total - 10
     expect(result[:grade].status).to eq "Released"
     expect(result[:grade].feedback).to eq "good jorb!"
+    expect(result[:grade].points_adjustment).to eq -10
+    expect(result[:grade].points_adjustment_feedback).to eq "reduced by 10 points"
   end
 
   it "adds the group id if supplied" do

--- a/spec/services/creates_grade/builds_grade_spec.rb
+++ b/spec/services/creates_grade/builds_grade_spec.rb
@@ -43,8 +43,8 @@ describe Services::Actions::BuildsGrade do
     expect(result[:grade].raw_score).to eq world.assignment.point_total - 10
     expect(result[:grade].status).to eq "Released"
     expect(result[:grade].feedback).to eq "good jorb!"
-    expect(result[:grade].points_adjustment).to eq -10
-    expect(result[:grade].points_adjustment_feedback).to eq "reduced by 10 points"
+    expect(result[:grade].adjustment_points).to eq -10
+    expect(result[:grade].adjustment_points_feedback).to eq "reduced by 10 points"
   end
 
   it "adds the group id if supplied" do

--- a/spec/support/api_calls/rubric_grade_put.rb
+++ b/spec/support/api_calls/rubric_grade_put.rb
@@ -33,14 +33,19 @@ class RubricGradePUT
 
   # "assignment id" and "student_id" or "group_id" is passed through the route
   def params
-    { "points_given" => assignment.point_total,
-      "points_possible" => assignment.point_total,
+    { "points_possible" => assignment.point_total,
       "criterion_grades" => criterion_grades_params,
       "level_badges" => [level_badge_params(level_badge)],
       "level_ids" => (criteria.collect { |c| c.levels.pluck(:id) }).flatten,
       "criterion_ids" => criteria.pluck(:id),
       "controller" => "grades",
-      "grade" => { "status" => "Released", "feedback" => "good jorb!" }
+      "grade" => {
+        "raw_score" => assignment.point_total - 10,
+        "status" => "Released",
+        "feedback" => "good jorb!",
+        "points_adjustment" => "-10",
+        "points_adjustment_feedback" => "reduced by 10 points"
+      }
     }
   end
 

--- a/spec/support/api_calls/rubric_grade_put.rb
+++ b/spec/support/api_calls/rubric_grade_put.rb
@@ -43,8 +43,8 @@ class RubricGradePUT
         "raw_score" => assignment.point_total - 10,
         "status" => "Released",
         "feedback" => "good jorb!",
-        "points_adjustment" => "-10",
-        "points_adjustment_feedback" => "reduced by 10 points"
+        "adjustment_points" => "-10",
+        "adjustment_points_feedback" => "reduced by 10 points"
       }
     }
   end

--- a/spec/views/api/grades/group_index_spec.rb
+++ b/spec/views/api/grades/group_index_spec.rb
@@ -6,7 +6,7 @@ describe "api/grades/group_index" do
     world = World.create.with(:course, :assignment, :student, :grade)
 
     # Expected instance variables on render:
-    @grades = create(:grade)
+    @grades = [create(:grade)]
     @student_ids = [1,2,3,4,5]
     @grades_status_options = ["In Progress","Graded", "Released"]
   end

--- a/spec/views/api/grades/group_index_spec.rb
+++ b/spec/views/api/grades/group_index_spec.rb
@@ -25,8 +25,8 @@ describe "api/grades/group_index" do
     expect(json["data"][0]["attributes"]["student_id"]).to eq(@grades[0].student_id)
     expect(json["data"][0]["attributes"]["feedback"]).to eq(@grades[0].feedback)
     expect(json["data"][0]["attributes"]["status"]).to eq(@grades[0].status)
-    expect(json["data"][0]["attributes"]["points_adjustment"]).to eq(@grades[0].points_adjustment)
-    expect(json["data"][0]["attributes"]["points_adjustment_feedback"]).to eq(@grades[0].points_adjustment_feedback)
+    expect(json["data"][0]["attributes"]["adjustment_points"]).to eq(@grades[0].adjustment_points)
+    expect(json["data"][0]["attributes"]["adjustment_points_feedback"]).to eq(@grades[0].adjustment_points_feedback)
   end
 
   it "adds grading status options to meta data" do

--- a/spec/views/api/grades/group_index_spec.rb
+++ b/spec/views/api/grades/group_index_spec.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+require "rails_spec_helper"
+
+describe "api/grades/group_index" do
+  before(:all) do
+    world = World.create.with(:course, :assignment, :student, :grade)
+
+    # Expected instance variables on render:
+    @grades = create(:grade)
+    @student_ids = [1,2,3,4,5]
+    @grades_status_options = ["In Progress","Graded", "Released"]
+  end
+
+  it "responds with an array of gradew" do
+    render
+    json = JSON.parse(response.body)
+    expect(json["data"][0]["type"]).to eq("grades")
+  end
+
+  it "adds the attributes to the grade" do
+    render
+    json = JSON.parse(response.body)
+    expect(json["data"][0]["attributes"]["id"]).to eq(@grades[0].id)
+    expect(json["data"][0]["attributes"]["assignment_id"]).to eq(@grades[0].assignment_id)
+    expect(json["data"][0]["attributes"]["student_id"]).to eq(@grades[0].student_id)
+    expect(json["data"][0]["attributes"]["feedback"]).to eq(@grades[0].feedback)
+    expect(json["data"][0]["attributes"]["status"]).to eq(@grades[0].status)
+    expect(json["data"][0]["attributes"]["points_adjustment"]).to eq(@grades[0].points_adjustment)
+    expect(json["data"][0]["attributes"]["points_adjustment_feedback"]).to eq(@grades[0].points_adjustment_feedback)
+  end
+
+  it "adds grading status options to meta data" do
+    render
+    json = JSON.parse(response.body)
+    expect(json["meta"]["grade_status_options"]).to eq(@grade_status_options)
+  end
+end

--- a/spec/views/api/grades/show_spec.rb
+++ b/spec/views/api/grades/show_spec.rb
@@ -22,6 +22,8 @@ describe "api/grades/show" do
     expect(json["data"]["attributes"]["student_id"]).to eq(@grade.student_id)
     expect(json["data"]["attributes"]["feedback"]).to eq(@grade.feedback)
     expect(json["data"]["attributes"]["status"]).to eq(@grade.status)
+    expect(json["data"]["attributes"]["points_adjustment"]).to eq(@grade.points_adjustment)
+    expect(json["data"]["attributes"]["points_adjustment_feedback"]).to eq(@grade.points_adjustment_feedback)
   end
 
   it "adds grading status options to meta data" do

--- a/spec/views/api/grades/show_spec.rb
+++ b/spec/views/api/grades/show_spec.rb
@@ -4,6 +4,8 @@ require "rails_spec_helper"
 describe "api/grades/show" do
   before(:all) do
     world = World.create.with(:course, :assignment, :student, :grade)
+
+    # Expected instance variables on render:
     @grade = world.grade
     @grade_status_options = ["In Progress","Graded", "Released"]
   end

--- a/spec/views/api/grades/show_spec.rb
+++ b/spec/views/api/grades/show_spec.rb
@@ -24,8 +24,8 @@ describe "api/grades/show" do
     expect(json["data"]["attributes"]["student_id"]).to eq(@grade.student_id)
     expect(json["data"]["attributes"]["feedback"]).to eq(@grade.feedback)
     expect(json["data"]["attributes"]["status"]).to eq(@grade.status)
-    expect(json["data"]["attributes"]["points_adjustment"]).to eq(@grade.points_adjustment)
-    expect(json["data"]["attributes"]["points_adjustment_feedback"]).to eq(@grade.points_adjustment_feedback)
+    expect(json["data"]["attributes"]["adjustment_points"]).to eq(@grade.adjustment_points)
+    expect(json["data"]["attributes"]["adjustment_points_feedback"]).to eq(@grade.adjustment_points_feedback)
   end
 
   it "adds grading status options to meta data" do

--- a/spec/views/assignments/individual/_table_body_spec.rb
+++ b/spec/views/assignments/individual/_table_body_spec.rb
@@ -30,12 +30,12 @@ describe "assignments/individual/_table_body" do
 
     describe "with a score" do
       context "and the grade is present and instructor modified" do
-        it "renders the raw score" do
+        it "renders the final score" do
           @grade.update(raw_score: @assignment.point_total)
           allow(@grade).to receive(:present?) {true}
           allow(@grade).to receive(:instructor_modified) {true}
           render
-          assert_select "td.status-or-score", text: "#{points @grade.raw_score}"
+          assert_select "td.status-or-score", text: "#{points @grade.final_score}"
         end
       end
 
@@ -45,7 +45,7 @@ describe "assignments/individual/_table_body" do
           allow(@grade).to receive(:present?) {false}
           allow(@grade).to receive(:instructor_modified) {true}
           render
-          assert_select "td.status-or-score", text: "#{points @grade.raw_score}"
+          assert_select "td.status-or-score", text: "#{points @grade.final_score}"
         end
       end
 
@@ -55,7 +55,7 @@ describe "assignments/individual/_table_body" do
           allow(@grade).to receive(:present?) {true}
           allow(@grade).to receive(:instructor_modified) {false}
           render
-          assert_select "td.status-or-score", text: "#{points @grade.raw_score}"
+          assert_select "td.status-or-score", text: "#{points @grade.final_score}"
         end
       end
     end

--- a/spec/views/assignments/predictor_data_spec.rb
+++ b/spec/views/assignments/predictor_data_spec.rb
@@ -41,7 +41,7 @@ describe "assignments/predictor_data" do
       status: "Released"
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "final_score" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "final_points" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "includes the pass fail status with the grade when the assignment is pass fail" do
@@ -52,7 +52,7 @@ describe "assignments/predictor_data" do
     @assignment.update(pass_fail: true)
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "pass_fail_status" => "passed", "final_score" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "pass_fail_status" => "passed", "final_points" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "does not include assignments with no points" do

--- a/spec/views/assignments/predictor_data_spec.rb
+++ b/spec/views/assignments/predictor_data_spec.rb
@@ -41,7 +41,7 @@ describe "assignments/predictor_data" do
       status: "Released"
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "raw_score" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "final_score" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "includes the pass fail status with the grade when the assignment is pass fail" do
@@ -52,7 +52,7 @@ describe "assignments/predictor_data" do
     @assignment.update(pass_fail: true)
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "pass_fail_status" => "passed", "raw_score" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "pass_fail_status" => "passed", "final_score" => 1000, "score" => 1000, "predicted_score" => 999 })
   end
 
   it "does not include assignments with no points" do


### PR DESCRIPTION
This feature adds the ability to adjust the total points assigned on a rubric graded assignment. It adds an `adjustment_points` and `adjustment_points_feedback` field on the grade, and uses the existing `final_score` to store the adjusted score.

### Grading Form:
![screen shot 2016-03-09 at 12 56 14 pm](https://cloud.githubusercontent.com/assets/1138350/13683416/8ccf2a5e-e6d4-11e5-855e-c59f885a6ddd.png)

### Student Grade View:
![screen shot 2016-03-09 at 2 02 20 pm](https://cloud.githubusercontent.com/assets/1138350/13683413/89f05150-e6d4-11e5-8607-aa4d59f53662.png)

### Ruby Concerns:
A temporary method `final_points` has been added to the Grade model, to handle older grades that have a null `final_score` by passing through the `raw_score`.

### Javascript Concerns:
The Smart Number module has been updated to handle negative numbers.
