### PR TITLE
1920 assignment settings

### DIFF
--- a/app/views/assignments/settings.html.haml
+++ b/app/views/assignments/settings.html.haml
@@ -170,7 +170,7 @@
                     = assignment.try(:due_at) || "No Due Date"
                   %li
                     Accepted Until:
-                    = assignment.try(:accept_until) || "Always Accepted"
+                    = assignment.try(:accepts_submissions_until) || "Always Accepted"
               %td
                 .right
                   %ul.button-bar

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -2,6 +2,8 @@
 
 %h3.pagetitle= @title
 
+= render "users/buttons"
+
 .pageContent
   = render "layouts/alerts"
 


### PR DESCRIPTION
This PR fixes an out of date display of assignment accept until dates - the assignment settings page was referencing a field that no longer exists. Updated to reflect the new terminology.