### PR TITLE
1780 change see results to see grade

### DIFF
--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -20,7 +20,7 @@
 
       - if presenter.grades_available_for?(current_student)
         %li
-          %a{ :href => "#tab4"} My Results
+          %a{ :href => "#tab4"} My Grade
         - if !presenter.hide_analytics?
           %li
             %a{ :href => "#tab5"} Class Analytics

--- a/app/views/students/syllabus/_student_table.haml
+++ b/app/views/students/syllabus/_student_table.haml
@@ -64,7 +64,7 @@
 
             / Results /
             - if grade_visible_for_assignment
-              %li= link_to glyph(:eye) + "See Results", assignment_path(assignment, anchor: "tab4"), class: "button"
+              %li= link_to glyph(:eye) + "See Grade", assignment_path(assignment, anchor: "tab4"), class: "button"
 
             / Groups /
             - if assignment.has_groups?

--- a/spec/views/students/_assignments_spec.rb
+++ b/spec/views/students/_assignments_spec.rb
@@ -115,7 +115,7 @@ describe "students/syllabus/_assignments" do
     it "shows a button to see more results if the grade is released" do
       create(:grade, course: @course, assignment: @assignment, student: @student, raw_score: 2000, status: "Released")
       render
-      assert_select "a", text: "See Results", count: 1
+      assert_select "a", text: "See Grade", count: 1
     end
 
     it "shows a button to see the group if a group exists" do


### PR DESCRIPTION
Changed "See results" to "See grade" and "My Results" to "My Grade" on student view assignment feedback.


<img width="1246" alt="see-grade" src="https://cloud.githubusercontent.com/assets/12573921/13988559/ddf006a2-f0e2-11e5-86a7-2990a80eda77.png">

<img width="797" alt="my-grade" src="https://cloud.githubusercontent.com/assets/12573921/13988576/f2e5e522-f0e2-11e5-9111-4f7e69a13d0a.png">


Closes issue #1780