### PR TITLE
Cleaned up froala implementation

### DIFF
--- a/app/assets/javascripts/angular-froala/angular-froala.js
+++ b/app/assets/javascripts/angular-froala/angular-froala.js
@@ -75,7 +75,7 @@ angular.module('froala', []).
 				};
 
 				ngModel.$render = function(){
-					element.froalaEditor('setHTML', ngModel.$viewValue || '', true);
+					element.froalaEditor('html.set', ngModel.$viewValue || '', true);
 				};
 
 				var froala = element.froalaEditor(options).data('fa.froalaEditor');

--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -156,12 +156,12 @@
   $scope.froalaOptions = {
     inlineMode: false,
     minHeight: 100,
-    buttons: [
-      'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough', 'subscript',
-      'superscript', 'fontFamily', 'fontSize', 'sep', 'inlineStyle', 'blockStyle',
-      'sep', 'formatBlock', 'align', 'insertOrderedList', 'insertUnorderedList',
+    toolbarButtons: [
+      'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough',
+      'fontFamily', 'fontSize', 'color', 'sep', 'blockStyle', 'emoticons',
+      'insertTable', 'sep', 'formatBlock', 'align', 'insertOrderedList',
       'outdent', 'indent', 'insertHorizontalRule', 'createLink', 'undo', 'redo',
-      'removeFormat', 'selectAll'
+      'clearFormatting', 'selectAll', 'html'
     ]
   }
 ]

--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -155,7 +155,7 @@
 
   $scope.froalaOptions = {
     inlineMode: false,
-    minHeight: 100,
+    heightMin: 200,
     toolbarButtons: [
       'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough',
       'fontFamily', 'fontSize', 'color', 'sep', 'blockStyle', 'emoticons',

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -222,22 +222,23 @@
 
   $scope.froalaOptions = {
     inlineMode: false,
-    minHeight: 100,
-    buttons: [
-      "bold", "italic", "underline", "strikeThrough",
-      "insertOrderedList", "insertUnorderedList"
+    heightMin: 120,
+    toolbarButtons: [
+      'bold', 'italic', 'underline', 'strikeThrough',
+      'sep', 'formatBlock', 'insertOrderedList', 'insertUnorderedList',
+      'insertHorizontalRule', 'insertLink'
     ]
   }
 
   $scope.froalaSummaryOptions = {
     inlineMode: false,
-    minHeight: 100,
-    buttons: [
-      'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough', 'subscript',
-      'superscript', 'fontFamily', 'fontSize', 'sep', 'inlineStyle', 'blockStyle',
-      'sep', 'formatBlock', 'align', 'insertOrderedList', 'insertUnorderedList',
+    heightMin: 200,
+    toolbarButtons: [
+      'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough',
+      'fontFamily', 'fontSize', 'color', 'sep', 'blockStyle', 'emoticons',
+      'insertTable', 'sep', 'formatBlock', 'align', 'insertOrderedList',
       'outdent', 'indent', 'insertHorizontalRule', 'createLink', 'undo', 'redo',
-      'removeFormat', 'selectAll'
+      'clearFormatting', 'selectAll', 'html'
     ]
   }
 ]

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -26,13 +26,13 @@ $( "#tabs" ).tabs({
  $('.froala').froalaEditor({
   key: '6Ud1QBRVCDLPAZMBQ==',
   inlineMode: false,
-  minHeight: 280,
-  buttons: [
-    'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough', 'subscript',
-    'superscript', 'fontFamily', 'fontSize', 'sep', 'inlineStyle', 'blockStyle',
-    'sep', 'formatBlock', 'align', 'insertOrderedList', 'insertUnorderedList',
+  heightMin: 200,
+  toolbarButtons: [
+    'fullscreen', 'bold', 'italic', 'underline', 'strikeThrough',
+    'fontFamily', 'fontSize', 'color', 'sep', 'blockStyle', 'emoticons',
+    'insertTable', 'sep', 'formatBlock', 'align', 'insertOrderedList',
     'outdent', 'indent', 'insertHorizontalRule', 'createLink', 'undo', 'redo',
-    'removeFormat', 'selectAll'
+    'clearFormatting', 'selectAll', 'html'
   ]
 })
 


### PR DESCRIPTION
This PR trims down the number of froala utilities in use overall, particularly on the Criterion Grade implementation. It makes the utility consistent between the Rubric Grade overall feedback, Grade feedback, and other text editing field implementations. It also fixes 1/2 JS issues that came about as a result of the upgrade. 