### PR TITLE
BadgeProctor and Invisible Level Badges

### DIFF
--- a/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
@@ -34,11 +34,6 @@
   $scope.pointsMissing = ()->
     $scope.pointsDifference() > 0 and $scope.pointsAssigned() > 0
 
-  # check whether points overview is hidden
-  # $scope.pointsOverviewHidden = ()->
-  #  element = angular.element(document.querySelector('#points-overview'))
-  #  element.is('visible')
-
   $scope.pointsSatisfied = ()->
     $scope.pointsDifference() == 0 and $scope.pointsAssigned() > 0
 

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -3,14 +3,15 @@ class API::BadgesController < ApplicationController
   # GET api/assignments/:assignment_id/badges
   def index
     @badges = current_course.badges.select(
+      :can_earn_multiple_times,
+      :course_id,
+      :description,
+      :icon,
       :id,
       :name,
-      :description,
       :point_total,
-      :visible,
-      :visible_when_locked,
-      :can_earn_multiple_times,
       :position,
-      :icon)
+      :visible,
+      :visible_when_locked)
   end
 end

--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -40,7 +40,7 @@ class GradebookExporter
     # TODO: improve the performance here
     course.assignments.inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
-      score = GradeProctor.new(grade).viewable?(student, course) ? grade.raw_score : ""
+      score = GradeProctor.new(grade).viewable? ? grade.raw_score : ""
       memo << score
       memo
     end

--- a/app/exporters/multiplied_gradebook_exporter.rb
+++ b/app/exporters/multiplied_gradebook_exporter.rb
@@ -24,7 +24,7 @@ class MultipliedGradebookExporter < GradebookExporter
     # TODO: improve the performance here
     course.assignments.inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
-      if GradeProctor.new(grade).viewable? student, course
+      if GradeProctor.new(grade).viewable?
         memo << grade.raw_score
         memo << grade.score
       else

--- a/app/models/abilities/grade_ability.rb
+++ b/app/models/abilities/grade_ability.rb
@@ -1,11 +1,11 @@
 module GradeAbility
   def define_grade_abilities(user, course)
     can :read, Grade do |grade|
-      GradeProctor.new(grade).viewable? user, course
+      GradeProctor.new(grade).viewable? user: user, course: course
     end
 
     can :update, Grade do |grade|
-      GradeProctor.new(grade).updatable? user, course
+      GradeProctor.new(grade).updatable? user: user, course: course
     end
   end
 end

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -179,7 +179,7 @@ class UnlockCondition < ActiveRecord::Base
       check_if_grade_earned_meets_condition_value(grade)
     elsif condition_date?
       check_if_grade_earned_met_condition_date(grade)
-    elsif GradeProctor.new(grade).viewable?(student)
+    elsif GradeProctor.new(grade).viewable?(user: student)
       return true
     else
       return false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,7 +329,7 @@ class User < ActiveRecord::Base
   # Checking specifically if there is a released grade for an assignment
   def grade_released_for_assignment?(assignment)
     grade = grade_for_assignment(assignment)
-    GradeProctor.new(grade).viewable? self, assignment.course
+    GradeProctor.new(grade).viewable?
   end
 
   # Grabbing the grade for an assignment
@@ -508,7 +508,7 @@ class User < ActiveRecord::Base
   # (complete or not)
   def self_reported_done?(assignment)
     grade = grade_for_assignment(assignment)
-    GradeProctor.new(grade).viewable?(self, assignment.course)
+    GradeProctor.new(grade).viewable?
   end
 
   ### GROUPS

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -136,7 +136,7 @@ class AssignmentPresenter < Showtime::Presenter
   def scores_for(user)
     scores = self.scores
     grade = grades.where(student_id: user.id).first
-    if GradeProctor.new(grade).viewable? user, course
+    if GradeProctor.new(grade).viewable? user: user, course: course
       scores[:user_score] = grade.raw_score
     end
     scores

--- a/app/services/creates_criterion_grade/builds_earned_level_badges.rb
+++ b/app/services/creates_criterion_grade/builds_earned_level_badges.rb
@@ -24,7 +24,7 @@ module Services
           context[:earned_level_badges] = new_earned_level_badges(
             context[:assignment],
             context[:student],
-            !context[:student_visibile_status].nil?,
+            !context[:student_visible_status].nil?,
             context[:raw_params]["level_badges"]
           )
         end
@@ -34,9 +34,9 @@ module Services
         private
 
         def new_earned_level_badges(assignment, student, visible_status, level_badges_params)
+          destroy_exisiting_earned_badges(student.id, assignment.id)
           level_badges_params.collect do |params|
             level_badge = LevelBadge.where(badge_id: params["badge_id"], level_id: params["level_id"]).first
-            destroy_exisiting_earned_badges(student.id, params["badge_id"], params["level_id"])
             EarnedBadge.new(course_id: assignment.course.id, assignment_id: assignment.id,
                             student_id: student.id, student_visible: visible_status,
                             badge_id: level_badge.badge.id, level_id: level_badge.level.id,
@@ -56,8 +56,8 @@ module Services
         #   2. Currently there is a (race?) condition that causes badges to sometimes not load in the front end, in which
         #      case this will also mean badges that should be awarded will be lost.
         #   3. This is terrible for performace reasons, and won't allow us to track history through existing models.
-        def destroy_exisiting_earned_badges(student_id, badge_id, level_id)
-          EarnedBadge.where(student_id: student_id, badge_id: badge_id, level_id: level_id).destroy_all
+        def destroy_exisiting_earned_badges(student_id, assignment_id)
+          EarnedBadge.where(student_id: student_id, assignment_id: assignment_id).destroy_all
         end
       end
     end

--- a/app/views/api/badges/index.json.jbuilder
+++ b/app/views/api/badges/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.data @badges do |badge|
-  next unless badge.visible_for_student?(@student)
+  next unless BadgeProctor.new(badge).viewable?(current_user)
   json.type "badges"
   json.id   badge.id.to_s
   json.attributes do

--- a/app/views/assignments/_rubric_preview.html.haml
+++ b/app/views/assignments/_rubric_preview.html.haml
@@ -27,9 +27,9 @@
               .level-description= level.description
 
               .row.badge-row
-                - level.level_badges.each_with_index do |badge, index|
-                  - if index < 2
+                - level.level_badges.each_with_index do |level_badge, index|
+                  - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
                     .level-badge-image
-                      %img{:src => badge.badge.try(:icon), class: "level_badge" }
+                      %img{:src => level_badge.badge.try(:icon), class: "level_badge" }
           - if criterion.levels.size < presenter.rubric_max_level_count
             %td.filler(colspan="#{presenter.rubric_max_level_count - criterion.levels.size}")

--- a/app/views/grades/components/_criterion_grade_results.haml
+++ b/app/views/grades/components/_criterion_grade_results.haml
@@ -30,10 +30,10 @@
             .level-description= level.description
 
             .row.badge-row
-              - level.level_badges.each_with_index do |badge, index|
-                - if index < 2
+              - level.level_badges.each_with_index do |level_badge, index|
+                - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
                   %span.level-badge-image
-                    %img{:src => badge.badge.icon, width: "30px", height: "30px" }
+                    %img{:src => level_badge.badge.icon, width: "30px", height: "30px" }
               .clear
 
             - if current_user_is_staff? && presenter.viewable_rubric_level_earned?(current_student.id, level.id)

--- a/app/views/grades/mass_edit.html.haml
+++ b/app/views/grades/mass_edit.html.haml
@@ -49,7 +49,7 @@
                   - elsif @assignment.grade_checkboxes?
                     = gf.check_box :raw_score, {}, @assignment.point_total, nil
                   - else
-                    - if grade.persisted? && GradeProctor.new(grade).updatable?(current_user, current_course)
+                    - if grade.persisted? && GradeProctor.new(grade).updatable?(user: current_user, course: current_course)
                       = gf.text_field :raw_score, data: {autonumeric: true, "m-dec" => "0"}
 
                     - else

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -64,7 +64,7 @@
 
 #------------------------------------------------------------------------------#
 
-#                        Grading Assignment Types
+#                        Grading Assignment Type
 
 #------------------------------------------------------------------------------#
 
@@ -378,7 +378,7 @@
 
 #------------------------------------------------------------------------------#
 
-#                        Submission Assignment Types
+#                        Submission Assignment Type
 
 #------------------------------------------------------------------------------#
 
@@ -476,7 +476,7 @@
 
 #------------------------------------------------------------------------------#
 
-#                        Predictor Assignment Types
+#                        Predictor Assignment Type
 
 #------------------------------------------------------------------------------#
 
@@ -794,7 +794,7 @@
 
 #------------------------------------------------------------------------------#
 
-#                        Visibility Assignment Types
+#                        Visibility Assignment Type
 
 #------------------------------------------------------------------------------#
 
@@ -935,6 +935,14 @@
   }
 }
 
+
+#------------------------------------------------------------------------------#
+
+#                        Unlock Assignment Type
+
+#------------------------------------------------------------------------------#
+
+
 @assignments[:badge_is_an_unlock] = {
   quotes: {
     assignment_created: "Badges, to g**-d***** h*** with badges! We have no badges. In fact, we don’t need badges. I don't have to show you any stinking badges, you g**-d***** cabron and c****’ tu madre! – B. Traven",
@@ -942,13 +950,13 @@
   assignment_type: :unlocks,
   attributes: {
     name: "Unlocked-By-Badge-Example",
-    description: "Earning a Badge unlocks this assignment.",
+    description: "Earning the Badge Assignment-Unlock-Key unlocks this assignment.",
     due_at: 4.weeks.from_now,
     point_total: 180000,
   },
   unlock_condition: true,
   unlock_attributes: {
-    condition: :unlock_submission_condition,
+    condition: :badge_unlock_assignment_condition,
     condition_type: "Badge",
     condition_state: "Earned"
   }
@@ -1040,7 +1048,7 @@
   },
   assignment_type: :unlocks,
   attributes: {
-    name: "Unlocked-By-Grade-Earned",
+    name: "Unlocked-By-Grade-Earned-By-Date",
     description: "Earning a Grade for 'Unlock-Grade-Earned-By-Date-Key' unlocks this",
     due_at: 2.weeks.ago + 0.05,
   },
@@ -1131,6 +1139,23 @@
   }
 }
 
+@assignments[:group_unlock_submission_condition] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :unlocks,
+  attributes: {
+    name: "Group-Submission-Key",
+    description: "I'm the thing you need to submit to unlock 'Group-Assignment-Unlocked-By-Submission'",
+    due_at: 4.weeks.from_now,
+    point_total: 180000,
+    accepts_submissions: true,
+    accepts_attachments: true,
+    accepts_links: true,
+    accepts_text: true,
+  }
+}
+
 @assignments[:group_assignment_submission_is_an_unlock] = {
   quotes: {
     assignment_created: "My contention is that creativity now is as important in education as literacy, and we should treat it with the same status. – Sir Ken Robinson",
@@ -1138,7 +1163,7 @@
   assignment_type: :unlocks,
   attributes: {
     name: "Group-Assignment-Unlocked-By-Submission",
-    description: "All members of a Group Submitting 'Submission-Key' unlocks this assignment",
+    description: "All members of a Group Submitting 'Group-Submission-Key' unlocks this assignment",
     due_at: 3.weeks.from_now,
     point_total: 180000,
     grade_scope: "Group",
@@ -1149,7 +1174,7 @@
   },
   unlock_condition: true,
   unlock_attributes: {
-    condition: :unlock_submission_condition,
+    condition: :group_unlock_submission_condition,
     condition_type: "Assignment",
     condition_state: "Submitted"
   }
@@ -1192,7 +1217,11 @@
   }
 }
 
+#------------------------------------------------------------------------------#
 
+#                        Sorting Assignment Type
+
+#------------------------------------------------------------------------------#
 
 @assignments[:alphanum_1_condition] = {
   quotes: {

--- a/db/samples/badges.rb
+++ b/db/samples/badges.rb
@@ -1,0 +1,197 @@
+#----------------------------------------------------------------------------------------------------------------------#
+
+#                                          badge DEFAULT CONFIGURATION                                                 #
+
+#----------------------------------------------------------------------------------------------------------------------#
+
+# Add all attributes that will be passed on any badge creation here, with a default value
+# All assignment types will use defaults when individual attributes aren't supplied
+
+
+@badge_default_config = {
+  quotes: {
+    badge_created: "A badge has been created for each course that has badges",
+  },
+  attributes: {
+    name: "Generic badge",
+    point_total: 100 * rand(10),
+    description: nil,
+    visible: false,
+    can_earn_multiple_times: false
+  },
+  assign_samples: false, # assign earned badges on init
+  unlock_condition: false,
+  unlock_attributes: {
+    condition: :nil,
+    condition_type: nil,
+    condition_state: nil
+  }
+}
+
+#----------------------------------------------------------------------------------------------------------------------#
+#----------------------------------------------------------------------------------------------------------------------#
+
+@badges = {}
+
+@badges[:single_earn_badge_earned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Singularis Earned",
+    description: "An visible badge that can only be earned once. Earned badges assigned to all students",
+    visible: true,
+  },
+  assign_samples: true,
+}
+
+@badges[:single_earn_badge_unearned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Singularis Unearned",
+    description: "An visible badge that can only be earned once.",
+    visible: true,
+  },
+  assign_samples: false,
+}
+
+@badges[:multiple_earn_badge_earned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Multiplus Earned",
+    description: "A visible badge that can be seen by all and earned multiple times. Earned badges assigned to all students",
+    visible: true,
+    can_earn_multiple_times: true
+  },
+  assign_samples: true,
+}
+
+@badges[:multiple_earn_badge_unearned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Multiplus Unearned",
+    description: "A visible badge that can be seen by all and earned multiple times.",
+    visible: true,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+@badges[:invisible_badge_earned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Secretus Earned",
+    description: "An invisible badge that can be earned multiple times. Should only be visible to students once they earn it. Earned badges assigned to all students",
+    can_earn_multiple_times: true
+  },
+  assign_samples: true,
+}
+
+@badges[:invisible_badge_unearned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Secretus Unearned",
+    description: "An invisible badge that can be earned multiple times. Should only be visible to students once they earn it.",
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+
+@badges[:long_description] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Verbose Descriptor",
+    description: "A badge with a long description. Earned badges assigned to all students. A badge is a device or accessory, often containing the insignia of an organization, which is presented or displayed to indicate some feat of service, a special accomplishment, a symbol of authority granted by taking an oath (e.g., police and fire), a sign of legitimate employment or student status, or as a simple means of identification. They are also used in advertising, publicity, and for branding purposes. Police badges date back to medieval times when knights wore a coat of arms representing their allegiances and loyalty.[Wikipedia]",
+    visible: true,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+@badges[:visible_level_badge] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Gradualis Opticus",
+    description: "Level Badge - A visible badge associated with a Rubric Level.",
+    visible: true,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+@badges[:invisible_level_badge] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Gradualis Secretus",
+    description: "Level Badge - An invisible badge associated with a Rubric Level.",
+    visible: false,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+# Both badges and assignments need to already exists before we can assign
+# each to the other as condition. For now, badges are created first and can be
+# sample conditions for both badges and assignments.
+
+@badges[:badge_unlock_assignment_condition] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Assignment-Unlock-Key",
+    description: "This badge unlocks the assignment Unlocked-By-Badge-Example",
+    visible: true,
+    can_earn_multiple_times: false
+  },
+  assign_samples: false,
+}
+
+@badges[:badge_unlock_badge_condition] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Badge-Unlock-Key",
+    description: "This badge unlocks the badge Unlocked-By-Badge-Example",
+    visible: true,
+    can_earn_multiple_times: false
+  },
+  assign_samples: false,
+}
+
+@badges[:badge_is_an_unlock] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Unlocked-By-Badge",
+    description: "An visible badge which is unlocked by the badge Badge-Unlock-Key.",
+    visible: true,
+    can_earn_multiple_times: false
+  },
+  unlock_condition: true,
+  unlock_attributes: {
+    condition: :badge_unlock_badge_condition,
+    condition_type: "Badge",
+    condition_state: "Earned"
+  },
+  assign_samples: false,
+}

--- a/db/samples/courses.rb
+++ b/db/samples/courses.rb
@@ -20,8 +20,6 @@
   grade_levels: ["Amoeba", "Sponge", "Roundworm", "Jellyfish", "Leech", "Snail", "Sea Slug", "Fruit Fly", "Lobster", "Ant", "Honey Bee", "Cockroach", "Frog", "Mouse", "Rat", "Octopus", "Cat", "Chimpanzee", "Elephant", "Human", "Orca"].shuffle,
     # Not all courses have teams
   team_names: ["Harm & Hammer","Abusement Park","Silver Woogidy Woogidy Woogidy Snakes","Carpe Ludus","Eduception","Operation Unthinkable","Team Wang","The Carpal Tunnel Crusaders","Pwn Depot"].shuffle,
-    # Not all courses have badges
-  badge_names: ["Creative", "Inner Eye", "Patronus Producer","Cheerful Charmer","Invisiblity Cloak","Marauders Map","Lumos","Rune Reader","Tea Leaf Guru","Wizard Chess Grand Master","Green Thumb","Gamekeeper","Seeker","Alchemist","Healer","Parseltongue","House Cup"].shuffle,
   attributes: {
     academic_history_visible: false,
     accepts_submissions: false,
@@ -130,7 +128,6 @@
   },
   grade_levels: ["Hammurabi", "Confucius", "Socrates", "Cicero", "William of Ockham", "Mozi", "Xenophon", "Saint Augustine", "Plato", "Diogenes", "Machiavelli", "Aeschines", "Ghazali", "Martin Luther", "Aristotle", "Calvin", "Maimonides", "St. Thomas Aquinas", "Xun Zi", "Ibn Khaldun", "Thiruvalluvar", "Locke"].shuffle,
   team_names: ["Section 1", "Section 2", "Section 3", "Section 4", "Section 5", "Section 6", "Section 7", "Section 8", "Section 9", "Section 10", "Section 11", "Section 12", "Section 13", "Section 14", "Section 15", "Section 16"].shuffle,
-  badge_names: ["MINOR: Learning from Mistakes", "MINOR: Learning from Mistakes", "MINOR: Halloween Special", "MINOR: Thanksgiving Special", "MINOR: Now It is Personal", "MAJOR: Makeup Much", "MAJOR: Practice Makes Perfect", "MAJOR: Combo Platter", "MINOR: Makeup Some", "MINOR: Participatory Democrat", "MINOR: Number One", "MINOR: Rockstar", "MINOR: Over-achiever", "MINOR: Avid Reader", "MINOR: Nice Save!", "MINOR: The Nightstalker", "MINOR: Paragon of Virtue", "MAJOR: Bad Investment", "MINOR: Leader of the pack", "MINOR: Thoughtful Contribution"].shuffle,
   attributes: {
     academic_history_visible: true,
     accepts_submissions: true,
@@ -176,7 +173,6 @@
   },
   grade_levels: ["Shannon", "Weaver", "Vannevar Bush", "Turing", "Boole", "Gardner", "Shestakov", "Blackman", "Bode", "John Pierce", "Thorpe", "Renyi", "Cohen", "Berners Lee", "Nash", "Cailliau", "Andreessen", "Hartill", "Ada Lovelace", "Grace Hopper", "Henrietta Leavitt", "Anita Borg"].shuffle,
   team_names: ["Late Night Information Nation", "Heisenberg", "Big Red Dogs", "Liu Man Group", "The House that Cliff Built", "TMI"].shuffle,
-  badge_names: ["MINOR: Learning from Mistakes", "MINOR: Learning from Mistakes", "MINOR: Halloween Special", "MINOR: Thanksgiving Special", "MINOR: Now It is Personal", "MAJOR: Makeup Much", "MAJOR: Practice Makes Perfect", "MAJOR: Combo Platter", "MINOR: Makeup Some", "MINOR: Participatory Democrat", "MINOR: Number One", "MINOR: Rockstar", "MINOR: Over-achiever", "MINOR: Avid Reader", "MINOR: Nice Save!", "MINOR: The Nightstalker", "MINOR: Paragon of Virtue", "MAJOR: Bad Investment", "MINOR: Leader of the pack", "MINOR: Thoughtful Contribution"].shuffle,
   attributes: {
     academic_history_visible: true,
     accepts_submissions: true,

--- a/lib/badge_proctor.rb
+++ b/lib/badge_proctor.rb
@@ -1,0 +1,14 @@
+require_relative "badge_proctor/base"
+require_relative "badge_proctor/viewable"
+
+# determines what sort of CRUD operations can be performed
+# on a `badge` resource
+class BadgeProctor
+  include Viewable
+
+  attr_reader :badge
+
+  def initialize(badge)
+    @badge = badge
+  end
+end

--- a/lib/badge_proctor/base.rb
+++ b/lib/badge_proctor/base.rb
@@ -1,0 +1,15 @@
+# common methods for CRUD operations on a `Grade`
+class BadgeProctor
+  module Base
+
+    private
+
+    def badge_for_course?(course)
+      badge.course_id == course.id
+    end
+
+    def badge_earned_by_user?(user)
+      badge.student_id == user.id
+    end
+  end
+end

--- a/lib/badge_proctor/viewable.rb
+++ b/lib/badge_proctor/viewable.rb
@@ -1,0 +1,39 @@
+# determines if a `Badge` resource can be viewed for a specific user
+#
+# options include:
+#   course:  will verify the badge is for the course
+#   level:   will only show students invisible badges earned for the specific
+#            level. This is used for Rubric views to hide all invisible level
+#            badges on unearned levels, even if the student earned the badge in
+#            another context.
+#
+class BadgeProctor
+  module Viewable
+    include Base
+
+    def viewable?(user, options={})
+      return false if badge.nil?
+
+      course = options[:course] || badge.course
+      level = options[:level]
+      badge_for_course?(course) &&
+        (user.is_staff?(course) || badge_visible_by_student?(user,level))
+    end
+
+    private
+
+    def badge_visible_by_student?(student, level=nil)
+      badge.visible? || earned_badges_visible_by_student?(student, level)
+    end
+
+    def earned_badges_visible_by_student?(student, level=nil)
+      if level
+        EarnedBadge.where(student_id: student.id, badge_id: badge.id,
+          level_id: level.id, student_visible: true).present?
+      else
+        EarnedBadge.where(student_id: student.id, badge_id: badge.id,
+          student_visible: true).present?
+      end
+    end
+  end
+end

--- a/lib/badge_proctor/viewable.rb
+++ b/lib/badge_proctor/viewable.rb
@@ -1,8 +1,8 @@
-# determines if a `Badge` resource can be viewed for a specific user
+# Determines if a `Badge` resource can be viewed for a specific user
 #
-# options include:
-#   course:  will verify the badge is for the course
-#   level:   will only show students invisible badges earned for the specific
+# Options include:
+#   course:  Will verify the badge is for the course.
+#   level:   Will only show students invisible badges earned for the specific
 #            level. This is used for Rubric views to hide all invisible level
 #            badges on unearned levels, even if the student earned the badge in
 #            another context.

--- a/lib/grade_proctor/updatable.rb
+++ b/lib/grade_proctor/updatable.rb
@@ -1,14 +1,20 @@
-# determines if a `Grade` resource can be updated within a specific
-# user and course context
+# Determines if a `Grade` resource can be updated by a user. If no user is
+# supplied in the options, it will default to the Grade's student.
+#
+# Options include:
+#   course:  Will verify the grade is for the course
+#   user:    Determines permissions for supplied user rather than the
+#            grade's student
+#
 class GradeProctor
   module Updatable
     include Base
 
-    def updatable?(user=nil, course=nil)
+    def updatable?(options={})
       return false if grade.nil?
 
-      user ||= grade.student
-      course ||= grade.course
+      user = options[:user] || grade.student
+      course = options[:course] || grade.course
 
       grade_for_course?(course) &&
         (user.is_staff?(course) ||

--- a/lib/grade_proctor/viewable.rb
+++ b/lib/grade_proctor/viewable.rb
@@ -1,14 +1,20 @@
-# determines if a `Grade` resource can be viewed within a specific
-# user and course context
+# Determines if a `Grade` resource can be viewed by a user. If no user is
+# supplied in the options, it will default to the Grade's student.
+#
+# Options include:
+#   course:  Will verify the grade is for the course
+#   user:    Determines permissions for supplied user rather than the
+#            grade's student
+#
 class GradeProctor
   module Viewable
     include Base
 
-    def viewable?(user=nil, course=nil)
+    def viewable?(options={})
       return false if grade.nil?
 
-      user ||= grade.student
-      course ||= grade.course
+      user = options[:user] || grade.student
+      course = options[:course] || grade.course
 
       grade_for_course?(course) &&
         (user.is_staff?(course) ||

--- a/spec/lib/badge_proctor/viewable_spec.rb
+++ b/spec/lib/badge_proctor/viewable_spec.rb
@@ -1,0 +1,92 @@
+require "./lib/badge_proctor"
+
+describe BadgeProctor::Viewable do
+  let(:course) { double(:course, id: 456) }
+  let(:badge) { double(:badge, id: 789, course_id: course.id, visible?: false) }
+  let(:user) { double(:user, id: 123, is_staff?: false) }
+
+  describe "#viewable?" do
+    subject { BadgeProctor.new(badge) }
+
+    it "cannot be viewable if the badge is nil" do
+      subject = BadgeProctor.new(nil)
+      expect(subject).to_not be_viewable user, course: course
+    end
+
+    context "as a student" do
+      it "cannot view the badge if it's not visible" do
+        expect(subject).to_not be_viewable user, course: course
+      end
+
+      it "cannot view the badge if it's not part of the course" do
+        allow(badge).to receive(:course_id).and_return 789
+        expect(subject).to_not be_viewable user, course: course
+      end
+
+      it "can view the badge if it's visible" do
+        allow(badge).to receive(:visible?).and_return true
+        expect(subject).to be_viewable user, course: course
+      end
+
+      it "can view the badge if earned and the EarnedBadge is visible" do
+        world = World.create.create_badge
+        eb = create(:earned_badge,
+          course: world.course,
+          badge: world.badge,
+          student_visible: true)
+        subject = BadgeProctor.new(world.badge)
+        expect(subject).to be_viewable eb.student, course: eb.course
+      end
+
+      it "cannnot view the badge if earned but the EarnedBadge is invisible" do
+        world = World.create.create_badge(visible: false)
+        eb = create(:earned_badge,
+          course: world.course,
+          badge: world.badge,
+          student_visible: false)
+        subject = BadgeProctor.new(world.badge)
+        expect(subject).to_not be_viewable eb.student, course: eb.course
+      end
+
+      context "with level in options" do
+        it "is visible if the badge is earned for that level" do
+          world = World.create.create_badge(visible: false)
+          level = create(:level)
+          eb = create(:earned_badge,
+            course: world.course,
+            badge: world.badge,
+            level_id: level.id,
+            student_visible: true)
+          subject = BadgeProctor.new(world.badge)
+          expect(subject).to be_viewable eb.student,
+            level: level, course: eb.course
+        end
+
+        it "is not visible if the badge is earned but not for that level" do
+          world = World.create.create_badge(visible: false)
+          level = create(:level)
+          eb = create(:earned_badge,
+            course: world.course,
+            badge: world.badge,
+            student_visible: true)
+          subject = BadgeProctor.new(world.badge)
+          expect(subject).to_not be_viewable eb.student,
+            level: level, course: eb.course
+        end
+      end
+    end
+
+    context "as staff" do
+      let(:staff) { double(:user, id: 456, is_staff?: true) }
+
+      it "can view the badge if they're an instructor for the course" do
+        expect(subject).to be_viewable staff, course: course
+      end
+
+      it "cannot view the badge if they're not an instructor for the course" do
+        allow(staff).to receive(:is_staff?).with(course).and_return false
+        expect(subject).to_not be_viewable staff, course: course
+      end
+    end
+  end
+end

--- a/spec/lib/grade_proctor/updatable_spec.rb
+++ b/spec/lib/grade_proctor/updatable_spec.rb
@@ -14,7 +14,7 @@ describe GradeProctor::Updatable do
 
     it "cannot be updatable if the grade is nil" do
       subject = GradeProctor.new(nil)
-      expect(subject).to_not be_updatable user, course
+      expect(subject).to_not be_updatable user: user, course: course
     end
 
     context "as a student" do
@@ -22,17 +22,17 @@ describe GradeProctor::Updatable do
         before { allow(assignment).to receive(:student_logged?).and_return true }
 
         it "can update a grade" do
-          expect(subject).to be_updatable user, course
+          expect(subject).to be_updatable user: user, course: course
         end
 
         it "cannot update a grade that does not belong to them" do
           allow(grade).to receive(:student_id).and_return 456
-          expect(subject).to_not be_updatable user, course
+          expect(subject).to_not be_updatable user: user, course: course
         end
       end
 
       it "cannot update a grade that is updated by an instructor" do
-        expect(subject).to_not be_updatable user, course
+        expect(subject).to_not be_updatable user: user, course: course
       end
     end
 
@@ -40,12 +40,12 @@ describe GradeProctor::Updatable do
       let(:staff) { double(:user, id: 456, is_staff?: true) }
 
       it "can update if they are the instructor for the course" do
-        expect(subject).to be_updatable staff, course
+        expect(subject).to be_updatable user: staff, course: course
       end
 
       it "cannot update if they are not the instructor for the course" do
         allow(staff).to receive(:is_staff?).with(course).and_return false
-        expect(subject).to_not be_updatable staff, course
+        expect(subject).to_not be_updatable user: staff, course: course
       end
     end
   end

--- a/spec/lib/grade_proctor/viewable_spec.rb
+++ b/spec/lib/grade_proctor/viewable_spec.rb
@@ -12,33 +12,33 @@ describe GradeProctor::Viewable do
 
     it "cannot be viewable if the grade is nil" do
       subject = GradeProctor.new(nil)
-      expect(subject).to_not be_viewable user, course
+      expect(subject).to_not be_viewable user: user, course: course
     end
 
     context "as a student" do
       it "cannot view the grade if it's not assigned to them" do
         allow(grade).to receive(:student_id).and_return 456
-        expect(subject).to_not be_viewable user, course
+        expect(subject).to_not be_viewable user: user, course: course
       end
 
       it "cannot view the grade if it's not part of the course" do
         allow(grade).to receive(:is_released?).and_return true
         allow(grade).to receive(:course_id).and_return 789
-        expect(subject).to_not be_viewable user, course
+        expect(subject).to_not be_viewable user: user, course: course
       end
 
       it "can view the grade if it's been released" do
         allow(grade).to receive(:is_released?).and_return true
-        expect(subject).to be_viewable user, course
+        expect(subject).to be_viewable user: user, course: course
       end
 
       it "can view the grade if it's been graded and a release is not necessary" do
         allow(assignment).to receive(:release_necessary?).and_return false
-        expect(subject).to be_viewable user, course
+        expect(subject).to be_viewable user: user, course: course
       end
 
       it "cannot view the grade if it's been graded and a release is necessary" do
-        expect(subject).to_not be_viewable user, course
+        expect(subject).to_not be_viewable user: user, course: course
       end
     end
 
@@ -46,12 +46,12 @@ describe GradeProctor::Viewable do
       let(:staff) { double(:user, id: 456, is_staff?: true) }
 
       it "can view the grade if they are the instructor for the course" do
-        expect(subject).to be_viewable staff, course
+        expect(subject).to be_viewable user: staff, course: course
       end
 
       it "cannot view the grade if they are not the instructor for the course" do
         allow(staff).to receive(:is_staff?).with(course).and_return false
-        expect(subject).to_not be_viewable staff, course
+        expect(subject).to_not be_viewable user: staff, course: course
       end
     end
   end

--- a/spec/models/abilities/grade_ability_spec.rb
+++ b/spec/models/abilities/grade_ability_spec.rb
@@ -11,21 +11,21 @@ describe Ability do
   context "for a Grade" do
     it "can read a grade if the GradeProctor says it can" do
       allow_any_instance_of(GradeProctor).to  \
-        receive(:viewable?).with(student, course).and_return true
+        receive(:viewable?).with(user: student, course: course).and_return true
 
       expect(subject).to be_able_to(:read, Grade.new)
     end
 
     it "can't read a grade if the GradeProctor says it can't" do
       allow_any_instance_of(GradeProctor).to  \
-        receive(:viewable?).with(student, course).and_return false
+        receive(:viewable?).with(user: student, course: course).and_return false
 
       expect(subject).to_not be_able_to(:read, Grade.new)
     end
 
     it "can update a grade if the GradeProctor says it can" do
       allow_any_instance_of(GradeProctor).to  \
-        receive(:updatable?).with(student, course).and_return true
+        receive(:updatable?).with(user: student, course: course).and_return true
 
       expect(subject).to be_able_to(:update, Grade.new)
     end

--- a/spec/services/creates_criterion_grade/builds_earned_level_badges_spec.rb
+++ b/spec/services/creates_criterion_grade/builds_earned_level_badges_spec.rb
@@ -42,6 +42,7 @@ describe Services::Actions::BuildsEarnedLevelBadges do
   it "promises the built earned level badges" do
     result = described_class.execute context
     expect(result).to have_key :earned_level_badges
+    expect(result[:earned_level_badges].first.student_visible).to be_truthy
   end
 
   it "builds an earned badge for each record in the params" do
@@ -50,10 +51,14 @@ describe Services::Actions::BuildsEarnedLevelBadges do
       eq(raw_params["level_badges"].length)
   end
 
+  it "transfers the student visible state to the EarnedBadge" do
+    result = described_class.execute context
+  end
+
   # See note above #destroy_exisiting_earned_badges
   # This should not be the expected behavior
   it "clears out old badges" do
-    EarnedBadge.create(badge_id: badge_id, student_id: world.student.id, level_id: level_id)
+    EarnedBadge.create(badge_id: badge_id, student_id: world.student.id, assignment_id: world.assignment.id)
     expect { described_class.execute context }.to change { EarnedBadge.count }.by(-1)
   end
 end

--- a/spec/views/api/badges/index_spec.rb
+++ b/spec/views/api/badges/index_spec.rb
@@ -12,6 +12,7 @@ describe "api/badges/index" do
 
   before(:each) do
     allow(view).to receive(:current_course).and_return(@world.course)
+    allow(view).to receive(:current_user).and_return(double(:user, is_staff?: false, id: 555))
   end
 
   it "responds with an array of badges" do
@@ -20,11 +21,19 @@ describe "api/badges/index" do
     expect(json["data"].length).to eq(1)
   end
 
-  it "does not include badges invisible to students" do
-    allow(@badge).to receive(:visible_for_student?).and_return(false)
+  it "does not include invisible badges for students" do
+    allow(@badge).to receive(:visible?).and_return(false)
     render
     json = JSON.parse(response.body)
     expect(json["data"].length).to eq(0)
+  end
+
+  it "does include invisible badges for staff" do
+    allow(@badge).to receive(:visible?).and_return(false)
+    allow(view).to receive(:current_user).and_return(double(:gsi, is_staff?: true))
+    render
+    json = JSON.parse(response.body)
+    expect(json["data"].length).to eq(1)
   end
 
   it "adds the icon url to the badges" do


### PR DESCRIPTION
### BadgeProctor

This PR introduces a BadgeProctor. The badgeProctor takes the `viewable?` functionality of the GradeProctor and adapts it to viewing badges. It does not currently implement the `updatable?` functionality, pending discussion of CanCan and how we want to go about implementing permissions app wide.

It is implemented in this PR to determine the permissions for the new `Invisible Level Badges`. The existing places where the app could use the BadgeProctor to determine viewable permissions are not standardized and have some possible additional requirements, so I have left them for another PR.

One difference from the `GradeProctor` is that the `course` is handled from options params rather than as an optional variable

```
BadgeProctor.new(badge).viewable? some_user, course: some_course
GradeProctor.new(grade).viewable? some_user, some_course
```

I made this change since there is currently no place in the app where we need to determine if the badge is from a particular course, but there are additional factors relevant to the badge.  For instance, I am also currently handling `level` in options:

```
BadgeProctor.new(badge).viewable? some_user

BadgeProctor.new(badge).viewable? some_user, level: some_level
```

This probably warrants a discussion on how to better standardize the calls across Proctors, and I am open to other suggestions here for the BadgeProctor.

### Invisible Level Badges

Currently invisible badges were filtered out from the rubric design page. This PR allows invisible badges to be attached to Rubric Levels similar to the current visible level badges
  * Allows faculty to attach invisible badges to rubric levels
  * Allows faculty to view any invisible badges on a rubric
  * Allow students to see invisible badges they earned through a rubric
  * Prevents students from seeing earned invisible badges on other unearned levels
  * Normal behavior of earned invisible badges for students on the `my_badges` page

### Complete redo of sample badges
   * Ability to define and expand custom sample badge attributes
   * Sample Badges recreated based on available badge features
   * Awards sample badges consistently across students and only if set to be awarded
   * Awards sample badges multiple times only if this is possible for the badge
   * Adds a visible level badge to the top level of every rubric criteria
   * Adds an invisible level badge to the 2nd top level of every rubric criteria

### bugfixes
  * fixed spelling error preventing earning level badges
  * fixed method that is responsible for deleting all previous level badges for a rubric when grading

---
  closes 1832

  closes 1447