### PR TITLE
reduced text size, line-height and h2 size on features page

### DIFF
--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -74,11 +74,11 @@
       background-color: lighten($color-blue-4, 20%)
 
     .text
-      line-height: 2.25rem
-      font-size: 1.25rem
+      line-height: 1.75rem
+      font-size: 1.1rem
 
     h2
-      font-size: 2rem
+      font-size: 1.75rem
       color: $color-blue-3
       margin-bottom: 1rem
 


### PR DESCRIPTION
<img width="1092" alt="features-text" src="https://cloud.githubusercontent.com/assets/12573921/13988635/3b571268-f0e3-11e5-9b61-3825500841e6.png">


Closes issue #1766