### PR TITLE
1773 hero on press team research pages

### DIFF
--- a/app/assets/stylesheets/_homepage.sass
+++ b/app/assets/stylesheets/_homepage.sass
@@ -106,15 +106,16 @@
         font-size: .8rem
 
 a.outline-button
-  position: relative
-  top: 1rem
+  border-radius: .5rem
   border: 1px solid $color-blue-3
   color: $color-blue-3
-  border-radius: .5rem
   padding: .5rem
+  position: relative
+  top: 1rem
   &:hover
     background-color: $color-blue-3
     color: white
+    text-decoration: none
 
 @media (max-width: $media-medium-max)
   .homepage

--- a/app/assets/stylesheets/_pages.sass
+++ b/app/assets/stylesheets/_pages.sass
@@ -4,21 +4,18 @@
 .page
   .hero-section
     margin: 0
-    background:rgba(0,0,0,.1)
+    background:rgba(46,112,190,.3)
     background-position: top center
     background-repeat: no-repeat
     height: 100px
     padding: 40px 0 0
 
     h1
-      background-color: $color-white
-      color: $color-black
+      color: $color-white
       text-align: center
-      font-size: 2.2rem
-      font-weight: lighter
+      font-size: 2.5rem
       width: 50%
       margin: 0 auto
-      border-radius: 5rem
 
   .main-section
     background-color: $color-white


### PR DESCRIPTION
Removed white background from H1, changed text color to white and added blue overlay to hero image section. 

Also in this PR is the removal of the underlining of links from buttons with class .button-outline.

<img width="1231" alt="screen shot 2016-03-23 at 11 29 22 am" src="https://cloud.githubusercontent.com/assets/12573921/13990851/460956c2-f0ec-11e5-8a32-8ab66bd2dbfb.png">


Closes issue #1773