### PR TITLE
angular bugfix for removed method

### DIFF
--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -89,7 +89,6 @@
     points
 
   return {
-      getAssignment: getAssignment,
       getCriteria: getCriteria,
       getCriterionGrades: getCriterionGrades,
       getBadges: getBadges,


### PR DESCRIPTION
the method `getAssignment` was removed completely  in a recent PR (refactoring Grade routes) but the method is still referenced in the public-facing return from the service, causing errors on the rubric grading page.