### PR TITLE
fixes autosave on standard grade edit

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -162,9 +162,6 @@
       'sep', 'formatBlock', 'align', 'insertOrderedList', 'insertUnorderedList',
       'outdent', 'indent', 'insertHorizontalRule', 'createLink', 'undo', 'redo',
       'removeFormat', 'selectAll'
-    ],
-    saveURL: '/grades/' + $scope.gradeId + '/async_update',
-    saveRequestType: 'PUT',
-    saveParams: {"save_type": "feedback"}
+    ]
   }
 ]

--- a/app/assets/javascripts/angular/factories/Grade.js.coffee
+++ b/app/assets/javascripts/angular/factories/Grade.js.coffee
@@ -37,7 +37,7 @@
     timeSinceUpdate: ()->
       self = this
       Math.abs(new Date() - self.updated_at)
- 
+
     modelOptions: ()->
       {
         updateOn: 'default blur',
@@ -49,14 +49,15 @@
 
     # updating grade properties
     update: ()->
-      if this.releaseNecessary
-        self = this
-        @http.put("/grades/#{self.id}/async_update", self).success(
-          (data,status)->
-            self.updated_at = new Date()
-        )
-        .error((err)->
-        )
+      self = this
+      @http.put("/api/grades/#{self.id}", grade: self).success(
+        (data,status)->
+          console.log(data);
+          self.updated_at = new Date()
+      )
+      .error((err)->
+        console.log(err);
+      )
 
     params: ()->
       {

--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -5,8 +5,30 @@ class API::GradesController < ApplicationController
   # GET api/assignments/:assignment_id/students/:student_id/grade
   def show
     @grade = Grade.find_or_create(params[:assignment_id], params[:student_id])
-    @grade_status_options = @grade.assignment.release_necessary? ?
-      Grade::STATUSES : Grade::UNRELEASED_STATUSES
+    if @grade.assignment.release_necessary?
+      @grade_status_options = Grade::STATUSES
+    else
+      @grade_status_options = Grade::UNRELEASED_STATUSES
+    end
+  end
+
+  # POST api/grades/:grade_id
+  def update
+    grade = Grade.find(params[:id])
+    grade.assign_attributes(grade_params)
+    grade.instructor_modified = true
+    if grade.raw_score_changed?
+      grade.graded_at = DateTime.now
+    end
+    changes = grade.changes
+    if grade.save
+      render json: { message: {changes: changes}, success: true }
+    else
+      render json: {
+        message: "failed to save grade", success: false
+        },
+        status: 500
+    end
   end
 
   # GET api/assignments/:assignment_id/groups/:group_id/grades
@@ -22,10 +44,17 @@ class API::GradesController < ApplicationController
       @student_ids = students.pluck(:id)
       @grades =
         Grade.find_or_create_grades(params[:assignment_id], @student_ids)
-      @grade_status_options = assignment.release_necessary? ?
-        Grade::STATUSES : Grade::UNRELEASED_STATUSES
+      if assignment.release_necessary?
+        @grade_status_options = Grade::STATUSES
+      else
+        @grade_status_options = Grade::UNRELEASED_STATUSES
+      end
     end
   end
+
+  private
+
+  def grade_params
+    params.require(:grade).permit(:raw_score, :feedback, :status)
+  end
 end
-
-

--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -22,6 +22,7 @@ class API::GradesController < ApplicationController
     end
     changes = grade.changes
     if grade.save
+      grade.squish_history!
       render json: { message: {changes: changes}, success: true }
     else
       render json: {

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -84,21 +84,6 @@ class GradesController < ApplicationController
     end
   end
 
-  # PUT /grades/:id/async_update
-  def async_update
-    Grade.find(params[:id]).update_attributes(
-      {
-         feedback: params[:feedback],
-         instructor_modified: true,
-         status: params[:status],
-         updated_at: Time.now,
-         graded_at: DateTime.now,
-         raw_score: params[:raw_score]
-      }
-    )
-    render nothing: true
-  end
-
   # POST /grades/earn_student_badge
   def earn_student_badge
     @earned_badge = EarnedBadge.create params[:earned_badge]

--- a/app/models/concerns/historical.rb
+++ b/app/models/concerns/historical.rb
@@ -48,23 +48,8 @@ module Historical
     self
   end
 
-  def squish_history!
-    current_version = self.versions.last
-    previous_version = self.versions[-2]
-
-    if previous_version
-      current = PaperTrail.serializer.load(current_version.object)
-      current_version.changeset.each do |attribute, changes|
-        current[attribute] = changes.last
-      end
-      current_version.object = PaperTrail.serializer.dump(current)
-
-      changeset = previous_version.changeset.merge current_version.changeset
-      current_version.instance_variable_set "@changeset", changeset
-      current_version.save
-
-      previous_version.destroy!
-    end
+  def squish_history!(timeout_in_milliseconds=36_000) # 10 minutes
+    PaperTrailVersionSquisher.new(self).squish!(timeout_in_milliseconds)
   end
 
   private

--- a/app/models/concerns/historical.rb
+++ b/app/models/concerns/historical.rb
@@ -48,6 +48,25 @@ module Historical
     self
   end
 
+  def squish_history!
+    current_version = self.versions.last
+    previous_version = self.versions[-2]
+
+    if previous_version
+      current = PaperTrail.serializer.load(current_version.object)
+      current_version.changeset.each do |attribute, changes|
+        current[attribute] = changes.last
+      end
+      current_version.object = PaperTrail.serializer.dump(current)
+
+      changeset = previous_version.changeset.merge current_version.changeset
+      current_version.instance_variable_set "@changeset", changeset
+      current_version.save
+
+      previous_version.destroy!
+    end
+  end
+
   private
 
   def history=(history)

--- a/app/models/paper_trail_version_squisher.rb
+++ b/app/models/paper_trail_version_squisher.rb
@@ -1,0 +1,52 @@
+class PaperTrailVersionSquisher
+  attr_reader :model
+
+  def initialize(model)
+    @model = model
+  end
+
+  def squish!(timeout_in_milliseconds)
+    if current_version && previous_version &&
+        within_timeout?(timeout_in_milliseconds) && versions_match?
+      squish_object
+      squish_changeset
+
+      current_version.save
+
+      previous_version.destroy!
+    end
+  end
+
+  private
+
+  def current_version
+    @current_version ||= model.versions.order(:id).last
+  end
+
+  def previous_version
+    @previous_version ||= model.versions.order(:id)[-2]
+  end
+
+  def squish_changeset
+    changeset = previous_version.changeset.merge current_version.changeset
+    current_version.instance_variable_set "@changeset", changeset
+  end
+
+  def squish_object
+    current = PaperTrail.serializer.load(current_version.object)
+    current_version.changeset.each do |attribute, changes|
+      current[attribute] = changes.last
+    end
+    current_version.object = PaperTrail.serializer.dump(current)
+  end
+
+  def versions_match?
+    previous_version.event == current_version.event &&
+      previous_version.whodunnit == current_version.whodunnit
+  end
+
+  def within_timeout?(timeout_in_milliseconds)
+    ((Time.now.utc - current_version.created_at) / 60).abs <
+      timeout_in_milliseconds
+  end
+end

--- a/app/models/paper_trail_version_squisher.rb
+++ b/app/models/paper_trail_version_squisher.rb
@@ -9,7 +9,7 @@ class PaperTrailVersionSquisher
     if current_version && previous_version &&
         within_timeout?(timeout_in_milliseconds) && versions_match?
       squish_object
-      squish_changeset
+      squish_object_changes
 
       current_version.save
 
@@ -27,9 +27,9 @@ class PaperTrailVersionSquisher
     @previous_version ||= model.versions.order(:id)[-2]
   end
 
-  def squish_changeset
+  def squish_object_changes
     changeset = previous_version.changeset.merge current_version.changeset
-    current_version.instance_variable_set "@changeset", changeset
+    current_version.object_changes = PaperTrail.serializer.dump(changeset)
   end
 
   def squish_object

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,7 +112,6 @@ GradeCraft::Application.routes.draw do
   resources :unlock_conditions
 
   # earned badges grade routes
-  put "grades/:id/async_update", to: "grades#async_update"
   post "grades/earn_student_badge", to: "grades#earn_student_badge"
   post "grade/:grade_id/earn_student_badges", to: "grades#earn_student_badges"
   delete "grade/:grade_id/student/:student_id/badge/:badge_id/earned_badge/:id", to: "grades#delete_earned_badge"
@@ -357,6 +356,7 @@ GradeCraft::Application.routes.draw do
     get 'assignments/:assignment_id/groups/:group_id/criterion_grades', to: 'criterion_grades#group_index', defaults: { format: :json }
 
     #grades
+    resources :grades, only: :update, defaults: { format: :json }
     get 'assignments/:assignment_id/students/:student_id/grade', to: 'grades#show', defaults: { format: :json }
     get 'assignments/:assignment_id/groups/:group_id/grades', to: 'grades#group_index', defaults: { format: :json }
   end

--- a/spec/controllers/api/grades_controller_spec.rb
+++ b/spec/controllers/api/grades_controller_spec.rb
@@ -26,6 +26,28 @@ describe API::GradesController do
       end
     end
 
+    describe "update" do
+      it "updates feedback, status and raw score from params" do
+        post :update, { id: world.grade.id, grade: { raw_score: 20000, feedback: "good jorb!", status: "Graded" }}
+        world.grade.reload
+        expect(world.grade.feedback).to eq("good jorb!")
+        expect(world.grade.status).to eq("Graded")
+        expect(world.grade.raw_score).to eq(20000)
+      end
+
+      it "updates instructor modified to true" do
+        post :update, { id: world.grade.id, grade: { raw_score: 20000, feedback: "good jorb!" }}
+        world.grade.reload
+        expect(world.grade.instructor_modified).to be_truthy
+      end
+
+      it "timestamps the grade" do
+        current_time = DateTime.now
+        post :update, { id: world.grade.id, grade: { raw_score: 20000, feedback: "good jorb!" }}
+        expect(world.grade.reload.graded_at).to be > current_time
+      end
+    end
+
     describe "GET group_index" do
       before(:each) do
         world.create_group
@@ -57,6 +79,12 @@ describe API::GradesController do
     describe "GET show" do
       it "is a protected route" do
         expect(get :show, assignment_id: world.assignment.id, student_id: world.student.id, format: :json).to redirect_to(:root)
+      end
+    end
+
+    describe "PUT update" do
+      it "is a protected route" do
+        expect(post :update, id: world.grade.id, raw_score: 20000, format: :json).to redirect_to(:root)
       end
     end
 

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -197,49 +197,6 @@ describe GradesController do
       end
     end
 
-    describe "async_update" do
-
-      it "updates feedback, status and raw score from params" do
-        post :async_update, { id: @grade.id, raw_score: 20000, feedback: "good jorb!", status: "Graded" }
-        @grade.reload
-        expect(@grade.feedback).to eq("good jorb!")
-        expect(@grade.status).to eq("Graded")
-        expect(@grade.raw_score).to eq(20000)
-      end
-
-      it "updates instructor modified to true" do
-        post :async_update, { id: @grade.id, raw_score: 20000, feedback: "good jorb!" }
-        @grade.reload
-        expect(@grade.instructor_modified).to be_truthy
-      end
-
-      it "timestamps the grade" do
-          current_time = DateTime.now
-          post :async_update, { id: @grade.id, raw_score: 20000, feedback: "good jorb!" }
-          expect(@grade.reload.graded_at).to be > current_time
-        end
-
-      describe "manages update with model validations" do
-        it "handles commas in raw score params" do
-          post :async_update, { id: @grade.id, raw_score: "12,345", feedback: "good jorb!" }
-          @grade.reload
-          expect(@grade.score).to eq(12345)
-        end
-
-        it "handles reverting nil raw score" do
-          post :async_update, { id: @grade.id, raw_score: nil, feedback: "good jorb!" }
-          @grade.reload
-          expect(@grade.score).to eq(nil)
-        end
-
-        it "reverts empty raw score to nil, not zero" do
-          post :async_update, { id: @grade.id, raw_score: "", feedback: "good jorb!" }
-          @grade.reload
-          expect(@grade.score).to eq(nil)
-        end
-      end
-    end
-
     describe "earn_student_badge" do
       it "creates a new student badge from params" do
         badge = create(:badge)

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -78,6 +78,11 @@ describe Grade do
       subject.update(raw_score: "1,234")
       expect(subject.raw_score).to eq(1234)
     end
+
+    it "is converts blank string to nil" do
+      subject.update(raw_score: "")
+      expect(subject.raw_score).to eq(nil)
+    end
   end
 
   describe ".not_released" do

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -64,6 +64,19 @@ describe Grade do
   it_behaves_like "a historical model", :grade, raw_score: 1234
   it_behaves_like "a model that needs sanitization", :feedback
 
+  describe "#squish_history!", versioning: true do
+    it "squishes two previous changes into one" do
+      subject.save!
+      subject.update_attributes raw_score: 13_000
+      subject.squish_history!
+      subject.update_attributes feedback: "This is a change"
+      subject.squish_history!
+      expect(subject.versions.count).to eq 2
+      expect(subject.versions.last.changeset).to have_key :feedback
+      expect(subject.versions.last.changeset).to have_key :raw_score
+    end
+  end
+
   describe "versioning", versioning: true do
     it "ignores changes to predicted_score" do
       subject.save!

--- a/spec/toolkits/historical_toolkit.rb
+++ b/spec/toolkits/historical_toolkit.rb
@@ -137,7 +137,7 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
     end
   end
 
-  describe "#squish_history!", versioning: true, focus: true do
+  describe "#squish_history!", versioning: true do
     let(:updated_at) { 2.days.from_now }
 
     before do
@@ -164,8 +164,6 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
       expect(object["updated_at"]).to eq updated_at
       expect(object.keys).to include *updated_attributes.stringify_keys.keys
     end
-
-    xit "merges all the previous transactions"
 
     it "does not merge if the previous timestamp is greater than the limit" do
       expect { model.reload.squish_history!(1) }.to_not \

--- a/spec/toolkits/historical_toolkit.rb
+++ b/spec/toolkits/historical_toolkit.rb
@@ -165,12 +165,35 @@ RSpec.shared_examples "a historical model" do |fixture, updated_attributes|
       expect(object.keys).to include *updated_attributes.stringify_keys.keys
     end
 
-    xit "stores the new transaction id"
     xit "merges all the previous transactions"
-    xit "does not merge if the previous timestamp is greater than the limit"
-    xit "does not merge if the item id is not the same"
-    xit "does not merge if the item type is not the same"
-    xit "does not merge if the item event is not the same"
-    xit "does not merge if the responsible party is not the same"
+
+    it "does not merge if the previous timestamp is greater than the limit" do
+      expect { model.reload.squish_history!(1) }.to_not \
+        change { PaperTrail::Version.count }
+    end
+
+    it "does not merge if the item id is not the same" do
+      model.versions.last.update_attribute :item_id, 1234
+      expect { model.reload.squish_history! }.to_not \
+        change { PaperTrail::Version.count }
+    end
+
+    it "does not merge if the item type is not the same" do
+      model.versions.last.update_attribute :item_type, :blah
+      expect { model.reload.squish_history! }.to_not \
+        change { PaperTrail::Version.count }
+    end
+
+    it "does not merge if the item event is not the same" do
+      model.versions.last.update_attribute :event, :blah
+      expect { model.reload.squish_history! }.to_not \
+        change { PaperTrail::Version.count }
+    end
+
+    it "does not merge if the responsible party is not the same" do
+      model.versions.last.update_attribute :whodunnit, "blah"
+      expect { model.reload.squish_history! }.to_not \
+        change { PaperTrail::Version.count }
+    end
   end
 end


### PR DESCRIPTION
This fixes the autosave feature on Grade standard edit.  It introduces a new route `api/grades/:id` that uses strong params to update the grade attributes.

In order to not have submission history run a muck with the autoupdate, there is a history squisher that merges the history with the previous history version and deletes the previous history so they appear as one history item in the submission history.

![history_squisher](https://cloud.githubusercontent.com/assets/35017/14391501/454d7222-fd8a-11e5-9aaf-3f598742ae59.gif)
