### PR TITLE
reduced outline button border to 1px and added hover state

### DIFF
--- a/app/assets/stylesheets/_homepage.sass
+++ b/app/assets/stylesheets/_homepage.sass
@@ -108,10 +108,13 @@
 a.outline-button
   position: relative
   top: 1rem
-  border: 2px solid $color-blue-3
+  border: 1px solid $color-blue-3
   color: $color-blue-3
   border-radius: .5rem
   padding: .5rem
+  &:hover
+    background-color: $color-blue-3
+    color: white
 
 @media (max-width: $media-medium-max)
   .homepage


### PR DESCRIPTION
Reduced border to 1px on .outline-button found on Features page and changed hover state to blue background with white text. 

<img width="487" alt="reduced-border" src="https://cloud.githubusercontent.com/assets/12573921/13988471/791e6da4-f0e2-11e5-8812-155e687b8a87.png">

<img width="610" alt="on-hover" src="https://cloud.githubusercontent.com/assets/12573921/13988470/791d1b66-f0e2-11e5-8e28-b9556a51052c.png">


Closes #1772