### PR TITLE
update path parsing for group rubrics grades

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeCtrl.js.coffee
@@ -14,7 +14,6 @@
 
     $scope.rawScoreUpdating = false
     $scope.hasChanges = false
-    $scope.gradeStatuses = ["In Progress", "Graded", "Released"]
 
     # establish and populate all necessary collections for UI
     $scope.populateCollections(initData.badges, initData.assignment_score_levels)

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -21,10 +21,10 @@
         id: parseInt(window.location.search.match(/student_id=(\d+)/)[1])
       }
     # GRADING A GROUP FOR AN ASSIGNMENT
-    else if window.location.search.match(/group_id=/)
+    else if location.pathname.split('/')[3] == "groups"
       assignment.scope = {
         type: "GROUP",
-        id: parseInt(window.location.search.match(/group_id=(\d+)/)[1])
+        id: parseInt(location.pathname.split('/')[4])
       }
     # DESIGNING A RUBRIC
     else


### PR DESCRIPTION
This PR updates the Angular path parsing for group rubric grading. 

The new route does not have a `group_id` query (yay!) but we forgot to update this in Angular. We should remember to do this for the student route as well when it is updated.