### PR TITLE
1835 hide predicted grades

### DIFF
--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -7,6 +7,7 @@ module SubmissionGradeHistory
       .remove("name" => "feedback_read_at")
       .remove("name" => "feedback_reviewed")
       .remove("name" => "feedback_reviewed_at")
+      .remove("name" => "final_score")
       .remove("name" => "graded_at")
       .remove("name" => "graded_by_id")
       .remove("name" => "instructor_modified")

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -11,6 +11,7 @@ module SubmissionGradeHistory
       .remove("name" => "graded_at")
       .remove("name" => "graded_by_id")
       .remove("name" => "instructor_modified")
+      .remove("name" => "predicted_score")
       .remove("name" => "score")
       .remove("name" => "status")
       .remove("name" => "submission_id")


### PR DESCRIPTION
This PR does not display history versions for a `Grade`'s `predicted_score` and the `final_score`.

`final_score` was added here because it was often a repeat of the `raw_score`. Since we use `raw_score` for the student pretty much everywhere, that was being displayed and the `final_score` was not.

BEFORE:

<img width="1431" alt="screen shot 2016-03-31 at 8 51 45 am" src="https://cloud.githubusercontent.com/assets/35017/14176220/ef0dc492-f71d-11e5-845b-1f8cf5643464.png">

AFTER:

<img width="1425" alt="screen shot 2016-03-31 at 8 52 19 am" src="https://cloud.githubusercontent.com/assets/35017/14176224/f460fffe-f71d-11e5-8d20-bbcfa35f6398.png">

Closes #1835