### PR TITLE
Feature/1782 standard grade status

### DIFF
--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -41,8 +41,7 @@
         .display_on_hover.hover-style
           This feedback has been <strong>marked as read</strong> by the #{term_for :student}.
 
-    - if presenter.assignment.release_necessary?
-      %td= grade.status
+    %td= grade.status
 
     - if presenter.assignment.accepts_submissions?
       - submissions_for_assignment = presenter.submissions_for(student)

--- a/app/views/assignments/individual/_table_head.html.haml
+++ b/app/views/assignments/individual/_table_head.html.haml
@@ -17,8 +17,7 @@
 
   %th{scope: "col"} Read?
 
-  - if presenter.assignment.release_necessary?
-    %th{scope: "col"} Status
+  %th{scope: "col"} Status
 
   - if presenter.assignment.accepts_submissions?
     %th{scope: "col"} Submitted

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -53,7 +53,7 @@
 
                   = f.input :status, as: :select, :collection => Grade::STATUSES, :selected => @grade.status, :include_blank => false
                 - else
-                  = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => @grade.status, :include_blank => false
+                  = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => @grade.status || "Graded", :include_blank => false
                 .align-right.form_label Can the student see this grade?
           .clear
           %br

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -25,20 +25,6 @@
             - else
               = render partial: "grades/standard_edit/raw_score_grading_fields", locals: {f:f}
 
-          - if @assignment.release_necessary?
-            .assignment-status
-              = f.input :status,  as: :select, :collection => Grade::STATUSES, :selected => @grade.status, :include_blank => true
-              .form_label Can the student see this grade? (Won't be updated until the grade is submitted.)
-
-              -# angular code for status update
-              -# .input.select.optional.grade_status
-                %label.select.optional(for="grade_status") Status
-                %select.select.optional(name="grade[status]" id="grade_status")
-                  %option(value="{{grade_status}}" ng-repeat="grade_status in gradeStatuses" ng-selected="grade_status == grade.status") {{grade_status}}
-
-          - elsif @grade.status.blank?
-            = f.hidden_field :status, value: "Graded"
-
           .attachments(ng-cloak)
             .clear
             = render partial: "grades/standard_edit/standard_edit_attachment", locals: {f: f}
@@ -57,6 +43,21 @@
             #updated-at-current(ng-show="grade.updated_at" ng-class="{just_updated: grade.justUpdated()}")
               %span updated
               %span(am-time-ago="grade.updated_at")
+
+          .clear
+          %br
+          .right
+            .row
+              .assignment-status
+                - if @assignment.release_necessary?
+
+                  = f.input :status, as: :select, :collection => Grade::STATUSES, :selected => @grade.status, :include_blank => false
+                - else
+                  = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => @grade.status, :include_blank => false
+                .align-right.form_label Can the student see this grade?
+          .clear
+          %br
+
 
           .submit-buttons
             %ul


### PR DESCRIPTION
This is a small enhancement which will remove the possibility of grades submitted without a status. It makes the selection of Status explicit for all grades. If release is necessary the selector will present [In Progress, Graded, Released]. If no release is necessary, the Grader will still need to choose from [In Progress, or Graded], rather then defaulting to an invisible "Graded" value.  Additionally, the index of Grades will always show the Status, so that Grades without release will still display if they are "Graded" or "In Progress".

**The Good**: This standardizes the selectable grade Status with Rubric Graded assignments. Grades can't be submitted without a status. It also places the selector in the same location as the Rubric Grade form.

**The Bad**: This shares no code with the Rubric Grading logic, as it still relies on submitting a standard form, so it can't use the same check for a selected status on submit. Instead, the status bar has no "unselected" option. This may not be an acceptable solution since Graders who are not used to making this selection could end up with a lot of "In Progress" grades by default.