### PR TITLE
changed global link color to color-blue-3

### DIFF
--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -54,6 +54,10 @@ body
 
 a
   text-decoration: none
+  color: $color-blue-3
+  
+.assignment_type a, table a
+  text-decoration: none
   color: $color-blue-2
 
 a:hover


### PR DESCRIPTION
Changed global link color to $color-blue-3 from $color-blue-2 except for table a and .assignment_type a which were kept at $color-blue-2
<img width="976" alt="link-color-update" src="https://cloud.githubusercontent.com/assets/12573921/13988752/ba8634ba-f0e3-11e5-9206-92db325086a5.png">


Closes issue #1769