### PR TITLE
Updated announcements to go to all users

### DIFF
--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -80,7 +80,7 @@ describe AnnouncementsController do
             user_id: student.id, role: "student"
           expect {
             post :create, announcement: { title: "New Tour", body: body }
-          }.to change  { ActionMailer::Base.deliveries.count }.by 1
+          }.to change  { ActionMailer::Base.deliveries.count }.by 2
         end
       end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -68,7 +68,7 @@ describe Announcement do
         user_id: student.id, role: "student"
     end
 
-    it "sends an email to all the students in the course" do
+    it "sends an email to all the users in the course" do
       delivery = double(:email)
       expect(delivery).to receive(:deliver_now)
       expect(AnnouncementMailer).to receive(:announcement_email).with(subject, student).and_return delivery
@@ -77,7 +77,7 @@ describe Announcement do
   end
 
   describe "#read_count" do
-    it "is the number of students for the course who have not read the announcement" do
+    it "is the number of users for the course who have not read the announcement" do
       announcement = create :announcement
       create :announcement_state, announcement: announcement
       expect(announcement.read_count).to eq 1
@@ -133,11 +133,14 @@ describe Announcement do
       expect(states.count).to eq 1
     end
 
-    it "does not mark as read if the user is not a student" do
+    it "marks as read if the user is not a student" do
       CourseMembership.create course_id: subject.course.id,
         user_id: user.id, role: "professor"
       subject.mark_as_read! user
-      expect(subject.states).to be_empty
+      states = AnnouncementState.where(announcement_id: subject.id,
+                                               user_id: user.id,
+                                                  read: true)
+      expect(states.count).to eq 1
     end
 
     it "does not mark as read if the user is not part of the course" do


### PR DESCRIPTION
This PR updates the announcements feature so that they're sent to all course members (not just students).