### PR TITLE
add predictor threshold icon and slider

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -59,10 +59,15 @@
     else
       return true
 
+  $scope.predictionBelowThreshold = (article)->
+    article.has_threshold && article.grade.predicted_score < article.threshold_points
+
   $scope.articleNoPoints = (assignment)->
     if assignment.pass_fail && assignment.grade.pass_fail_status != "Pass"
       return true
     else if assignment.grade.score == null || assignment.grade.score == 0
+      return true
+    else if $scope.predictionBelowThreshold(assignment)
       return true
     else
       return false
@@ -285,7 +290,10 @@
         article_id = ui.handle.parentElement.dataset.id
         value = ui.value
 
-        if articleType == 'assignment'
+        if articleType == 'assignment' and $scope.predictionBelowThreshold(article)
+          article.grade.predicted_score = 0
+          PredictorService.postPredictedGrade(article_id,0)
+        else if articleType == 'assignment'
           article.grade.predicted_score = value
           PredictorService.postPredictedGrade(article_id,value)
         else

--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -35,6 +35,9 @@
         else
           return ""
 
+      scope.thresholdPoints = ()->
+        @target.threshold_points
+
       scope.conditions = ()->
         @target.unlock_conditions
 
@@ -69,6 +72,10 @@
         has_submission: {
           tooltip: 'You have submitted this ' + scope.targetTerm()
           icon: "fa-file"
+        }
+        has_threshold: {
+          tooltip: 'You must earn ' + scope.thresholdPoints() + ' points or above for this ' + scope.targetTerm()
+          icon: "fa-balance-scale"
         }
         is_locked: {
           tooltip: scope.conditions()

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "is_late", "closed_without_submission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
+    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "has_threshold", "is_late", "closed_without_submission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -23,7 +23,7 @@
 
     .article-predicted{'ng-if' => '! articleGraded(assignment)'}
       %div{'ng-if' => 'assignment.predictor_display_type == "slider"'}
-        .slider{'ui-slider'=>'slider(assignment)','min'=>'0', 'max'=>'{{assignment.point_total}}', 'ng-model'=>'assignment.grade.predicted_score', 'data'=>{'id'=>'{{assignment.id}}','article-type'=>'assignment'}}
+        .slider{'ui-slider'=>'slider(assignment)','min'=>'0', 'max'=>'{{assignment.point_total}}', 'ng-model'=>'assignment.grade.predicted_score', 'data'=>{'id'=>'{{assignment.id}}','article-type'=>'assignment', 'ng-class'=>'{"below-threshold" : predictionBelowThreshold(assignment)}'}}
 
         .grade{'ng-if' => '! hasLevels(assignment)'}
           {{assignment.grade.predicted_score | number}} / {{assignment.point_total | number}}
@@ -39,5 +39,3 @@
 
       %div{'ng-if' => 'assignment.predictor_display_type == "checkbox" && !assignment.pass_fail == true'}
         .predictor-binary-switch{'target'=>'assignment','target-type'=>'assignment','off-value'=>'0','on-value'=>'assignment.point_total'}
-
-

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -360,6 +360,9 @@ article.predictor-article
       background: $color-blue-1
       border-radius: 1rem
 
+article.predictor-article .ui-slider.below-threshold .ui-slider-range
+  background-color: $color-red-1
+
 /* Binary Switch */
 
 .predictor-binary-switch.badge

--- a/app/serializers/predicted_assignment_collection_serializer.rb
+++ b/app/serializers/predicted_assignment_collection_serializer.rb
@@ -42,6 +42,7 @@ class PredictedAssignmentCollectionSerializer
       :point_total,
       :points_predictor_display,
       :position,
+      :threshold_points,
       :required,
       :use_rubric,
       :visible,

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -47,9 +47,12 @@ class PredictedAssignmentSerializer < SimpleDelegator
   end
 
   private
-  
+
   attr_reader :assignment
 
+  # Selected attributes necessary for all method calls are declared in
+  # predicted_assignment_collection_serializer. Here we further refine down to
+  # only the attributes that will be passed to the front end.
   def select_attributes
     assignment.attributes.select do |attr,v|
       %w( accepts_submissions_until
@@ -61,6 +64,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
           pass_fail
           point_total
           position
+          threshold_points
         ).include?(attr)
     end
   end
@@ -68,17 +72,18 @@ class PredictedAssignmentSerializer < SimpleDelegator
   # boolean states for icons in predictor
   def boolean_flags
     {
-      is_required: is_required?,
+      accepting_submissions: accepting_submissions?,
+      closed_without_submission: closed_without_sumbission?,
+      has_been_unlocked: has_been_unlocked?,
       has_info: has_info?,
       has_rubric: has_rubric?,
-      accepting_submissions: accepting_submissions?,
       has_submission: has_submission?,
+      has_threshold: has_threshold?,
       is_a_condition: is_a_condition?,
       is_earned_by_group: is_earned_by_group?,
       is_late: is_late?,
-      closed_without_submission: closed_without_sumbission?,
       is_locked: is_locked?,
-      has_been_unlocked: has_been_unlocked?,
+      is_required: is_required?,
     }
   end
 
@@ -112,6 +117,10 @@ class PredictedAssignmentSerializer < SimpleDelegator
   def has_submission?
     !!assignment.accepts_submissions? && \
       student.submission_for_assignment(assignment).present?
+  end
+
+  def has_threshold?
+    assignment.threshold_points > 0
   end
 
   def closed_without_sumbission?

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -214,13 +214,13 @@
   }
 }
 
-@assignments[:standard_with_threshold__and_insufficient_grades] = {
+@assignments[:threshold_and_insufficient_grades] = {
   quotes: {
     assignment_created: nil
   },
   assignment_type: :grading,
   attributes: {
-    name: "Assignment with Points Threshold [Grades Below Threshold]",
+    name: "Points Threshold and Insufficent Grades",
     description: "Graded Assignment has a points threshold that no student met. Grades have a raw_score of 15000",
     open_at: 1.weeks.from_now,
     due_at: 1.weeks.from_now + 0.05,
@@ -774,6 +774,22 @@
     status: nil,
     predicted_score: -> { rand(25000) }
   }
+}
+
+@assignments[:predictor_slider_with_thresholds_and_levels] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :predictor,
+  attributes: {
+    name: "Level Slider and Threshold",
+    description: "Should have a slider with both Level and a Threshold Behavior",
+    due_at: 1.week.from_now,
+    point_total: 25000,
+    threshold_points: 15000,
+    points_predictor_display: "Slider",
+  },
+  assignment_score_levels: true,
 }
 
 #------------------------------------------------------------------------------#

--- a/spec/serializers/predicted_assignment_collection_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_collection_serializer_spec.rb
@@ -31,6 +31,7 @@ describe PredictedAssignmentCollectionSerializer do
        :point_total,
        :position,
        :required,
+       :threshold_points,
        :use_rubric,
        :visible,
        :visible_when_locked].each do |attribute|

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -73,7 +73,8 @@ describe PredictedAssignmentSerializer do
           name
           pass_fail
           point_total
-          position )
+          position
+          threshold_points )
       expect(exposed_attributes & subject.attributes.keys).to eq(exposed_attributes)
     end
 
@@ -169,6 +170,18 @@ describe PredictedAssignmentSerializer do
           allow(assignment).to receive(:accepts_submissions?).and_return true
           allow(user).to receive(:submission_for_assignment).and_return nil
           expect(subject[:has_submission]).to eq(false)
+        end
+      end
+
+      describe "has_threshold" do
+        it "is true when the assignment has a threshold" do
+          allow(assignment).to receive(:threshold_points).and_return 100
+          expect(subject[:has_threshold]).to eq(true)
+        end
+
+        it "is false when the assignment threshold is zero" do
+          allow(assignment).to receive(:threshold_points).and_return 0
+          expect(subject[:has_threshold]).to eq(false)
         end
       end
 


### PR DESCRIPTION
This feature extends the threshold assignment functionality into the predictor. Assignments with a threshold will present the scale icon in the icon bar.

Additionally, the threshold will influence the behavior of the slider. Sliders are still draggable and influence the prediction, but until the threshold is met, the fill color is red. If the slider is released before meeting the threshold, it snaps back to zero, and a zero prediction is persisted through AJAX.

I have also added a sample assignment with both levels and a threshold, to verify these two behaviors will work together, if ever implemented on the same assignment.