### PR TITLE
1819 context menu hides buttons on small screen

### DIFF
--- a/app/assets/stylesheets/_context_menu.sass
+++ b/app/assets/stylesheets/_context_menu.sass
@@ -15,6 +15,8 @@
       list-style-type: none
       margin-right: -4px
       text-transform: capitalize
+      padding: .5rem .4rem
+      font-size: .7rem
       display: inline-block
       border-right: 1px solid darken($color-blue-3, 20%)
       color: $color-blue-4
@@ -28,8 +30,6 @@
       & a
         color: $color-white
         display: block
-        padding: .5rem .4rem
-        font-size: .7rem
 
 @media (max-width: 1200px)
   .context_menu ul li a

--- a/app/assets/stylesheets/_context_menu.sass
+++ b/app/assets/stylesheets/_context_menu.sass
@@ -16,11 +16,11 @@
       margin-right: -4px
       text-transform: capitalize
       display: inline-block
-      border-left: 1px solid darken($color-blue-3, 20%)
+      border-right: 1px solid darken($color-blue-3, 20%)
       color: $color-blue-4
       border-radius: 0 !important
-      &:last-child
-        border-right: 1px solid darken($color-blue-3, 20%)
+      &:first-child
+        border-left: 1px solid darken($color-blue-3, 20%)
 
       &:hover
         background-color: $color-blue-1
@@ -36,3 +36,11 @@
     font-size: .6rem
     padding: .5rem .35rem
 
+@media (max-width: $media-small-max)
+  .context_menu ul 
+    margin: 0
+    li:first-child
+      border-left: none
+    .hide-for-small
+      display: none
+    

--- a/app/assets/stylesheets/_context_menu.sass
+++ b/app/assets/stylesheets/_context_menu.sass
@@ -1,8 +1,8 @@
 @import color
+@import layout
 
 .context_menu
   background-color: $color-blue-3
-  height: 2rem
   margin: 0
   width: 100%
   opacity: .8
@@ -10,27 +10,29 @@
   ul
     padding: 0
     margin: 0 0 0 1rem
-    position: relative
     
     li
       list-style-type: none
-      margin: 0
-      line-height: 2rem
+      margin-right: -4px
       text-transform: capitalize
-      display: block
-      padding: 0rem .5rem
-      font-size: .8rem
-      float: left
+      display: inline-block
       border-left: 1px solid darken($color-blue-3, 20%)
       color: $color-blue-4
       border-radius: 0 !important
-      border-collapse: collapse
+      &:last-child
+        border-right: 1px solid darken($color-blue-3, 20%)
 
       &:hover
         background-color: $color-blue-1
 
-      & > a
+      & a
         color: $color-white
-
-      & a:hover
         display: block
+        padding: .5rem .4rem
+        font-size: .7rem
+
+@media (max-width: 1200px)
+  .context_menu ul li a
+    font-size: .6rem
+    padding: .5rem .35rem
+

--- a/app/assets/stylesheets/_context_menu.sass
+++ b/app/assets/stylesheets/_context_menu.sass
@@ -32,7 +32,7 @@
         display: block
 
 @media (max-width: 1200px)
-  .context_menu ul li a
+  .context_menu ul li
     font-size: .6rem
     padding: .5rem .35rem
 

--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -5,7 +5,7 @@ $global-radius: $px-3
 // Media Query Sizes
 $media-xsmall-max:  20rem
 $media-small-max:   50rem // 640px
-$media-medium-max:  63rem // 1024px
+$media-medium-max:  64rem // 1024px
 $media-large-max:   90rem // 1440px
 $media-xlarge-max:  120rems
 

--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -4,7 +4,7 @@ $global-radius: $px-3
 
 // Media Query Sizes
 $media-xsmall-max:  20rem
-$media-small-max:   50rem // 640px
+$media-small-max:   40rem // 640px
 $media-medium-max:  64rem // 1024px
 $media-large-max:   90rem // 1440px
 $media-xlarge-max:  120rems

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -17,17 +17,17 @@
       - if presenter.team
         %li= link_to glyph("file-zip-o") + "Download Team Submissions", submissions_exports_path(assignment_id: presenter.assignment.id, team_id: presenter.team.id), method: :post
       - else
-        %li= link_to glyph("file-zip-o") + "Download All Submissions", submissions_exports_path(assignment_id: presenter.assignment.id), method: :post
+        %li.hide-for-small= link_to glyph("file-zip-o") + "Download All Submissions", submissions_exports_path(assignment_id: presenter.assignment.id), method: :post
 
-      %li
+      %li.hide-for-small
         %a{:href => import_grades_assignment_path(presenter.assignment) }
           = glyph(:upload)
           Import Grades
-      %li
+      %li.hide-for-small
         %a{:href => export_grades_assignment_path(presenter.assignment, format: "csv") }
           = glyph(:download)
           Download Grades
-      %li
+      %li.hide-for-small
         %a{:href => design_assignment_rubric_path(presenter.assignment) }
           = glyph(:sliders)
           - if presenter.rubric_designed?

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -34,7 +34,6 @@
             Edit Rubric
           - else
             Create Rubric
-      %li
 
       - if presenter.rubric_designed?
         - if presenter.has_reviewable_grades?


### PR DESCRIPTION
This PR is a first pass through improving the responsiveness of the context-menu ribbon (specifically on the instructor-side assignments page). Currently, menu items stack below the ribbon and are unable to be seen unless you hover when the menu width is larger than 1280px (or screen size is less than this). 

Styling changes make the ribbon more able to accommodate changes in browser window size as well as many menu items without stacking, and results in another row of buttons when many menu items are present (when rubrics, teams, etc are being used). On mobile, I am currently hiding "download all submissions," "import grades," "export grades" and "create/edit rubric" -- intent is to add dropdown menu to show these options later, but we can decide to show one or all in the time before this is implemented.

Other changes in this PR include two updated to rem values for small and medium query sizes as pixel values listed did not match rem values. 

<img width="1278" alt="current-version" src="https://cloud.githubusercontent.com/assets/12573921/14324191/df9cd056-fbf1-11e5-958b-4468a26b2860.png">

<img width="1279" alt="revised-version" src="https://cloud.githubusercontent.com/assets/12573921/14324200/e849dfdc-fbf1-11e5-8a8c-0908a0ef01dd.png">

<img width="409" alt="revised-mobile" src="https://cloud.githubusercontent.com/assets/12573921/14324252/0d04ddea-fbf2-11e5-81cc-d9557ffa79dc.png">


This closes issue #1819