### PR TITLE
1762 refine mobile navigation

### DIFF
--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -122,6 +122,7 @@ tbody
   padding: 2px 8px 0 7px
   text-align: center
   float: right
+  margin-right: .25em
 
 .flagged-user-icon > .fa-flag
   color: $color-grey-8

--- a/app/assets/stylesheets/_staff_sidebar.sass
+++ b/app/assets/stylesheets/_staff_sidebar.sass
@@ -69,14 +69,19 @@
       display: block
       padding: 2.4px
 
-    .staff-notification-badge
-      background-color: $color-red-1
-      color: $color-white
-      padding: .15rem .5rem
-      position: relative
-      top: -27px
-      margin: 0
-      left: 0px
+/* Positioning and styling of notification badges in staff-sidenav */
+.staff-sidenav li
+  position: relative
+  
+.staff-sidenav
+  .staff-notification-badge
+    background-color: $color-red-1
+    border-radius: 50%
+    color: $color-white
+    padding: .1rem .25rem
+    position: absolute
+    right: 0
+    top: 3
 
   /* Spacing the list divider */
   hr

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -20,6 +20,10 @@
     float: left
     margin-left: rem-calc(16)
     margin: 0
+    
+    i
+      display: none
+      
 
   /* Individual Tabs */
   .navbar-nav
@@ -59,16 +63,6 @@ li .announcement-notification-badge
 li a.notification-right
   padding: 1rem 0 1rem 1rem !important
 
-/* Reducing padding and font size for small screens */
-@media (max-width: $media-medium-max)
-  .student .offscreen-sidebar
-    text-transform: capitalize
-    li
-      border-bottom: 1px solid #ddd
-      color: $color-grey-2
-      background-color: $color-grey-6
-      font-weight: 300
-      padding: .65rem
-      display: block
-    li a
-      color: $color-grey-2
+@media (min-width: $media-small-max)
+  i
+    display: inline

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -48,6 +48,9 @@
 
     li a:hover, li:hover a
       color: $color-black
+    
+    h5, hr
+      display: none
 
 /* Setting the active tab and hover color */
 .navbar-nav li.active, .sub-nav .navbar-nav li:hover
@@ -65,8 +68,4 @@ li a.notification-right
 
 @media (min-width: $media-small-max)
   i
-    display: none
-  hr
-    display: none
-  h5
-    display: none
+    display: inline

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -64,13 +64,11 @@ li a.notification-right
   .student .offscreen-sidebar
     text-transform: capitalize
     li
-      border-bottom: 1px solid $color-blue-4
+      border-bottom: 1px solid $color-blue-2
       color: $color-white
-      background-color: $color-blue-2
-      padding: .5rem
+      background-color: $color-blue-1
+      font-weight: 300
+      padding: .65rem
       display: block
     li a
-      color: $color-white
-    ul li:hover
-      background-color: $color-blue-3
       color: $color-white

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -65,4 +65,8 @@ li a.notification-right
 
 @media (min-width: $media-small-max)
   i
-    display: inline
+    display: none
+  hr
+    display: none
+  h5
+    display: none

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -64,11 +64,11 @@ li a.notification-right
   .student .offscreen-sidebar
     text-transform: capitalize
     li
-      border-bottom: 1px solid $color-blue-2
-      color: $color-white
-      background-color: $color-blue-1
+      border-bottom: 1px solid #ddd
+      color: $color-grey-2
+      background-color: $color-grey-6
       font-weight: 300
       padding: .65rem
       display: block
     li a
-      color: $color-white
+      color: $color-grey-2

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -180,7 +180,6 @@ ul.subnav.logged-out
 .isCbFlyNavLeftActive .offscreen-sidebar
   margin-right: 0
   display: block
-  // padding-right: 1rem
 
 /* Large Screen Styles*/
 @media (min-width: $media-medium-max)

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -316,12 +316,13 @@ ul.subnav.logged-out
 
   .layout-left-flyout
     width: 250px
-
+    li
+      padding: .2em
     li, li a
-      color: $color-white
-      height: 1.5rem
+      color: $color-grey-2
       text-transform: capitalize
       font-size: 1rem
+      font-weight: 300
       &.active
         background-color: $color-blue-3
         color: $color-white
@@ -330,7 +331,7 @@ ul.subnav.logged-out
         text-decoration: none
 
     h5
-      color: $color-yellow-1
+      color: $color-blue-3
       text-transform: uppercase
       font-size: 1rem
       padding: .25rem 0 .25rem .5rem
@@ -338,15 +339,14 @@ ul.subnav.logged-out
       font-weight: normal
 
     hr
-      border-bottom-color: $color-blue-4
-      border-top-color: $color-blue-4
+      border-bottom-color: $color-grey-7
+      border-top-color: $color-grey-7
       margin: .5rem 0
 
   li.course-site
     background-color: darken($color-blue-1, 20%)
     width: 16rem
     padding: .5rem .75rem
-    // height: 2.75rem
     font-size: 1rem
 
     a

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -32,6 +32,8 @@ a.site-title
     list-style-type: none
     margin: 0
     padding: 0
+  a
+    display: block
 
 .layout-right-flyout
   right: 0

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -23,7 +23,7 @@ a.site-title
   z-index: 0
   top: 0
   transition: visibility 0 linear .2s
-  background-color: $color-blue-2
+  background-color: $color-blue-1
   transition: visibility 0 linear .2s
   -webkit-perspective: 1000
   -webkit-backface-visibility: hidden
@@ -61,6 +61,7 @@ a.site-title
 
 .cbFlyNavLeft-wrap
   display: block
+  box-sizing: border-box
   position: relative
   height: 100%
   overflow: hidden
@@ -183,7 +184,7 @@ ul.subnav.logged-out
 .isCbFlyNavLeftActive .offscreen-sidebar
   margin-right: 0
   display: block
-  padding-right: 1rem
+  // padding-right: 1rem
 
 /* Large Screen Styles*/
 @media (min-width: $media-medium-max)
@@ -318,17 +319,19 @@ ul.subnav.logged-out
     padding: 5px 10px
 
   .layout-left-flyout
-    padding: .25rem
-    width: 15.25rem
+    width: 250px
 
     li, li a
       color: $color-white
       height: 1.5rem
       text-transform: capitalize
-      padding: .15rem
       font-size: 1rem
-      &:hover, &.active
+      &.active
+        background-color: $color-yellow-1
+        color: $color-blue-1
+      &:hover
         color: $color-yellow-1
+        text-decoration: none
 
     h5
       color: $color-yellow-1

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -339,9 +339,10 @@ ul.subnav.logged-out
       font-weight: normal
 
     hr
-      border-bottom-color: $color-grey-7
-      border-top-color: $color-grey-7
+      border: none
+      border-bottom: 1px dashed $color-grey-5
       margin: .5rem 0
+      width: 100%
 
   li.course-site
     background-color: darken($color-blue-1, 20%)

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -23,7 +23,7 @@ a.site-title
   z-index: 0
   top: 0
   transition: visibility 0 linear .2s
-  background-color: $color-blue-1
+  background-color: $color-grey-6
   transition: visibility 0 linear .2s
   -webkit-perspective: 1000
   -webkit-backface-visibility: hidden
@@ -111,9 +111,8 @@ a.site-title
 .navbar ul
   list-style-type: none
 
-.btn-navbar-right
+.btn-navbar-right, .btn-navbar-left
   position: absolute
-  right: 0
   top: 7px
   font-size: 1.1rem
   width: 35px
@@ -122,18 +121,15 @@ a.site-title
   display: block
   z-index: 1
   color: $color-green-2
+  &:hover
+    color: $color-green-2
+    text-decoration: none
+
+.btn-navbar-right
+  right: 0
 
 .btn-navbar-left
-  position: absolute
   left: 0
-  top: 7px
-  font-size: 1.1rem
-  width: 35px
-  height: 40px
-  padding: 4px 0 0 10px
-  display: block
-  z-index: 1
-  color: $color-green-2
 
 /* Navbar Styles */
 .navbar
@@ -327,10 +323,10 @@ ul.subnav.logged-out
       text-transform: capitalize
       font-size: 1rem
       &.active
-        background-color: $color-yellow-1
-        color: $color-blue-1
+        background-color: $color-blue-3
+        color: $color-white
       &:hover
-        color: $color-yellow-1
+        color: $color-blue-3
         text-decoration: none
 
     h5
@@ -350,8 +346,8 @@ ul.subnav.logged-out
     background-color: darken($color-blue-1, 20%)
     width: 16rem
     padding: .5rem .75rem
-    height: 2.75rem
-    font-size: 2rem
+    // height: 2.75rem
+    font-size: 1rem
 
     a
       color: $color-green-2

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -325,6 +325,7 @@ ul.subnav.logged-out
       &.active
         background-color: $color-blue-3
         color: $color-white
+    a
       &:hover
         color: $color-blue-3
         text-decoration: none

--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -65,8 +65,7 @@ a:hover
   text-decoration: underline
 
 hr
-  border-color: $color-grey-3
-  border-width: 1px 0 0
+  border: 1px solid $color-grey-3
   margin: 1.5rem auto
 
 .label.alert.round

--- a/app/views/layouts/_top_bar.haml
+++ b/app/views/layouts/_top_bar.haml
@@ -19,8 +19,6 @@
                 %span.course= "#{current_course.courseno} "
                 %span.course_name= "#{current_course.name} "
                 %span.course_semester= "#{current_course.try(:semester)} #{current_course.try(:year)}"
-                - if current_course.tagline?
-                  %span.tagline= current_course.try(:tagline)
           %ul.nav.nav-pill.right
             = render "layouts/navigation/authenticated_nav"
         %nav.mobile-nav.hide-for-large

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -50,7 +50,7 @@
 %hr
 
 %h5 Coursework
-%li= link_to_unless_current glyph(:bars) + "#{term_for :assignments}", assignments_path
+%li= link_to_unless_current glyph('file-text') + "#{term_for :assignments}", assignments_path
 - if current_course.has_badges?
   %li= link_to_unless_current glyph(:shield) + "#{term_for :badges}", badges_path
 - if current_course.team_challenges?
@@ -96,7 +96,7 @@
 %h5 Course Setup
 %li= link_to_unless_current glyph(:cog) + "Options", edit_course_path(current_course)
 %li= link_to_unless_current glyph(:book) + "#{term_for :assignment_types}", assignment_types_path
-%li= link_to_unless_current glyph(:sliders) + "Predictor Preview", predictor_path
+%li= link_to_unless_current glyph(:tasks) + "Predictor Preview", predictor_path
 %li= link_to_unless_current glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
 %li= link_to_unless_current glyph(:bullhorn) + "Announcements", announcements_path
 %li= link_to_unless_current glyph(:calendar) + "Calendar Events", events_path

--- a/app/views/students/_student_profile_tabs.haml
+++ b/app/views/students/_student_profile_tabs.haml
@@ -1,4 +1,5 @@
 %ul
+  %h5 Navigation
   - if current_user_is_staff?
     %li{class: ("active" if current_page?(student_path(current_student))) }
       = link_to_unless_current "#{term_for :assignments}", student_path(current_student)
@@ -38,3 +39,4 @@
     - if current_course.has_teams? && current_course.teams_visible?
       %li{class: ("active" if current_page?(my_team_path)) }
         = link_to_unless_current glyph(:users) + "#{term_for :teams}", my_team_path
+    %hr

--- a/app/views/students/_student_profile_tabs.haml
+++ b/app/views/students/_student_profile_tabs.haml
@@ -6,27 +6,27 @@
       %li{class: ("active" if current_page?(student_course_progress_path(current_student))) }
         = link_to_unless_current "Grading Scheme", student_course_progress_path(current_student)
     %li{class: ("active" if current_page?(student_predictor_path(current_student))) }
-      = link_to_unless_current "Grade Predictor", student_predictor_path(current_student)
+      = link_to_unless_current glyph("level-up") + "Grade Predictor", student_predictor_path(current_student)
     - if current_course.has_badges?
       %li{class: ("active" if current_page?(student_badges_path(current_student))) }
-        = link_to_unless_current "#{term_for :badges}", student_badges_path(current_student)
+        = link_to_unless_current glyph(:shield) + "#{term_for :badges}", student_badges_path(current_student)
     - if current_course.has_teams? && current_course.teams_visible?
       %li{class: ("active" if current_page?(student_teams_path(current_student))) }
-        = link_to_unless_current "#{term_for :teams}", student_teams_path(current_student)
+        = link_to_unless_current glyph(:users) + "#{term_for :teams}", student_teams_path(current_student)
   - else
     - if current_course.use_timeline?
       %li{class: ("active" if current_page?(dashboard_path)) }
-        = link_to_unless_current "Timeline", dashboard_path
+        = link_to_unless_current glyph(:home) + "Timeline", dashboard_path
     %li{class: ("active" if current_page?(syllabus_path)) }
-      = link_to_unless_current "#{term_for :assignments}", syllabus_path
+      = link_to_unless_current glyph(:bars) + "#{term_for :assignments}", syllabus_path
     - if current_course.grade_scheme_elements.present?
       %li{class: ("active" if current_page?(course_progress_path)) }
-        = link_to_unless_current "Grading Scheme", course_progress_path
+        = link_to_unless_current glyph("level-up") + "Grading Scheme", course_progress_path
     %li{class: ("active" if current_page?(predictor_path)) }
-      = link_to_unless_current "Grade Predictor", predictor_path
+      = link_to_unless_current glyph(:sliders) + "Grade Predictor", predictor_path
     - if current_course.has_badges?
       %li{class: ("active" if current_page?(my_badges_path)) }
-        = link_to_unless_current "#{term_for :badges}", my_badges_path
+        = link_to_unless_current glyph(:shield) + "#{term_for :badges}", my_badges_path
     - if current_course.announcements.present?
       %li{class: ("active" if current_page?(announcements_path)) }
         - unread_count = unread_count_for current_student, current_course
@@ -37,4 +37,4 @@
           = link_to_unless_current "Announcements", announcements_path
     - if current_course.has_teams? && current_course.teams_visible?
       %li{class: ("active" if current_page?(my_team_path)) }
-        = link_to_unless_current "#{term_for :teams}", my_team_path
+        = link_to_unless_current glyph(:users) + "#{term_for :teams}", my_team_path

--- a/app/views/students/_student_profile_tabs.haml
+++ b/app/views/students/_student_profile_tabs.haml
@@ -6,7 +6,7 @@
       %li{class: ("active" if current_page?(student_course_progress_path(current_student))) }
         = link_to_unless_current "Grading Scheme", student_course_progress_path(current_student)
     %li{class: ("active" if current_page?(student_predictor_path(current_student))) }
-      = link_to_unless_current glyph("level-up") + "Grade Predictor", student_predictor_path(current_student)
+      = link_to_unless_current glyph("tasks") + "Grade Predictor", student_predictor_path(current_student)
     - if current_course.has_badges?
       %li{class: ("active" if current_page?(student_badges_path(current_student))) }
         = link_to_unless_current glyph(:shield) + "#{term_for :badges}", student_badges_path(current_student)
@@ -18,12 +18,12 @@
       %li{class: ("active" if current_page?(dashboard_path)) }
         = link_to_unless_current glyph(:home) + "Timeline", dashboard_path
     %li{class: ("active" if current_page?(syllabus_path)) }
-      = link_to_unless_current glyph(:bars) + "#{term_for :assignments}", syllabus_path
+      = link_to_unless_current glyph('file-text') + "#{term_for :assignments}", syllabus_path
     - if current_course.grade_scheme_elements.present?
       %li{class: ("active" if current_page?(course_progress_path)) }
         = link_to_unless_current glyph("level-up") + "Grading Scheme", course_progress_path
     %li{class: ("active" if current_page?(predictor_path)) }
-      = link_to_unless_current glyph(:sliders) + "Grade Predictor", predictor_path
+      = link_to_unless_current glyph(:tasks) + "Grade Predictor", predictor_path
     - if current_course.has_badges?
       %li{class: ("active" if current_page?(my_badges_path)) }
         = link_to_unless_current glyph(:shield) + "#{term_for :badges}", my_badges_path


### PR DESCRIPTION
This PR takes a first pass at refining the mobile menu experience on both the student and instructor side. Menus styles are now much more consistent with each other and will be combined in the future to one left-hand menu rather than both right and left.

<img width="383" alt="instructor-side_mobile-menu" src="https://cloud.githubusercontent.com/assets/12573921/14187815/d081d9f2-f752-11e5-97d2-16a4b6668fc6.png">
<img width="358" alt="student-side_mobile-menu" src="https://cloud.githubusercontent.com/assets/12573921/14187816/d0828e74-f752-11e5-81f9-045dd65fb24f.png">
