### PR TITLE
1971 Fix sporadically failing tests for destroyable

### DIFF
--- a/lib/grade_proctor.rb
+++ b/lib/grade_proctor.rb
@@ -14,5 +14,7 @@ class GradeProctor
     @grade = grade
   end
 
-  alias_method :destroyable?, :updatable?
+  def destroyable?(options={})
+    updatable? options
+  end
 end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -362,10 +362,8 @@ describe GradesController do
       end
 
       it "redirects to the assignments if the professor does not have access" do
-        # destroyable is aliased as updatable and alias_method does not allow
-        # mocking
         allow_any_instance_of(GradeProctor).to \
-          receive(:updatable?).and_return false
+          receive(:destroyable?).and_return false
         expect(delete :destroy, { id: @grade.id }).to \
           redirect_to(assignment_path(@grade.assignment))
       end


### PR DESCRIPTION
Defines the `#destroyable?` method on a `GradeProctor` that calls `#updatable?` instead of aliasing it via the `alias_method` call.

I believe the "`destroyable?` is not defined error was because the `GradeProctor` was being loaded without the `Updatable` module being realized and therefore, no `updatable?` method was available to alias.

The fix was to define the `#destroyable?` method and just call `#updatable?`.

Closes #1971 