### PR TITLE
1740 Nil Changeset bug

### DIFF
--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -48,7 +48,9 @@ class HistoryFilter
 
     from_versions.each_with_index do |history_item, index|
       history_item.changeset.each_pair do |key, value|
-        if !["created_at", "updated_at"].include?(key) && value.is_a?(Array)
+        if !["created_at", "updated_at"].include?(key) &&
+            value.is_a?(Array) &&
+            to_versions.size > index
           to_versions[index].changeset.merge!({ "#{key}" => value })
         end
       end

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -99,6 +99,17 @@ describe HistoryFilter do
                               "attribute2" => [nil, "http://example.org"],
                               "attribute1" => [nil, "blah"]}]
     end
+
+    it "does not merge if the destination does not exist" do
+      history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
+                                changeset: { "event" => "create",
+                                             "object" => "FromObject",
+                                             "attribute1" => [nil, "blah"]})
+      ]
+      result = described_class.new(history).merge("FromObjectType" => "ToObjectType")
+        .changesets
+      expect(result).to be_empty
+    end
   end
 
   describe "#remove" do


### PR DESCRIPTION
A bug occurred on production for https://rollbar.com/gradecraft/gradecraft-development/items/1482/?person_page=0&#traceback.

This is a result of merging histories where the destination changeset does not exist.

This adds a check to the `#merge` operation on `HistoryFilter` to ensure that the destination exists before merging in the changeset.

Fixes #1740 