### PR TITLE
1779 link sidebar to course progress

### DIFF
--- a/app/assets/stylesheets/_student_sidebar.sass
+++ b/app/assets/stylesheets/_student_sidebar.sass
@@ -29,6 +29,9 @@
 
   a
     color: $color-blue-4
+    font-family: 'Light-Weight'
+    &:hover
+      color: $color-green-2
 
   hr
     margin: .25rem 0
@@ -58,11 +61,6 @@
       margin-bottom: 0
     .button:hover
       background-color: $color-blue-4
-
-    .assignment-name
-      font-family: 'Light-Weight'
-      a:hover
-        color: $color-green-2
 
   ul.block-grid
     margin: 0.5rem auto !important

--- a/app/views/students/sidebar/_sidebar_earned_points_and_level.haml
+++ b/app/views/students/sidebar/_sidebar_earned_points_and_level.haml
@@ -7,7 +7,7 @@
     / Display current level if it is present
     %br
     You have achieved the
-    %span.bold #{current_student.grade_level_for_course(current_course)} level
+    %span.bold= link_to "#{current_student.grade_level_for_course(current_course)} level", course_progress_path
   - cache multi_cache_key :student_sidebar_total_score, current_student, current_course do
     - scores = total_scores_for_chart current_student, current_course
     #data-predictor{"data-predictor" =>  scores.to_json}


### PR DESCRIPTION
Applied styles originally targeting .assignment-name to all links inside .sidebar and linked level name in sidebar to grading scheme page.

Closes issue #1779