### PR TITLE
check for nil values summing earned badges

### DIFF
--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -66,6 +66,9 @@ class Badge < ActiveRecord::Base
   end
 
   def earned_badge_total_points(student)
-    earned_badges.where(student_id: student, student_visible: true).pluck("score").sum
+    earned_badges.where(
+      student_id: student,
+      student_visible: true
+    ).pluck("score").map(&:to_i).sum
   end
 end

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -304,5 +304,4 @@ describe Badge do
       expect(badge.earned_badge_total_points(student)).to eq(1000)
     end
   end
-
 end


### PR DESCRIPTION
This pull request addresses an error reported on [Rollbar](https://rollbar.com/gradecraft/gradecraft-development/items/1313/), most likely caused by calling sum on an array EarnedBadge scores where one or more EB had a nil score.

This error shouldn't occur in future classes (in theory) because we are now defaulting to a score of zero if the Badge.total_points is nil. (This same `cache_associations` callback also makes this error very hard to replicate). However, protecting against nil values is not a bad thing to do, so we should still add this to the codebase.

closes #1895 