### PR TITLE
1839 - Refactor submission scopes

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -25,20 +25,18 @@ class Submission < ActiveRecord::Base
   has_many :submission_files, dependent: :destroy, autosave: true
   accepts_nested_attributes_for :submission_files
 
-  scope :ungraded2, -> do
-    # TODO: Add index on grades.submission_id
-
-    includes(:grade, :assignment)
-      .where("(assignments.release_necessary = true AND "\
-              "grades.status != :released) OR "\
-             "(assignments.release_necessary = false AND "\
-              "grades.status NOT IN (:graded, :released)) OR "\
-             "grades.id IS NULL", graded: "Graded",
-             released: "Released")
-      .references(:grade, :assignment)
+  scope :with_grade, -> do
+    joins("INNER JOIN grades ON "\
+      "grades.group_id = submissions.group_id OR "\
+      "(grades.assignment_id = submissions.assignment_id AND "\
+      "grades.student_id = submissions.student_id)")
   end
 
-  scope :ungraded, -> { where("NOT EXISTS(SELECT 1 FROM grades WHERE submission_id = submissions.id OR (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (status = ? OR status = ?))", "Graded", "Released") }
+  scope :ungraded, -> do
+    includes(:assignment, :group, :student)
+      .where.not(id: with_grade.where(grades: { status: ["Graded", "Released"] }))
+  end
+
   scope :resubmitted, -> { includes(:grade).where(grades: { status: ["Graded", "Released"] })
                                            .where("grades.graded_at < submitted_at") }
   scope :order_by_submitted, -> { order("submitted_at ASC") }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -25,8 +25,20 @@ class Submission < ActiveRecord::Base
   has_many :submission_files, dependent: :destroy, autosave: true
   accepts_nested_attributes_for :submission_files
 
+  scope :ungraded2, -> do
+    # TODO: Add index on grades.submission_id
+
+    includes(:grade, :assignment)
+      .where("(assignments.release_necessary = true AND "\
+              "grades.status != :released) OR "\
+             "(assignments.release_necessary = false AND "\
+              "grades.status NOT IN (:graded, :released)) OR "\
+             "grades.id IS NULL", graded: "Graded",
+             released: "Released")
+      .references(:grade, :assignment)
+  end
+
   scope :ungraded, -> { where("NOT EXISTS(SELECT 1 FROM grades WHERE submission_id = submissions.id OR (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (status = ? OR status = ?))", "Graded", "Released") }
-  scope :graded, -> { where(:grade) }
   scope :resubmitted, -> { includes(:grade).where(grades: { status: ["Graded", "Released"] })
                                            .where("grades.graded_at < submitted_at") }
   scope :order_by_submitted, -> { order("submitted_at ASC") }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -168,6 +168,28 @@ describe Submission do
     end
   end
 
+  describe ".ungraded", focus: true do
+    before { subject.save }
+
+    it "returns the submissions that do not have any grades" do
+      graded_submission = create(:submission)
+      create :grade, submission: graded_submission, status: "Released"
+      expect(Submission.ungraded2).to eq [subject]
+    end
+
+    it "returns the submissions that have a grade but it's in progress" do
+      create :grade, submission: subject, status: "In Progress"
+      expect(Submission.ungraded2).to eq [subject]
+    end
+
+    it "returns the submissions that have been graded but not released" do
+      subject.save
+      subject.assignment.update_attributes(release_necessary: true)
+      create :grade, submission: subject, status: "Graded"
+      expect(Submission.ungraded2).to eq [subject]
+    end
+  end
+
   describe ".resubmitted" do
     it "returns the submissions that have been submitted after they were graded" do
       grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -168,25 +168,28 @@ describe Submission do
     end
   end
 
-  describe ".ungraded", focus: true do
+  describe ".ungraded" do
+    let(:course) { subject.course }
     before { subject.save }
 
     it "returns the submissions that do not have any grades" do
-      graded_submission = create(:submission)
-      create :grade, submission: graded_submission, status: "Released"
-      expect(Submission.ungraded2).to eq [subject]
+      expect(Submission.ungraded).to eq [subject]
     end
 
     it "returns the submissions that have a grade but it's in progress" do
-      create :grade, submission: subject, status: "In Progress"
-      expect(Submission.ungraded2).to eq [subject]
+      create :grade, course: course, assignment: subject.assignment,
+        student: subject.student, submission: subject, status: "In Progress"
+      expect(Submission.ungraded).to eq [subject]
     end
 
-    it "returns the submissions that have been graded but not released" do
-      subject.save
-      subject.assignment.update_attributes(release_necessary: true)
-      create :grade, submission: subject, status: "Graded"
-      expect(Submission.ungraded2).to eq [subject]
+    it "does not return submissions that have been graded or released" do
+      create :grade, course: course, assignment: subject.assignment,
+        student: subject.student, submission: subject, status: "Graded"
+      expect(Submission.ungraded).to be_empty
+    end
+
+    it "handles additional parameters" do
+      expect(subject.course.submissions.ungraded).to eq [subject]
     end
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -170,7 +170,10 @@ describe Submission do
 
   describe ".ungraded" do
     let(:course) { subject.course }
-    before { subject.save }
+    before do
+      Submission.destroy_all
+      subject.save
+    end
 
     it "returns the submissions that do not have any grades" do
       expect(Submission.ungraded).to eq [subject]


### PR DESCRIPTION
This PR improves the performance of the `Submission.ungraded` scope.

### Implementation

The old scope was this:

```
where("NOT EXISTS(SELECT 1 FROM grades WHERE submission_id = submissions.id OR (assignment_id = submissions.assignment_id AND student_id = submissions.student_id) AND (status = ? OR status = ?))", "Graded", "Released")
```

The new scope is this:

```
  scope :with_grade, -> do
    joins("INNER JOIN grades ON "\
      "grades.group_id = submissions.group_id OR "\
      "(grades.assignment_id = submissions.assignment_id AND "\
      "grades.student_id = submissions.student_id)")
  end

  scope :ungraded, -> do
    includes(:assignment, :group, :student)
      .where.not(id: with_grade.where(grades: { status: ["Graded", "Released"] }))
  end
```

### Performance

This resulted in improved performance for the query runtime.

These times below are based on a course that has 2071 submissions and 15,054 grades.

The old run time for the scope was `7842.8ms`.

The new run time for the scope is `24.8ms`.

In addition, rendering the page used to take 4 queries for each row since the assignment, student, and team were lazy loaded.

This is what the old sql query breakdown looked like for rendering the ungraded submissions view:

<img width="727" alt="screen_shot_2016-04-05_at_5_29_01_pm" src="https://cloud.githubusercontent.com/assets/35017/14298696/3c6f89d4-fb54-11e5-9e58-edb06b6c8443.png">

This is what the new sql query breakdown looks like for rendering the ungraded submissions view. We cannot eager load the team retrieval so there is still some sql queries back to the server.

<img width="716" alt="screen_shot_2016-04-05_at_5_29_35_pm" src="https://cloud.githubusercontent.com/assets/35017/14298725/6e469a06-fb54-11e5-900d-7ca43a320e12.png">

Closes #1839