### PR TITLE
Fixed tab display bug on group show view

### DIFF
--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -61,7 +61,7 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def has_persisted_grades?
-    grades { |grade| grade if grade.persisted? }
+    grades.any?(&:persisted?)
   end
 
   def has_reviewable_grades?

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -60,6 +60,10 @@ class Assignments::Presenter < Showtime::Presenter
     grades.present?
   end
 
+  def has_persisted_grades?
+    grades { |grade| grade if grade.persisted? }
+  end
+
   def has_reviewable_grades?
     grades.instructor_modified.present?
   end

--- a/app/views/assignments/_show_instructor.haml
+++ b/app/views/assignments/_show_instructor.haml
@@ -17,11 +17,11 @@
       - if presenter.grade_with_rubric?
         %li
           %a{ "href" => "#tabt3"} Grading Rubric
-      - if presenter.has_grades?
+      - if presenter.has_persisted_grades?
         %li
-          %a{ :href => "#tabt4"} Class Analytics
+          %a{ "href" => "#tabt4"} Class Analytics
 
-    #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
+    #tabt1.ui-tabs-panel
       .ui-tabs-panel#tab.active{role: "tabpanel", "aria-hidden" => false }
         - if presenter.group_assignment?
           = render "assignments/group/group_show", presenter: presenter
@@ -29,14 +29,10 @@
           = render "assignments/individual/individual_show", presenter: presenter
       .ui-tabs-panel#tabt2{role: "tabpanel", "aria-hidden" => false }
         = render "assignments/description_and_downloads", presenter: presenter
-
       - if presenter.grade_with_rubric?
-        .content#tabt3{role: "tabpanel", "aria-hidden" => false }
+        .ui-tabs-panel#tabt3{role: "tabpanel", "aria-hidden" => false }
           .tab-container
             = render partial: "rubrics/components/rubric_table", locals: { rubric: presenter.rubric, presenter: presenter, student: nil, include_grade_info: false }
-      - if presenter.has_grades?
+      - if presenter.has_persisted_grades?
         .ui-tabs-panel#tabt4{role: "tabpanel", "aria-hidden" => false }
-          - if presenter.group_assignment?
-            = render "grades/analytics/group_analytics", presenter: presenter
-          - else
-            = render "grades/analytics/instructor_analytics", presenter: presenter
+          = render "grades/analytics/instructor_analytics", presenter: presenter

--- a/app/views/assignments/_show_instructor.haml
+++ b/app/views/assignments/_show_instructor.haml
@@ -35,4 +35,7 @@
             = render partial: "rubrics/components/rubric_table", locals: { rubric: presenter.rubric, presenter: presenter, student: nil, include_grade_info: false }
       - if presenter.has_persisted_grades?
         .ui-tabs-panel#tabt4{role: "tabpanel", "aria-hidden" => false }
-          = render "grades/analytics/instructor_analytics", presenter: presenter
+          - if presenter.group_assignment?
+            = render "grades/analytics/group_analytics", presenter: presenter
+          - else
+            = render "grades/analytics/instructor_analytics", presenter: presenter

--- a/app/views/assignments/group/_group_show.haml
+++ b/app/views/assignments/group/_group_show.haml
@@ -2,7 +2,7 @@
   - if ! presenter.groups.present?
     No #{term_for :groups} have been created! You can either have #{term_for :students} self-create their #{term_for :groups}, or you can create them manually #{link_to "here", new_group_path}.
   - else
-    %table.dynatable
+    %table
       %thead= render partial: "assignments/group/table_head", locals: { presenter: presenter }
       %tbody= render partial: "assignments/group/table_body", locals: { presenter: presenter }
       .right

--- a/app/views/assignments/group/_table_head.html.haml
+++ b/app/views/assignments/group/_table_head.html.haml
@@ -1,5 +1,5 @@
 %tr
   %th{:width => "20%"} #{term_for :group} Name
   %th Status
-  %th
-  %th
+  %th{"data-dynatable-no-sort" => "true" }
+  %th{"data-dynatable-no-sort" => "true" }

--- a/app/views/grades/analytics/_group_analytics.haml
+++ b/app/views/grades/analytics/_group_analytics.haml
@@ -1,6 +1,6 @@
 .tab-container
   %h4.bold Basic Stats
-  - if presenter.grades_available_for?(current_user)
+  - if presenter.has_grades?
     %ul
       %li
         %span.small_uppercase Average Score:
@@ -12,8 +12,6 @@
         %span.small_uppercase High Score:
         = points presenter.assignment.high_score
 
-
-  - if presenter.grades_available_for?(current_user)
     %h4.bold Grade Distribution
     .grades_per_assign{ "data-scores" => presenter.scores_for(current_user).to_json }
 

--- a/app/views/grades/analytics/_individual_analytics.haml
+++ b/app/views/grades/analytics/_individual_analytics.haml
@@ -1,6 +1,6 @@
 .tab-container
   %h4.bold Basic Stats
-  - if presenter.grades_available_for? current_student
+  - if presenter.has_grades?
     %ul
     %li
       %span.small_uppercase Average Score:
@@ -12,7 +12,6 @@
       %span.small_uppercase High Score:
       = points presenter.assignment.high_score
 
-  - if presenter.has_scores_for?(current_student)
     %br
     %h4.bold Grade Distribution
     .grades_per_assign{ "data-scores" => presenter.scores_for(current_student).to_json, :style => "width: 200px" }


### PR DESCRIPTION
This PR fixes a bug where the assignment presenter method `has_grades?` was returning true the second time it was called (below a table where grades were created but not persisted). This display of tab content without it's associated tab broke the tab interaction. 