### PR TITLE
Display add and import buttons on student index

### DIFF
--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -2,6 +2,8 @@
 
 %h3.pagetitle= @title
 
+= render "users/buttons"
+
 .pageContent
   = render "layouts/alerts"
 


### PR DESCRIPTION
We'd built the ability for instructors to add new users and import them en masse but forgotten to add the buttons to the intuitive place - the student index! This PR displays the partial for the user management buttons on that page. 