### PR TITLE
handle excluded grades in the predictor

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -65,7 +65,7 @@
   $scope.articleNoPoints = (assignment)->
     if assignment.pass_fail && assignment.grade.pass_fail_status != "Pass"
       return true
-    else if assignment.grade.score == null || assignment.grade.score == 0
+    else if assignment.grade.score == null || assignment.grade.score == 0 || assignment.grade.is_excluded
       return true
     else if $scope.predictionBelowThreshold(assignment)
       return true
@@ -124,7 +124,8 @@
     _.each(assignments, (assignment)->
       # use raw score to keep weighting calculation on assignment type level
       if assignment.grade.final_points != null
-        total += assignment.grade.final_points
+        if ! assignment.grade.is_excluded
+          total += assignment.grade.final_points
       else if ! assignment.pass_fail && ! assignment.closed_without_sumbission && includePredicted
         total += assignment.grade.predicted_score
     )

--- a/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_assignments.html.haml
@@ -12,7 +12,7 @@
 
   .predictor-article-main
 
-    .article-graded{'ng-if' => 'articleGraded(assignment)'}
+    .article-graded{'ng-if' => 'articleGraded(assignment)', 'ng-class'=>'{"excluded" : assignment.grade.is_excluded}'}
       .grade{'ng-if' => 'assignment.pass_fail == false'}
         {{assignment.grade.final_points | number}} / {{assignment.point_total | number}}
       .grade{'ng-if' => 'assignment.pass_fail == true'}
@@ -20,6 +20,8 @@
           {{termFor["pass"]}} / {{termFor["fail"]}}
         .status{{'ng-if'=>'assignment.grade.pass_fail_status'}}
           {{termFor[assignment.grade.pass_fail_status]}}
+      .excluded{{'ng-if'=>'assignment.grade.is_excluded'}}
+        This grade has been excluded
 
     .article-predicted{'ng-if' => '! articleGraded(assignment)'}
       %div{'ng-if' => 'assignment.predictor_display_type == "slider"'}

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -261,6 +261,7 @@ article.predictor-article
 
 .predictor-article-main
   padding-top: 8px
+  margin-top: -7px
 
 article.predictor-article.status-late
   background-color: $color-yellow-1
@@ -319,6 +320,13 @@ article.predictor-article.status-graded.status-no-points
   text-align: center
   font-size: $predictor-font-size-2
   color: $color-blue-2
+
+.article-graded.excluded
+  .grade
+    color: $color-red-1
+  .excluded
+    color: $color-red-1
+    text-align: center
 
 .badge-complete .value
   padding-top: 30px

--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -50,6 +50,10 @@ class NullGrade
     nil
   end
 
+  def excluded_from_course_score?
+    false
+  end
+
   def student_id
     0
   end

--- a/app/serializers/predicted_grade_serializer.rb
+++ b/app/serializers/predicted_grade_serializer.rb
@@ -8,12 +8,30 @@
 class PredictedGradeSerializer
   attr_reader :current_user
 
-  def id
-    grade.id
+  def initialize(assignment, grade, current_user)
+    @assignment = assignment
+    @grade = grade
+    @current_user = current_user
+  end
+
+  def attributes
+    {
+      id: id,
+      predicted_score: predicted_score,
+      score: score,
+      final_points: final_points,
+      is_excluded: excluded?
+    }
   end
 
   def pass_fail_status
     grade.pass_fail_status if GradeProctor.new(grade).viewable?
+  end
+
+  private
+
+  def id
+    grade.id
   end
 
   def predicted_score
@@ -30,22 +48,9 @@ class PredictedGradeSerializer
     grade.score if GradeProctor.new(grade).viewable?
   end
 
-  def initialize(assignment, grade, current_user)
-    @assignment = assignment
-    @grade = grade
-    @current_user = current_user
+  def excluded?
+    grade.excluded_from_course_score?
   end
-
-  def attributes
-    {
-      id: id,
-      predicted_score: predicted_score,
-      score: score,
-      final_points: final_points,
-    }
- end
-
-  private
 
   def show_zero_in_predictor(score)
     score.nil? &&

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -49,7 +49,8 @@
     instructor_modified: false,
     status: nil,
     predicted_score: -> { 0 },
-    feedback: nil
+    feedback: nil,
+    excluded_from_course_score: false
   },
   assignment_score_levels: false,
   rubric: false,
@@ -502,6 +503,29 @@
   }
 }
 
+@assignments[:predictor_with_excluded_grade_assignment] = {
+  quotes: {
+    assignment_created: nil,
+  },
+  assignment_type: :predictor,
+  attributes: {
+    name: "Excluded Grade Assignment",
+    description: "Points displayed with exclusion message and stying, points not added to total",
+    due_at: 1.week.ago,
+    point_total: 15000,
+    points_predictor_display: "Slider",
+  },
+  grades: true,
+  grade_attributes: {
+    instructor_modified: true,
+    predicted_score: -> { rand(15000) },
+    status: "Graded",
+    excluded_from_course_score: true,
+    instructor_modified: true
+  }
+}
+
+
 @assignments[:predictor_past_assignment] = {
   quotes: {
     assignment_created: nil,
@@ -935,13 +959,11 @@
   }
 }
 
-
 #------------------------------------------------------------------------------#
 
 #                        Unlock Assignment Type
 
 #------------------------------------------------------------------------------#
-
 
 @assignments[:badge_is_an_unlock] = {
   quotes: {

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -180,11 +180,11 @@ describe AssignmentsController do
           get :predictor_data, format: :json, id: @student.id
           expect(assigns(:assignments).current_user).to eq(@professor)
           expect(assigns(:assignments).student).to eq(@student)
-          assigns(:assignments)[0].grade.tap do |assigned_grade|
-            expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.final_points).to eq(nil)
-            expect(assigned_grade.score).to eq(nil)
-            expect(assigned_grade.predicted_score).to eq(0)
+          assigns(:assignments)[0].grade.attributes.tap do |assigned_grade|
+            expect(assigned_grade[:id]).to eq(grade.id)
+            expect(assigned_grade[:final_points]).to eq(nil)
+            expect(assigned_grade[:score]).to eq(nil)
+            expect(assigned_grade[:predicted_score]).to eq(0)
           end
         end
 
@@ -193,11 +193,11 @@ describe AssignmentsController do
           get :predictor_data, format: :json, id: @student.id
           expect(assigns(:assignments).current_user).to eq(@professor)
           expect(assigns(:assignments).student).to eq(@student)
-          assigns(:assignments)[0].grade.tap do |assigned_grade|
-            expect(assigned_grade.id).to eq(grade.id)
-            expect(assigned_grade.final_points).to eq(grade.raw_score)
-            expect(assigned_grade.score).to eq(grade.score)
-            expect(assigned_grade.predicted_score).to eq(0)
+          assigns(:assignments)[0].grade.attributes.tap do |assigned_grade|
+            expect(assigned_grade[:id]).to eq(grade.id)
+            expect(assigned_grade[:final_points]).to eq(grade.raw_score)
+            expect(assigned_grade[:score]).to eq(grade.score)
+            expect(assigned_grade[:predicted_score]).to eq(0)
           end
         end
       end
@@ -298,8 +298,8 @@ describe AssignmentsController do
       it "includes student grade with no score if not released" do
         grade = create(:unreleased_grade, student: @student, assignment: @assignment, course_id: @course.id)
         get :predictor_data, format: :json, id: @student.id
-        expect(assigns(:assignments)[0].grade.score).to eq(nil)
-        expect(assigns(:assignments)[0].grade.final_points).to eq(nil)
+        expect(assigns(:assignments)[0].grade.attributes[:score]).to eq(nil)
+        expect(assigns(:assignments)[0].grade.attributes[:final_points]).to eq(nil)
       end
 
       it "assigns a unreleased grade for the assignment with only predicted score data" do
@@ -307,11 +307,11 @@ describe AssignmentsController do
         get :predictor_data, format: :json, id: @student.id
         expect(assigns(:assignments).current_user).to eq(@student)
         expect(assigns(:assignments).student).to eq(@student)
-        assigns(:assignments)[0].grade.tap do |assigned_grade|
-          expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.final_points).to eq(nil)
-          expect(assigned_grade.score).to eq(nil)
-          expect(assigned_grade.predicted_score).to eq(500)
+        assigns(:assignments)[0].grade.attributes.tap do |assigned_grade|
+          expect(assigned_grade[:id]).to eq(grade.id)
+          expect(assigned_grade[:final_points]).to eq(nil)
+          expect(assigned_grade[:score]).to eq(nil)
+          expect(assigned_grade[:predicted_score]).to eq(500)
         end
       end
 
@@ -320,11 +320,11 @@ describe AssignmentsController do
         get :predictor_data, format: :json, id: @student.id
         expect(assigns(:assignments).current_user).to eq(@student)
         expect(assigns(:assignments).student).to eq(@student)
-        assigns(:assignments)[0].grade.tap do |assigned_grade|
-          expect(assigned_grade.id).to eq(grade.id)
-          expect(assigned_grade.final_points).to eq(grade.raw_score)
-          expect(assigned_grade.score).to eq(grade.score)
-          expect(assigned_grade.predicted_score).to eq(500)
+        assigns(:assignments)[0].grade.attributes.tap do |assigned_grade|
+          expect(assigned_grade[:id]).to eq(grade.id)
+          expect(assigned_grade[:final_points]).to eq(grade.raw_score)
+          expect(assigned_grade[:score]).to eq(grade.score)
+          expect(assigned_grade[:predicted_score]).to eq(500)
         end
       end
 

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -3,7 +3,7 @@ require "toolkits/historical_toolkit"
 require "toolkits/sanitization_toolkit"
 require_relative "../support/uni_mock/rails"
 
-describe Grade do
+describe Grade  do
   include UniMock::StubRails
 
   before { stub_env "development" }

--- a/spec/models/null_grade_spec.rb
+++ b/spec/models/null_grade_spec.rb
@@ -61,6 +61,10 @@ describe NullGrade do
     expect(subject).to_not be_is_released
   end
 
+  it "is not excluded" do
+    expect(subject).to_not be_excluded_from_course_score
+  end
+
   it "is graded" do
     expect(subject).to be_is_graded
   end

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -14,12 +14,12 @@ describe PredictedAssignmentSerializer do
     it "creates a grade if it does not have one for the assignment" do
       current_time = DateTime.now
       grade = subject.grade
-      expect(Grade.find(grade.id).created_at).to be > current_time
+      expect(Grade.find(grade.attributes[:id]).created_at).to be > current_time
     end
 
     it "returns the grade if one already exists for the user and assignment" do
       existing_grade = Grade.create(assignment: assignment, student: user)
-      expect(subject.grade.id).to eq existing_grade.id
+      expect(subject.grade.attributes[:id]).to eq existing_grade.id
     end
 
     it "returns an instance of a predicted grade" do
@@ -28,7 +28,7 @@ describe PredictedAssignmentSerializer do
 
     it "returns a nil predicted grade if the user cannot create grades" do
       subject = described_class.new assignment, user, NullStudent.new
-      expect(subject.grade.id).to eq 0
+      expect(subject.grade.attributes[:id]).to eq 0
     end
   end
 

--- a/spec/serializers/predicted_grade_serializer_spec.rb
+++ b/spec/serializers/predicted_grade_serializer_spec.rb
@@ -7,18 +7,18 @@ require "./lib/grade_proctor"
 describe PredictedGradeSerializer do
   let(:course) { double(:course) }
   let(:assignment) { double(:assignment, accepts_submissions?: true, submissions_have_closed?: true )}
-  let(:grade) { double(:grade, id: 123, pass_fail_status: :pass, predicted_score: 88, score: 78, final_points: 84, student: user, course: course, assignment: assignment) }
+  let(:grade) do
+    double(
+      :grade, id: 123, pass_fail_status: :pass, predicted_score: 88,
+      score: 78, final_points: 84, excluded_from_course_score?: false,
+      student: user, course: course, assignment: assignment
+    )
+  end
   let(:user) { double(:user, submission_for_assignment: "sumbission") }
   let(:other_user) { double(:other_user) }
   subject { described_class.new assignment, grade, user }
 
   before { allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return true }
-
-  describe "#id" do
-    it "returns the grade's id" do
-      expect(subject.id).to eq grade.id
-    end
-  end
 
   describe "#pass_fail_status" do
     it "returns the grade's pass fail status if it's visible" do
@@ -31,83 +31,85 @@ describe PredictedGradeSerializer do
     end
   end
 
-  describe "#score" do
-    it "returns the grade's score if it's visible" do
-      expect(subject.score).to eq grade.score
-    end
-
-    it "returns nil if it's not visible" do
-      allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
-      expect(subject.score).to be_nil
-    end
-
-    it "returns 0 with no score and no sumbission if the assignment submissions have closed" do
-      allow(grade).to receive(:score).and_return nil
-      allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.score).to eq(0)
-    end
-
-    it "doesn't override the score is present regardless of submission status" do
-      allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.score).to eq(grade.score)
-    end
-
-    it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_points).to eq(0)
-    end
-  end
-
-  describe "#final_points" do
-    it "returns the grade's final score if it's visible" do
-      expect(subject.final_points).to eq grade.final_points
-    end
-
-    it "returns nil if it's not visible" do
-      allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
-      expect(subject.final_points).to be_nil
-    end
-
-    it "returns 0 with no final score and no sumbission if the assignment submissions have closed" do
-      allow(grade).to receive(:final_points).and_return nil
-      allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.final_points).to eq(0)
-    end
-
-    it "doesn't override the final score if present regardless of submission status" do
-      allow(user).to receive(:submission_for_assignment).and_return nil
-      expect(subject.final_points).to eq(grade.final_points)
-    end
-
-    it "always returns 0 for Null Student if the assignment sumbission has closed" do
-      expect(described_class.new(assignment, NullGrade.new, NullStudent.new).final_points).to eq(0)
-    end
-  end
-
-  describe "#predicted_score" do
-    it "returns the grade's predicted score if the user is a student" do
-      allow(grade.student).to \
-        receive(:is_student?).with(grade.course).and_return true
-      expect(subject.predicted_score).to eq grade.predicted_score
-    end
-
-    it "returns 0 predicted_score if user is not same as student for grade" do
-      expect((described_class.new assignment, grade, other_user).predicted_score).to eq 0
-    end
-
-    it "returns predicted score for student even if it's not visible" do
-      allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
-      expect(subject.predicted_score).to eq grade.predicted_score
-    end
-  end
-
   describe "#attributes" do
     it "returns a hash of grade attributes overriden by Class methods" do
       expect(subject.attributes).to eq({
-        id: subject.id,
-        predicted_score: subject.predicted_score,
-        score: subject.score,
-        final_points: subject.final_points
+        id: grade.id,
+        predicted_score: 88,
+        score: 78,
+        final_points: 84,
+        is_excluded: grade.excluded_from_course_score?
       })
     end
+
+    describe "predicted_score" do
+      it "returns the grade's predicted score if the user is a student" do
+        allow(grade.student).to \
+          receive(:is_student?).with(grade.course).and_return true
+        expect(subject.attributes[:predicted_score]).to eq grade.predicted_score
+      end
+
+      it "returns 0 predicted_score if user is not same as student for grade" do
+        expect((described_class.new assignment, grade, other_user).attributes[:predicted_score]).to eq 0
+      end
+
+      it "returns predicted score for student even if it's not visible" do
+        allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
+        expect(subject.attributes[:predicted_score]).to eq grade.predicted_score
+      end
+    end
+
+    describe "final_points" do
+      it "returns the grade's final score if it's visible" do
+        expect(subject.attributes[:final_points]).to eq grade.final_points
+      end
+
+      it "returns nil if it's not visible" do
+        allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
+        expect(subject.attributes[:final_points]).to be_nil
+      end
+
+      it "returns 0 with no final score and no sumbission if the assignment submissions have closed" do
+        allow(grade).to receive(:final_points).and_return nil
+        allow(user).to receive(:submission_for_assignment).and_return nil
+        expect(subject.attributes[:final_points]).to eq(0)
+      end
+
+      it "doesn't override the final score if present regardless of submission status" do
+        allow(user).to receive(:submission_for_assignment).and_return nil
+        expect(subject.attributes[:final_points]).to eq(grade.final_points)
+      end
+
+      it "always returns 0 for Null Student if the assignment sumbission has closed" do
+        expect(described_class.new(assignment, NullGrade.new, NullStudent.new).attributes[:final_points]).to eq(0)
+      end
+    end
+
+    describe "score" do
+      it "returns the grade's score if it's visible" do
+        expect(subject.attributes[:score]).to eq grade.score
+      end
+
+      it "returns nil if it's not visible" do
+        allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
+        expect(subject.attributes[:score]).to be_nil
+      end
+
+      it "returns 0 with no score and no sumbission if the assignment submissions have closed" do
+        allow(grade).to receive(:score).and_return nil
+        allow(user).to receive(:submission_for_assignment).and_return nil
+        expect(subject.attributes[:score]).to eq(0)
+      end
+
+      it "doesn't override the score is present regardless of submission status" do
+        allow(user).to receive(:submission_for_assignment).and_return nil
+        expect(subject.attributes[:score]).to eq(grade.score)
+      end
+
+      it "always returns 0 for Null Student if the assignment sumbission has closed" do
+        expect(described_class.new(assignment, NullGrade.new, NullStudent.new).attributes[:score]).to eq(0)
+      end
+    end
+
   end
 end

--- a/spec/views/assignments/predictor_data_spec.rb
+++ b/spec/views/assignments/predictor_data_spec.rb
@@ -41,7 +41,13 @@ describe "assignments/predictor_data" do
       status: "Released"
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "final_points" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq(
+      { "id" => grade.id,
+        "final_points" => 1000,
+        "score" => 1000,
+        "predicted_score" => 999,
+        "is_excluded" => false
+      })
   end
 
   it "includes the pass fail status with the grade when the assignment is pass fail" do
@@ -52,7 +58,14 @@ describe "assignments/predictor_data" do
     @assignment.update(pass_fail: true)
     render
     json = JSON.parse(response.body)
-    expect(json["assignments"][0]["grade"]).to eq({ "id" => grade.id, "pass_fail_status" => "passed", "final_points" => 1000, "score" => 1000, "predicted_score" => 999 })
+    expect(json["assignments"][0]["grade"]).to eq(
+      { "id" => grade.id,
+        "pass_fail_status" => "passed",
+        "final_points" => 1000,
+        "score" => 1000,
+        "predicted_score" => 999,
+        "is_excluded" => false
+      })
   end
 
   it "does not include assignments with no points" do


### PR DESCRIPTION
This pull request adds handling for excluded grades in the predictor.  The boolean `is_excluded` is added to the grade JSON nested within the assignments, courtesy of the PredictedGradeSerializer.

In the predictor minimal styling is applied to the excluded grades. The box is gray to match other assignments with zero points, and a notice under the grades mentions that it was excluded. The points are also ignored in the summing of the total earned and predicted points. I have left further refinements to future work on the predictor styling as a whole.

Some additional refactoring of the PredictedGradeSerializer includes making methods called by `attributes` private, which required updating many of the specs that rely on the Assignment and related Serializers.

<img width="671" alt="screen shot 2016-04-19 at 10 31 10 am" src="https://cloud.githubusercontent.com/assets/1138350/14645038/2b816614-0622-11e6-99fe-7c407adc34e5.png">
