### PR TITLE
1746 merge history transaction

### DIFF
--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -46,16 +46,17 @@ class HistoryFilter
       (to_versions << history.select { |h| h.version.item_type == to }).flatten!
     end
 
-    from_versions.each do |history_item|
-      history_item.changeset.each_pair do |key, value|
+    from_versions.each do |from_history_item|
+      from_history_item.changeset.each_pair do |key, value|
         if !["created_at", "updated_at"].include?(key) && value.is_a?(Array)
-          to_version = to_versions.find do |version|
-            version.transaction_id == history_item.transaction_id
+          to_version = to_versions.find do |to_history_item|
+            to_history_item.version.transaction_id ==
+              from_history_item.version.transaction_id
           end
           to_version.changeset.merge!({ "#{key}" => value }) if to_version
         end
       end
-      exclude("object" => history_item.changeset["object"])
+      exclude("object" => from_history_item.changeset["object"])
     end
 
     self

--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -46,12 +46,13 @@ class HistoryFilter
       (to_versions << history.select { |h| h.version.item_type == to }).flatten!
     end
 
-    from_versions.each_with_index do |history_item, index|
+    from_versions.each do |history_item|
       history_item.changeset.each_pair do |key, value|
-        if !["created_at", "updated_at"].include?(key) &&
-            value.is_a?(Array) &&
-            to_versions.size > index
-          to_versions[index].changeset.merge!({ "#{key}" => value })
+        if !["created_at", "updated_at"].include?(key) && value.is_a?(Array)
+          to_version = to_versions.find do |version|
+            version.transaction_id == history_item.transaction_id
+          end
+          to_version.changeset.merge!({ "#{key}" => value }) if to_version
         end
       end
       exclude("object" => history_item.changeset["object"])

--- a/app/presenters/submission_grade_history.rb
+++ b/app/presenters/submission_grade_history.rb
@@ -2,6 +2,7 @@ module SubmissionGradeHistory
   def submission_grade_filtered_history(submission, grade, only_student_visible_grades=true)
     HistoryFilter.new(submission.historical_collection_merge(submission.submission_files)
       .historical_merge(grade).history)
+      .merge("SubmissionFile" => "Submission")
       .remove("name" => "admin_notes")
       .remove("name" => "feedback_read")
       .remove("name" => "feedback_read_at")
@@ -20,7 +21,6 @@ module SubmissionGradeHistory
       .remove("name" => "file")
       .remove("name" => "store_dir")
       .remove("name" => "id")
-      .merge("SubmissionFile" => "Submission")
       .transform { |history|
         if history.version.item_type == "SubmissionFile"
           history.changeset["event"] = "upload"

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -83,13 +83,15 @@ describe HistoryFilter do
 
   describe "#merge" do
     it "merges the changeset from one object to another" do
-      history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
-                                transaction_id: 123,
+      history = [OpenStruct.new(version: OpenStruct.new(
+                                          item_type: "FromObjectType",
+                                          transaction_id: 123),
                                 changeset: { "event" => "create",
                                              "object" => "FromObject",
                                              "attribute1" => [nil, "blah"]}),
-                 OpenStruct.new(version: OpenStruct.new(item_type: "ToObjectType"),
-                                transaction_id: 123,
+                 OpenStruct.new(version: OpenStruct.new(
+                                          item_type: "ToObjectType",
+                                          transaction_id: 123),
                                 changeset: { "event" => "create",
                                              "object" => "ToObject",
                                              "attribute2" => [nil, "http://example.org"]})
@@ -103,8 +105,9 @@ describe HistoryFilter do
     end
 
     it "does not merge if the destination does not exist" do
-      history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
-                                transaction_id: 123,
+      history = [OpenStruct.new(version: OpenStruct.new(
+                                          item_type: "FromObjectType",
+                                          transaction_id: 123),
                                 changeset: { "event" => "create",
                                              "object" => "FromObject",
                                              "attribute1" => [nil, "blah"]})
@@ -115,11 +118,13 @@ describe HistoryFilter do
     end
 
     it "does not merge if the transaction ids do not match" do
-      history = [OpenStruct.new(version: OpenStruct.new(item_type: "From"),
-                                transaction_id: 123,
+      history = [OpenStruct.new(version: OpenStruct.new(
+                                            item_type: "From",
+                                            transaction_id: 123),
                                 changeset: {}),
-                 OpenStruct.new(version: OpenStruct.new(item_type: "To"),
-                                transaction_id: 456,
+                 OpenStruct.new(version: OpenStruct.new(
+                                          item_type: "To",
+                                          transaction_id: 456),
                                 changeset: {})
       ]
       result = described_class.new(history).merge("From" => "To").changesets

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -84,10 +84,12 @@ describe HistoryFilter do
   describe "#merge" do
     it "merges the changeset from one object to another" do
       history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
+                                transaction_id: 123,
                                 changeset: { "event" => "create",
                                              "object" => "FromObject",
                                              "attribute1" => [nil, "blah"]}),
                  OpenStruct.new(version: OpenStruct.new(item_type: "ToObjectType"),
+                                transaction_id: 123,
                                 changeset: { "event" => "create",
                                              "object" => "ToObject",
                                              "attribute2" => [nil, "http://example.org"]})
@@ -102,12 +104,25 @@ describe HistoryFilter do
 
     it "does not merge if the destination does not exist" do
       history = [OpenStruct.new(version: OpenStruct.new(item_type: "FromObjectType"),
+                                transaction_id: 123,
                                 changeset: { "event" => "create",
                                              "object" => "FromObject",
                                              "attribute1" => [nil, "blah"]})
       ]
       result = described_class.new(history).merge("FromObjectType" => "ToObjectType")
         .changesets
+      expect(result).to be_empty
+    end
+
+    it "does not merge if the transaction ids do not match" do
+      history = [OpenStruct.new(version: OpenStruct.new(item_type: "From"),
+                                transaction_id: 123,
+                                changeset: {}),
+                 OpenStruct.new(version: OpenStruct.new(item_type: "To"),
+                                transaction_id: 456,
+                                changeset: {})
+      ]
+      result = described_class.new(history).merge("From" => "To").changesets
       expect(result).to be_empty
     end
   end


### PR DESCRIPTION
Merges history via the `transaction_id` instead of the index as was before and could result in missing data.

Closes #1746