### PR TITLE
1816 change grading scheme progress bar color

### DIFF
--- a/app/assets/stylesheets/_student_dashboard.sass
+++ b/app/assets/stylesheets/_student_dashboard.sass
@@ -19,35 +19,35 @@ img.earned
   opacity: 1
 
 .bar_magic
-  height: 2rem
-  padding-top: .5rem
-  border: 1px solid $color-grey-5
-  border-radius: 25px
   background-color:$color-grey-6
   border-collapse: true
+  border-radius: 16px
+  margin: 2px
+  margin: 3px auto
+  padding: .5rem 0
+  width: 95%
 
 .bar_magic.success
-  color: $color-white
   background-color: $color-green-2
-  border: 1px solid $color-green-2
+  color: $color-white
 
   .has-tip
     color: $color-white
 
 .bar_magic.current
-  border: 1px solid $color-grey-4
-  padding-top: .85rem
-  height: 3rem
+  background-color: transparentize($color-green-2, .8)
+  padding: .5rem 0
 
 p.predictor-description
   margin: 0.25rem 0 .5rem
 
 /*striping on course progress display*/
 .striped
+  background-image: repeating-linear-gradient(45deg, $color-green-2, $color-green-2 35px, $color-blue-2 35px, $color-blue-2 70px)
+  border-radius: 25px
   height: .75rem
   margin-left: 0.5rem
-  border-radius: 25px
-  background-image: repeating-linear-gradient(45deg, $color-green-2, $color-green-2 35px, $color-blue-2 35px, $color-blue-2 70px)
+  margin-top: .25rem
 
 #levels_per_assignment
   min-height: 200px

--- a/app/assets/stylesheets/_student_dashboard.sass
+++ b/app/assets/stylesheets/_student_dashboard.sass
@@ -47,7 +47,7 @@ p.predictor-description
   height: .75rem
   margin-left: 0.5rem
   border-radius: 25px
-  background-image: repeating-linear-gradient(45deg, $color-yellow-1, $color-yellow-1 35px, $color-blue-3 35px, $color-blue-3 70px)
+  background-image: repeating-linear-gradient(45deg, $color-green-2, $color-green-2 35px, $color-blue-2 35px, $color-blue-2 70px)
 
 #levels_per_assignment
   min-height: 200px

--- a/app/views/students/course_progress.html.haml
+++ b/app/views/students/course_progress.html.haml
@@ -1,31 +1,32 @@
 %h3.pagetitle= "Grading Scheme"
 
 .pageContent
-  = render "layouts/alerts"
+  .grading-scheme-bars
+    = render "layouts/alerts"
 
-  - @grade_scheme_elements.each do |element|
-    - if current_student.cached_score_for_course(current_course) < element.low_range
-      .progress.bar_magic.transparent.center
-        .meter
-          %i.fa.fa-lock
+    - @grade_scheme_elements.each do |element|
+      - if current_student.cached_score_for_course(current_course) < element.low_range
+        .progress.bar_magic.transparent.center
+          .meter
+            %i.fa.fa-lock
+            %span= element.name
+            %span=points element.low_range
+      - elsif current_student.cached_score_for_course(current_course) >= element.high_range
+        .progress.bar_magic.success.center
+          .meter
+            %i.fa.fa-star
+            %span= element.name
+            %span has already been achieved!
+            %span=points element.low_range
+      - else
+        .progress.bar_magic.current.center
+          %span Your rank:
           %span= element.name
-          %span=points element.low_range
-    - elsif current_student.cached_score_for_course(current_course) >= element.high_range
-      .progress.bar_magic.success.center
-        .meter
-          %i.fa.fa-star
-          %span= element.name
-          %span has already been achieved!
-          %span=points element.low_range
-    - else
-      .progress.bar_magic.current.center
-        %span Your rank:
-        %span= element.name
-        %span with
-        %span.underline=points current_student.cached_score_for_course(current_course)
-        %span points.
-        %span.hide-for-small= points element.points_to_next_level(current_student, current_course)
-        %span.hide-for-small= " points to the next level!"
-        .striped{:style => "width: #{element.progress_percent(current_student)}%;"}
+          %span with
+          %span.underline=points current_student.cached_score_for_course(current_course)
+          %span points.
+          %span.hide-for-small= points element.points_to_next_level(current_student, current_course)
+          %span.hide-for-small= " points to the next level!"
+          .striped{:style => "width: #{element.progress_percent(current_student)}%;"}
 
-  = render partial: "courses/grading_philosophy", locals: { course: current_course }
+    = render partial: "courses/grading_philosophy", locals: { course: current_course }


### PR DESCRIPTION
This PR makes some minor edits to the look and feel of the grading scheme progress bars. Color of the striped progress bar was updated to match the color scheme and margin was added between bars to prevent the "blob" look when leveling up. Also - heights were removed from bars to make grading scheme more responsive overall. Text no longer exceeds divs when scaling browser window down.

Ordered the sass alphabetically.... sorry git looks like massive changes!

Closes issues #1817 and #1816