### PR TITLE
1861 max width content

### DIFF
--- a/app/assets/stylesheets/_breadcrumbs.sass
+++ b/app/assets/stylesheets/_breadcrumbs.sass
@@ -8,7 +8,6 @@
   height: 1.5rem
   background-color: $color-blue-2
   opacity: .8
-  border-left: 1px solid $color-blue-3
   font-weight: 300
 
   a

--- a/app/assets/stylesheets/_footer.sass
+++ b/app/assets/stylesheets/_footer.sass
@@ -4,11 +4,10 @@
 .footer
   position: relative
   clear: both
-  width: calc(100% - 4rem)
   padding: 4rem 2rem
   background-color: $color-grey-2
   opacity: .9
-  height: 60px
+  box-sizing: border-box
   color: $color-grey-5
   font-size: 1rem
 
@@ -20,7 +19,6 @@
       display: inline
       list-style-type: none
       text-transform: uppercase
-      margin-right: 1rem
       a
         color: $color-grey-5
 
@@ -30,11 +28,26 @@
     &.social
       font-size: 1.25rem
 
+    li:not(:last-of-type)
+      margin-right: 1rem
+
+  .footer-logo
+    display: none
+
   .michigan
     color: $color-grey-4
+    margin-top: 1rem
 
 .logged-in .footer
-  padding: 1rem 2rem
+  padding: 2rem 2rem
+  max-width: 1500px
+  margin: 0 auto
+
+  .footer-links
+    display: none
+
+  .footer-logo
+    display: block
 
 @media (max-width: $media-small-max)
   .footer

--- a/app/assets/stylesheets/_footer.sass
+++ b/app/assets/stylesheets/_footer.sass
@@ -51,8 +51,7 @@
 
 @media (max-width: $media-small-max)
   .footer
-    height: auto !important
-    padding: 1rem 2rem
+    padding: 1rem 1rem
     font-size: .8rem
     text-align: center
     position: relative
@@ -60,8 +59,16 @@
     .left
       width: 100%
       text-align: center
+      float: none
 
     .right
       width: 100%
-      margin-bottom: 1rem
+      margin-bottom: .5rem
       text-align: center
+      float: none
+
+  .logged-in .footer
+    padding: 1rem 1rem
+
+    .footer-logo
+      margin: 0 auto

--- a/app/assets/stylesheets/_footer.sass
+++ b/app/assets/stylesheets/_footer.sass
@@ -11,6 +11,7 @@
   color: $color-grey-5
   font-size: 1rem
   width: 100%
+  flex-shrink: 0
 
   ul
     margin: 0

--- a/app/assets/stylesheets/_footer.sass
+++ b/app/assets/stylesheets/_footer.sass
@@ -4,12 +4,13 @@
 .footer
   position: relative
   clear: both
-  padding: 4rem 2rem
+  padding: 3rem 2rem
   background-color: $color-grey-2
   opacity: .9
   box-sizing: border-box
   color: $color-grey-5
   font-size: 1rem
+  width: 100%
 
   ul
     margin: 0

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -5,16 +5,26 @@ body
   margin: 0 auto
   padding: 0
   position: relative
+  display: -webkit-box
+  display: -webkit-flex
+  display: -ms-flexbox
   display: flex
-  min-height: 100vh
+  -webkit-box-orient: vertical
+  -webkit-box-direction: normal
+  -webkit-flex-direction: column
+  -ms-flex-direction: column
   flex-direction: column
+  height: 100vh
 
 .inner-wrap
   margin: 2rem auto 0 auto
   max-width: 1500px
   width: 100%
+  -webkit-box-flex: 1
+  -webkit-flex: 1 0 auto
+  -ms-flex: 1 0 auto
   flex: 1 0 auto
-  background-color: white
+  background-color: $color-white
 
 .outer-wrap
   padding: 0.1rem 0

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -7,9 +7,9 @@ body
   position: relative
 
 .inner-wrap
-  margin: 2rem 0 0
+  margin: 2rem auto 0 auto
+  max-width: 1500px
   width: 100%
-  height: 100%
 
 .outer-wrap
   padding: 0.1rem 0

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -32,7 +32,7 @@ body
   min-height: 100%
 
 .student.mainContent
-  width: calc(100% - 318px)
+  width: 100%
   float: left
 
 /* Allow other things to appear above the timeline */

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -5,11 +5,16 @@ body
   margin: 0 auto
   padding: 0
   position: relative
+  display: flex
+  min-height: 100vh
+  flex-direction: column
 
 .inner-wrap
   margin: 2rem auto 0 auto
   max-width: 1500px
   width: 100%
+  flex: 1 0 auto
+  background-color: white
 
 .outer-wrap
   padding: 0.1rem 0
@@ -29,11 +34,12 @@ body
 .pageContent
   padding: 1rem
   background-color: $color-white
-  min-height: 100%
+  // min-height: 100%
 
 .student.mainContent
   width: 100%
   float: left
+  flex: 1
 
 /* Allow other things to appear above the timeline */
 .vco-storyjs

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -27,19 +27,13 @@ body
   &.student
     padding-top: .2rem
 
-.sidebar-container
-  &.student
-    width: calc(100%)
 
 .pageContent
   padding: 1rem
   background-color: $color-white
-  // min-height: 100%
 
 .student.mainContent
   width: 100%
-  float: left
-  flex: 1
 
 /* Allow other things to appear above the timeline */
 .vco-storyjs

--- a/app/assets/stylesheets/_login.sass
+++ b/app/assets/stylesheets/_login.sass
@@ -5,7 +5,7 @@
   padding: 3rem 1rem
   width: calc(100% - 2.5rem)
   height: calc(100% - 280px)
-  background-color: rgba(1, 1, 1, .2)
+
   .alert-bkg
     margin-left: -1rem
     margin-bottom: 1rem

--- a/app/assets/stylesheets/_newsletter.sass
+++ b/app/assets/stylesheets/_newsletter.sass
@@ -9,6 +9,7 @@
   clear: both
   color: $color-grey-4
   background-color: $color-blue-4
+  width: 100%
 
   .title
     display: inline

--- a/app/assets/stylesheets/_pages.sass
+++ b/app/assets/stylesheets/_pages.sass
@@ -1,6 +1,12 @@
 @import color
 @import layout
 
+.public
+  flex: 1
+
+.public-with-background
+  background-color: rgba($color-blue-3, .5)
+
 .page
   .hero-section
     margin: 0

--- a/app/assets/stylesheets/_pages.sass
+++ b/app/assets/stylesheets/_pages.sass
@@ -2,7 +2,19 @@
 @import layout
 
 .public
-  flex: 1
+  display: -webkit-box
+  display: -webkit-flex
+  display: -ms-flexbox
+  display: flex
+  -webkit-box-orient: vertical
+  -webkit-box-direction: normal
+  -webkit-flex-direction: column
+  -ms-flex-direction: column
+  flex-direction: column
+  -webkit-box-flex: 1
+  -webkit-flex: 1 0 auto
+  -ms-flex: 1 0 auto
+  flex: 1 0 auto
 
 .public-with-background
   background-color: rgba($color-blue-3, .5)

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -9,7 +9,7 @@ $predictor-font-size-4 : .85rem
 $predictor-font-size-5 : .55rem
 
 #predictor-main-content
-  background-color: rgba(255,255,255,0.5)
+  background-color: rgba(255,255,255,0.8)
   // Clear tabs:
   margin-top: 0rem
   padding-bottom: 1rem
@@ -27,6 +27,7 @@ $predictor-font-size-5 : .55rem
 
 .graphics-screen.sticky-item.stuck
   background-color: $color-white
+  max-width: 1500px
   z-index: 100
   position: fixed
   top: 45px

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -8,8 +8,10 @@ $predictor-font-size-3 : 1rem
 $predictor-font-size-4 : .85rem
 $predictor-font-size-5 : .55rem
 
-#predictor-main-content
+.predictor-inner.inner-wrap
   background-color: rgba(255,255,255,0.8)
+
+#predictor-main-content
   // Clear tabs:
   margin-top: 0rem
   padding-bottom: 1rem

--- a/app/assets/stylesheets/_signup.sass
+++ b/app/assets/stylesheets/_signup.sass
@@ -1,11 +1,13 @@
 @import color
 @import layout
 
+.center-items
+  align-items: center
+  justify-content: center
+  display: flex
+
 section.pilot
-  margin-top: 45px
-  background-color: rgba($color-blue-3, .5)
   color: $color-white
-  padding: 4em 2em
 
   h1, p
     color: $color-grey-2
@@ -28,4 +30,8 @@ section.pilot
 @media (max-width: $media-small-max)
   section.pilot
     padding: .5em 1em
+    margin-top: 45px
+
+  .center-items
+    display: block
 

--- a/app/assets/stylesheets/_signup.sass
+++ b/app/assets/stylesheets/_signup.sass
@@ -2,8 +2,18 @@
 @import layout
 
 .center-items
+  padding-top: 50px
+  -webkit-box-align: center
+  -webkit-align-items: center
+  -ms-flex-align: center
   align-items: center
+  -webkit-box-pack: justify
+  -webkit-justify-content: center
+  -ms-flex-pack: justify
   justify-content: center
+  display: -webkit-box
+  display: -ms-flexbox
+  display: -webkit-flex
   display: flex
 
 section.pilot

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -3,8 +3,8 @@
 
 /* Tabs on the student dashboard */
 .sub-nav
-  margin: 0
-  padding: 1.5rem 0.5rem 0.75rem 1.5rem
+  margin: 10px 0 0 0
+  padding: 0.75rem 0rem
   display: block
   position: relative
   overflow: hidden
@@ -34,16 +34,14 @@
     li
       font-size: .8rem
       background-color: $color-blue-2
-      border-top-left-radius: $global-radius
-      border-top-right-radius: $global-radius
-      margin: 0 0.5rem 0 0
-      padding: 1rem 0
+      margin: 0 0.25rem 0 0
+      padding: 0.8rem 0
       text-transform: uppercase
       a
-        padding: 1em
+        padding: 0.8rem 0.5rem
         color: $color-white
     li.active
-      padding: 1rem .75rem !important
+      padding: .8rem .5rem !important
     
     h5, hr
       display: none

--- a/app/assets/stylesheets/_student_subnav.sass
+++ b/app/assets/stylesheets/_student_subnav.sass
@@ -3,12 +3,14 @@
 
 /* Tabs on the student dashboard */
 .sub-nav
-  margin: 1.5rem 0 0 1rem
-  padding: 0.5
+  margin: 0
+  padding: 1.5rem 0.5rem 0.75rem 1.5rem
   display: block
   position: relative
   overflow: hidden
   width: auto
+  background-color: $color-blue-2
+  opacity: .9
 
   ul
     margin: 0
@@ -17,8 +19,6 @@
   li
     display: inline
     list-style-type: none
-    float: left
-    margin-left: rem-calc(16)
     margin: 0
     
     i
@@ -32,30 +32,26 @@
     padding: 0
 
     li
-      font-size: .75rem
-      height: 1rem
+      font-size: .8rem
       background-color: $color-blue-2
       border-top-left-radius: $global-radius
       border-top-right-radius: $global-radius
       margin: 0 0.5rem 0 0
-      padding: 0.5rem 0
-      text-transform: capitalize
+      padding: 1rem 0
+      text-transform: uppercase
       a
         padding: 1em
         color: $color-white
     li.active
-      padding: .5rem .75rem !important
-
-    li a:hover, li:hover a
-      color: $color-black
+      padding: 1rem .75rem !important
     
     h5, hr
       display: none
 
 /* Setting the active tab and hover color */
 .navbar-nav li.active, .sub-nav .navbar-nav li:hover
-  background-color: $color-yellow-1
-  color: $color-black!important
+  background-color: $color-blue-3
+  color: $color-white
 
 li .announcement-notification-badge
   position: relative

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -10,10 +10,8 @@ a.site-title
   color: $color-blue-1
 
 .container
-  width: 95%
+  width: 100%
   margin: 0 auto
-  &.navbar
-    width: 100%
 
 /* In app mobile left flyout menu styles */
 .layout-left-flyout
@@ -116,6 +114,12 @@ a.site-title
   top: 0 !important
   z-index: 1000
   height: 45px !important
+
+.logged-out
+  .navbar
+    background-color: $color-blue-1
+
+.the-nav
   background-color: $color-blue-1
 
 ul.subnav.logged-out
@@ -184,20 +188,12 @@ ul.subnav.logged-out
 @media (min-width: $media-medium-max)
   .navbar
     height: auto
-  .container
-    width: 95%
-    margin: 0 auto
+
   .the-nav
     display: block
-  .the-nav .nav
-    display: block
-  .the-nav .nav-pill:after
-    content: ""
-    display: table
-    clear: both
-  .the-nav .nav-pill.left
-    height: 45px
-    overflow: hidden
+    max-width: 1500px
+    margin: 0 auto
+
   .the-nav .nav-pill.right
     z-index: 100
   .the-nav > .nav
@@ -280,6 +276,9 @@ ul.subnav.logged-out
 @media (max-width: $media-medium-max)
   .logged-in .navbar .nav-collapse
     display: none
+
+  .navbar
+    background-color: $color-blue-1
 
   .nav.nav-pill
     padding: 0

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -197,6 +197,9 @@ ul.subnav.logged-out
 
   .the-nav .nav-pill.right
     z-index: 100
+  .the-nav .nav-pill.left
+    height: 45px
+    overflow: hidden
   .the-nav > .nav
     margin: 0
     padding-left: 0

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -9,6 +9,9 @@ img.profile-pic
 a.site-title
   color: $color-blue-1
 
+.logo-home
+  border: none
+
 .container
   width: 100%
   margin: 0 auto

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -121,6 +121,7 @@ a.site-title
 
 .the-nav
   background-color: $color-blue-1
+  height: 45px
 
 ul.subnav.logged-out
   left: -6.25rem

--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -80,7 +80,6 @@ h3.pagetitle
   width: calc(100% - 2rem)
   display: inline-block
   color: $color-white
-  border-left: 1px solid $color-blue-3
   padding: 1rem 1rem .5rem
   font-size: 1.8rem
   background-color: $color-blue-2

--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -87,6 +87,12 @@ h3.pagetitle
   font-weight: 100
   opacity: .8
 
+.student
+  h3.pagetitle
+    background-color: $color-white
+    color: $color-blue-2
+    opacity: 1
+
 /** Subtitle **/
 h4.subtitle
   font-size: 1.3rem

--- a/app/views/layouts/_footer.haml
+++ b/app/views/layouts/_footer.haml
@@ -4,12 +4,12 @@
     %li= link_to glyph(:twitter), "https://twitter.com/gradecraft", :target => "_blank"
     %li= link_to glyph(:facebook), "https://facebook.com/gradecraft", :target => "_blank"
 .left
-  %ul
+  = image_tag "gradecraft_logo.png", :width => "150", :class => "footer-logo"
+  %ul.footer-links
     %li= link_to_unless_current "Features", features_path
     %li= link_to_unless_current "Research", research_path
     %li= link_to_unless_current "Press", press_path
     %li= link_to_unless_current "Team", our_team_path
     %li= link_to "Blog", "http://blog.gradecraft.com", :target => "_blank"
-  %br
   .uppercase.small.michigan= "© 2012-#{Date.today.year} Regents of the University of Michigan"
 .clear

--- a/app/views/layouts/_public.haml
+++ b/app/views/layouts/_public.haml
@@ -1,2 +1,2 @@
-.public
+%div{:class => ["public", yield(:public_class)]}
   = yield

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -10,7 +10,3 @@
 
   / Page content
   .mainContent{ class: (@display_sidebar ? "student" : "") }= render "layouts/content"
-
-  - if @display_sidebar == true
-    .student-sidebar.hide-for-medium.hide-for-small
-      = render "students/student_sidebar"

--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -3,5 +3,3 @@
   = content_nav do
     = render "students/student_profile_tabs"
   .student.mainContent= render "layouts/content"
-  .student-sidebar.hide-for-medium.hide-for-small
-    = render "students/student_sidebar"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,7 +14,7 @@
   %body(class="#{body_class}")
     = render "layouts/top_bar"
     - if current_user
-      .inner-wrap
+      .inner-wrap.clearfix
         - if current_user_is_staff?
           = render "layouts/staff"
         - else

--- a/app/views/layouts/predictor.html.haml
+++ b/app/views/layouts/predictor.html.haml
@@ -10,10 +10,9 @@
     = yield(:head)
 
   %body(class="#{body_class}")
+    = render "layouts/top_bar"
     .off-canvas-wrap{:"data-offcanvas" => true}
       .inner-wrap
-        .fixed
-          = render "layouts/top_bar"
 
         - if current_user
           .outer-wrap{role: "main"}

--- a/app/views/layouts/predictor.html.haml
+++ b/app/views/layouts/predictor.html.haml
@@ -12,25 +12,23 @@
   %body(class="#{body_class}")
     = render "layouts/top_bar"
     .off-canvas-wrap{:"data-offcanvas" => true}
-      .inner-wrap
+      .outer-wrap{role: "main"}
 
-        - if current_user
-          .outer-wrap{role: "main"}
-            = render "layouts/alerts"
-            .show-for-medium-up
-              = content_nav do
-                = render "students/student_profile_tabs"
-            = render "layouts/content"
+    - if current_user
 
-          = render "layouts/help/uservoice"
+      .inner-wrap.clearfix.predictor-inner
+        = render "layouts/alerts"
+        .show-for-medium-up
+          = content_nav do
+            = render "students/student_profile_tabs"
+        = render "layouts/content"
 
-          .footer
-            = render "layouts/footer"
-        - else
-          = render "layouts/public"
-          .row.panel.footer
-            .columns
-              = render "layouts/footer"
-        = render "layouts/background"
-        = render "layouts/google_analytics"
-        = javascript_include_tag "application", "data-turbolinks-track" => true
+      = render "layouts/help/uservoice"
+
+    - else
+      = render "layouts/public"
+    .footer
+      = render "layouts/footer"
+    = render "layouts/background"
+    = render "layouts/google_analytics"
+    = javascript_include_tag "application", "data-turbolinks-track" => true

--- a/app/views/pages/um_pilot.haml
+++ b/app/views/pages/um_pilot.haml
@@ -1,3 +1,4 @@
+- content_for :public_class, 'public-with-background center-items'
 %section.pilot
   .student-pilot
     .pilot-text

--- a/app/views/user_sessions/new.html.haml
+++ b/app/views/user_sessions/new.html.haml
@@ -1,3 +1,4 @@
+- content_for :public_class, 'public-with-background'
 .login
   .alert-bkg= render "layouts/alerts"
   #login-form


### PR DESCRIPTION
This PR implements a design change to constrain the max-width of the content in the application to 1500px as well as implements a sticky footer throughout the app with flexbox. Also included in this PR are style revisions to the student side of the application including removal of the sidebar and updated sub navigation styling. These changes are made in anticipation of the implementation of the student dashboard to replace the current timeline with modular data.

### Before
![screen shot 2016-06-05 at 10 01 09 am](https://cloud.githubusercontent.com/assets/12573921/15805880/7dc077ba-2b04-11e6-9022-322a3196892d.png)

![screen shot 2016-06-05 at 10 02 43 am](https://cloud.githubusercontent.com/assets/12573921/15805888/b394ccce-2b04-11e6-898f-9460bf6ff384.png)


### After
![screen shot 2016-06-05 at 10 00 34 am](https://cloud.githubusercontent.com/assets/12573921/15805881/819d9a02-2b04-11e6-8214-5ec6f8184508.png)

![screen shot 2016-06-05 at 10 02 24 am](https://cloud.githubusercontent.com/assets/12573921/15805889/b6617718-2b04-11e6-9d1a-b94c483bb555.png)

Closes issue #1861 