### PR TITLE
Added predicted grade to graphic

### DIFF
--- a/app/assets/javascripts/angular/templates/ng_predictor_graphic.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_graphic.html.haml
@@ -16,6 +16,7 @@
           %rect.key{"width"=>"20", "height"=>"20"}
           %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
             Total Predicted: {{allPointsPredicted() | number}} (left to earn: {{allPointsPredicted() - allPointsEarned() | number}})
-
-
-
+        %g{"id" => "svg-predicted-grade"}
+          %text.description
+            Predicted Final Grade:
+            {{predictedGradeLevel()}}

--- a/app/assets/javascripts/angular/templates/ng_predictor_main.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_predictor_main.html.haml
@@ -10,20 +10,14 @@
   .collapse-all-toggler
     .collapse-arrow.outdent
     .predictor-section-title
-      .predictor-section-title-name
-        %span.desktop-only
-          Predicted Final Grade:
-        {{predictedGradeLevel()}}
       .predictor-section-title-predicted-points{{'ng-if'=>'weightsAvailable()'}}
         .predictor-title-right-span
           Unused {{termFor.weights}} :
         .predictor-section-title-weights
           .coin{{'ng-repeat' => 'coin in unusedWeightsRange()'}}
 
-
 #assignment-types{'ng-include' => true, 'src' => "'ng_predictor_assignment_types.html'"}
 
 #badges{'ng-include'=> true, 'src' => "'ng_predictor_badges.html'"}
 
 #challenges{'ng-include'=> true, 'src' => "'ng_predictor_challenges.html'"}
-

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -19,7 +19,7 @@ $predictor-font-size-5 : .55rem
 // SVG
 
 .graphics-wrap
-  height: 118px
+  height: 138px
 
 .graphics-screen
   height: 150px
@@ -33,7 +33,7 @@ $predictor-font-size-5 : .55rem
 
 #predictor-graphic
   width: 100%
-  height: 120px
+  height: 140px
   margin: 0
   background-color: $color-white
   .grade-point-axis
@@ -61,6 +61,10 @@ $predictor-font-size-5 : .55rem
       fill: $color-blue-3
       width: 20
       height: 20
+  #svg-predicted-grade
+    font-size: $predictor-font-size-3
+    font-weight: bold
+    -webkit-transform: translate(10px,130px) /* Safari */
 
 // ICONS AND TOOLTIPS
 

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -473,6 +473,7 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
 // small
 @media (max-width: $media-small-max)
   #predictor-graphic
+    height: 175px
     .grade-point-axis text
       font-size: $predictor-font-size-5
     #svg-keys
@@ -480,6 +481,9 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
     #svg-predicted-key
       transform: translate(10px,120px)
       -webkit-transform: translate(10px,120px)
+    #svg-predicted-grade
+      transform: translate(10px, 160px)
+      -webkit-transform: translate(10px, 160px)
   .collapse-arrow.doubled
     margin: 35px 0 0 0
   article.predictor-article
@@ -513,9 +517,9 @@ article.predictor-article .ui-slider.below-threshold .ui-slider-range
       margin: 0
       font-size: $predictor-font-size-1
   #predictor-main-header
-    height: 60px
+    height: 66px
     margin-top: 0px
-    padding-top: 10px
+    padding-top: 30px
   .predictor-section
     height: 70px
     .collapse-arrow


### PR DESCRIPTION
This PR adds the predicted grade text to the chart to take advantage of the way that it is already sticky, and allows students to see it while they review all assignments for the course.
<img width="1195" alt="screen shot 2016-05-28 at 8 59 55 am" src="https://cloud.githubusercontent.com/assets/234276/15627462/cc52fd92-24b2-11e6-88cd-7f54f7f2f7ac.png">


Open question: how should we handle the need for something to expand/collapse all subsections (used to be the predicted grade, now an empty bar)?