### PR TITLE
Fix ungraded group submission issue

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -27,8 +27,8 @@ class Submission < ActiveRecord::Base
 
   scope :with_grade, -> do
     joins("INNER JOIN grades ON "\
-      "grades.group_id = submissions.group_id OR "\
-      "(grades.assignment_id = submissions.assignment_id AND "\
+      "grades.assignment_id = submissions.assignment_id AND "\
+      "(grades.group_id = submissions.group_id OR "\
       "grades.student_id = submissions.student_id)")
   end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -194,6 +194,14 @@ describe Submission do
     it "handles additional parameters" do
       expect(subject.course.submissions.ungraded).to eq [subject]
     end
+
+    it "returns the group submissions that do not have a grade" do
+      group = create :group
+      create :grade, course: course, group: group, submission: subject,
+        status: "Graded"
+      subject.update_attributes group_id: group.id, student_id: nil
+      expect(Submission.ungraded).to eq [subject]
+    end
   end
 
   describe ".resubmitted" do


### PR DESCRIPTION
Rearrange assignment check on ungraded submissions so that the assignments are always checked.

The old join only checked assignments for individual submissions and now it checks for both individual and group submissions.