### PR TITLE
1853 implement stacktablejs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require underscore
 //= require jquery.dynatable
 //= require dynatable
+//= require stacktable.min
 //= require lodash.min
 
 //= require angular/angular

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require jquery.dynatable
 //= require dynatable
 //= require stacktable.min
+//= require mobile_tables
 //= require lodash.min
 
 //= require angular/angular

--- a/app/assets/javascripts/mobile_tables.js
+++ b/app/assets/javascripts/mobile_tables.js
@@ -1,0 +1,8 @@
+//Initialize stacktable on all dynatables
+$(".dynatable, .instructor-assignments").cardtable();
+
+//Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
+$(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").attr("colspan","2");
+
+//Add class to headers on stacktable and instrictor-assignment tables
+$(".stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").addClass("table-header-row");

--- a/app/assets/javascripts/mobile_tables.js
+++ b/app/assets/javascripts/mobile_tables.js
@@ -1,5 +1,5 @@
 //Initialize stacktable on all dynatables
-$(".dynatable, .instructor-assignments").cardtable();
+$(".dynatable, .instructor-assignments, .badge-index-table").cardtable();
 
 //Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
 $(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").attr("colspan","2");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -110,4 +110,4 @@ $(".btn-public-nav").click(function(){
 });
 
 //stacktable
-$(".dynatable").stacktable();
+$(".dynatable").cardtable();

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -113,7 +113,7 @@ $(".btn-public-nav").click(function(){
 $(".dynatable, .instructor-assignments").cardtable();
 
 //Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
-$(".stacktable tr:last-child .st-val, .stacktable:not(.instructor-assignments) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").attr("colspan","2");
+$(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.instructor-assignments, .no-table-header) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").attr("colspan","2");
 
 //Add class to headers on stacktable and instrictor-assignment tables
-$(".stacktable:not(.instructor-assignments) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").addClass("table-header-row");
+$(".stacktable:not(.instructor-assignments, .no-table-header) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").addClass("table-header-row");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -110,7 +110,10 @@ $(".btn-public-nav").click(function(){
 });
 
 //Initialize stacktable on all dynatables
-$(".dynatable").cardtable();
+$(".dynatable, .instructor-assignments").cardtable();
 
-//Add colspan attribute to last row of each table with buttons
-$(".stacktable tr:last-child .st-val, .stacktable tr:first-child .st-val").attr("colspan","2");
+//Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
+$(".stacktable tr:last-child .st-val, .stacktable:not(.instructor-assignments) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").attr("colspan","2");
+
+//Add class to headers on stacktable and instrictor-assignment tables
+$(".stacktable:not(.instructor-assignments) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").addClass("table-header-row");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -113,7 +113,7 @@ $(".btn-public-nav").click(function(){
 $(".dynatable, .instructor-assignments").cardtable();
 
 //Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
-$(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.instructor-assignments, .no-table-header) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").attr("colspan","2");
+$(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").attr("colspan","2");
 
 //Add class to headers on stacktable and instrictor-assignment tables
-$(".stacktable:not(.instructor-assignments, .no-table-header) tr:first-child .st-val, .instructor-assignments tr:nth-child(2) .st-val").addClass("table-header-row");
+$(".stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").addClass("table-header-row");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -108,3 +108,6 @@ $(".course-info-btn").click(function(){
 $(".btn-public-nav").click(function(){
     $(".public-nav").slideToggle();
 });
+
+//stacktable
+$(".dynatable").stacktable();

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -113,4 +113,4 @@ $(".btn-public-nav").click(function(){
 $(".dynatable").cardtable();
 
 //Add colspan attribute to last row of each table with buttons
-$(".stacktable tr:last-child .st-val").attr("colspan","2");
+$(".stacktable tr:last-child .st-val, .stacktable tr:first-child .st-val").attr("colspan","2");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -109,11 +109,3 @@ $(".btn-public-nav").click(function(){
     $(".public-nav").slideToggle();
 });
 
-//Initialize stacktable on all dynatables
-$(".dynatable, .instructor-assignments").cardtable();
-
-//Add colspan attribute to last row of each table with buttons and to headers on stacktable and instrictor-assignment tables
-$(".stacktable:not(.no-button-bar) tr:last-child .st-val, .stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").attr("colspan","2");
-
-//Add class to headers on stacktable and instrictor-assignment tables
-$(".stacktable:not(.second-row-header, .no-table-header) tr:first-child .st-val, .second-row-header tr:nth-child(2) .st-val").addClass("table-header-row");

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -109,5 +109,8 @@ $(".btn-public-nav").click(function(){
     $(".public-nav").slideToggle();
 });
 
-//stacktable
+//Initialize stacktable on all dynatables
 $(".dynatable").cardtable();
+
+//Add colspan attribute to last row of each table with buttons
+$(".stacktable tr:last-child .st-val").attr("colspan","2");

--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -99,7 +99,6 @@ tbody
       padding: 0
       margin-left: -5px
       a
-        margin: 0 !important
         color: $color-white !important
 
       .button

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -113,6 +113,8 @@ a:hover + .display_on_hover
     margin-bottom: 1rem
 
 @media (max-width: $media-medium-max)
+  .student.mainContent
+    width: 100%
   .mainContainer.staff
     width: 100%
   .box
@@ -124,8 +126,6 @@ a:hover + .display_on_hover
     width: 23%
 
 @media (max-width: $media-small-max)
-  .mainContent
-    width: 100% !important
   .mainContainer.staff
     width: 100%
   .badge-icon

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -100,7 +100,6 @@ i.missing_grade
       border-radius: $global-radius
       padding: 2px 5px
       white-space: nowrap
-      line-height: 1.2rem
       margin-bottom: .2rem !important
 
 @media (max-width: 1200px)
@@ -114,5 +113,15 @@ i.missing_grade
     border-radius: $global-radius
     padding: 2px 5px
     white-space: nowrap
-    line-height: 1.2rem
     margin-bottom: .2rem !important
+
+@media (max-width: $media-medium-max)
+  tbody ul.button-bar li a.button
+    font-size: .6rem
+    display: inline-block
+    padding: 1px 2px
+    margin: .25rem !important
+
+@media (max-width: 800px)
+  .dynatable-sort-header
+    pointer-events: none

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -109,7 +109,6 @@ i.missing_grade
       font-size: .7rem
 
   tbody ul.button-bar li a.button
-    display: block
     border-radius: $global-radius
     padding: 2px 5px
     white-space: nowrap
@@ -120,8 +119,10 @@ i.missing_grade
     font-size: .6rem
     display: inline-block
     padding: 1px 2px
-    margin: .25rem !important
 
 @media (max-width: 800px)
   .dynatable-sort-header
     pointer-events: none
+
+  th a:hover
+    color: $color-blue-3

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -142,6 +142,9 @@ i.missing_grade
       a
         color: $color-white
 
+    .st-key
+      text-transform: capitalize
+
     tr:last-child, tr:first-child
       .st-key
         display: none

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -9,12 +9,15 @@ table
   text-align: left
   width: 100%
   background-color: $color-white
+  border-collapse: collapse
 
   tr:nth-child(even)
     background-color: $color-grey-6 !important
 
-  td
+  tr
     border-bottom: 1px solid $color-grey-5
+
+  td
     padding: .5rem
 
   td .center
@@ -158,13 +161,13 @@ i.missing_grade
   table.no-button-bar 
     tr:last-child
       .st-key
-        display: block
+        display: table-cell
 
   table.no-table-header
     tr:first-child
       text-align: left
       .st-key
-        display: block
+        display: table-cell
         padding: .25rem
       .st-key, .st-val
         font-size: .7rem

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -146,9 +146,23 @@ i.missing_grade
 
       .st-val
         padding: .5em
-        font-size: .85em
+        font-size: .85rem
 
 table.instructor-assignments 
   tr:nth-child(2)
     .st-key
       display: none
+
+table.no-button-bar 
+  tr:last-child
+    .st-key
+      display: block
+
+table.no-table-header
+  tr:first-child
+    text-align: left
+    .st-key
+      display: block
+      padding: .25rem
+    .st-key, .st-val
+      font-size: .7rem

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -126,3 +126,11 @@ i.missing_grade
 
   th a:hover
     color: $color-blue-3
+
+  table
+    border: 1px solid $color-grey-5
+    margin-bottom: 2em
+
+    tr:last-child
+      .st-key
+        display: none

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -13,7 +13,7 @@ table
   tr:nth-child(even)
     background-color: $color-grey-6 !important
 
-  td
+  td:not:last-child
     border-bottom: 1px solid $color-grey-5
     padding: .5rem
 
@@ -129,8 +129,21 @@ i.missing_grade
 
   table
     border: 1px solid $color-grey-5
-    margin-bottom: 2em
+    margin-bottom: 1em
 
-    tr:last-child
+    tr:first-child
+      background-color: $color-blue-2 !important
+      color: $color-white
+      a
+        color: $color-white
+
+    tr:last-child, tr:first-child
       .st-key
         display: none
+
+    tr:first-child
+      text-align: center
+
+      .st-val
+        padding: .5em
+        font-size: .85em

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -96,6 +96,16 @@ i.missing_grade
     th.draggable, td.draggable
       display: none
 
+@media (max-width: 2400px)
+  table.default_assignments_dynatable
+    tbody ul.button-bar li a.button
+      display: block
+      border-radius: $global-radius
+      padding: 2px 5px
+      white-space: nowrap
+      margin-bottom: .2rem !important
+      margin-right: 0
+
 @media (max-width: 1200px)
   table
     th, td
@@ -117,16 +127,6 @@ i.missing_grade
 
   tbody ul.button-bar li:not(:last-of-type) a.button
     margin-right: .5rem
-
-@media (max-width: 2400px)
-  table.default_assignments_dynatable
-    tbody ul.button-bar li a.button
-      display: block
-      border-radius: $global-radius
-      padding: 2px 5px
-      white-space: nowrap
-      margin-bottom: .2rem !important
-      margin-right: 0
 
 @media (max-width: 800px)
   .dynatable-sort-header

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -135,6 +135,7 @@ i.missing_grade
     .table-header-row
       background-color: $color-blue-2 !important
       color: $color-white
+      text-align: center
       a
         color: $color-white
 
@@ -143,13 +144,13 @@ i.missing_grade
         display: none
 
     tr:first-child
-      text-align: center
-
       .st-val
         padding: .5em
         font-size: .85rem
 
-table.instructor-assignments 
+table.second-row-header
+  tr:first-child
+    display: none
   tr:nth-child(2)
     .st-key
       display: none

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -96,15 +96,6 @@ i.missing_grade
     th.draggable, td.draggable
       display: none
 
-@media (max-width: 2400px)
-  table.default_assignments_dynatable
-    tbody ul.button-bar li a.button
-      display: block
-      border-radius: $global-radius
-      padding: 2px 5px
-      white-space: nowrap
-      margin-bottom: .2rem !important
-
 @media (max-width: 1200px)
   table
     th, td
@@ -126,6 +117,16 @@ i.missing_grade
 
   tbody ul.button-bar li:not(:last-of-type) a.button
     margin-right: .5rem
+
+@media (max-width: 2400px)
+  table.default_assignments_dynatable
+    tbody ul.button-bar li a.button
+      display: block
+      border-radius: $global-radius
+      padding: 2px 5px
+      white-space: nowrap
+      margin-bottom: .2rem !important
+      margin-right: 0
 
 @media (max-width: 800px)
   .dynatable-sort-header

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -13,7 +13,7 @@ table
   tr:nth-child(even)
     background-color: $color-grey-6 !important
 
-  td:not:last-child
+  td
     border-bottom: 1px solid $color-grey-5
     padding: .5rem
 
@@ -148,23 +148,23 @@ i.missing_grade
         padding: .5em
         font-size: .85rem
 
-table.second-row-header
-  tr:first-child
-    display: none
-  tr:nth-child(2)
-    .st-key
+  table.second-row-header
+    tr:first-child
       display: none
+    tr:nth-child(2)
+      .st-key
+        display: none
 
-table.no-button-bar 
-  tr:last-child
-    .st-key
-      display: block
+  table.no-button-bar 
+    tr:last-child
+      .st-key
+        display: block
 
-table.no-table-header
-  tr:first-child
-    text-align: left
-    .st-key
-      display: block
-      padding: .25rem
-    .st-key, .st-val
-      font-size: .7rem
+  table.no-table-header
+    tr:first-child
+      text-align: left
+      .st-key
+        display: block
+        padding: .25rem
+      .st-key, .st-val
+        font-size: .7rem

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -111,6 +111,7 @@ i.missing_grade
   tbody ul.button-bar li a.button
     border-radius: $global-radius
     padding: 2px 5px
+    display: block
     white-space: nowrap
     margin-bottom: .2rem !important
 

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -124,6 +124,9 @@ i.missing_grade
     display: inline-block
     padding: 1px 2px
 
+  tbody ul.button-bar li:not(:last-of-type) a.button
+    margin-right: .5rem
+
 @media (max-width: 800px)
   .dynatable-sort-header
     pointer-events: none

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -154,12 +154,23 @@ i.missing_grade
         padding: .5em
         font-size: .85rem
 
+  .badge-index-table
+    .st-key
+      width: 25%
+    .st-val
+      width: 75%
+    .button-bar
+      text-align: right
+
   table.second-row-header
     tr:first-child
       display: none
     tr:nth-child(2)
       .st-key
         display: none
+      .st-val
+        padding: .5em
+        font-size: .85rem
 
   table.no-button-bar 
     tr:last-child

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -127,11 +127,11 @@ i.missing_grade
   th a:hover
     color: $color-blue-3
 
-  table
+  table.stacktable
     border: 1px solid $color-grey-5
     margin-bottom: 1em
 
-    tr:first-child
+    .table-header-row
       background-color: $color-blue-2 !important
       color: $color-white
       a
@@ -147,3 +147,8 @@ i.missing_grade
       .st-val
         padding: .5em
         font-size: .85em
+
+table.instructor-assignments 
+  tr:nth-child(2)
+    .st-key
+      display: none

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -9,6 +9,7 @@
   *= require jquery.dynatable
   *= require angular-tooltips.min
   *= require timelineJS/timeline
+  *= require stacktable.css
   *= require plugins/char_counter.min.css
   *= require plugins/code_view.min.css
   *= require plugins/colors.min.css

--- a/app/views/assignment_types/index.html.haml
+++ b/app/views/assignment_types/index.html.haml
@@ -42,7 +42,7 @@
 
   %h4.subtitle= "#{term_for :student} Scores"
 
-  %table.dynatable
+  %table.dynatable.no-table-header.no-button-bar
     %thead
       %tr
         %th First Name
@@ -64,7 +64,7 @@
 
   %h4.subtitle= "#{term_for :student} Grade Counts"
 
-  %table.dynatable
+  %table.dynatable.no-table-header.no-button-bar
     %thead
       %tr
         %th First Name

--- a/app/views/assignments/index.html.haml
+++ b/app/views/assignments/index.html.haml
@@ -24,12 +24,12 @@
             %i.fa.fa-angle-double-right.fa-fw
           .assignment-type-name #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden
-          %table{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
+          %table.instructor-assignments{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr
                 %th.draggable
-                %th
                 %th{scope: "col", :width => "20%"} Name
+                %th
                 %th Due
                 %th{:style => "display: none"} Due Date
                 %th{scope: "col", :width => "10%"}  Max Points
@@ -41,8 +41,8 @@
                 %tr{id: "assignment-#{assignment.id}"}
                   %td.draggable
                     %i.fa.fa-arrows-v
-                  %td= render "index_icons", assignment: assignment
                   %td= link_to assignment.name, assignment
+                  %td= render "index_icons", assignment: assignment
                   %td= assignment.try(:due_at) || "Ongoing"
                   %td{:style => "display: none"}
                     - if assignment.due_at.present?

--- a/app/views/assignments/index.html.haml
+++ b/app/views/assignments/index.html.haml
@@ -24,7 +24,7 @@
             %i.fa.fa-angle-double-right.fa-fw
           .assignment-type-name #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden
-          %table.instructor-assignments{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
+          %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr
                 %th.draggable

--- a/app/views/assignments/individual/_individual_show.haml
+++ b/app/views/assignments/individual/_individual_show.haml
@@ -6,7 +6,7 @@
       = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), prompt: "– Select #{(term_for :team).titleize} –"
 
 = form_tag edit_status_assignment_grades_path(presenter.assignment), method: :get do
-  %table.dynatable
+  %table.dynatable.no-table-header
     %thead= render partial: "assignments/individual/table_head", locals: { presenter: presenter }
     %tbody= render partial: "assignments/individual/table_body", locals: { presenter: presenter }
 

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -1,4 +1,4 @@
-%table.dynatable
+%table.dynatable.no-table-header
   %thead
     %tr
       - if presenter.badge.is_unlockable?

--- a/app/views/badges/components/_description.haml
+++ b/app/views/badges/components/_description.haml
@@ -1,4 +1,1 @@
--# pass badge.name as link or plain text
-.badge-title= title
-
 = raw badge.description

--- a/app/views/badges/components/_icon.haml
+++ b/app/views/badges/components/_icon.haml
@@ -1,3 +1,2 @@
 = link_to image_tag(badge.icon, {class: "badge-icon", width: 40, alt: badge.name}), badge_path(badge)
-- if badge.point_total.present? && badge.point_total > 0
-  .italic= "#{points badge.point_total} points"
+

--- a/app/views/badges/components/_name.haml
+++ b/app/views/badges/components/_name.haml
@@ -1,0 +1,2 @@
+-# pass badge.name as link or plain text
+.badge-title= title

--- a/app/views/badges/components/_points.haml
+++ b/app/views/badges/components/_points.haml
@@ -1,0 +1,2 @@
+- if badge.point_total.present? && badge.point_total > 0
+  .italic= "#{points badge.point_total} points"

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -7,13 +7,14 @@
 .pageContent
   = render "layouts/alerts"
 
-  %table.badge-index-table{:class => ("student-index" if presenter.view_student_context?)}
+  %table.badge-index-table.second-row-header{:class => ("student-index" if presenter.view_student_context?)}
     %thead
       %tr
         %th.sort-column
-        %th.badge-name-column
-        %th.lock-icon-column
-        %th.icon-column
+        %th.badge-name-column Name
+        %th.icon-column Icon
+        %th.points-column Point Value
+        %th.lock-icon-column Locked?
         %th.earned_column Earned
         %th.description-column Description
         %th.button-column
@@ -37,14 +38,20 @@
                 = render partial: "badges/components/name",
                   locals: { badge: badge, title: link_to(badge.name, badge_path(badge)) }
 
-            // Lock Condition Icons
-            %td
-              = render partial: "badges/components/hover_icons", locals: { badge: badge }
-
             // Badge Icon
             %td
               = render partial: "badges/components/icon", locals: { badge: badge }
 
+            // Point Value
+            %td
+              - if current_course.valuable_badges?
+                = render partial: "badges/components/points", locals: { badge: badge }
+
+            // Lock Condition Icons
+            %td
+              = render partial: "badges/components/hover_icons", locals: { badge: badge }
+
+            // Badge Count
             %td
               = render partial: "badges/components/count", locals: { badge: badge, count: presenter.earned_badges_count(badge) }
 

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -11,6 +11,7 @@
     %thead
       %tr
         %th.sort-column
+        %th.badge-name-column
         %th.lock-icon-column
         %th.icon-column
         %th.earned_column Earned
@@ -22,10 +23,19 @@
         - if BadgeProctor.new(badge).viewable?(current_student || current_user)
           %tr{id: "badge-#{badge.id}"}
             - if !presenter.view_student_context?
-              %td.center
-                %i.fa.fa-arrows-v.draggable
+              %td.center.draggable
+                %i.fa.fa-arrows-v
             - else
               %td
+
+            // Badge Name
+            %td
+              - if current_user_is_staff? && presenter.view_student_context?
+                = render partial: "badges/components/name",
+                  locals: { badge: badge, title: link_to(badge.name, student_badge_show_path(presenter.student, badge)) }
+              - else
+                = render partial: "badges/components/name",
+                  locals: { badge: badge, title: link_to(badge.name, badge_path(badge)) }
 
             // Lock Condition Icons
             %td

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -13,7 +13,7 @@
 
     = form_tag edit_status_assignment_grades_path(assignment), method: :get do
 
-      %table.dynatable
+      %table.dynatable.no-table-header
         %thead
           %tr
             - if assignment.is_individual?

--- a/app/views/info/_students_table.haml
+++ b/app/views/info/_students_table.haml
@@ -1,4 +1,4 @@
-%table.dynatable{role: "grid"}
+%table.dynatable.no-button-bar{role: "grid"}
   %thead
     %tr
       %th{ scope: "column", :width => "20%" }= course.user_term

--- a/app/views/info/_ungraded_submissions_table.haml
+++ b/app/views/info/_ungraded_submissions_table.haml
@@ -6,7 +6,7 @@
   %h4.assignment_name
     = link_to assignment.name, assignment
     = link_to glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
-  %table.dynatable{"aria-describedby" => "ungradedTableCaption"}
+  %table.dynatable.no-table-header{"aria-describedby" => "ungradedTableCaption"}
     %thead
       %tr
         - if assignment.is_individual?

--- a/app/views/info/awarded_badges.html.haml
+++ b/app/views/info/awarded_badges.html.haml
@@ -12,7 +12,7 @@
           .sr-only Select #{term_for :team}
         = select_tag :team_id, options_for_select(@teams.map { |t| [t.name, t.id] }, @team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  %table.dynatable
+  %table.dynatable.no-table-header.no-button-bar
     %caption.sr-only All Awarded Achievements
     %thead
       %tr

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -12,5 +12,5 @@
   .mainContent{ class: (@display_sidebar ? "student" : "") }= render "layouts/content"
 
   - if @display_sidebar == true
-    .student-sidebar
+    .student-sidebar.hide-for-medium.hide-for-small
       = render "students/student_sidebar"

--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -3,5 +3,5 @@
   = content_nav do
     = render "students/student_profile_tabs"
   .student.mainContent= render "layouts/content"
-  .student-sidebar.hide-for-small
+  .student-sidebar.hide-for-medium.hide-for-small
     = render "students/student_sidebar"

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -7,7 +7,7 @@
 .pageContent
   = render "layouts/alerts"
 
-  %table.dynatable
+  %table.dynatable.no-table-header
     %thead
       %tr
         %th

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -10,9 +10,9 @@
   %table.dynatable.no-table-header
     %thead
       %tr
-        %th
         %th First Name
         %th Last Name
+        %th Avatar
         %th Role
         %th #{term_for :team}
         %th{:style => "min-width: 200px"}
@@ -20,11 +20,11 @@
       - @staff.each do |user|
         %tr
           %td
-            - if user.avatar_file_name.present?
-              %img.img-rounded{:src => user.avatar_file_name, :width => 30}
-          %td
             = link_to user.first_name, staff_path(user)
           %td= link_to user.last_name, staff_path(user)
+          %td
+            - if user.avatar_file_name.present?
+              %img.img-rounded{:src => user.avatar_file_name, :width => 30}
           %td= user.role(current_course).capitalize
           %td
             - user.team_leaderships_for_course(current_course).each do |leadership|

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -4,7 +4,7 @@
       %th
       %th First Name
       %th Last Name
-      %th
+      %th Avatar
       - if current_course.in_team_leaderboard? || current_course.character_names?
         %th Screenname
       - if current_course.has_teams?

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -1,10 +1,10 @@
-%table.dynatable
+%table.dynatable.no-table-header
   %thead
     %tr
       %th
-      %th
       %th First Name
       %th Last Name
+      %th
       - if current_course.in_team_leaderboard? || current_course.character_names?
         %th Screenname
       - if current_course.has_teams?
@@ -20,11 +20,11 @@
         %td
           = div_for student do
             = link_to flagged_user_icon(current_course, current_user, student.id), flag_user_path(student), method: :post, remote: true, class: "flagged-user-icon"
+        %td= link_to student.first_name, student_path(student)
+        %td= link_to student.last_name, student_path(student)
         %td
           - if student.avatar_file_name.present?
             %img.img-rounded{:src => student.avatar_file_name, :width => 30}
-        %td= link_to student.first_name, student_path(student)
-        %td= link_to student.last_name, student_path(student)
         - if current_course.in_team_leaderboard? || current_course.character_names?
           %td
             = student.display_name

--- a/app/views/students/leaderboard.html.haml
+++ b/app/views/students/leaderboard.html.haml
@@ -12,7 +12,7 @@
           .sr-only Select #{term_for :team}
         = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  %table.dynatable
+  %table.dynatable.second-row-header
     %thead
       %tr
         %th

--- a/app/views/students/syllabus/_assignment_table.haml
+++ b/app/views/students/syllabus/_assignment_table.haml
@@ -1,7 +1,7 @@
 %thead
   %tr
-    %th
     %th= "#{term_for :assignment}"
+    %th
     %th Points
     %th Due
     %th
@@ -10,8 +10,8 @@
 - presenter.assignments_for(assignment_type).each do |assignment|
   - if presenter.assignment_visible?(assignment)
     %tr
-      %td= render "students/syllabus/components/assignment_icons", presenter: presenter, assignment: assignment
       %td= link_to assignment.name, assignment_path(assignment) if presenter.name_visible?(assignment)
+      %td= render "students/syllabus/components/assignment_icons", presenter: presenter, assignment: assignment
       %td
         - if presenter.points_visible?(assignment)
           - if assignment.pass_fail?

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -15,5 +15,5 @@
         %p.description= raw assignment_type.description
 
       // Display the assignments for each assignment type in a responsive table, below header.
-      %table.dynatable
+      %table.default_assignments_dynatable.dynatable
         = render "students/syllabus/assignment_table", presenter: presenter, assignment_type: assignment_type

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -12,7 +12,7 @@
 
   %h4.subtitle= "#{term_for :student} Roster"
 
-  %table.dynatable
+  %table.dynatable.no-table-header
     %thead
       %tr
         %th First Name

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,7 +14,7 @@
           .sr-only Select #{term_for :team}
         = select_tag :team_id, options_for_select(@teams.map { |t| [t.name, t.id] }, @team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  %table.dynatable
+  %table.dynatable.no-table-header
     %thead
       %tr
         %th First Name

--- a/vendor/assets/javascripts/stacktable.min.js
+++ b/vendor/assets/javascripts/stacktable.min.js
@@ -1,0 +1,21 @@
+!function(t){t.fn.cardtable=function(a){var s,d=this,e={headIndex:0},n=t.extend({},e,a)
+return s=a&&a.headIndex?a.headIndex:0,d.each(function(){var a=t(this)
+if(!a.hasClass("stacktable")){var s=t(this).prop("class"),d=t("<div></div>")
+"undefined"!=typeof n.myClass&&d.addClass(n.myClass)
+var e,l,h,i,r,c=""
+a.addClass("stacktable large-only"),e=a.find("caption").clone(),l=a.find("tr").eq(0),a.find("tbody tr").each(function(){h="",i="",r=t(this).prop("class"),t(this).find("td,th").each(function(a){""!==t(this).html()&&(i+='<tr class="'+r+'">',i+=l.find("td,th").eq(a).html()?'<td class="st-key">'+l.find("td,th").eq(a).html()+"</td>":'<td class="st-key"></td>',i+='<td class="st-val '+t(this).prop("class")+'">'+t(this).html()+"</td>",i+="</tr>")}),c+='<table class=" '+s+' stacktable small-only"><tbody>'+h+i+"</tbody></table>"}),a.find("tfoot tr td").each(function(a,d){""!==t.trim(t(d).text())&&(c+='<table class="'+s+' stacktable small-only"><tbody><tr><td>'+t(d).html()+"</td></tr></tbody></table>")}),d.prepend(e),d.append(t(c)),a.before(d)}})},t.fn.stacktable=function(a){var s,d=this,e={headIndex:0},n=t.extend({},e,a)
+return s=a&&a.headIndex?a.headIndex:0,d.each(function(){var a=t(this).prop("class"),d=t('<table class="'+a+' stacktable small-only"><tbody></tbody></table>')
+"undefined"!=typeof n.myClass&&d.addClass(n.myClass)
+var e,l,h,i,r,c,o=""
+e=t(this),e.addClass("stacktable large-only"),l=e.find("caption").clone(),h=e.find("tr").eq(0),e.find("tr").each(function(a){i="",r="",c=t(this).prop("class"),0===a?o+='<tr class=" '+c+' "><th class="st-head-row st-head-row-main" colspan="2">'+t(this).find("th,td").eq(s).html()+"</th></tr>":(t(this).find("td,th").each(function(a){a===s?i='<tr class="'+c+'"><th class="st-head-row" colspan="2">'+t(this).html()+"</th></tr>":""!==t(this).html()&&(r+='<tr class="'+c+'">',r+=h.find("td,th").eq(a).html()?'<td class="st-key">'+h.find("td,th").eq(a).html()+"</td>":'<td class="st-key"></td>',r+='<td class="st-val '+t(this).prop("class")+'">'+t(this).html()+"</td>",r+="</tr>")}),o+=i+r)}),d.prepend(l),d.append(t(o)),e.before(d)})},t.fn.stackcolumns=function(a){var s=this,d={},e=t.extend({},d,a)
+return s.each(function(){var a=t(this),s=a.find("tr").eq(0).find("td,th").length
+if(!(3>s)){var d=t('<table class="stacktable small-only"></table>')
+"undefined"!=typeof e.myClass&&d.addClass(e.myClass),a.addClass("stacktable large-only")
+for(var n=t("<tbody></tbody>"),l=1;s>l;)a.find("tr").each(function(a){var s=t("<tr></tr>")
+0===a&&s.addClass("st-head-row st-head-row-main")
+var d=t(this).find("td,th").eq(0).clone().addClass("st-key"),e=l
+if(t(this).find("*[colspan]").length){var h=0
+t(this).find("td,th").each(function(){var a=t(this).attr("colspan")
+return a?(a=parseInt(a,10),e-=a-1,h+a>l&&(e+=h+a-l-1),h+=a):h++,h>l?!1:void 0})}var i=t(this).find("td,th").eq(e).clone().addClass("st-val").removeAttr("colspan")
+s.append(d,i),n.append(s)}),++l
+d.append(t(n)),a.before(d)}})}}(jQuery)

--- a/vendor/assets/stylesheets/stacktable.css
+++ b/vendor/assets/stylesheets/stacktable.css
@@ -1,0 +1,17 @@
+.stacktable { width: 100%; }
+.st-head-row { padding-top: 1em; }
+.st-head-row.st-head-row-main { font-size: 1.5em; padding-top: 0; }
+.st-key { width: 49%; text-align: right; padding-right: 1%; }
+.st-val { width: 49%; padding-left: 1%; }
+
+
+
+/* RESPONSIVE EXAMPLE */
+
+.stacktable.large-only { display: table; }
+.stacktable.small-only { display: none; }
+
+@media (max-width: 800px) {
+  .stacktable.large-only { display: none; }
+  .stacktable.small-only { display: table; }
+}

--- a/vendor/assets/stylesheets/stacktable.css
+++ b/vendor/assets/stylesheets/stacktable.css
@@ -1,8 +1,27 @@
-.stacktable { width: 100%; }
-.st-head-row { padding-top: 1em; }
-.st-head-row.st-head-row-main { font-size: 1.5em; padding-top: 0; }
-.st-key { width: 49%; text-align: right; padding-right: 1%; }
-.st-val { width: 49%; padding-left: 1%; }
+.stacktable { 
+  width: 100%;
+}
+
+.st-head-row { 
+  padding: .75em .25em;
+  font-size: .85em;
+}
+
+.st-head-row.st-head-row-main { 
+  font-size: 1.5em; 
+  padding-top: 0;
+}
+
+.st-key { 
+  width: 49%; 
+  padding-right: 1%;
+  font-weight: bold;
+}
+
+.st-val { 
+  width: 49%; 
+  padding-left: 1%; 
+}
 
 
 


### PR DESCRIPTION
This PR implements Stacktable.js plugin to improve responsiveness of tables throughout app. Several variations of Stacktable.js's cardtable layout are provided: (1) for tables with both styled header and footer with button bar, (2) with neither header nor button bar, (3) with just header and (4) with just footer.

### Before
<img width="322" alt="before-tables" src="https://cloud.githubusercontent.com/assets/12573921/15632993/e14dc7be-256f-11e6-9c5a-5fe5115856bd.png">

### After
<img width="333" alt="after-tables" src="https://cloud.githubusercontent.com/assets/12573921/15632989/c1e68082-256f-11e6-9585-25c9ce682731.png">

### What's Next
Some tables would benefit from an additional cell that concatenates first and last name so headers can present full name. Also - there is a "Due Date" field that is originally hidden that will need to be re-hidden on mobile tables.

Closes issue #1853 