### PR TITLE
remove limit on rubric badges displayed

### DIFF
--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -179,7 +179,6 @@ button.delete
   .badge-row
     overflow: hidden
     padding: 5px
-    height: 60px
     &:hover
       background: $color-green-1
 

--- a/app/views/assignments/_rubric_preview.html.haml
+++ b/app/views/assignments/_rubric_preview.html.haml
@@ -28,7 +28,7 @@
 
               .row.badge-row
                 - level.level_badges.each_with_index do |level_badge, index|
-                  - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
+                  - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level)
                     .level-badge-image
                       %img{:src => level_badge.badge.try(:icon), class: "level_badge" }
           - if criterion.levels.size < presenter.rubric_max_level_count

--- a/app/views/grades/components/_criterion_grade_results.haml
+++ b/app/views/grades/components/_criterion_grade_results.haml
@@ -31,7 +31,7 @@
 
             .row.badge-row
               - level.level_badges.each_with_index do |level_badge, index|
-                - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
+                - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level)
                   %span.level-badge-image
                     %img{:src => level_badge.badge.icon, width: "30px", height: "30px" }
               .clear


### PR DESCRIPTION
This bugfix removes the limit on the number of badges shown on the rubric preview, and the criterion grade results partials. All visible badges attached to a level should now be shown.  The only style change  is removing the fixed height on the containing div.  Criterion rows with lots of badges will now be larger, but not in a manner than really breaks the views.

#### Rubric Preview:
<img width="889" alt="screen shot 2016-04-14 at 9 46 57 am" src="https://cloud.githubusercontent.com/assets/1138350/14530311/6d8efc10-0226-11e6-954e-0d6afd87d6f2.png">

#### Grade Results:
<img width="631" alt="screen shot 2016-04-14 at 9 46 13 am" src="https://cloud.githubusercontent.com/assets/1138350/14530308/69977150-0226-11e6-941e-02580125c6b2.png">