### PR TITLE
Refactor/1902 grade with rubric

### DIFF
--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -61,7 +61,7 @@
           tooltip: scope.description()
           icon: "fa-info-circle"
         }
-        has_rubric: {
+        is_rubric_graded: {
           tooltip: 'This ' + scope.targetTerm() + ' is rubric graded'
           icon: "fa-th"
         }

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -18,7 +18,7 @@
     }
     badges = []
     challenges = []
-    icons = ["has_info", "is_required", "has_rubric", "accepting_submissions", "has_submission", "has_threshold", "is_late", "closed_without_submission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
+    icons = ["has_info", "is_required", "is_rubric_graded", "accepting_submissions", "has_submission", "has_threshold", "is_late", "closed_without_submission", "is_locked", "has_been_unlocked", "is_a_condition", "is_earned_by_group"]
     unusedWeights = null
 
     getGradeLevels = ()->

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -100,10 +100,6 @@ class Assignment < ActiveRecord::Base
     super.presence || 0
   end
 
-  def has_rubric?
-    !!rubric
-  end
-
   def grade_with_rubric?
     use_rubric && rubric.present? && rubric.designed?
   end

--- a/app/presenters/assignment_presenter.rb
+++ b/app/presenters/assignment_presenter.rb
@@ -107,8 +107,13 @@ class AssignmentPresenter < Showtime::Presenter
     assignment.fetch_or_create_rubric
   end
 
-  def rubric_designed?
-    !assignment.rubric.nil? && assignment.rubric.designed?
+  def grade_with_rubric?
+    assignment.grade_with_rubric?
+  end
+
+  # show the rubric preview tab on student's view
+  def show_rubric_preview?(user)
+    grade_with_rubric? && !grades_available_for?(user) && ( !user || assignment.description_visible_for_student?(user) )
   end
 
   def criterion_grades(user_id)
@@ -123,10 +128,6 @@ class AssignmentPresenter < Showtime::Presenter
 
   def rubric_level_earned?(user_id, level_id)
     criterion_grades(user_id).any? { |criterion_grade| criterion_grade.level_id == level_id }
-  end
-
-  def use_rubric?
-    assignment.use_rubric?
   end
 
   def scores

--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -76,7 +76,7 @@ class PredictedAssignmentSerializer < SimpleDelegator
       closed_without_submission: closed_without_sumbission?,
       has_been_unlocked: has_been_unlocked?,
       has_info: has_info?,
-      has_rubric: has_rubric?,
+      is_rubric_graded: is_rubric_graded?,
       has_submission: has_submission?,
       has_threshold: has_threshold?,
       is_a_condition: is_a_condition?,
@@ -95,8 +95,8 @@ class PredictedAssignmentSerializer < SimpleDelegator
     !assignment.description.blank?
   end
 
-  def has_rubric?
-    !!assignment.has_rubric?
+  def is_rubric_graded?
+    assignment.grade_with_rubric?
   end
 
   def is_earned_by_group?

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -30,12 +30,12 @@
       %li.hide-for-small
         %a{:href => design_assignment_rubric_path(presenter.assignment) }
           = glyph(:sliders)
-          - if presenter.rubric_designed?
+          - if presenter.grade_with_rubric?
             Edit Rubric
           - else
             Create Rubric
 
-      - if presenter.rubric_designed?
+      - if presenter.grade_with_rubric?
         - if presenter.has_reviewable_grades?
           %li
             %a{:href => criterion_grades_review_assignment_path(presenter.assignment) }

--- a/app/views/assignments/_show_instructor.haml
+++ b/app/views/assignments/_show_instructor.haml
@@ -14,7 +14,7 @@
         %a{ "href" => "#tab"} Grades
       %li
         %a{ "href" => "#tabt2"} Description & Downloads
-      - if presenter.rubric_designed?
+      - if presenter.grade_with_rubric?
         %li
           %a{ "href" => "#tabt3"} Grading Rubric
       - if presenter.has_grades?
@@ -30,7 +30,7 @@
       .ui-tabs-panel#tabt2{role: "tabpanel", "aria-hidden" => false }
         = render partial: "assignments/description_and_downloads", locals: { presenter: presenter }
 
-      - if presenter.rubric_designed?
+      - if presenter.grade_with_rubric?
         .content#tabt3{role: "tabpanel", "aria-hidden" => false }
           %br
           = render partial: "assignments/rubric_preview", locals: { presenter: presenter }

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -8,17 +8,17 @@
   #tabs.ui-tabs.ui-widget
     %ul.ui-tabs-nav{role: "tablist"}
       %li
-        %a{ "href" => "#tab1"} Description & Downloads
-      - if presenter.rubric_designed? && !presenter.grades_available_for?(current_student) && ( !current_student || presenter.assignment.description_visible_for_student?(current_student) )
+        %a{ "href" => "#tab1"} Description &amp; Downloads
+      - if presenter.show_rubric_preview? current_student
         %li
           %a{ "href" => "#tab2"} Grading Rubric
-      - if presenter.has_submission_for?(current_student)
+      - if presenter.has_submission_for? current_student
         %li
           %a{ :href => "#tab3"} My Submission
         %li
           %a{ href: "#history" } My Submission History
 
-      - if presenter.grades_available_for?(current_student)
+      - if presenter.grades_available_for? current_student
         %li
           %a{ :href => "#tab4"} My Grade
         - if !presenter.hide_analytics?
@@ -27,23 +27,23 @@
 
     #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
       #tab1.active
-        = render partial: "assignments/description_and_downloads", locals: { presenter: presenter }
-      - if presenter.rubric_designed? && !presenter.grades_available_for?(current_student) && ( !current_student || presenter.assignment.description_visible_for_student?(current_student) )
+        = render "assignments/description_and_downloads", presenter: presenter
+      - if presenter.show_rubric_preview? current_student
         #tab2
-          = render partial: "assignments/rubric_preview", locals: { presenter: presenter }
-      - if presenter.has_submission_for?(current_student)
+          = render "assignments/rubric_preview", presenter: presenter
+      - if presenter.has_submission_for? current_student
         #tab3
-          = render partial: "submissions/submission_content",
-              locals: { presenter: ShowSubmissionPresenter.new(id: presenter.submission_for_assignment(current_student).id,
-                assignment_id: presenter.assignment.id, course: current_course) }
+          = render "submissions/submission_content",
+              presenter: ShowSubmissionPresenter.new(id: presenter.submission_for_assignment(current_student).id,
+              assignment_id: presenter.assignment.id, course: current_course)
         #history
           = history_timeline presenter.submission_grade_history(current_student)
-      - if presenter.grades_available_for?(current_student)
+      - if presenter.grades_available_for? current_student
         #tab4
-          = render partial: "grades/grade_content", locals: { presenter: presenter }
+          = render "grades/grade_content", presenter: presenter
         - if !presenter.hide_analytics?
           #tab5
             - if presenter.assignment.has_groups?
-              = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
+              = render "grades/analytics/group_analytics", presenter: presenter
             - else
-              = render partial: "grades/analytics/individual_analytics", locals: { presenter: presenter }
+              = render "grades/analytics/individual_analytics", presenter: presenter

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -27,23 +27,23 @@
 
     #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
       #tab1.active
-        = render "assignments/description_and_downloads", presenter: presenter
+        = render partial: "assignments/description_and_downloads", locals: { presenter: presenter }
       - if presenter.show_rubric_preview? current_student
         #tab2
-          = render "assignments/rubric_preview", presenter: presenter
+          = render partial: "assignments/rubric_preview", locals: { presenter: presenter }
       - if presenter.has_submission_for? current_student
         #tab3
-          = render "submissions/submission_content",
-              presenter: ShowSubmissionPresenter.new(id: presenter.submission_for_assignment(current_student).id,
-              assignment_id: presenter.assignment.id, course: current_course)
+          = render partial: "submissions/submission_content",
+              locals: { presenter: ShowSubmissionPresenter.new(id: presenter.submission_for_assignment(current_student).id,
+                assignment_id: presenter.assignment.id, course: current_course) }
         #history
           = history_timeline presenter.submission_grade_history(current_student)
       - if presenter.grades_available_for? current_student
         #tab4
-          = render "grades/grade_content", presenter: presenter
+          = render partial: "grades/grade_content", locals: { presenter: presenter }
         - if !presenter.hide_analytics?
           #tab5
             - if presenter.assignment.has_groups?
-              = render "grades/analytics/group_analytics", presenter: presenter
+              = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
             - else
-              = render "grades/analytics/individual_analytics", presenter: presenter
+              = render partial: "grades/analytics/individual_analytics", locals: { presenter: presenter }

--- a/app/views/assignments/criterion_grades_review.html.haml
+++ b/app/views/assignments/criterion_grades_review.html.haml
@@ -14,7 +14,7 @@
           Select #{term_for :team}
         = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  - if presenter.rubric_designed?
+  - if presenter.grade_with_rubric?
     - presenter.students_being_graded.each do |student|
       - grade_for_assignment = student.grade_for_assignment(presenter.assignment)
       - if grade_for_assignment.present? && grade_for_assignment.instructor_modified?

--- a/app/views/assignments/index.html.haml
+++ b/app/views/assignments/index.html.haml
@@ -51,11 +51,11 @@
                     %td.foobers= "#{term_for :pass}/#{term_for :fail}"
                   - else
                     %td.doobers= points assignment.point_total
-                  %td= "Yes" if assignment.rubric and assignment.rubric.designed?
+                  %td= "Yes" if assignment.grade_with_rubric?
                   %td
                     .right
                       %ul.button-bar
-                        - if ! ( assignment.rubric and assignment.rubric.designed? and assignment.use_rubric? )
+                        - if ! assignment.grade_with_rubric?
                           %li= link_to glyph(:check) + "Quick Grade", mass_grade_assignment_path(assignment), class: "button"
                         %li= link_to glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
                         %li= link_to glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy

--- a/app/views/grades/_grade_content.haml
+++ b/app/views/grades/_grade_content.haml
@@ -22,6 +22,6 @@
 
   = render "grades/components/badges", grade: grade if grade.earned_badges.present?
 
-  .rubric-container= render "grades/components/criterion_grade_results", presenter: presenter if presenter.rubric_designed?
+  .rubric-container= render "grades/components/criterion_grade_results", presenter: presenter if presenter.grade_with_rubric?
 
   = render partial: "grades/components/request_feedback", locals: { grade: grade, assignment: presenter.assignment } if current_user_is_student?

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -15,7 +15,7 @@
           locals: { presenter: ShowSubmissionPresenter.new(id: @submission.id,
             assignment_id: @assignment.id, course: current_course) }
 
-  - if @rubric && @rubric.designed? and @assignment.use_rubric
+  - if @assignment.grade_with_rubric?
     = render "rubric_edit"
   - else
     = render "standard_edit"

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -598,13 +598,6 @@ describe Assignment do
     end
   end
 
-  describe "#has_rubric?" do
-    it "has a rubric if one is defined" do
-      subject.build_rubric
-      expect(subject).to have_rubric
-    end
-  end
-
   describe "#grade_with_rubric?" do
     it "is true if all required conditions are met" do
       subject.create_rubric

--- a/spec/models/rubric_spec.rb
+++ b/spec/models/rubric_spec.rb
@@ -47,7 +47,6 @@ describe Rubric do
 
     it "returns true if criteria are present" do
       criterion = create(:criterion, rubric: rubric)
-
       expect(rubric.designed?).to eq(true)
     end
 
@@ -55,5 +54,4 @@ describe Rubric do
       expect(rubric.designed?).to eq(false)
     end
   end
-
 end

--- a/spec/presenters/assignment_presenter_spec.rb
+++ b/spec/presenters/assignment_presenter_spec.rb
@@ -96,25 +96,44 @@ describe AssignmentPresenter do
     end
   end
 
-  describe "#rubric_designed?" do
-    let(:rubric) { double(:rubric, designed?: true) }
-
-    it "is not designed if there is no rubric attached to the assignment" do
-      allow(assignment).to receive(:rubric).and_return nil
-      expect(subject.rubric_designed?).to eq false
-    end
-
-    it "is not designed if the rubric was not designed" do
-      allow(assignment).to receive(:rubric).and_return rubric
-      allow(rubric).to receive(:designed?).and_return false
-      expect(subject.rubric_designed?).to eq false
+  describe "#grade_with_rubric?" do
+    it "is not to be used if the assignment doesn't grade with a rubric" do
+      allow(assignment).to receive(:grade_with_rubric?).and_return false
+      expect(subject.grade_with_rubric?).to eq false
     end
   end
 
-  describe "#use_rubric?" do
-    it "is not to be used if the assignment should not use a rubric" do
-      allow(assignment).to receive(:use_rubric?).and_return false
-      expect(subject.use_rubric?).to eq false
+  describe "#show_rubric_preview?" do
+    before do
+      allow(subject).to receive(:grade_with_rubric?).and_return true
+      allow(subject).to receive(:grades_available_for?).and_return false
+      allow(assignment).to receive(:description_visible_for_student?).and_return true
+    end
+
+    let(:user) { double(:user) }
+
+    it "is true when all criteria are met" do
+      expect(subject.show_rubric_preview?(user)).to eq(true)
+    end
+
+    it "is false if not grading with a rubric" do
+      allow(subject).to receive(:grade_with_rubric?).and_return false
+      expect(subject.show_rubric_preview?(user)).to eq(false)
+    end
+
+    it "is false if user has available grades" do
+      allow(subject).to receive(:grades_available_for?).and_return true
+      expect(subject.show_rubric_preview?(user)).to eq(false)
+    end
+
+    it "is true if there is no user" do
+      allow(assignment).to receive(:description_visible_for_student?).and_return false
+      expect(subject.show_rubric_preview?(nil)).to eq(true)
+    end
+
+    it "is false if the description_visible_for_student is false" do
+      allow(assignment).to receive(:description_visible_for_student?).and_return false
+      expect(subject.show_rubric_preview?(user)).to eq(false)
     end
   end
 

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -104,15 +104,15 @@ describe PredictedAssignmentSerializer do
         end
       end
 
-      describe "has_rubric" do
-        it "is true when assignment has a rubric" do
-          allow(assignment).to receive(:has_rubric?).and_return true
-          expect(subject[:has_rubric]).to eq(true)
+      describe "is_rubric_graded" do
+        it "is true when assignment#grade_with_rubric? is true" do
+          allow(assignment).to receive(:grade_with_rubric?).and_return true
+          expect(subject[:is_rubric_graded]).to eq(true)
         end
 
-        it "is false if assignment has no rubric" do
-          allow(assignment).to receive(:has_rubric?).and_return false
-          expect(subject[:has_rubric]).to eq(false)
+        it "is false if assignment#grade_with_rubric? is false" do
+          allow(assignment).to receive(:grade_with_rubric?).and_return false
+          expect(subject[:is_rubric_graded]).to eq(false)
         end
       end
 


### PR DESCRIPTION
This PR standardizes the logic around presenting rubrics in the views and the predictor.  Previously we had a number of ways of determining if an assignment was actually rubric graded throughout the app. This logic has been now all been changed to use the existing assignment method `grade_with_rubric?`. Additionally the method `has_rubric?` has been removed.  

When using the presenter, we also now use `presenter.grade_with_rubric` to keep the naming consistent.

When passing this boolean to js, it is set to `is_rubric_graded` to fit with the names of existing booleans.

closes 1902