### PR TITLE
validate students on predicted models

### DIFF
--- a/app/models/predicted_earned_badge.rb
+++ b/app/models/predicted_earned_badge.rb
@@ -10,7 +10,8 @@ class PredictedEarnedBadge < ActiveRecord::Base
   end
   scope :for_student, ->(student) { where(student_id: student.id) }
 
-  validates :badge_id, uniqueness: { scope: :student_id }
+  validates :student, presence: true
+  validates :badge, presence: true, uniqueness: { scope: :student_id }
 
   def total_predicted_points
     self.badge.point_total * predicted_times_earned

--- a/app/models/predicted_earned_challenge.rb
+++ b/app/models/predicted_earned_challenge.rb
@@ -10,5 +10,6 @@ class PredictedEarnedChallenge < ActiveRecord::Base
   end
   scope :for_student, ->(student) { where(student_id: student.id) }
 
-  validates :challenge_id, uniqueness: { scope: :student_id }
+  validates :student, presence: true
+  validates :challenge, presence: true, uniqueness: { scope: :student_id }
 end

--- a/app/models/predicted_earned_grade.rb
+++ b/app/models/predicted_earned_grade.rb
@@ -11,5 +11,6 @@ class PredictedEarnedGrade < ActiveRecord::Base
   end
   scope :for_student, ->(student) { where(student_id: student.id) }
 
-  validates :assignment_id, uniqueness: { scope: :student_id }
+  validates :student, presence: true
+  validates :assignment, presence: true, uniqueness: { scope: :student_id }
 end


### PR DESCRIPTION
This PR makes sure the Predicted models validates the student.

This will keep PredictedEarnedBadges from saving with a `student_id` of 0. It does not however address how PredictedEarnedBadges were created in production without a student, since the calls to update are not silenced in Angular when a student is not present.

If possible I would like to know the first and last `created_at` date on the 768 instances before they are deleted, to know if this is an additional bug that need to be found and addressed.

closes 2013