### PR TITLE
1747 grade routes destroy refactor

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -174,15 +174,16 @@ class GradesController < ApplicationController
   # DELETE /grades/:id
   def destroy
     grade = Grade.find(params[:id])
-    redirect_to assignment_path(grade.assignment) and return \
-      unless GradeProctor.new(grade).destroyable?(course: current_course,
-        user: current_user)
+    authorize! :destroy, grade
     grade.destroy
     score_recalculator(grade.student)
 
     redirect_to assignment_path(grade.assignment),
       notice: "#{grade.student.name}'s #{grade.assignment.name} grade was "\
               "successfully deleted."
+  rescue CanCan::AccessDenied
+    # This is handled here so that a different redirect path can be specified
+    redirect_to assignment_path(grade.assignment)
   end
 
   # POST /grades/:id/feedback_read

--- a/app/models/abilities/grade_ability.rb
+++ b/app/models/abilities/grade_ability.rb
@@ -8,5 +8,10 @@ module GradeAbility
       GradeProctor.new(grade).updatable? (options || {})
         .merge({ user: user, course: course })
     end
+
+    can :destroy, Grade do |grade, options|
+      GradeProctor.new(grade).destroyable? (options || {})
+        .merge({ user: user, course: course })
+    end
   end
 end

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -32,4 +32,4 @@
           %td= g.status
           %td= link_to "Edit Grade", edit_assignment_grade_path(g.assignment_id, student_id: g.student_id), class: "button"
           %td= link_to "See Grade", grade_path(g), class: "button"
-          %td= link_to "Delete Grade", assignment_grade_path(g.assignment_id, student_id: g.student_id), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+          %td= link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ GradeCraft::Application.routes.draw do
     resources :submissions, except: :index
 
     # TODO: Use plural resource and move to assignments/grades where appropriate
-    resource :grade, only: [:edit, :update, :destroy] do
+    resource :grade, only: [:edit, :update] do
       resources :earned_badges
     end
 
@@ -98,7 +98,7 @@ GradeCraft::Application.routes.draw do
     end
   end
 
-  resources :grades, only: [:show] do
+  resources :grades, only: [:show, :destroy] do
     member do
       post :exclude
       post :feedback_read

--- a/lib/grade_proctor.rb
+++ b/lib/grade_proctor.rb
@@ -13,4 +13,6 @@ class GradeProctor
   def initialize(grade)
     @grade = grade
   end
+
+  alias_method :destroyable?, :updatable?
 end

--- a/spec/models/abilities/grade_ability_spec.rb
+++ b/spec/models/abilities/grade_ability_spec.rb
@@ -30,12 +30,19 @@ describe Ability do
       expect(subject).to be_able_to(:update, Grade.new)
     end
 
-    it "passes on the options to the GradeProctor" do
+    it "passes on the options to the GradeProctor on update" do
       expect_any_instance_of(GradeProctor).to  \
         receive(:updatable?).with(user: student, course: course,
                                   student_logged: false).and_return true
 
       expect(subject).to be_able_to(:update, Grade.new, student_logged: false)
+    end
+
+    it "can destroy a grade if the GradeProctor says it can" do
+      allow_any_instance_of(GradeProctor).to  \
+        receive(:destroyable?).with(user: student, course: course).and_return true
+
+      expect(subject).to be_able_to(:destroy, Grade.new)
     end
   end
 end


### PR DESCRIPTION
Changes the `Grades#destroy` controller action to use a simple `Grade` object as the parameter instead of an `Assignment` and `student_id`. 

The path was changed from `DELETE assignments/:id/grade?student_id=:student_id` to `DELETE grades/:id`.

The `GradeProctor` got a new method (`#destroyable?`) which is basically just an aliased `#updatable?` method.

Closes #1747