### PR TITLE
View fixes when released grade has no score

### DIFF
--- a/app/views/grades/components/_score.haml
+++ b/app/views/grades/components/_score.haml
@@ -1,20 +1,16 @@
 -# Requires: grade, assignment, assignment_type
-- if assignment_type.student_weightable?
-  -# Checking to see if this student has weighted this assignment anything other than 1
-  - if (grade.student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || grade.student.weight_for_assignment_type(assignment_type) > 1
-    - if GradeProctor.new(grade).viewable?
+- if GradeProctor.new(grade).viewable? && grade.final_points
+  - if assignment_type.student_weightable?
+    -# Checking to see if this student has weighted this assignment anything other than 1
+    - if (grade.student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_assignment_weight != 1) || grade.student.weight_for_assignment_type(assignment_type) > 1
       = "#{points grade.final_points} / #{ points assignment.point_total } points (Raw)"
       .bold= "#{ points grade.score } / #{points grade.point_total} points (Multiplied)"
     - else
-      .italic= "#{points grade.point_total} points possible"
-  - else
-    - if GradeProctor.new(grade).viewable?
       .bold= "#{points grade.final_points} / #{ points grade.point_total } points"
-    - else
-      .italic= "#{points assignment.point_total} points possible"
-- else
-  - if GradeProctor.new(grade).viewable?
+  - else
     .bold
       = "#{points grade.final_points} / #{points grade.point_total} points earned"
-  - else
-    .italic= "#{points assignment.point_total} points possible"
+- else
+  .italic= "#{points assignment.point_total} points possible"
+
+

--- a/app/views/grades/components/_threshold.haml
+++ b/app/views/grades/components/_threshold.haml
@@ -1,8 +1,10 @@
 %p
-  - if grade.raw_score < grade.assignment.threshold_points
+  - if !grade.raw_score.present?
+    = "The threshold for this #{ term_for("assignment") } is #{grade.assignment.threshold_points} points"
+  - elsif grade.raw_score < grade.assignment.threshold_points
     %span Your raw score was
     %span.bold= " #{ points grade.raw_score } "
-    %span but the threshold for this assigment is
+    %span= "but the threshold for this #{ term_for("assignment") } is"
     %span.bold= " #{ points grade.assignment.threshold_points }"
 
 


### PR DESCRIPTION
This patch fixes the grade `score` and `threshold` components for a released grade without a score. For the threshold we verify that there is a `raw_score`, and show just the threshold points if none. For the score, we show "X points possible" whenever there is no `final_score` or the grade is not viewable.
#### Before:
![screen shot 2016-04-11 at 12 09 18 pm](https://cloud.githubusercontent.com/assets/1138350/14433906/44e820e2-ffde-11e5-9459-c97947cb3905.png)

#### After:
![screen shot 2016-04-11 at 12 04 37 pm](https://cloud.githubusercontent.com/assets/1138350/14433768/a3996e58-ffdd-11e5-9ba4-20039f19cd8d.png)