### PR TITLE
removed overriding style from link in .tab-container

### DIFF
--- a/app/assets/stylesheets/_tabs.sass
+++ b/app/assets/stylesheets/_tabs.sass
@@ -5,7 +5,7 @@
   padding: 1rem
 
   a
-    color: $color-blue-3 !important
+    color: $color-blue-3
 
 .tabs-content
   border: none


### PR DESCRIPTION
!important on .tab-container link styling overriding .button styles.

Closes issue #1855 