### PR TITLE
1747 grade routes edit refactor

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -1,24 +1,29 @@
 @gradecraft.controller 'GradeRubricCtrl', ['$scope', 'Restangular', 'RubricService', '$q', ($scope, Restangular, RubricService, $q) ->
 
-  $scope.assignment = RubricService.assignment
   $scope.courseBadges = RubricService.badges
   $scope.criteria = RubricService.criteria
   $scope.criterionGrades = RubricService.criterionGrades
   $scope.grade = RubricService.grade
   $scope.gradeStatusOptions = RubricService.gradeStatusOptions
 
-  RubricService.getAssignment(window.location)
-
   # Criterion factory is dependent on CriterionGrades existing in scope
-  $scope.init = ()->
-    $q.all([RubricService.getCriterionGrades($scope.assignment)])
+  $scope.init = (assignment_id, scope_type, scoped_id)->
+    $scope.assignment = {
+      id: assignment_id,
+      scope: {
+        type: scope_type,
+        id: scoped_id
+      }
+    }
+    $scope.services()
 
-  $scope.init().then(()->
-    RubricService.getCriteria($scope.assignment, $scope)
-  )
-
-  RubricService.getBadges()
-  RubricService.getGrade($scope.assignment)
+  $scope.services = () ->
+    promises = [
+      RubricService.getCriterionGrades($scope.assignment),
+      RubricService.getCriteria($scope.assignment, $scope),
+      RubricService.getBadges(),
+      RubricService.getGrade($scope.assignment)]
+    $q.all(promises)
 
   $scope.pointsPossible = ()->
     RubricService.pointsPossible()

--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -20,7 +20,7 @@
   $scope.services = () ->
     promises = [
       RubricService.getCriterionGrades($scope.assignment),
-      RubricService.getCriteria($scope.assignment, $scope),
+      RubricService.getCriteria($scope.assignment.id, $scope),
       RubricService.getBadges(),
       RubricService.getGrade($scope.assignment)]
     $q.all(promises)

--- a/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
@@ -11,8 +11,8 @@
   RubricService.getBadges()
   RubricService.getCriteria($scope.assignment, $scope)
 
-  $scope.init = (rubricId, pointTotal)->
-    $scope.rubricId = rubricId
+  $scope.init = (assignmentId, pointTotal)->
+    $scope.assignmentId = assignmentId
     $scope.pointTotal = parseInt(pointTotal)
 
   # distill key/value pairs for criterion ids and relative order

--- a/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
@@ -1,19 +1,21 @@
-@gradecraft.controller 'RubricCtrl', ['$scope', 'Restangular', 'Criterion', 'CourseBadge', 'RubricService', '$http', ($scope, Restangular, Criterion, CourseBadge, RubricService, $http) ->
+@gradecraft.controller 'RubricCtrl', ['$scope', 'Restangular', 'Criterion', 'CourseBadge', 'RubricService', '$http', '$q', ($scope, Restangular, Criterion, CourseBadge, RubricService, $http, $q) ->
   Restangular.setRequestSuffix('.json')
 
-  $scope.assignment = RubricService.assignment
   $scope.courseBadges = RubricService.badges
   $scope.criteria = RubricService.criteria
 
   $scope.savedCriterionCount = 0
 
-  RubricService.getAssignment(window.location)
-  RubricService.getBadges()
-  RubricService.getCriteria($scope.assignment, $scope)
-
   $scope.init = (assignmentId, pointTotal)->
     $scope.assignmentId = assignmentId
     $scope.pointTotal = parseInt(pointTotal)
+    $scope.services()
+
+  $scope.services = () ->
+    promises = [
+      RubricService.getBadges()
+      RubricService.getCriteria($scope.assignmentId, $scope)]
+    $q.all(promises)
 
   # distill key/value pairs for criterion ids and relative order
   $scope.pointsAssigned = ()->

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -29,7 +29,7 @@
     )
 
   getCriterionGrades = (assignment)->
-    if assignment.scope.type == "STUDENT"
+    if assignment.scope.type == "student"
       $http.get('/api/assignments/' + assignment.id + '/students/' + assignment.scope.id + '/criterion_grades/').success((res)->
         addCriterionGrades(res.data)
       )
@@ -50,7 +50,7 @@
     )
 
   getGrade = (assignment)->
-    if assignment.scope.type == "STUDENT"
+    if assignment.scope.type == "student"
       $http.get('/api/assignments/' + assignment.id + '/students/' + assignment.scope.id + '/grade/').success((res)->
         angular.copy(res.data.attributes, grade)
         angular.copy(res.meta.grade_status_options, gradeStatusOptions)
@@ -67,7 +67,7 @@
       )
 
   putRubricGradeSubmission = (assignment, params, returnURL)->
-    scopeRoute = if assignment.scope.type == "STUDENT" then "students" else "groups"
+    scopeRoute = if assignment.scope.type == "student" then "students" else "groups"
     $http.put("/api/assignments/#{assignment.id}/#{scopeRoute}/#{assignment.scope.id}/criterion_grades", params).success(
       (data)->
         console.log(data)

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -14,24 +14,11 @@
 
   getAssignment = (location)->
     assignment.id = parseInt(location.pathname.split('/')[2])
-    # GRADING A STUDENT FOR AN ASSIGNMENT
-    if location.search.match(/student_id=/)
-      assignment.scope = {
-        type: "STUDENT",
-        id: parseInt(window.location.search.match(/student_id=(\d+)/)[1])
-      }
-    # GRADING A GROUP FOR AN ASSIGNMENT
-    else if location.pathname.split('/')[3] == "groups"
-      assignment.scope = {
-        type: "GROUP",
-        id: parseInt(location.pathname.split('/')[4])
-      }
     # DESIGNING A RUBRIC
-    else
-      assignment.scope = {
-        type: "DESIGN_MODE",
-        id: null
-      }
+    assignment.scope = {
+      type: "DESIGN_MODE",
+      id: null
+    }
 
   # TODO: $scope should not be passed around if we want to avoid tight coupling
   getCriteria = (assignment, $scope)->

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -12,14 +12,6 @@
   badges = {}
   criterionGrades = {}
 
-  getAssignment = (location)->
-    assignment.id = parseInt(location.pathname.split('/')[2])
-    # DESIGNING A RUBRIC
-    assignment.scope = {
-      type: "DESIGN_MODE",
-      id: null
-    }
-
   # TODO: $scope should not be passed around if we want to avoid tight coupling
   getCriteria = (assignmentId, $scope)->
     _scope = $scope

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -33,7 +33,7 @@
       $http.get('/api/assignments/' + assignment.id + '/students/' + assignment.scope.id + '/criterion_grades/').success((res)->
         addCriterionGrades(res.data)
       )
-    else if assignment.scope.type == "GROUP"
+    else if assignment.scope.type == "group"
       $http.get('/api/assignments/' + assignment.id + '/groups/' + assignment.scope.id + '/criterion_grades/').success((res)->
 
         # The API sends all student information so we can add the ability to custom grade group members
@@ -56,7 +56,7 @@
         angular.copy(res.meta.grade_status_options, gradeStatusOptions)
         thresholdPoints = res.meta.threshold_points
       )
-    else if assignment.scope.type == "GROUP"
+    else if assignment.scope.type == "group"
       $http.get('/api/assignments/' + assignment.id + '/groups/' + assignment.scope.id + '/grades/').success((res)->
 
         # The API sends all student information so we can add the ability to custom grade group members

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -21,9 +21,9 @@
     }
 
   # TODO: $scope should not be passed around if we want to avoid tight coupling
-  getCriteria = (assignment, $scope)->
+  getCriteria = (assignmentId, $scope)->
     _scope = $scope
-    $http.get('/api/assignments/' + assignment.id + '/criteria').success((res)->
+    $http.get('/api/assignments/' + assignmentId + '/criteria').success((res)->
       angular.forEach(res.data, (criterion, index)->
         criterionObject = new Criterion(criterion.attributes, _scope)
         criteria.push criterionObject

--- a/app/controllers/assignments/groups_controller.rb
+++ b/app/controllers/assignments/groups_controller.rb
@@ -12,8 +12,6 @@ class Assignments::GroupsController < ApplicationController
 
     if @assignment.grade_with_rubric?
       @rubric = @assignment.rubric
-      # This is sent to the Angular controlled submit button
-      @return_path = URI(request.referer).path
     end
   end
 

--- a/app/controllers/assignments/groups_controller.rb
+++ b/app/controllers/assignments/groups_controller.rb
@@ -9,10 +9,7 @@ class Assignments::GroupsController < ApplicationController
     @submission_id = @assignment.submissions.where(group_id: @group.id).first.try(:id)
     @title = "Grading #{ @group.name }'s #{@assignment.name}"
     @assignment_score_levels = @assignment.assignment_score_levels
-
-    if @assignment.grade_with_rubric?
-      @rubric = @assignment.rubric
-    end
+    @rubric = @assignment.rubric if @assignment.grade_with_rubric?
   end
 
   # PUT /assignments/:assignment_id/groups/:id/graded

--- a/app/controllers/assignments/students_controller.rb
+++ b/app/controllers/assignments/students_controller.rb
@@ -1,0 +1,8 @@
+class Assignments::StudentsController < ApplicationController
+  before_filter :ensure_staff?
+
+  def grade
+    grade = Grade.find_or_create params[:assignment_id], params[:student_id]
+    redirect_to edit_grade_path grade
+  end
+end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -38,8 +38,7 @@ class GradesController < ApplicationController
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end
 
-      path = session[:return_to].present? ? session[:return_to] :
-        assignment_path(grade.assignment)
+      path = session[:return_to] || assignment_path(grade.assignment)
       redirect_to path,
         notice: "#{grade.student.name}'s #{grade.assignment.name} was successfully updated"
     else # failure

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -28,7 +28,7 @@ class GradesController < ApplicationController
 
   # To avoid duplicate grades, we don't supply a create method. Update will
   # create a new grade if none exists, and otherwise update the existing grade
-  # PUT /assignments/:assignment_id/grade
+  # PUT /grades/:id
   def update
     grade = Grade.find params[:id]
 

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -1,6 +1,6 @@
 class GradesController < ApplicationController
   respond_to :html, :json
-  before_filter :set_assignment, only: [:edit, :update]
+  before_filter :set_assignment, only: [:update]
   before_filter :ensure_staff?,
     except: [:feedback_read, :show, :predict_score, :async_update]
   before_filter :ensure_student?, only: [:feedback_read, :predict_score]
@@ -18,37 +18,13 @@ class GradesController < ApplicationController
     @title = "#{name}'s Grade for #{@grade.assignment.name}"
   end
 
-  def edit2
+  # GET /grades/:id/edit
+  def edit
     @grade = Grade.find params[:id]
     @title = "Editing #{@grade.student.name}'s Grade "\
       "for #{@grade.assignment.name}"
     @badges = @grade.student.earnable_course_badges_for_grade(@grade)
     @submission = @grade.student.submission_for_assignment(@grade.assignment)
-    render :edit
-  end
-
-  # GET /assignments/:assignment_id/grade/edit?student_id=:id
-  def edit
-    @student = current_student
-
-    @grade = Grade.find_or_create(@assignment.id, @student.id)
-    @title = "Editing #{@student.name}'s Grade for #{@assignment.name}"
-
-    @submission = @student.submission_for_assignment(@assignment)
-
-    @badges = @student.earnable_course_badges_for_grade(@grade)
-    @assignment_score_levels =
-      @assignment.assignment_score_levels.order_by_value
-
-    if @assignment.grade_with_rubric?
-      @rubric = @assignment.rubric
-      @criterion_grades = serialized_criterion_grades
-      # This is sent to the Angular controlled submit button
-      @return_path =
-        URI(request.referer).path + "?student_id=#{current_student.id}"
-    end
-
-    @serialized_init_data = serialized_init_data
   end
 
   # To avoid duplicate grades, we don't supply a create method. Update will
@@ -72,7 +48,7 @@ class GradesController < ApplicationController
       end
 
     else # failure
-      redirect_to edit_assignment_grade_path(@assignment, student_id: @grade.student.id), alert: "#{@grade.student.name}'s #{@assignment.name} was not successfully submitted! Please try again."
+      redirect_to edit_grade_path(@grade), alert: "#{@grade.student.name}'s #{@assignment.name} was not successfully submitted! Please try again."
     end
   end
 

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -18,6 +18,15 @@ class GradesController < ApplicationController
     @title = "#{name}'s Grade for #{@grade.assignment.name}"
   end
 
+  def edit2
+    @grade = Grade.find params[:id]
+    @title = "Editing #{@grade.student.name}'s Grade "\
+      "for #{@grade.assignment.name}"
+    @badges = @grade.student.earnable_course_badges_for_grade(@grade)
+    @submission = @grade.student.submission_for_assignment(@grade.assignment)
+    render :edit
+  end
+
   # GET /assignments/:assignment_id/grade/edit?student_id=:id
   def edit
     @student = current_student

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -1,6 +1,5 @@
 class GradesController < ApplicationController
   respond_to :html, :json
-  before_filter :set_assignment, only: [:update]
   before_filter :ensure_staff?,
     except: [:feedback_read, :show, :predict_score, :async_update]
   before_filter :ensure_student?, only: [:feedback_read, :predict_score]
@@ -215,9 +214,5 @@ class GradesController < ApplicationController
 
   def rubric_criteria_with_levels
     @rubric_criteria_with_levels ||= @rubric.criteria.ordered.includes(:levels)
-  end
-
-  def set_assignment
-    @assignment = Assignment.find(params[:assignment_id]) if params[:assignment_id]
   end
 end

--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -40,4 +40,24 @@ module GradesHelper
     # This cache key is busted when a grade is updated
     "#{course.cache_key}/unreleased_grades_count"
   end
+
+  def initial_grade_json(grade)
+    JbuilderTemplate.new(ApplicationController.new.view_context).encode do |json|
+      json.grade do
+        json.partial! "grades/grade", grade: grade, assignment: grade.assignment
+      end
+
+      json.badges do
+        json.partial! "grades/badges", badges: grade.student.earnable_course_badges_for_grade(grade), student_id: grade.student_id
+      end
+
+      json.assignment do
+        json.partial! "grades/assignment", assignment: grade.assignment
+      end
+
+      json.assignment_score_levels do
+        json.partial! "grades/assignment_score_levels", assignment_score_levels: grade.assignment.assignment_score_levels.order_by_value
+      end
+    end.to_json
+  end
 end

--- a/app/views/assignments/grades/index.html.haml
+++ b/app/views/assignments/grades/index.html.haml
@@ -21,7 +21,7 @@
         %h4.uppercase= student.name
         .left
           %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.point_total} points "
-        .right= link_to "Edit #{student.first_name}'s Grade", edit_assignment_grade_path(presenter.assignment, student_id: student.id), class: "button"
+        .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
         %br
         %br
         .rubric-container= render partial: "grades/components/criterion_grade_results", locals: { presenter: presenter, current_student: student }

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -56,4 +56,4 @@
                 .right
                   %ul.button-bar
                     - if group_presenter.assignment_graded?
-                      %li= link_to glyph(:edit) + "Override Grade", edit_grade_path(grade), class: "button"
+                      %li= link_to glyph(:edit) + "Override Grade", assignment_student_grade_path(group_presenter.assignment, student), method: :post, class: "button"

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -56,4 +56,4 @@
                 .right
                   %ul.button-bar
                     - if group_presenter.assignment_graded?
-                      %li= link_to glyph(:edit) + "Override Grade", edit_assignment_grade_path(presenter.assignment, student_id: student.id), class: "button"
+                      %li= link_to glyph(:edit) + "Override Grade", edit_grade_path(grade), class: "button"

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -15,6 +15,6 @@
         = prop.title
 
   - if @rubric
-    = render "/grades/rubric_edit"
+    = render partial: "/grades/rubric_edit", locals: { rubric: @rubric, return_path: URI(request.referer).path }
   - else
-    = render "standard_edit"
+    = render partial: "standard_edit"

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -15,6 +15,6 @@
         = prop.title
 
   - if @rubric
-    = render partial: "/grades/rubric_edit", locals: { rubric: @rubric, scope_type: "GROUP", scoped_id: @group.id, return_path: URI(request.referer).path }
+    = render partial: "/grades/rubric_edit", locals: { rubric: @rubric, scope_type: "group", scoped_id: @group.id, return_path: URI(request.referer).path }
   - else
     = render partial: "standard_edit"

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -15,6 +15,6 @@
         = prop.title
 
   - if @rubric
-    = render partial: "/grades/rubric_edit", locals: { rubric: @rubric, return_path: URI(request.referer).path }
+    = render partial: "/grades/rubric_edit", locals: { rubric: @rubric, scope_type: "GROUP", scoped_id: @group.id, return_path: URI(request.referer).path }
   - else
     = render partial: "standard_edit"

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -74,7 +74,7 @@
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               %li= link_to glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - has_submission = presenter.assignment.accepts_submissions? && !submissions_for_assignment.empty?
-            %li= link_to glyph(:check) + "Grade", edit_grade_path(grade), class: "button #{has_submission ? "danger" : ""}"
+            %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student), method: :post, class: "button #{has_submission ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -66,15 +66,15 @@
           - if grade.instructor_modified?
             %li= link_to glyph(:eye) + "See Grade", grade_path(grade), class: "button"
             - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(submissions_for_assignment)
-              %li= link_to glyph(:edit) + "Re-grade", edit_assignment_grade_path(presenter.assignment, student_id: student.id), class: "button danger"
+              %li= link_to glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
             - else
-              %li= link_to glyph(:edit) + "Edit Grade", edit_assignment_grade_path(presenter.assignment, student_id: student.id), class: "button"
+              %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
             %li= link_to glyph(:trash) + "Delete Grade", remove_grade_path(grade), class: "button", data: { confirm: "Are you sure?" }, :method => :post
           - else
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               %li= link_to glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - has_submission = presenter.assignment.accepts_submissions? && !submissions_for_assignment.empty?
-            %li= link_to glyph(:check) + "Grade", edit_assignment_grade_path(presenter.assignment, student_id: student.id), class: "button #{has_submission ? "danger" : ""}"
+            %li= link_to glyph(:check) + "Grade", edit_grade_path(grade), class: "button #{has_submission ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -33,7 +33,7 @@
             %label.larger
               <strong>Criterion</strong>:&nbsp;Max&nbsp;points
 
-          %td.level.heading(colspan="#{@rubric.max_level_count}")
+          %td.level.heading(colspan="#{rubric.max_level_count}")
             %label.larger
               %strong Level:
               Points Awarded
@@ -63,7 +63,7 @@
               .level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
                 %img(ng-src="{{levelBadge.badge.icon}}" height="50px")
               .clear
-          %td.filler(ng-show="criterion.levels.length < #{@rubric.max_level_count}" colspan="{{#{@rubric.max_level_count} - criterion.levels.length}}")
+          %td.filler(ng-show="criterion.levels.length < #{rubric.max_level_count}" colspan="{{#{rubric.max_level_count} - criterion.levels.length}}")
           %td.comments-box
             %textarea(ng-model="criterion.comments" froala="froalaOptions")
 
@@ -109,4 +109,4 @@
     %br
 
     .right
-      %button#submit-grade(ng-click="submitGrade('#{@return_path}')" ng-class='{"disabled" : !grade.status}') Submit Grade
+      %button#submit-grade(ng-click="submitGrade('#{return_path}')" ng-class='{"disabled" : !grade.status}') Submit Grade

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -1,5 +1,5 @@
 .pageContent
-  #rubric-grader(ng-app="gradecraft" ng-controller="GradeRubricCtrl")
+  #rubric-grader(ng-app="gradecraft" ng-controller="GradeRubricCtrl" ng-init="init(#{rubric.assignment_id}, '#{scope_type}', #{scoped_id})")
     .row
       #rubric-heading.columns
         %h3.text-right

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -3,31 +3,31 @@
 
   %section
     %hr.dotted
-    = simple_form_for @grade, url: assignment_grade_path(@assignment), method: :patch do |f|
-      = hidden_field_tag :student_id, current_student.id
-      = f.hidden_field :submission_id, value: @submission.try(:id)
+    = simple_form_for grade, url: assignment_grade_path(grade.assignment), method: :patch do |f|
+      = hidden_field_tag :student_id, grade.student_id
+      = f.hidden_field :submission_id, value: submission.try(:id)
 
-      #grade(ng-controller="GradeCtrl" ng-init="init(#{@serialized_init_data})")
-        .panel.splash(ng-cloak) Loading grade for #{@student.name}...
+      #grade(ng-controller="GradeCtrl" ng-init="init(#{initial_grade_json(grade)})")
+        .panel.splash(ng-cloak) Loading grade for #{grade.student.name}...
 
         .panel(ng-cloak)
-          - if @assignment.pass_fail?
+          - if grade.assignment.pass_fail?
             .switch-label
               = "#{term_for :pass} / #{term_for :fail} Status"
             .pass-fail-grade-toggle
               .switch.pass-fail-contingent{data: {:on => "#{term_for :pass}", :off => "#{term_for :fail}"}}
-                = f.check_box :pass_fail_status, { :checked=> @grade.pass_fail_status == "Pass" }, checked_value = "Pass", unchecked_value = "Fail"
-                - label_text = @grade.pass_fail_status ? (term_for @grade.pass_fail_status) : (term_for :fail)
+                = f.check_box :pass_fail_status, { :checked=> grade.pass_fail_status == "Pass" }, checked_value = "Pass", unchecked_value = "Fail"
+                - label_text = grade.pass_fail_status ? (term_for grade.pass_fail_status) : (term_for :fail)
                 = f.label :pass_fail_status, label_text
           - else
-            - if @assignment_score_levels.count > 0 # use this longhand method to save a request
-              = render partial: "grades/standard_edit/score_level_grading_fields", locals: {f:f}
+            - if grade.assignment.assignment_score_levels.count > 0 # use this longhand method to save a request
+              = render partial: "grades/standard_edit/score_level_grading_fields", locals: { f:f, assignment: grade.assignment }
             - else
-              = render partial: "grades/standard_edit/raw_score_grading_fields", locals: {f:f}
+              = render partial: "grades/standard_edit/raw_score_grading_fields", locals: { f:f, assignment: grade.assignment }
 
           .attachments(ng-cloak)
             .clear
-            = render partial: "grades/standard_edit/standard_edit_attachment", locals: {f: f}
+            = render partial: "grades/standard_edit/standard_edit_attachment", locals: { f: f, grade: grade }
 
           .text-feedback
             = f.hidden_field :graded_by_id, :value => current_user.id
@@ -39,7 +39,7 @@
               "ng-model-options" => "{ debounce: 1000 }"
 
           %span.last-updated
-            #updated-at(ng-hide="grade.updated_at")= "Last updated #{time_ago_in_words(@grade.updated_at)} ago"
+            #updated-at(ng-hide="grade.updated_at")= "Last updated #{time_ago_in_words(grade.updated_at)} ago"
             #updated-at-current(ng-show="grade.updated_at" ng-class="{just_updated: grade.justUpdated()}")
               %span updated
               %span(am-time-ago="grade.updated_at")
@@ -49,11 +49,11 @@
           .right
             .row
               .assignment-status
-                - if @assignment.release_necessary?
+                - if grade.assignment.release_necessary?
 
-                  = f.input :status, as: :select, :collection => Grade::STATUSES, :selected => @grade.status, :include_blank => false
+                  = f.input :status, as: :select, :collection => Grade::STATUSES, :selected => grade.status, :include_blank => false
                 - else
-                  = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => @grade.status || "Graded", :include_blank => false
+                  = f.input :status, as: :select, :collection => Grade::UNRELEASED_STATUSES, :selected => grade.status || "Graded", :include_blank => false
                 .align-right.form_label Can the student see this grade?
           .clear
           %br
@@ -61,19 +61,19 @@
 
           .submit-buttons
             %ul
-              %li= submit_tag "#{@grade.persisted? && @grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
-              %li= link_to glyph("times-circle") + "Cancel", assignment_path(@assignment), class: "button"
+              %li= submit_tag "#{grade.persisted? && grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
+              %li= link_to glyph("times-circle") + "Cancel", assignment_path(grade.assignment), class: "button"
 
         %section
 
         - if current_course.badges.present?
           %section
             #awarded(ng-cloak)
-              = render partial: "grades/standard_edit/badges_awarded"
+              = render partial: "grades/standard_edit/badges_awarded", locals: { badges: badges }
               .clear
 
             #available.empty(ng-cloak)
-              = render partial: "grades/standard_edit/badges_available"
+              = render partial: "grades/standard_edit/badges_available", locals: { badges: badges }
               .clear
 
           .panel(ng-if="debug" ng-cloak)

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -3,8 +3,7 @@
 
   %section
     %hr.dotted
-    = simple_form_for grade, url: assignment_grade_path(grade.assignment), method: :patch do |f|
-      = hidden_field_tag :student_id, grade.student_id
+    = simple_form_for grade do |f|
       = f.hidden_field :submission_id, value: submission.try(:id)
 
       #grade(ng-controller="GradeCtrl" ng-init="init(#{initial_grade_json(grade)})")

--- a/app/views/grades/components/_edit_button.html.haml
+++ b/app/views/grades/components/_edit_button.html.haml
@@ -1,5 +1,5 @@
 - if grade.group.nil?
-  - path = edit_assignment_grade_path(grade.assignment, student_id: grade.student_id)
+  - path = edit_grade_path(grade)
 - else
   - path = grade_assignment_group_path(grade.assignment, grade.group)
 

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -16,6 +16,6 @@
             assignment_id: @grade.assignment.id, course: current_course) }
 
   - if @grade.assignment.grade_with_rubric?
-    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, return_path: URI(request.referer || "").path }
+    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, scope_type: "STUDENT", scoped_id: @grade.student_id, return_path: URI(request.referer || "").path }
   - else
     = render partial: "standard_edit", locals: { grade: @grade, badges: @badges, submission: @submission }

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -16,6 +16,6 @@
             assignment_id: @grade.assignment.id, course: current_course) }
 
   - if @grade.assignment.grade_with_rubric?
-    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, scope_type: "STUDENT", scoped_id: @grade.student_id, return_path: URI(request.referer || "").path }
+    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, scope_type: "student", scoped_id: @grade.student_id, return_path: URI(request.referer || "").path }
   - else
     = render partial: "standard_edit", locals: { grade: @grade, badges: @badges, submission: @submission }

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -1,21 +1,21 @@
-= content_nav_for @assignment, "Edit Grade"
+= content_nav_for @grade.assignment, "Edit Grade"
 
 %h3.pagetitle= @title
 
 .pageContent
   = render partial: "layouts/alerts", locals: { model: @grade, display_flash: false }
 
-  = render partial: "submissions/assignment_guidelines", locals: { assignment: @assignment }
+  = render partial: "submissions/assignment_guidelines", locals: { assignment: @grade.assignment }
 
-  - if @assignment.accepts_submissions? && @student.submission_for_assignment(@assignment).present?
+  - if @grade.assignment.accepts_submissions? && @submission.present?
     %section
 
-      %h4.uppercase= "#{@student.first_name}'s Submission"
+      %h4.uppercase= "#{@grade.student.first_name}'s Submission"
       = render partial: "submissions/submission_content",
-          locals: { presenter: Submissions::ShowPresenter.new(id: @submission.id,
-            assignment_id: @assignment.id, course: current_course) }
+        locals: { presenter: Submissions::ShowPresenter.new(id: @submission.id,
+            assignment_id: @grade.assignment.id, course: current_course) }
 
-  - if @assignment.grade_with_rubric?
-    = render "rubric_edit"
+  - if @grade.assignment.grade_with_rubric?
+    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, return_path: URI(request.referer || "").path }
   - else
-    = render "standard_edit"
+    = render partial: "standard_edit", locals: { grade: @grade, badges: @badges, submission: @submission }

--- a/app/views/grades/standard_edit/_badges_available.html.haml
+++ b/app/views/grades/standard_edit/_badges_available.html.haml
@@ -1,4 +1,4 @@
-- if @badges.present?
+- if badges.present?
   %h4#badges-available
     #{term_for :badges} available
     %button#add-badges(ng-click="addRemainingEarnedBadges($event)" ng-show="badgesAvailable()") Add All

--- a/app/views/grades/standard_edit/_badges_awarded.html.haml
+++ b/app/views/grades/standard_edit/_badges_awarded.html.haml
@@ -2,7 +2,7 @@
   #{term_for :badges} Awarded for this #{term_for :assignment}
   %button#remove-badges(ng-click="removeAllEarnedBadges($event)" ng-show="badgesAwarded()") Remove All
 
-- if @badges.present?
+- if badges.present?
 
   .grade-badge.hexagon.awarded(title="{{badge.point_total}} Points: {{badge.description}}" ng-repeat="badge in badges" ng-class="{unearned: badge.unearned(), earned: badge.earned()}" ng-click="badge.deleteEarnedStudentBadge()" hide-after-fade)
 

--- a/app/views/grades/standard_edit/_raw_score_grading_fields.html.haml
+++ b/app/views/grades/standard_edit/_raw_score_grading_fields.html.haml
@@ -1,9 +1,9 @@
 .raw-score
-  = f.label :raw_score, "Raw Score (#{@assignment.point_total} Points Possible)"
+  = f.label :raw_score, "Raw Score (#{assignment.point_total} Points Possible)"
   = f.text_field :raw_score,
-    default: @assignment.point_total,
+    default: assignment.point_total,
     label: "Score",
-    hint: "Total Assignment Points: #{ points @assignment.point_total }",
+    hint: "Total Assignment Points: #{ points assignment.point_total }",
     "ng-model" => "grade.raw_score",
     "ng-change" => "grade.update()",
     "ng-click" => "grade.enableCustomValue()",

--- a/app/views/grades/standard_edit/_score_level_grading_fields.html.haml
+++ b/app/views/grades/standard_edit/_score_level_grading_fields.html.haml
@@ -2,7 +2,7 @@
 
   -# dynamic label for select box
   %label(for="grade_raw_score" ng-click="grade.disableCustomValue()" ng-class="{'inactive': grade.is_custom_value}")
-    Raw Score (#{@assignment.point_total} Points Possible)
+    Raw Score (#{assignment.point_total} Points Possible)
 
   %select#grade_raw_score(name="grade[raw_score]" ng-model="grade.raw_score" ng-disabled="grade.is_custom_value" ng-click="grade.enableScoreLevels($event)" ng-change="grade.update()" ng-class="{'disabled': grade.is_custom_value}")
     %option(value="{{scoreLevel.value}}" ng-repeat="scoreLevel in assignmentScoreLevels" ng-selected="grade.raw_score == scoreLevel.value") {{scoreLevel.name}} ({{scoreLevel.formatted_value}} points)
@@ -12,9 +12,9 @@
   %label#custom-value-label(for="grade_raw_score" ng-click="grade.enableCustomValue()" ng-class="{'disabled': ! grade.is_custom_value}")
     Custom Value
   = f.text_field :raw_score,
-    default: @assignment.point_total,
+    default: assignment.point_total,
     label: "Score",
-    hint: "Total Assignment Points: #{ points @assignment.point_total }",
+    hint: "Total Assignment Points: #{ points assignment.point_total }",
     "ng-model" => "grade.raw_score",
     "ng-change" => "grade.update()",
     "ng-click" => "grade.enableCustomValue()",

--- a/app/views/grades/standard_edit/_standard_edit_attachment.html.haml
+++ b/app/views/grades/standard_edit/_standard_edit_attachment.html.haml
@@ -1,11 +1,11 @@
 .grade-attachments
   .bold Attachments
-  = f.simple_fields_for :grade_files, @grade.grade_files.new do |gf|
+  = f.simple_fields_for :grade_files, grade.grade_files.new do |gf|
     = gf.file_field :file, :multiple => true
-  - if @grade.grade_files.exists?
+  - if grade.grade_files.exists?
     %h5.bold Uploaded files
     %ul.uploaded-files
-      - @grade.grade_files.each do |gf|
+      - grade.grade_files.each do |gf|
         - next if gf.new_record?
         %li
           - if ! gf.file_processing
@@ -16,6 +16,6 @@
               Refresh page to confirm upload has completed
           - else
             = link_to gf.filename, gf.url, :target => "_blank"
-            = link_to "(Remove)", remove_uploads_path({ :model => "GradeFile", grade_id: @grade.id, :upload_id => gf.id } )
+            = link_to "(Remove)", remove_uploads_path({ :model => "GradeFile", grade_id: grade.id, :upload_id => gf.id } )
   %br
   %br

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -51,7 +51,7 @@
                     %ul.button-bar
                       %li= link_to glyph(:eye) + "See Grade", grade_path(grade), class: "button"
                       - if assignment.is_individual?
-                        %li= link_to glyph(:edit) + "Edit Grade", edit_assignment_grade_path(assignment_id: assignment.id, student_id: student.id), class: "button"
+                        %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
                       - elsif assignment.has_groups?
                         %li= link_to glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
                 %td.center= check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-#{grade_type}-grades-command']" }

--- a/app/views/info/_ungraded_submissions_table.haml
+++ b/app/views/info/_ungraded_submissions_table.haml
@@ -39,7 +39,7 @@
               %ul.button-bar
                 - if assignment.is_individual?
                   %li= link_to glyph(:eye) + "See Submission", assignment_submission_path(assignment, id: submission.id), class: "button"
-                  %li= link_to glyph(:check) + "Grade", edit_assignment_grade_path(assignment_id: assignment.id, student_id: student.id), class: "button"
+                  %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
                 - elsif assignment.has_groups?
                   %li= link_to glyph(:eye) + "See Submission", assignment_submission_path(assignment.id, id: submission.id), class: "button"
                   %li= link_to glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"

--- a/app/views/info/gradebook.html.haml
+++ b/app/views/info/gradebook.html.haml
@@ -28,7 +28,7 @@
             - current_course.assignments.each do |assignment|
               - assignment.grade_for_student(student).tap do |grade|
                 - if grade
-                  %td= link_to "#{grade.score}", edit_assignment_grade_path(assignment, student_id: student.id)
+                  %td= link_to "#{grade.score}", edit_grade_path(grade)
                 - else
                   %td
             - if current_course.valuable_badges?

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -51,7 +51,7 @@
                 .right
                   %ul.button-bar
                     %li= link_to glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    %li= link_to glyph(:edit) + "Edit Grade", edit_assignment_grade_path(assignment_id:assignment.id, student_id: re.student.try(:id)), class: "button"
+                    %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(re.student.grade_for_assignment(re.assignment)), class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -52,7 +52,7 @@
                 .right
                   %ul.button-bar
                     %li= link_to glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                    %li= link_to glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -37,6 +37,7 @@
         - resubmissions.each do |re|
           %tr
             - if re.assignment.is_individual?
+              - grade = re.student.grade_for_assignment(re.assignment)
               %td= link_to re.student.first_name, student_path(re.student)
               %td= link_to re.student.last_name, student_path(re.student)
               - if current_course.has_teams?
@@ -44,14 +45,14 @@
                   - team = re.student.team_for_course(current_course)
                   - if team.present?
                     = link_to team.name, team
-              %td= points re.student.grade_for_assignment(re.assignment).score
-              %td= re.student.grade_for_assignment(re.assignment).graded_at
+              %td= points grade.score
+              %td= grade.graded_at
               %td= re.submitted_at
               %td
                 .right
                   %ul.button-bar
                     %li= link_to glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(re.student.grade_for_assignment(re.assignment)), class: "button"
+                    %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -49,7 +49,7 @@
               %ul.button-bar
                 - if submission.assignment.is_individual?
                   %li= link_to glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  %li= link_to glyph(:check) + "Grade", edit_assignment_grade_path(assignment_id: submission.assignment.id, student_id: submission.student.try(:id)), class: "button"
+                  %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
                 - else
                   %li= link_to glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
                   %li= link_to glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -7,7 +7,7 @@
 .pageContent
   = render "layouts/alerts"
 
-  #rubric(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@rubric[:id]}, #{@assignment.point_total})")
+  #rubric(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@assignment.id}, #{@assignment.point_total})")
 
     #points-overview-floating(ng-cloak ng-hide="angular.element('#points-overview').isOnscreen()")
       %h4#points-legend

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -34,5 +34,5 @@
           %td= grade.graded_at
           %td
             %ul.button-bar
-              %li= link_to glyph(:edit) + "Edit", edit_assignment_grade_path(grade.assignment, student_id: grade.student.id), class: "button"
+              %li= link_to glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
               %li= link_to glyph(:trash) + "Delete", remove_grade_path(grade), class: "button", data: { confirm: "Are you sure?" }, :method => :post

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -30,6 +30,6 @@
           %td= g.predicted_points
           %td= g.feedback
           %td= g.status
-          %td= link_to "Edit Grade", edit_assignment_grade_path(g.assignment_id, student_id: g.student_id), class: "button"
+          %td= link_to "Edit Grade", edit_grade_path(g), class: "button"
           %td= link_to "See Grade", grade_path(g), class: "button"
           %td= link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/students/syllabus/components/_grade_buttons.haml
+++ b/app/views/students/syllabus/components/_grade_buttons.haml
@@ -3,7 +3,7 @@
   / Grade Management /
   - if current_user_is_staff?
     - if assignment.is_individual?
-      %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(presenter.grade_for(assignment)), class: "button"
+      %li= link_to glyph(:edit) + "Edit Grade", assignment_student_grade_path(assignment, presenter.student), method: :post, class: "button"
     - elsif assignment.has_groups?
       %li= link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(assignment, presenter.group_for(assignment)), class: "button"
 - else

--- a/app/views/students/syllabus/components/_grade_buttons.haml
+++ b/app/views/students/syllabus/components/_grade_buttons.haml
@@ -9,6 +9,6 @@
 - else
   - if current_user_is_staff?
     - if assignment.is_individual?
-      %li= link_to glyph(:check) + "Grade", edit_grade_path(presenter.grade_for(assignment)), class: "button"
+      %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(assignment, presenter.student), method: :post, class: "button"
     - elsif assignment.has_groups? && presenter.group_for(assignment).present?
       %li= link_to glyph(:check) + "Grade", grade_assignment_group_path(assignment, presenter.group_for(assignment)), class: "button"

--- a/app/views/students/syllabus/components/_grade_buttons.haml
+++ b/app/views/students/syllabus/components/_grade_buttons.haml
@@ -3,12 +3,12 @@
   / Grade Management /
   - if current_user_is_staff?
     - if assignment.is_individual?
-      %li= link_to glyph(:edit) + "Edit Grade", edit_assignment_grade_path(assignment.id, student_id: presenter.student.id), class: "button"
+      %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(presenter.grade_for(assignment)), class: "button"
     - elsif assignment.has_groups?
       %li= link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(assignment, presenter.group_for(assignment)), class: "button"
 - else
   - if current_user_is_staff?
     - if assignment.is_individual?
-      %li= link_to glyph(:check) + "Grade", edit_assignment_grade_path(assignment_id: assignment.id, student_id: presenter.student.id), class: "button"
+      %li= link_to glyph(:check) + "Grade", edit_grade_path(presenter.grade_for(assignment)), class: "button"
     - elsif assignment.has_groups? && presenter.group_for(assignment).present?
       %li= link_to glyph(:check) + "Grade", grade_assignment_group_path(assignment, presenter.group_for(assignment)), class: "button"

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -9,7 +9,7 @@
       %li
         = link_to glyph(:trash) + "Delete Submission", assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), data: { confirm: "Are you sure?",  method: :delete }
 
-      %li= link_to glyph(:check) + "Grade", edit_assignment_grade_path(presenter.assignment, presenter.submission, student_id: presenter.student.id)
+      %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, presenter.student), method: :post
 - elsif presenter.assignment.has_groups?
   .context_menu
     %ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,9 +91,6 @@ GradeCraft::Application.routes.draw do
 
     resources :submissions, except: :index
 
-    # TODO: Use plural resource and move to assignments/grades where appropriate
-    resource :grade, only: [:update]
-
     resource :rubric do
       get :existing_criteria
       resources :criteria
@@ -102,7 +99,7 @@ GradeCraft::Application.routes.draw do
     end
   end
 
-  resources :grades, only: [:show, :destroy, :edit] do
+  resources :grades, only: [:show, :destroy, :edit, :update] do
     member do
       post :exclude
       post :feedback_read

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,9 +88,7 @@ GradeCraft::Application.routes.draw do
     resources :submissions, except: :index
 
     # TODO: Use plural resource and move to assignments/grades where appropriate
-    resource :grade, only: [:edit, :update] do
-      resources :earned_badges
-    end
+    resource :grade, only: [:edit, :update]
 
     resource :rubric do
       get :existing_criteria

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,10 +85,14 @@ GradeCraft::Application.routes.draw do
       put :graded, on: :member
     end
 
+    resources :students, only: [], module: :assignments do
+      post :grade
+    end
+
     resources :submissions, except: :index
 
     # TODO: Use plural resource and move to assignments/grades where appropriate
-    resource :grade, only: [:edit, :update]
+    resource :grade, only: [:update]
 
     resource :rubric do
       get :existing_criteria
@@ -98,9 +102,8 @@ GradeCraft::Application.routes.draw do
     end
   end
 
-  resources :grades, only: [:show, :destroy] do
+  resources :grades, only: [:show, :destroy, :edit] do
     member do
-      get :edit2
       post :exclude
       post :feedback_read
       post :include

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ GradeCraft::Application.routes.draw do
 
   resources :grades, only: [:show, :destroy] do
     member do
+      get :edit2
       post :exclude
       post :feedback_read
       post :include

--- a/spec/controllers/assignments/students_controller_spec.rb
+++ b/spec/controllers/assignments/students_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_spec_helper"
+
+describe Assignments::StudentsController do
+  let(:world) { World.create.with(:course, :assignment, :professor, :student) }
+
+  describe "#grade" do
+
+    context "as a professor" do
+      before(:each) { login_user(world.professor) }
+
+      it "creates the grade for the assignment and student if it doesn't exist" do
+        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+
+        grade = Grade.unscoped.last
+        expect(grade.assignment_id).to eq world.assignment.id
+        expect(grade.student_id).to eq world.student.id
+      end
+
+      it "redirects to the edit grade view" do
+        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+
+        expect(response).to redirect_to edit_grade_path(Grade.unscoped.last)
+      end
+    end
+
+    context "as a student" do
+      before(:each) { login_user(world.student) }
+
+      it "redirects to the root" do
+        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end

--- a/spec/controllers/assignments/students_controller_spec.rb
+++ b/spec/controllers/assignments/students_controller_spec.rb
@@ -9,7 +9,7 @@ describe Assignments::StudentsController do
       before(:each) { login_user(world.professor) }
 
       it "creates the grade for the assignment and student if it doesn't exist" do
-        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+        post :grade, assignment_id: world.assignment.id, student_id: world.student.id
 
         grade = Grade.unscoped.last
         expect(grade.assignment_id).to eq world.assignment.id
@@ -17,7 +17,7 @@ describe Assignments::StudentsController do
       end
 
       it "redirects to the edit grade view" do
-        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+        post :grade, assignment_id: world.assignment.id, student_id: world.student.id
 
         expect(response).to redirect_to edit_grade_path(Grade.unscoped.last)
       end
@@ -27,7 +27,7 @@ describe Assignments::StudentsController do
       before(:each) { login_user(world.student) }
 
       it "redirects to the root" do
-        get :grade, assignment_id: world.assignment.id, student_id: world.student.id
+        post :grade, assignment_id: world.assignment.id, student_id: world.student.id
 
         expect(response).to redirect_to root_path
       end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -62,65 +62,24 @@ describe GradesController do
       end
     end
 
-    describe "GET edit2" do
+    describe "GET edit" do
       it "assigns grade parameters and renders edit" do
-        get :edit2, { id: @grade.id }
+        get :edit, { id: @grade.id }
         expect(assigns(:grade)).to eq(@grade)
         expect(assigns(:title)).to \
           eq("Editing #{@grade.student.name}'s Grade for #{@grade.assignment.name}")
         expect(response).to render_template(:edit)
       end
-    end
-
-    describe "GET edit" do
-      it "creates a grade if none present" do
-        assignment = create(:assignment, course: @course)
-        expect{get :edit, { assignment_id: assignment.id, student_id: @student.id }}.to change{Grade.count}.by(1)
-      end
-
-      it "assigns grade parameters and renders edit" do
-        get :edit, { assignment_id: @assignment.id, student_id: @student.id }
-        expect(assigns(:assignment)).to eq(@assignment)
-        expect(assigns(:student)).to eq(@student)
-        expect(assigns(:grade)).to eq(@grade)
-        expect(assigns(:title)).to eq("Editing #{@student.name}'s Grade for #{@assignment.name}")
-        expect(response).to render_template(:edit)
-      end
 
       context "with additional grade items" do
         it "assigns existing submissions, badges and score levels" do
-          assignment = create(:assignment, course: @course)
-          submission = create(:submission, student: @student, assignment: assignment)
+          submission = create(:submission, student: @student, assignment: @assignment)
           badge = create(:badge, course: @course)
-          score_level = create(:assignment_score_level, assignment: assignment)
 
-          get :edit, { assignment_id: assignment.id, student_id: @student.id }
+          get :edit, { id: @grade.id }
           expect(assigns(:submission)).to eq(submission)
           expect(assigns(:badges)).to eq([badge])
-          expect(assigns(:assignment_score_levels)).to eq([score_level])
         end
-      end
-
-      it "assigns json values for angular use" do
-        get :edit, { assignment_id: @assignment.id, student_id: @student.id }
-        json = JSON.parse(assigns(:serialized_init_data))
-        expect(json).to have_key("grade")
-        expect(json).to have_key("badges")
-        expect(json).to have_key("assignment")
-        expect(json).to have_key("assignment_score_levels")
-      end
-
-      it "if rubric present, assigns the rubric and rubric grades" do
-        allow(request).to receive(:referer).and_return("http://gradecraft.com/assignments/123")
-        assignment = create(:assignment, course: @course)
-        rubric = create(:rubric_with_criteria, assignment: assignment)
-        criterion = rubric.criteria.first
-        level = rubric.criteria.first.levels.first
-        criterion_grade = CriterionGrade.create( assignment_id: assignment.id, student_id: @student.id, criterion_id: criterion.id, level_id: level.id)
-        get :edit, { id: @grade.id, assignment_id: assignment.id, student_id: @student.id }
-        expect(assigns(:rubric)).to eq(rubric)
-        expect(JSON.parse(assigns(:criterion_grades))).to eq([{ "id" => criterion_grade.id, "criterion_id" => criterion.id, "level_id" => level.id, "comments" => nil }])
-        expect(assigns(:return_path)).to eq("/assignments/123?student_id=#{@student.id}")
       end
     end
 
@@ -195,7 +154,7 @@ describe GradesController do
       it "redirects on failure" do
         allow_any_instance_of(Grade).to receive(:update_attributes).and_return false
         put :update, { assignment_id: @assignment.id, student_id: @student.id, grade: {}}
-        expect(response).to redirect_to(edit_assignment_grade_path(@assignment.id, student_id: @student.id))
+        expect(response).to redirect_to(edit_grade_path(@grade))
       end
     end
 
@@ -380,9 +339,7 @@ describe GradesController do
       end
 
       it "all redirect to root" do
-        [ Proc.new { get :edit, {grade_id: @grade.id, assignment_id: @assignment.id }},
-          Proc.new { get :update, {grade_id: @grade.id, assignment_id: @assignment.id }},
-          Proc.new { get :edit, {grade_id: @grade.id, assignment_id: @assignment.id }},
+        [ Proc.new { get :edit, {id: @grade.id }},
           Proc.new { get :update, {grade_id: @grade.id, assignment_id: @assignment.id }},
           Proc.new { get :remove, { id: @assignment.id, grade_id: @grade.id }},
           Proc.new { delete :destroy, { id: @grade.id }},

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -62,6 +62,16 @@ describe GradesController do
       end
     end
 
+    describe "GET edit2" do
+      it "assigns grade parameters and renders edit" do
+        get :edit2, { id: @grade.id }
+        expect(assigns(:grade)).to eq(@grade)
+        expect(assigns(:title)).to \
+          eq("Editing #{@grade.student.name}'s Grade for #{@grade.assignment.name}")
+        expect(response).to render_template(:edit)
+      end
+    end
+
     describe "GET edit" do
       it "creates a grade if none present" do
         assignment = create(:assignment, course: @course)

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -323,7 +323,7 @@ describe GradesController do
 
       it "all redirect to root" do
         [ Proc.new { get :edit, {id: @grade.id }},
-          Proc.new { get :update, {grade_id: @grade.id, assignment_id: @assignment.id }},
+          Proc.new { get :update, { id: @grade.id }},
           Proc.new { get :remove, { id: @assignment.id, grade_id: @grade.id }},
           Proc.new { delete :destroy, { id: @grade.id }},
         ].each do |protected_route|

--- a/spec/features/grading_an_individual_assignment_spec.rb
+++ b/spec/features/grading_an_individual_assignment_spec.rb
@@ -9,6 +9,7 @@ feature "grading an individual assignment" do
     let!(:assignment) { create :assignment, name: "Assignment Name", course: course, assignment_type: assignment_type }
     let(:student) { create :user, first_name: "Hermione", last_name: "Granger" }
     let!(:course_membership_2) { create :student_course_membership, user: student, course: course }
+    let!(:grade) { create :grade, assignment: assignment, student: student }
 
     before(:each) do
       login_as professor
@@ -33,7 +34,7 @@ feature "grading an individual assignment" do
         click_link "Grade"
       end
 
-      expect(current_path).to eq edit_assignment_grade_path(assignment)
+      expect(current_path).to eq edit_grade_path(grade)
 
       within(".pageContent") do
         fill_in("grade_raw_score", with: 100)

--- a/spec/performers/controller_calls/grades_controller_worker_calls_spec.rb
+++ b/spec/performers/controller_calls/grades_controller_worker_calls_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GradesController, type: :controller, background_job: true do
     before(:each) { enroll_and_login_professor }
 
     describe "#update" do
-      let(:request_attrs) {{ assignment_id: assignment.id, grade: { raw_score: 50 } }}
+      let(:request_attrs) {{ id: grade.id, grade: { raw_score: 50 } }}
       subject { put :update, request_attrs }
 
       before do

--- a/spec/support/world.rb
+++ b/spec/support/world.rb
@@ -6,7 +6,8 @@ class World
   class Instance
     attr_reader :assignments, :badges, :challenges, :courses,
       :course_memberships, :criteria, :criterion_grades, :grades,
-      :grade_scheme_elements, :groups, :rubrics, :students, :teams, :users
+      :grade_scheme_elements, :groups, :rubrics, :students, :professors,
+      :teams, :users
 
     def assignment
       assignments.first
@@ -42,6 +43,14 @@ class World
 
     def group
       groups.first
+    end
+
+    def professors
+      course_memberships.select{ |cm| cm.role == "professor" }.map(&:user)
+    end
+
+    def professor
+      professors.first
     end
 
     def rubric
@@ -132,6 +141,15 @@ class World
     def create_group(attributes={})
       course = attributes.delete(:course) || self.course
       groups << FactoryGirl.create(:group, attributes.merge(course: course, approved: "Approved"))
+    end
+
+    def create_professor(attributes={})
+      course = attributes.delete(:course) || self.course
+      user = FactoryGirl.create(:user, attributes)
+      course_memberships << FactoryGirl.create(:course_membership, course: course,
+                                               user: user, role: "professor") if course
+      users << user
+      self
     end
 
     def create_rubric(attributes={})

--- a/spec/views/grades/_standard_edit_spec.rb
+++ b/spec/views/grades/_standard_edit_spec.rb
@@ -15,6 +15,8 @@ describe "grades/_standard_edit" do
     allow(view).to receive(:current_student).and_return(@student)
     current_user = double
     allow(current_user).to receive(:id) {0}
+    allow(view).to receive(:grade).and_return(@grade)
+    allow(view).to receive(:submission).and_return(nil)
     allow(view).to receive(:current_user).and_return(current_user)
     allow(view).to receive(:current_course).and_return(@course)
   end

--- a/spec/views/info/resubmissions_spec.rb
+++ b/spec/views/info/resubmissions_spec.rb
@@ -22,6 +22,8 @@ describe "info/resubmissions" do
     @submission_2 = create(:submission, assignment: @assignment_2, course: @course, student: @user_2)
     @course.submissions << [ @submission_1, @submission_2 ]
     @resubmissions = @course.submissions
+    create(:grade, assignment: @assignment_1, student: @user_1)
+    create(:grade, assignment: @assignment_2, student: @user_2)
   end
 
   before(:each) do


### PR DESCRIPTION
Moves the `#edit` and `#update` endpoints for a `GradesController` to use a `grade_id` instead of an `assignment_id` and `student_id`. This cleaned up the controller methods quite a bit and used resourceful routing for the two actions.

For rubric grades, an update was necessary for the Angular code so it no longer gathered the `assignment_id` and `student_id` or `group_id` from the url. Instead, these are now passed in via `ng-init` to the front end from the erb view.

In addition, the old grade update path performed a `Grade.find_or_create` in the action. This is not possible in the new `Grade#edit` path because a grade id is required. So the path `POST /assignments/:assignment_id/students/:student_id/grade` path was created to perform a `Grade.find_or_create` and then redirect to `Grade#edit` when the grade is not known.