### PR TITLE
1801 images shrink with page window

### DIFF
--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -13,6 +13,7 @@
     .ui-tabs-panel
       padding: 0
       float: left
+      width: 100%
 
     ul
       width: 210px
@@ -28,7 +29,7 @@
         padding: 0
 
   .hero-section
-    background:rgba(0,0,0,0.1)
+    background:rgba(46,112,190,0.3)
     padding: 1rem 0 1rem
 
     h1
@@ -36,8 +37,7 @@
       color: $color-white
       font-weight: lighter
       width: 50%
-      height: 150px
-      margin: 2rem auto 1rem
+      margin: 2rem auto 2.75rem
 
     h3
       font-size: 1.1rem
@@ -49,21 +49,28 @@
     .promo-text
       color: $color-white
 
-  .double-height-feature-section
-    height: 75% !important
-
   .feature-section
-    height: 50%
     padding: 2rem
+    display: -webkit-box
+    display: -webkit-flex
+    display: -ms-flexbox
+    display: flex
+    -webkit-box-align: center
+    -webkit-align-items: center
+    -ms-flex-align: center
+    align-items: center
+    
+    &.double-height-feature-section
+      display: block
 
     .image-container
     img
-      position: relative
-      width: 90%
+      width: 100%
       max-width: 350px
+      height: auto
 
       &.center-image
-        height: 40%
+        width: 100%
 
     &.white
       background-color: $color-white
@@ -74,10 +81,12 @@
     .text
       line-height: 1.75rem
       font-size: 1.1rem
-    
-    .image-container, .text 
-      top: 50%
-      transform: translateY(-50%)
+      
+      &.right
+        -webkit-box-ordinal-group: 2
+        -webkit-order: 1
+        -ms-flex-order: 1
+        order: 1
 
     h2
       font-size: 1.75rem
@@ -96,9 +105,12 @@
       text-align: left
 
     .half
-      width: calc(50% - 6rem)
-      margin: 0 2rem 0 3rem !important
-      position: relative
+      padding: 0 2rem 0 3rem
+      box-sizing: border-box
+      -webkit-box-flex: 1
+      -webkit-flex: 1
+      -ms-flex: 1
+      flex: 1
 
     .whole
       margin 0 auto
@@ -107,7 +119,6 @@
 
       p
         width: 75%
-        font-size: 1.5rem
 
 @media (max-width: $media-small-max)
   .features
@@ -120,6 +131,7 @@
 
     .feature-section
       height: auto !important
+      display: block
 
       .image-container
         margin: 1rem auto !important
@@ -128,7 +140,6 @@
       img, .text, .center-image
         margin: 0 auto !important
         padding: 0 !important
-        max-width: 100%
         height: auto !important
 
       .half

--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -57,12 +57,10 @@
     padding: 2rem
 
     .image-container
-      width: 100%
-      padding-top: 2%
-
     img
       position: relative
-      height: 90%
+      width: 90%
+      max-width: 350px
 
       &.center-image
         height: 40%
@@ -76,6 +74,8 @@
     .text
       line-height: 1.75rem
       font-size: 1.1rem
+    
+    .image-container, .text 
       top: 50%
       transform: translateY(-50%)
 

--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -76,6 +76,8 @@
     .text
       line-height: 1.75rem
       font-size: 1.1rem
+      top: 50%
+      transform: translateY(-50%)
 
     h2
       font-size: 1.75rem


### PR DESCRIPTION
This fixed the vertical alignment of text and images on the features pages by removing the fixed height and adding a flex property. This allows the background color containers to be responsive to the content without text exceeding the divs. 

This closes issue #1767 and #1801