### PR TITLE
use grade status constants

### DIFF
--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -6,7 +6,7 @@ class API::GradesController < ApplicationController
   def show
     @grade = Grade.find_or_create(params[:assignment_id], params[:student_id])
     @grade_status_options = @grade.assignment.release_necessary? ?
-      ["In Progress", "Graded", "Released"] : ["In Progress", "Graded"]
+      Grade::STATUSES : Grade::UNRELEASED_STATUSES
   end
 
   # GET api/assignments/:assignment_id/groups/:group_id/grades
@@ -19,7 +19,7 @@ class API::GradesController < ApplicationController
       @student_ids = students.pluck(:id)
       @grades = Grade.find_or_create_grades(params[:assignment_id], @student_ids)
       @grade_status_options = assignment.release_necessary? ?
-        ["In Progress", "Graded", "Released"] : ["In Progress", "Graded"]
+        Grade::STATUSES : Grade::UNRELEASED_STATUSES
     end
   end
 end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -16,9 +16,7 @@ class Grade < ActiveRecord::Base
     :feedback_reviewed, :feedback_reviewed_at, :is_custom_value, :graded_at
 
   STATUSES = ["In Progress", "Graded", "Released"]
-
-  # Note Pass and Fail use term_for in the views
-  PASS_FAIL_STATUS = ["Pass", "Fail"]
+  UNRELEASED_STATUSES = ["In Progress", "Graded"]
 
   belongs_to :course, touch: true
   belongs_to :assignment, touch: true

--- a/app/views/grades/_group_standard_edit.html.haml
+++ b/app/views/grades/_group_standard_edit.html.haml
@@ -15,10 +15,10 @@
 
   - if @assignment.release_necessary?
     - if current_user_is_gsi?
-      = f.input :status, as: :select, :collection => ["In Progress", "Graded"], :selected => @group.students.first.grade_for_assignment(@assignment).try(:status)
+      = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => @group.students.first.grade_for_assignment(@assignment).try(:status)
       .form_label Is this grade ready to be reviewed?
     - else
-      = f.input :status,  as: :select, :collection => ["In Progress", "Graded", "Released"], :selected => @group.students.first.grade_for_assignment(@assignment).try(:status)
+      = f.input :status,  as: :select, :collection => Grade::STATUSES, :selected => @group.students.first.grade_for_assignment(@assignment).try(:status)
   - else
     = f.hidden_field :status, value: 'Graded'
 

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -37,7 +37,7 @@
 
           - if @assignment.release_necessary?
             .assignment-status
-              = f.input :status,  as: :select, :collection => ["In Progress", "Graded", "Released"], :selected => @grade.status, :include_blank => true
+              = f.input :status,  as: :select, :collection => Grade::STATUSES, :selected => @grade.status, :include_blank => true
               .form_label Can the student see this grade? (Won't be updated until the grade is submitted.)
 
               -# angular code for status update

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -5,6 +5,20 @@ require "toolkits/sanitization_toolkit"
 describe Grade do
   subject { build(:grade) }
 
+  describe "constants" do
+    describe "STATUSES" do
+      it "returns an array of all the status values" do
+        expect(described_class::STATUSES).to eq ["In Progress", "Graded", "Released"]
+      end
+    end
+
+    describe "UNRELEASED_STATUSES" do
+      it "returns an array of all the status values" do
+        expect(described_class::UNRELEASED_STATUSES).to eq ["In Progress", "Graded"]
+      end
+    end
+  end
+
   describe "validations" do
     it "is valid with an assignment, student, assignment_type, and course" do
       expect(subject).to be_valid


### PR DESCRIPTION
As per suggestion from @jwright, this refactors all grade status arrays to reference constants on the Grade model. (*Note:* one reference remains on `app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee`; this file is due for a more thorough refactoring, so I have left it for now.)

closes #1695 