### PR TITLE
check threshold for nil values

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -58,6 +58,8 @@ class Assignment < ActiveRecord::Base
   # Strip points from pass/fail assignments
   before_save :zero_points_for_pass_fail
 
+  before_save :reset_default_for_nil_values
+
   # Check to make sure the assignment has a name before saving
   validates :course_id, presence: true
   validates_presence_of :name
@@ -366,5 +368,10 @@ class Assignment < ActiveRecord::Base
 
   def zero_points_for_pass_fail
     self.point_total = 0 if self.pass_fail?
+    self.threshold_points = 0 if self.pass_fail?
+  end
+
+  def reset_default_for_nil_values
+    self.threshold_points = 0 if self.threshold_points.nil?
   end
 end

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -120,7 +120,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
   end
 
   def has_threshold?
-    assignment.threshold_points > 0
+    assignment.threshold_points && assignment.threshold_points > 0
   end
 
   def closed_without_sumbission?

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -27,9 +27,16 @@
           = f.text_field :point_total
 
     .form-item
-      = f.label :threshold_points, "Points Threshold"
-      = f.text_field :threshold_points
-      .form_label If you set a points threshold, any student earning fewer points will receive no points for the assignment.
+      - if f.object.pass_fail?
+        .pass-fail-contingent.hidden
+          = f.label :threshold_points, "Points Threshold"
+          = f.text_field :threshold_points
+          .form_label If you set a points threshold above zero, any student earning fewer points will receive no points for the assignment.
+      - else
+        .pass-fail-contingent
+          = f.label :threshold_points, "Points Threshold"
+          = f.text_field :threshold_points
+          .form_label If you set a points threshold above zero, any student earning fewer points will receive no points for the assignment.
 
     .form-item
       = f.input :open_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -161,9 +161,11 @@ describe Assignment do
   describe "pass-fail assignments" do
     it "sets point total to zero on save" do
       subject.point_total = 3000
+      subject.threshold_points = 2000
       subject.pass_fail = true
       subject.save
       expect(subject.point_total).to eq(0)
+      expect(subject.threshold_points).to eq(0)
     end
   end
 


### PR DESCRIPTION
This PR addresses the [error reported in Rollbar](https://rollbar.com/gradecraft/gradecraft-development/items/1515/) where `threshold_points` were `nil`.

### The Problem

`threshold_points` defaults to 0, however there is not a nil constraint on the field, and deleting the zero on the assignment edit form will update the field to nil.  This was most likely compounded by the wording on the form field "If you set the threshold points ..." which would have probably prompted users to actively delete the zero points from the field.

### The Solution

  1. In the serializer, we now check for threshold points to avoid errors on assignments where this is currently nil
  2. In the Assignment model, I have added a before_save hook to reset nil threshold_points to 0. I named this method `reset_default_for_nil_values` so we can expand this method to reset any other nil values on assignments before save
 3. In the view, I have changed the wording to `If you set a points threshold above zero...` to indicate to the that zero is an acceptable default value.

### Additional Enhancements

I have wrapped the `threshold_points` in the form within a conditional that will only display if the assignment is not pass_fail.  It will now behave the same as the "Total Possible Points" field. I have also added it to the `zero_points_for_pass_fail` before save hook to assure it will be zero for all Pass/Fail assignments.
