### PR TITLE
Fix group resubmissions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -27,9 +27,8 @@ class Submission < ActiveRecord::Base
 
   scope :ungraded, -> { where("NOT EXISTS(SELECT 1 FROM grades WHERE submission_id = submissions.id OR (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (status = ? OR status = ?))", "Graded", "Released") }
   scope :graded, -> { where(:grade) }
-  scope :resubmitted, -> { joins(:grade).where(grades: { status: ["Graded", "Released"] })
-                                        .where("grades.graded_at < submitted_at")
-                                      }
+  scope :resubmitted, -> { includes(:grade).where(grades: { status: ["Graded", "Released"] })
+                                           .where("grades.graded_at < submitted_at") }
   scope :order_by_submitted, -> { order("submitted_at ASC") }
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -168,7 +168,7 @@ describe Submission do
     end
   end
 
-  describe ".resubmitted" do
+  describe ".resubmitted", focus: true do
     it "returns the submissions that have been submitted after they were graded" do
       grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)
       subject.submitted_at = DateTime.now
@@ -188,6 +188,21 @@ describe Submission do
       subject.submitted_at = 2.days.ago
       subject.save
       expect(Submission.resubmitted).to be_empty
+    end
+
+    it "returns one submission for a group resubmissions" do
+      student1 = create(:user)
+      student2 = create(:user)
+      group = create(:group, assignments: [subject.assignment])
+      group.students << [student1, student2]
+      grade1 = create(:grade, submission: subject, student: student1,
+                      status: "Graded", graded_at: 1.day.ago)
+      grade2 = create(:grade, submission: subject, student: student2,
+                      status: "Graded", graded_at: 1.day.ago)
+      subject.submitted_at = DateTime.now
+      subject.group_id = group.id
+      subject.save
+      expect(Submission.resubmitted).to eq [subject]
     end
   end
 


### PR DESCRIPTION
Group resubmissions were displaying multiple times for the same submission.

<img width="360" alt="screen_shot_2016-03-27_at_9 09 19_pm_720" src="https://cloud.githubusercontent.com/assets/35017/14078339/fdb28f94-f4c2-11e5-93e1-c9cffcabc76d.png">

This was caused because the query was using a LEFT JOIN (AR `joins` method) which was pulling in a resubmission for each grade. SInce grades are created for groups for each student in the group, then the same submission was being displayed, one for each student in the group.

To remedy this, the `joins` was changed to an `includes` which changes the relationship to a LEFT OUTER JOIN and therefore, only retrieving one row per submission.