### PR TITLE
removed iframe, added panel for students with link to canvas and ctools

### DIFF
--- a/app/assets/stylesheets/_signup.sass
+++ b/app/assets/stylesheets/_signup.sass
@@ -1,14 +1,31 @@
 @import color
+@import layout
 
 section.pilot
-  position: relative
-  padding: 3rem 2rem
-  background-color: $color-blue-3
-  opacity: .8
-  margin: 0 auto
+  margin-top: 45px
+  background-color: rgba($color-blue-3, .5)
   color: $color-white
-  width: 100%
+  padding: 4em 2em
 
-  h1
-    font-size: 2rem
-    font-weight: normal !important
+  h1, p
+    color: $color-grey-2
+    text-align: center
+  
+  .instructor-pilot, .student-pilot
+    max-width: 500px
+    margin: 2em auto
+  
+    .pilot-text
+      background-color: $color-white
+      padding: 2em
+  
+.instructor-pilot
+  border-left: 10px solid $color-green-2
+
+.student-pilot
+  border-left: 10px solid $color-blue-3
+  
+@media (max-width: $media-small-max)
+  section.pilot
+    padding: .5em 1em
+

--- a/app/views/pages/um_pilot.haml
+++ b/app/views/pages/um_pilot.haml
@@ -1,5 +1,16 @@
 %section.pilot
-  %h1.bold Are you an instructor at UM interested in using GradeCraft? 
-  %p Tell us a little bit about your course and we'll be in touch shortly to get you set up.
-
-  <iframe src="https://docs.google.com/a/umich.edu/forms/d/1AzqyS-vDUxvyohO_5mYOYRYqvJkA9_o74_ZPokRVwew/viewform?embedded=true" width="730" height="900" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+  .instructor-pilot
+    .pilot-text
+      %h1.bold Are you an instructor at UM interested in using GradeCraft? 
+      %p 
+        %a{ :href => 'https://docs.google.com/a/umich.edu/forms/d/1AzqyS-vDUxvyohO_5mYOYRYqvJkA9_o74_ZPokRVwew/viewform?embedded=true', :title => "" } Tell us a little bit about your course
+        and we'll be in touch shortly to get you set up.
+  .student-pilot
+    .pilot-text
+      %h1.bold Are you a student in a GradeCraft course? 
+      %p 
+        Please try logging in via 
+        %a{ :href => 'https://umich.instructure.com/', :title => ""} Canvas 
+        or 
+        %a{ :href => 'https://ctools.umich.edu/', :title => ""} CTools 
+        or reach out to your instructor. 


### PR DESCRIPTION
This PR attempts to reduce the amount of students filling out the UM instructor interest form by presenting them with a prompt to try logging in via Canvas or CTools. 

Stick footer will need to be implemented site-wide to prevent background from showing below footer on pages with minimal content. 

![screen shot 2016-04-05 at 7 52 17 pm](https://cloud.githubusercontent.com/assets/12573921/14301730/2ffab796-fb68-11e5-9202-a47412ffe223.png)

Closes issue #1673