### PR TITLE
Note check

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -14,7 +14,7 @@ class Assignment < ActiveRecord::Base
     :assignment_score_levels_attributes, :assignment_type, :assignment_type_id,
     :course, :course_id, :description, :due_at, :grade_scope, :hide_analytics,
     :include_in_predictor, :include_in_timeline, :include_in_to_do,
-    :mass_grade_type, :name, :notify_released, :open_at, :pass_fail,
+    :mass_grade_type, :name, :open_at, :pass_fail,
     :point_total, :points_predictor_display, :purpose, :release_necessary,
     :required, :resubmissions_allowed, :show_description_when_locked,
     :show_purpose_when_locked, :show_name_when_locked,

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -18,7 +18,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def require_notify_released_success
-    if @grade.assignment.notify_released? && GradeProctor.new(@grade).viewable?
+    if GradeProctor.new(@grade).viewable?
       require_success(notify_released_messages, max_result_size: 200) { notify_grade_released }
     end
   end

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -122,11 +122,6 @@
       .form_label Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
 
     .form-item
-      = f.label :notify_released, "Notify by email?"
-      = f.check_box :notify_released
-      .form_label Do you want to notify students by email when a grade is awarded? If grade release is necessary, this email will not be sent out until the grade is officially released.
-
-    .form-item
       = f.label :include_in_timeline, "Timeline"
       = f.check_box :include_in_timeline, {"aria-describedby" => "txtIncludeInTimeline"}
       .form_label{id: "txtIncludeInTimeline"} Can #{term_for :students} see this #{term_for :assignment} in the course timeline? Note that #{term_for :assignments} without open or due dates will be excluded automatically.

--- a/db/migrate/20160527024024_drop_notify_stateon_assignment.rb
+++ b/db/migrate/20160527024024_drop_notify_stateon_assignment.rb
@@ -1,0 +1,5 @@
+class DropNotifyStateonAssignment < ActiveRecord::Migration
+  def change
+    remove_column :assignments, :notify_released
+  end
+end

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -35,7 +35,6 @@
     grade_scope: "Individual",
     hide_analytics: nil,
     mass_grade_type: nil,
-    notify_released: false,
     points_predictor_display: nil,
     release_necessary: false,
     student_logged: false,
@@ -973,39 +972,6 @@ Hockney",
     due_at: 4.weeks.from_now,
     point_total: 150000,
     release_necessary: true,
-    notify_released: true,
-  }
-}
-
-@assignments[:sends_email_notes_immediately] = {
-  quotes: {
-    assignment_created: "Do not keep children to their studies by compulsion \
-but by play. – Plato",
-  },
-  assignment_type: :notifications,
-  attributes: {
-    name: "Grades Released Triggers Email",
-    description: "I send out emails when grades are released",
-    due_at: 4.weeks.from_now,
-    point_total: 150000,
-    release_necessary: false,
-    notify_released: true,
-  }
-}
-
-@assignments[:does_not_send_emails] = {
-  quotes: {
-    assignment_created: "You're always you, and that don't change, and you're \
-always changing, and there's nothing you can do about it. ― Neil Gaiman",
-  },
-  assignment_type: :notifications,
-  attributes: {
-    name: "No Emails Assignment",
-    description: "I do not send out email notifications to students",
-    due_at: 4.weeks.from_now,
-    point_total: 150000,
-    release_necessary: false,
-    notify_released: false,
   }
 }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160511163640) do
+ActiveRecord::Schema.define(version: 20160527024024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,7 +121,6 @@ ActiveRecord::Schema.define(version: 20160511163640) do
     t.string   "media_credit",                 limit: 255
     t.string   "media_caption",                limit: 255
     t.string   "points_predictor_display",     limit: 255
-    t.boolean  "notify_released",                          default: true
     t.string   "mass_grade_type",              limit: 255
     t.boolean  "include_in_timeline",                      default: true
     t.boolean  "include_in_predictor",                     default: true

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
       context "@grade is student visible and grade assignment is set to notify on release" do
         before(:each) do
           allow_any_instance_of(GradeProctor).to receive(:viewable?) { true }
-          allow(performer_grade).to receive_message_chain(:assignment, :notify_released?) { true }
         end
 
         it "should require success with notify released messages" do
@@ -136,56 +135,6 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
           expect(performer.outcome_messages.first).to match(/Successfully sent notification/)
         end
       end
-
-      context "@grade assignment is not set to notify on release but grade is student visible" do
-        before(:each) do
-          allow_any_instance_of(GradeProctor).to receive(:viewable?) { true }
-          allow(performer_grade).to receive_message_chain(:assignment, :notify_released?) { false }
-        end
-
-        it "should not trigger the require success" do
-          expect(performer).not_to receive(:require_success)
-          subject
-        end
-
-        it "should return nil" do
-          expect(subject).to eq(nil)
-        end
-      end
-
-      context "@grade assignment is set to notify on release but grade is not student visible" do
-        before(:each) do
-          allow_any_instance_of(GradeProctor).to receive(:viewable?) { false }
-          allow(performer_grade).to receive_message_chain(:assignment, :notify_released?) { true }
-        end
-
-        it "should not trigger the require success" do
-          expect(performer).not_to receive(:require_success)
-          subject
-        end
-
-        it "should return nil" do
-          expect(subject).to eq(nil)
-        end
-      end
-
-      context "@grade assignment is not set to notify on release and grade is not student visible" do
-        before(:each) do
-          allow_any_instance_of(GradeProctor).to \
-            receive(:viewable?).and_return false
-          allow(performer_grade).to receive_message_chain(:assignment, :notify_released?) { false }
-        end
-
-        it "should not trigger the require success" do
-          expect(performer).not_to receive(:require_success)
-          subject
-        end
-
-        it "should return nil" do
-          expect(subject).to eq(nil)
-        end
-      end
-
     end
   end
 


### PR DESCRIPTION
This PR removes the requirement that instructors declare per assignment whether or not students should receive an email receipt for a new grade. 

This feature will be brought back in the reverse order - students will be able to decide if they want to receive emails of notifications or turn them off and see them only in GC Announcements. 