### PR TITLE
predictor uses text on zero point badges

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -180,6 +180,10 @@
       )
     total
 
+  $scope.badgePointsDisplay = (badge)->
+   return "earned" if badge.total_earned_points == 0
+   badge.total_earned_points
+
   # Total points possible to earn from challenges
   $scope.maxChallengePoints = ()->
     total = 0
@@ -237,10 +241,7 @@
       return ""
 
   $scope.badgeCompleted = (badge)->
-    if (badge.point_total == badge.total_earned_points && ! badge.can_earn_multiple_times)
-      return true
-    else
-      return false
+    ! badge.can_earn_multiple_times && badge.earned_badge_count > 0
 
   # We keep the predictor open on closed assignments IF the student has a
   # a submission

--- a/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/PredictorDirectives.js.coffee
@@ -122,7 +122,10 @@
           else
             if @target.grade.predicted_score == @offValue then @offValue else @onValue
         else if @targetType == 'badge'
-          if @target.prediction.times_earned == 0 then @offValue else @onValue
+          if @target.point_total == 0
+            if @target.prediction.times_earned == 0 then "won't earn" else "will earn"
+          else
+            if @target.prediction.times_earned == 0 then @offValue else @onValue
 
       scope.toggleSwitch = ()->
         if @targetType == 'assignment'
@@ -145,6 +148,25 @@
     link: (scope, el, attr)->
       scope.atMin = ()->
         @target.prediction.times_earned <= @target.earned_badge_count
+      scope.textForTotal = ()->
+        if @target.point_total == 0
+          ""
+        else
+          @target.prediction.times_earned * @target.point_total
+      scope.textForSwitch = ()->
+        if @target.point_total == 0
+          if scope.atMin()
+            switch @target.prediction.times_earned
+              when 0 then "won't earn"
+              when 1 then "earned 1 time"
+              else "earned " + @target.prediction.times_earned + " times"
+          else
+            if @target.prediction.times_earned == 1
+              "will earn 1 time"
+            else
+              "will earn " + @target.prediction.times_earned + " times"
+        else
+          @target.prediction.times_earned + " x " + @target.point_total
       scope.increment = ()->
         @target.prediction.times_earned += 1
         PredictorService.postPredictedBadge(@target.id,@target.prediction.times_earned)

--- a/app/assets/javascripts/angular/templates/ng_predictor_badges.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_badges.html.haml
@@ -22,7 +22,7 @@
 
         .badge-complete{'ng-if'=>'badgeCompleted(badge)'}
           .value
-            {{badge.total_earned_points}}
+            {{badgePointsDisplay(badge)}}
 
         .badge-predicted{'ng-if'=>'!badgeCompleted(badge)'}
 

--- a/app/assets/javascripts/angular/templates/ng_predictor_counter.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_counter.html.haml
@@ -3,6 +3,6 @@
     .switch-up-button{'ng-click'=>'increment()'}
     .switch-down-button{'ng-class'=>'{"disabled": atMin()}', 'ng-click'=>'decrement()'}
 .time-earned-prediction
-  {{target.prediction.times_earned}} x {{target.point_total}}
+  {{textForSwitch()}}
 .badge-total-prediction
-  {{target.prediction.times_earned * target.point_total}}
+  {{textForTotal()}}

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -436,7 +436,9 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
     background-color: transparent
   .time-earned-prediction
     font-size: $predictor-font-size-2
-    padding: 10px 0 0 4px
+    line-height: 1.5rem
+    text-align: center
+    padding: 10px 12px 0 20px
   .badge-total-prediction
     font-size: $predictor-font-size-1
     clear: both
@@ -522,7 +524,7 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
     width: 100%
 
 // medium
-@media (min-width: $media-small-max) and (max-width: $media-medium-max)
+@media (min-width: $media-small-max) and (max-width: $media-medium-max + 5rem)
   article.predictor-article
     width: 48%
   .predictor-section-title-predicted-points
@@ -538,7 +540,7 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
     width: 100%
 
 // large
-@media (min-width: $media-medium-max) and (max-width: $media-large-max)
+@media (min-width: $media-medium-max + 5rem) and (max-width: $media-large-max)
   article.predictor-article
     width: 19%
   #predictor-main-content.with-sidebar

--- a/db/samples/badges.rb
+++ b/db/samples/badges.rb
@@ -15,7 +15,7 @@
   },
   attributes: {
     name: "Generic badge",
-    point_total: 100 * rand(10),
+    point_total: (100 * rand(1..10) + 100),
     description: nil,
     visible: false,
     can_earn_multiple_times: false
@@ -87,6 +87,83 @@
   assign_samples: false,
 }
 
+@badges[:long_description] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Verbose Descriptor",
+    description: "A badge with a long description. Earned badges assigned to
+      all students. A badge is a device or accessory, often containing the
+      insignia of an organization, which is presented or displayed to indicate
+      some feat of service, a special accomplishment, a symbol of authority
+      granted by taking an oath (e.g., police and fire), a sign of legitimate
+      employment or student status, or as a simple means of identification.
+      They are also used in advertising, publicity, and for branding purposes.
+      Police badges date back to medieval times when knights wore a coat of arms
+      representing their allegiances and loyalty.[Wikipedia]",
+    visible: true,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+@badges[:zero_points_single_earn_badge] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Zephirum Singularis",
+    description: "A zero points badge that can be earned once.",
+    visible: true,
+    point_total: 0,
+    can_earn_multiple_times: false
+  },
+  assign_samples: false,
+}
+
+@badges[:zero_points_single_earn_badge_earned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Zephirum Earned",
+    description: "A zero points badge already earned by all students.",
+    visible: true,
+    point_total: 0,
+    can_earn_multiple_times: false
+  },
+  assign_samples: true,
+}
+
+@badges[:zero_points_multiple_earn_badge] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Zephira Multiplus",
+    visible: true,
+    description: "A zero points badge that can be earned multiple times.",
+    point_total: 0,
+    can_earn_multiple_times: true
+  },
+  assign_samples: false,
+}
+
+@badges[:zero_points_multiple_earn_badge_earned] = {
+  quotes: {
+    badge_created: nil,
+  },
+  attributes: {
+    name: "Zephira Earned",
+    visible: true,
+    description: "A zero points badge that can be earned multiple times.",
+    point_total: 0,
+    can_earn_multiple_times: true
+  },
+  assign_samples: true,
+}
+
 @badges[:invisible_badge_earned] = {
   quotes: {
     badge_created: nil,
@@ -109,27 +186,6 @@
     name: "Secretus Unearned",
     description: "An invisible badge that can be earned multiple times. Should
       only be visible to students once they earn it.",
-    can_earn_multiple_times: true
-  },
-  assign_samples: false,
-}
-
-@badges[:long_description] = {
-  quotes: {
-    badge_created: nil,
-  },
-  attributes: {
-    name: "Verbose Descriptor",
-    description: "A badge with a long description. Earned badges assigned to
-      all students. A badge is a device or accessory, often containing the
-      insignia of an organization, which is presented or displayed to indicate
-      some feat of service, a special accomplishment, a symbol of authority
-      granted by taking an oath (e.g., police and fire), a sign of legitimate
-      employment or student status, or as a simple means of identification.
-      They are also used in advertising, publicity, and for branding purposes.
-      Police badges date back to medieval times when knights wore a coat of arms
-      representing their allegiances and loyalty.[Wikipedia]",
-    visible: true,
     can_earn_multiple_times: true
   },
   assign_samples: false,


### PR DESCRIPTION
This pull request handles Badges with zero points in the Predictor.  Instead of multiplying zero point by the times earned, and passing through the resulting zero, this will return human readable explanations based on the earned state, and the will to earn.

<img width="913" alt="screen shot 2016-04-27 at 12 48 39 pm" src="https://cloud.githubusercontent.com/assets/1138350/14861662/278a296e-0c7c-11e6-9d97-4b37d93c336c.png">

Above we see four badges, the first two can only be earned once, and none of which have additional predicted earnings.  If the student hasn't earned a badge and doesn't intend to, the predictor displays "won't earn". If they have earned the badge, it will display "earned" or "earned x times".

If the student adds predictions:

<img width="912" alt="screen shot 2016-04-27 at 12 48 55 pm" src="https://cloud.githubusercontent.com/assets/1138350/14861748/8e8f3b7c-0c7c-11e6-8eef-1f0c3b4b98e3.png">

Badge predictor widgets now read "will earn" or "will earn x times"

closes #1651 