### PR TITLE
Insert new criterion levels between min and max

### DIFF
--- a/app/assets/javascripts/angular/factories/Criterion.js.coffee
+++ b/app/assets/javascripts/angular/factories/Criterion.js.coffee
@@ -42,6 +42,12 @@
       if @criterionGradeLevelId and @criterionGradeLevelId == newLevel.id
         @selectedLevel = newLevel
 
+    # For adding new levels through UI, we want to insert them
+    # before the Full Credit Level
+    insertLevel: (attrs={})->
+      newLevel = new Level(@, attrs, @$scope)
+      @levels.splice(-1, -1, newLevel)
+
     addLevels: (levels)->
       angular.forEach(levels, (level,index)=>
         @addLevel(level)

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -40,7 +40,7 @@
           .level-wrapper
             .level(name="levelForm" ng-repeat="level in criterion.levels" ng-form ng-submit="level.create()" ng-class="{saved: level.isSaved(), nocredit: level.noCredit}")
               = render "rubrics/new_level"
-        %button.add-level(name="newLevel" ng-click="criterion.addLevel()" ng-show="criterion.isSaved()")
+        %button.add-level(name="newLevel" ng-click="criterion.insertLevel()" ng-show="criterion.isSaved()")
           + Level
 
     %button#new-rubric-criterion(type="button" ng-click="newCriterion()" ng-hide) + Criterion


### PR DESCRIPTION
This is a UX enhancement which inserts new levels in between the min and max
levels.
![screen shot 2016-03-07 at 4 05 20 pm](https://cloud.githubusercontent.com/assets/1138350/13583354/d19feb26-e47e-11e5-9cf4-c212f5168750.png)

closes #1703