### PR TITLE
bugfix for group rubric grades missing submission id

### DIFF
--- a/app/services/creates_criterion_grade/verifies_assignment_student.rb
+++ b/app/services/creates_criterion_grade/verifies_assignment_student.rb
@@ -11,6 +11,9 @@ module Services
         begin
           context[:assignment] = Assignment.find(context[:raw_params]["assignment_id"])
           context[:student] = User.find(context[:raw_params]["student_id"])
+          if context[:raw_params]["group_id"]
+            context[:group] = Group.find(context[:raw_params]["group_id"])
+          end
         rescue ActiveRecord::RecordNotFound
           context.fail_with_rollback!("Unable to verify both student and assignment", error_code: 404)
         end

--- a/app/services/creates_grade/associates_submission_with_grade.rb
+++ b/app/services/creates_grade/associates_submission_with_grade.rb
@@ -8,8 +8,13 @@ module Services
       expects :grade
 
       executed do |context|
-        s = Submission.where({ assignment_id: context[:assignment].id,
+        if context[:group]
+          s = Submission.where({ assignment_id: context[:assignment].id,
+                               group_id: context[:group].id }).first
+        else
+          s = Submission.where({ assignment_id: context[:assignment].id,
                                student_id: context[:student].id }).first
+        end
         context[:grade].submission_id = s.nil? ? nil : s.id
       end
     end

--- a/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
+++ b/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
@@ -17,6 +17,12 @@ describe Services::Actions::VerifiesAssignmentStudent do
     expect(result).to have_key :assignment
   end
 
+  it "returns the group if present" do
+    raw_params["group_id"] = world.group.id
+    result = described_class.execute raw_params: raw_params
+    expect(result).to have_key :group
+  end
+
   it "halts with error if assignment is not found" do
     raw_params["assignment_id"] = 1000
     expect { described_class.execute raw_params: raw_params }.to \

--- a/spec/services/creates_grade/associates_submission_with_grade_spec.rb
+++ b/spec/services/creates_grade/associates_submission_with_grade_spec.rb
@@ -4,7 +4,7 @@ require "./app/services/creates_grade/associates_submission_with_grade"
 
 describe Services::Actions::AssociatesSubmissionWithGrade do
 
-  let(:world) { World.create.with(:course, :student, :assignment, :grade) }
+  let(:world) { World.create.with(:course, :student, :assignment, :grade, :group) }
   let(:context) {{ assignment: world.assignment, student: world.student, grade: world.grade }}
 
   it "expect student to be added to the context" do
@@ -19,14 +19,35 @@ describe Services::Actions::AssociatesSubmissionWithGrade do
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
+  it "expect grade to be added to the context" do
+    context.delete(:grade)
+    expect { described_class.execute context }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
   it "adds a submission_id to the grade" do
+    submission = create(:submission, assignment: world.assignment, student: world.student)
+    result = described_class.execute context
+    expect(result[:grade].submission_id).to eq submission.id
+  end
+
+  it "adds nil as submission_id if no submission" do
     result = described_class.execute context
     expect(result[:grade].submission_id).to be_nil
   end
 
-  it "adds nil as submission_id if no submission" do
-    submission = create(:submission, assignment: world.assignment, student: world.student)
-    result = described_class.execute context
-    expect(result[:grade].submission_id).to eq submission.id
+  describe "with a group in the context" do
+    it "adds the group submission_id to the grade" do
+      context[:group] = world.group
+      submission = create(:submission, assignment: world.assignment, group: world.group)
+      result = described_class.execute context
+      expect(result[:grade].submission_id).to eq submission.id
+    end
+
+    it "adds nil as submission_id if no submission" do
+      context[:group] = world.group
+      result = described_class.execute context
+      expect(result[:grade].submission_id).to be_nil
+    end
   end
 end


### PR DESCRIPTION
This addresses the bug where rubric grades for groups did not persist the submission id.
This is because the service was looking for a submission with the student id and returning
nil. This adds the group to the service context, and checks to see if a group is available.
If it is, it will check for a group submission, otherwise it will default to the previous
behavior.

closes #1752