### PR TITLE
1747 grade earned badge routes

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -152,6 +152,7 @@
     grade_id: $scope.grade.id,
     assignment_id: $scope.grade.assignment_id
     score: badge.point_total
+    student_visible: $scope.grade.student_visible
 
   $scope.froalaOptions = {
     inlineMode: false,

--- a/app/assets/javascripts/angular/factories/BadgeFactory.js.coffee
+++ b/app/assets/javascripts/angular/factories/BadgeFactory.js.coffee
@@ -65,7 +65,7 @@
       JSON.stringify(this.earnedBadge)
 
     earnBadgeForStudent: (requestParams)->
-      $http.post("/grades/earn_student_badge", requestParams).then ((response)->
+      $http.post("/api/earned_badges", requestParams).then ((response)->
         if typeof response.data == 'object'
           console.log "Successfully created Earned Badge"
           response.data

--- a/app/assets/javascripts/angular/factories/Grade.js.coffee
+++ b/app/assets/javascripts/angular/factories/Grade.js.coffee
@@ -9,7 +9,7 @@
       @student_id = attrs.student_id
       @assignment_id = attrs.assignment_id
       @releaseNecessary = attrs.assignment.release_necessary
-      console.log("Release Necessary: #{@releaseNecessary}")
+      @student_visible = attrs.student_visible
       @http = http
       @updated_at = null
 

--- a/app/controllers/api/earned_badges_controller.rb
+++ b/app/controllers/api/earned_badges_controller.rb
@@ -1,0 +1,9 @@
+require_relative "../../services/creates_earned_badge"
+
+class API::EarnedBadgesController < ApplicationController
+  # POST /api/earned_badges
+  def create
+    result = Services::CreatesEarnedBadge.award params[:earned_badge]
+    render json: result.earned_badge
+  end
+end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -1,5 +1,3 @@
-require_relative "../services/creates_earned_badge"
-
 class GradesController < ApplicationController
   respond_to :html, :json
   before_filter :set_assignment, only: [:edit, :update]
@@ -67,13 +65,6 @@ class GradesController < ApplicationController
     else # failure
       redirect_to edit_assignment_grade_path(@assignment, student_id: @grade.student.id), alert: "#{@grade.student.name}'s #{@assignment.name} was not successfully submitted! Please try again."
     end
-  end
-
-  # POST /grades/earn_student_badge
-  def earn_student_badge
-    result = Services::CreatesEarnedBadge.award params[:earned_badge]
-    logger.info result.earned_badge.errors.full_messages
-    render json: result.earned_badge
   end
 
   # POST /grades/earn_student_badges

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -1,3 +1,5 @@
+require_relative "../services/creates_earned_badge"
+
 class GradesController < ApplicationController
   respond_to :html, :json
   before_filter :set_assignment, only: [:edit, :update]
@@ -69,9 +71,9 @@ class GradesController < ApplicationController
 
   # POST /grades/earn_student_badge
   def earn_student_badge
-    @earned_badge = EarnedBadge.create params[:earned_badge]
-    logger.info @earned_badge.errors.full_messages
-    render json: @earned_badge
+    result = Services::CreatesEarnedBadge.award params[:earned_badge]
+    logger.info result.earned_badge.errors.full_messages
+    render json: result.earned_badge
   end
 
   # POST /grades/earn_student_badges

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -210,7 +210,7 @@ class GradesController < ApplicationController
       end
 
       json.badges do
-        json.partial! "grades/badges", badges: @badges, student_id: @student[:id]
+        json.partial! "grades/badges", badges: @badges, student_id: @student.id
       end
 
       json.assignment do

--- a/app/services/creates_earned_badge.rb
+++ b/app/services/creates_earned_badge.rb
@@ -7,8 +7,8 @@ module Services
   class CreatesEarnedBadge
     extend LightService::Organizer
 
-    def self.award(params)
-      with(params: params).reduce(
+    def self.award(attributes)
+      with(attributes: attributes).reduce(
         Actions::CreatesEarnedBadge,
         Actions::RecalculatesStudentScore,
         Actions::NotifiesOfEarnedBadge

--- a/app/services/creates_earned_badge.rb
+++ b/app/services/creates_earned_badge.rb
@@ -1,0 +1,18 @@
+require "light-service"
+require_relative "creates_earned_badge/creates_earned_badge"
+require_relative "creates_earned_badge/notifies_of_earned_badge"
+require_relative "creates_earned_badge/recalculates_student_score"
+
+module Services
+  class CreatesEarnedBadge
+    extend LightService::Organizer
+
+    def self.award(params)
+      with(params: params).reduce(
+        Actions::CreatesEarnedBadge,
+        Actions::RecalculatesStudentScore,
+        Actions::NotifiesOfEarnedBadge
+      )
+    end
+  end
+end

--- a/app/services/creates_earned_badge/creates_earned_badge.rb
+++ b/app/services/creates_earned_badge/creates_earned_badge.rb
@@ -3,7 +3,15 @@ module Services
     class CreatesEarnedBadge
       extend LightService::Action
 
+      expects :attributes
+      promises :earned_badge
+
       executed do |context|
+        context.earned_badge = EarnedBadge.new context.attributes
+        unless context.earned_badge.save
+          message = "The earned badge is invalid and cannot be saved"
+          context.fail_with_rollback! message
+        end
       end
     end
   end

--- a/app/services/creates_earned_badge/creates_earned_badge.rb
+++ b/app/services/creates_earned_badge/creates_earned_badge.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class CreatesEarnedBadge
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -3,7 +3,13 @@ module Services
     class NotifiesOfEarnedBadge
       extend LightService::Action
 
+      expects :earned_badge
+
       executed do |context|
+        if context.earned_badge.student_visible?
+          NotificationMailer.earned_badge_awarded(context.earned_badge.id)
+            .deliver_now
+        end
       end
     end
   end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class NotifiesOfEarnedBadge
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/creates_earned_badge/recalculates_student_score.rb
+++ b/app/services/creates_earned_badge/recalculates_student_score.rb
@@ -3,7 +3,14 @@ module Services
     class RecalculatesStudentScore
       extend LightService::Action
 
+      expects :earned_badge
+
       executed do |context|
+        if context.earned_badge.badge.point_total?
+          ScoreRecalculatorJob.new(user_id: context.earned_badge.student_id,
+                                   course_id: context.earned_badge.course_id)
+            .enqueue
+        end
       end
     end
   end

--- a/app/services/creates_earned_badge/recalculates_student_score.rb
+++ b/app/services/creates_earned_badge/recalculates_student_score.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class RecalculatesStudentScore
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/views/earned_badges/_form.html.haml
+++ b/app/views/earned_badges/_form.html.haml
@@ -3,11 +3,11 @@
 = simple_form_for([@badge, @earned_badge]) do |f|
   .italic= "You are awarding the #{@badge.name} #{term_for :badge} to..."
 
-  = hidden_field_tag :badge_id, @badge.id
-  = hidden_field_tag :student_visible, true
+  = f.hidden_field :badge_id, value: @badge.id
+  = f.hidden_field :student_visible, value: true
 
   %section
-    = select_tag :student_id, options_from_collection_for_select(current_course.students, "id", "name", @earned_badge.try(:student_id)), :prompt => "Select Student"
+    = f.select :student_id, options_from_collection_for_select(@students, "id", "name", @earned_badge.try(:student_id)), :prompt => "Select Student"
 
   %section
     .textarea

--- a/app/views/grades/_grade.json.jbuilder
+++ b/app/views/grades/_grade.json.jbuilder
@@ -1,6 +1,8 @@
 json.(grade, :id, :status, :raw_score, :feedback, :is_custom_value, :student_id,
   :assignment_id)
 
+json.student_visible GradeProctor.new(grade).viewable?
+
 json.assignment do
   json.release_necessary assignment.release_necessary
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,6 @@ GradeCraft::Application.routes.draw do
   resources :unlock_conditions
 
   # earned badges grade routes
-  post "grades/earn_student_badge", to: "grades#earn_student_badge"
   post "grade/:grade_id/earn_student_badges", to: "grades#earn_student_badges"
   delete "grade/:grade_id/student/:student_id/badge/:badge_id/earned_badge/:id", to: "grades#delete_earned_badge"
   delete "grade/:grade_id/earned_badges", to: "grades#delete_all_earned_badges"
@@ -365,6 +364,9 @@ GradeCraft::Application.routes.draw do
 
     # levels
     resources :levels, only: :update
+
+    # earned badges
+    resources :earned_badges, only: :create
 
     #17b. Predictor, Student View
     resources :predicted_earned_badges, only: [:index, :update]

--- a/spec/controllers/api/earned_badges_controller_spec.rb
+++ b/spec/controllers/api/earned_badges_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_spec_helper"
+
+describe API::EarnedBadgesController do
+  let(:world) { World.create.with(:course, :student, :badge) }
+  let(:professor) { create(:professor_course_membership, course: world.course).user }
+
+  context "as professor" do
+    before(:each) { login_user(professor) }
+
+    describe "POST create" do
+      it "creates a new student badge from params" do
+          params = { earned_badge:
+                     { badge_id: world.badge.id, student_id: world.student.id }}
+          expect{post :create, params.merge(format: :json)}.to \
+            change {EarnedBadge.count}.by(1)
+        end
+    end
+  end
+end

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -57,15 +57,20 @@ describe EarnedBadgesController do
 
     describe "POST create" do
       it "creates the earned badge with valid attributes" do
-        params = attributes_for(:earned_badge)
-        params[:badge_id] = @badge.id
-        params[:student_id] = @student.id
-        expect{ post :create, badge_id: @badge.id, student_id: @student.id, earned_badge: params }.to change(EarnedBadge.student_visible, :count).by(1)
+        expect{ post :create, badge_id: @badge.id, earned_badge: { badge_id: @badge.id,
+                                              student_id: @student.id,
+                                              student_visible: true,
+                                              feedback: "You did great!" }}.to \
+          change(EarnedBadge.student_visible, :count).by(1)
         expect(response).to redirect_to badge_path(@badge)
       end
 
       it "doesn't create earned badges with invalid attributes" do
-        expect{ post :create, badge_id: @badge.id, earned_badge: attributes_for(:earned_badge, badge_id: @badge.id, student_id: nil) }.to_not change(EarnedBadge,:count)
+        expect{ post :create, badge_id: @badge.id, earned_badge: { badge_id: @badge.id,
+                                                          student_id: nil,
+                                                          student_visible: true,
+                                                          feedback: "You rock!" }}.to_not \
+          change(EarnedBadge,:count)
       end
     end
 
@@ -143,15 +148,14 @@ describe EarnedBadgesController do
 
     describe "POST update" do
       it "updates the earned badge" do
-        params = { feedback: "more feedback" }
+        params = { badge_id: @badge.id, student_id: @student.id, feedback: "great!" }
         post :update, { id: @earned_badge.id, badge_id: @badge.id, earned_badge: params }
-        expect(@earned_badge.reload.feedback).to eq("more feedback")
+        expect(@earned_badge.reload.feedback).to eq("great!")
         expect(response).to redirect_to(badge_path(@badge))
       end
 
       it "renders the edit template if the update fails" do
-        params = { feedback: "more feedback" }
-        params[:student_id] = nil
+        params = { badge_id: @badge.id, student_id: nil, feedback: "great!" }
         post :update, { id: @earned_badge.id, badge_id: @badge.id, earned_badge: params }
         expect(response).to render_template(:edit)
       end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -189,14 +189,6 @@ describe GradesController do
       end
     end
 
-    describe "earn_student_badge" do
-      it "creates a new student badge from params" do
-        badge = create(:badge)
-        params = { earned_badge: { badge_id: badge.id, student_id: @student } }
-        expect{post :earn_student_badge, params}.to change {EarnedBadge.count}.by(1)
-      end
-    end
-
     describe "earn_student_badges" do
       it "creates new student badges from params" do
         badge_1 = create(:badge)

--- a/spec/features/awarding_a_badge_spec.rb
+++ b/spec/features/awarding_a_badge_spec.rb
@@ -28,7 +28,7 @@ feature "awarding a badge" do
       expect(current_path).to eq new_badge_earned_badge_path(badge)
 
       within(".pageContent") do
-        select "Hermione Granger", from: "student_id"
+        select "Hermione Granger", from: "earned_badge_student_id"
         click_button "Award badge"
       end
       expect(page).to have_notification_message("notice", "The Fancy Badge badge was successfully awarded to Hermione Granger")

--- a/spec/services/creates_earned_badge/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/creates_earned_badge_spec.rb
@@ -3,19 +3,14 @@ require "active_record_spec_helper"
 require "./app/services/creates_earned_badge/creates_earned_badge"
 
 describe Services::Actions::CreatesEarnedBadge do
-  let(:assignment) { create :assignment, course: course }
-  let(:badge) { create :badge, course: course }
-  let(:course) { create :course }
-  let(:course_membership) { create :student_course_membership, course: course }
-  let(:grade) { create :grade, course: course, student: student }
-  let(:student) { course_membership.user }
+  let(:world) { World.create.with(:course, :assignment, :student, :badge, :grade) }
 
   let(:attributes) do
     {
-      student_id: student.id,
-      badge_id: badge.id,
-      assignment_id: assignment.id,
-      grade_id: grade.id,
+      student_id: world.student.id,
+      badge_id: world.badge.id,
+      assignment_id: world.assignment.id,
+      grade_id: world.grade.id,
       score: 800,
       student_visible: true,
       feedback: "You are so awesome!"

--- a/spec/services/creates_earned_badge/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/creates_earned_badge_spec.rb
@@ -1,0 +1,41 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_earned_badge/creates_earned_badge"
+
+describe Services::Actions::CreatesEarnedBadge do
+  let(:assignment) { create :assignment, course: course }
+  let(:badge) { create :badge, course: course }
+  let(:course) { create :course }
+  let(:course_membership) { create :student_course_membership, course: course }
+  let(:grade) { create :grade, course: course, student: student }
+  let(:student) { course_membership.user }
+
+  let(:attributes) do
+    {
+      student_id: student.id,
+      badge_id: badge.id,
+      assignment_id: assignment.id,
+      grade_id: grade.id,
+      score: 800,
+      student_visible: true,
+      feedback: "You are so awesome!"
+    }
+  end
+
+  it "expects attributes to create the earned badge" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "promises the created earned badge" do
+    result = described_class.execute attributes: attributes
+    expect(result).to have_key :earned_badge
+    expect(result.earned_badge).to be_persisted
+  end
+
+  it "halts if the earned badge is invalid" do
+    attributes[:student_id] = nil
+    expect { described_class.execute attributes: attributes }.to \
+      raise_error LightService::FailWithRollbackError
+  end
+end

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -1,0 +1,28 @@
+require "action_mailer"
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_earned_badge/notifies_of_earned_badge"
+require "./app/mailers/application_mailer"
+require "./app/mailers/notification_mailer"
+
+describe Services::Actions::NotifiesOfEarnedBadge do
+  let(:delivery) { double(:email) }
+  let(:earned_badge) { create :earned_badge }
+
+  it "expects an earned badge to send the notification about" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "sends a notification to the student of the newly awarded badge if the badge is student visible" do
+    earned_badge.update_attributes(student_visible: true)
+    expect(delivery).to receive(:deliver_now)
+    expect(NotificationMailer).to receive(:earned_badge_awarded).with(earned_badge.id).and_return delivery
+    described_class.execute earned_badge: earned_badge
+  end
+
+  it "does not send the notification if the badge is not student visible" do
+    expect(NotificationMailer).to_not receive(:earned_badge_awarded)
+    described_class.execute earned_badge: earned_badge
+  end
+end

--- a/spec/services/creates_earned_badge/recalculates_student_score_spec.rb
+++ b/spec/services/creates_earned_badge/recalculates_student_score_spec.rb
@@ -1,0 +1,32 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_earned_badge/recalculates_student_score"
+
+describe Services::Actions::RecalculatesStudentScore do
+  let(:earned_badge) { create :earned_badge }
+
+  before do
+    class FakeJob
+      def initialize(attributes); end
+      def enqueue; end
+    end
+
+    stub_const("ScoreRecalculatorJob", FakeJob)
+  end
+
+  it "expects an earned badge to recalculate the score for" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "recalculates the score if there is a point total" do
+    expect_any_instance_of(ScoreRecalculatorJob).to receive(:enqueue)
+    described_class.execute earned_badge: earned_badge
+  end
+
+  it "does not recalculate the score if there is no point total" do
+    earned_badge.badge.update_attributes(point_total: nil)
+    expect_any_instance_of(ScoreRecalculatorJob).to_not receive(:enqueue)
+    described_class.execute earned_badge: earned_badge
+  end
+end

--- a/spec/services/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge_spec.rb
@@ -10,34 +10,34 @@ describe Services::CreatesEarnedBadge do
     let(:grade) { create :grade, course: course, student: student }
     let(:student) { course_membership.user }
 
-    let(:params) do
-      { earned_badge: {
-          student_id: student.id,
-          badge_id: badge.id,
-          assignment_id: assignment.id,
-          grade_id: grade.id,
-          score: 800,
-          student_visible: true,
-          feedback: "You are so awesome!" }
+    let(:attributes) do
+      {
+        student_id: student.id,
+        badge_id: badge.id,
+        assignment_id: assignment.id,
+        grade_id: grade.id,
+        score: 800,
+        student_visible: true,
+        feedback: "You are so awesome!"
       }
     end
 
     it "creates a new earned badge" do
       expect(Services::Actions::CreatesEarnedBadge).to \
         receive(:execute).and_call_original
-      described_class.award params
+      described_class.award attributes
     end
 
     it "recalculates the student's score" do
       expect(Services::Actions::RecalculatesStudentScore).to \
         receive(:execute).and_call_original
-      described_class.award params
+      described_class.award attributes
     end
 
     it "notifies the student of the awarded badge" do
       expect(Services::Actions::NotifiesOfEarnedBadge).to \
         receive(:execute).and_call_original
-      described_class.award params
+      described_class.award attributes
     end
   end
 end

--- a/spec/services/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge_spec.rb
@@ -3,19 +3,14 @@ require "./app/services/creates_earned_badge"
 
 describe Services::CreatesEarnedBadge do
   describe ".award" do
-    let(:assignment) { create :assignment, course: course }
-    let(:badge) { create :badge, course: course }
-    let(:course) { create :course }
-    let(:course_membership) { create :student_course_membership, course: course }
-    let(:grade) { create :grade, course: course, student: student }
-    let(:student) { course_membership.user }
+    let(:world) { World.create.with(:course, :assignment, :student, :badge, :grade) }
 
     let(:attributes) do
       {
-        student_id: student.id,
-        badge_id: badge.id,
-        assignment_id: assignment.id,
-        grade_id: grade.id,
+        student_id: world.student.id,
+        badge_id: world.badge.id,
+        assignment_id: world.assignment.id,
+        grade_id: world.grade.id,
         score: 800,
         student_visible: true,
         feedback: "You are so awesome!"

--- a/spec/services/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge_spec.rb
@@ -22,6 +22,15 @@ describe Services::CreatesEarnedBadge do
       }
     end
 
+    before do
+      class FakeJob
+        def initialize(attributes); end
+        def enqueue; end
+      end
+
+      stub_const("ScoreRecalculatorJob", FakeJob)
+    end
+
     it "creates a new earned badge" do
       expect(Services::Actions::CreatesEarnedBadge).to \
         receive(:execute).and_call_original

--- a/spec/services/creates_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge_spec.rb
@@ -1,0 +1,43 @@
+require "active_record_spec_helper"
+require "./app/services/creates_earned_badge"
+
+describe Services::CreatesEarnedBadge do
+  describe ".award" do
+    let(:assignment) { create :assignment, course: course }
+    let(:badge) { create :badge, course: course }
+    let(:course) { create :course }
+    let(:course_membership) { create :student_course_membership, course: course }
+    let(:grade) { create :grade, course: course, student: student }
+    let(:student) { course_membership.user }
+
+    let(:params) do
+      { earned_badge: {
+          student_id: student.id,
+          badge_id: badge.id,
+          assignment_id: assignment.id,
+          grade_id: grade.id,
+          score: 800,
+          student_visible: true,
+          feedback: "You are so awesome!" }
+      }
+    end
+
+    it "creates a new earned badge" do
+      expect(Services::Actions::CreatesEarnedBadge).to \
+        receive(:execute).and_call_original
+      described_class.award params
+    end
+
+    it "recalculates the student's score" do
+      expect(Services::Actions::RecalculatesStudentScore).to \
+        receive(:execute).and_call_original
+      described_class.award params
+    end
+
+    it "notifies the student of the awarded badge" do
+      expect(Services::Actions::NotifiesOfEarnedBadge).to \
+        receive(:execute).and_call_original
+      described_class.award params
+    end
+  end
+end


### PR DESCRIPTION
Moves the routes `POST grade/earn_student_badge` to `POST api/earned_badges` and allows both the `POST api/earned_badges.json` and the `POST earned_badges` to use a service to create an `EarnedBadge`.

The previous version of `POST grade/earn_student_badge` did not send out the new badge notification nor did it recalculate the student's score. Now, with the new `CreatesEarnedBage` service, it does both.

Closes #1747