### PR TITLE
default to zero for adjustment points

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -198,7 +198,7 @@
       raw_score: $scope.pointsAllocated(),
       feedback: $scope.grade.feedback,
       status:   $scope.grade.status,
-      adjustment_points: $scope.grade.adjustment_points,
+      adjustment_points: $scope.grade.adjustment_points || 0,
       adjustment_points_feedback: $scope.grade.adjustment_points_feedback
     }
 


### PR DESCRIPTION
This fixes a bug where deleting all digits from the adjustment field would render a server error when trying to parse the adjusted points, effectively disabling the submit button. This is the most simple solution I could find without adding more magical behavior to SmartNumber, and hopefully will be transparent to the user.

closes 1798