### PR TITLE
1215 scroll large tables on desktop

### DIFF
--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -36,6 +36,10 @@ table
       a, a.active, a.sorted
         color: $color-white !important
 
+.scroll-table
+  overflow-x: scroll
+  display: block
+
 /* Styling pattern tables for assignment outcome overview */
 td.complete, tr.achieved
   background-color: $color-green-1

--- a/app/views/assignment_types/all_grades.html.haml
+++ b/app/views/assignment_types/all_grades.html.haml
@@ -26,7 +26,7 @@
     Numbers reflect streaks - how many times in a row a #{(term_for :student).downcase} has earned the maximum number of points on an #{term_for :assignment}
 
   / Gradebook Pattern Table
-  #gradebook
+  .scroll-table#gradebook
     %table
       %thead
         %tr

--- a/app/views/assignment_types/index.html.haml
+++ b/app/views/assignment_types/index.html.haml
@@ -42,42 +42,44 @@
 
   %h4.subtitle= "#{term_for :student} Scores"
 
-  %table.dynatable.no-table-header.no-button-bar
-    %thead
-      %tr
-        %th First Name
-        %th Last Name
-        - @assignment_types.each do |at|
-          %th= "#{at.name} Points"
-          - if at.student_weightable?
-            %th= "#{at.name} Weighted Points"
-    %tbody
-      - @students.each do |student|
+  .scroll-table
+    %table.dynatable.no-table-header.no-button-bar
+      %thead
         %tr
-          %td= link_to student.first_name, student_path(student)
-          %td= link_to student.last_name, student_path(student)
+          %th First Name
+          %th Last Name
           - @assignment_types.each do |at|
-            %td= points at.visible_score_for_student(student)
+            %th= "#{at.name} Points"
             - if at.student_weightable?
-              %td= points at.raw_score_for_student(student)
-              %span.sr-only= at.name
+              %th= "#{at.name} Weighted Points"
+      %tbody
+        - @students.each do |student|
+          %tr
+            %td= link_to student.first_name, student_path(student)
+            %td= link_to student.last_name, student_path(student)
+            - @assignment_types.each do |at|
+              %td= points at.visible_score_for_student(student)
+              - if at.student_weightable?
+                %td= points at.raw_score_for_student(student)
+                %span.sr-only= at.name
 
   %h4.subtitle= "#{term_for :student} Grade Counts"
 
-  %table.dynatable.no-table-header.no-button-bar
-    %thead
-      %tr
-        %th First Name
-        %th Last Name
-        - @assignment_types.each do |at|
-          %th= "#{at.name} Grade Count"
-          %th= "#{at.name} Grades > 0 Count"
-
-    %tbody
-      - @students.each do |student|
+  .scroll-table
+    %table.dynatable.no-table-header.no-button-bar
+      %thead
         %tr
-          %td= link_to student.first_name, student_path(student)
-          %td= link_to student.last_name, student_path(student)
+          %th First Name
+          %th Last Name
           - @assignment_types.each do |at|
-            %td= points at.grades.where(student_id: student.id).graded_or_released.count
-            %td= points "#{at.grades.where(student_id: student.id).graded_or_released.positive.count }"
+            %th= "#{at.name} Grade Count"
+            %th= "#{at.name} Grades > 0 Count"
+
+      %tbody
+        - @students.each do |student|
+          %tr
+            %td= link_to student.first_name, student_path(student)
+            %td= link_to student.last_name, student_path(student)
+            - @assignment_types.each do |at|
+              %td= points at.grades.where(student_id: student.id).graded_or_released.count
+              %td= points "#{at.grades.where(student_id: student.id).graded_or_released.positive.count }"


### PR DESCRIPTION
This PR adds a scrollable class to use on tables that are too wide to display data correctly on desktop. This class adds a horizontal scroll to the table to prevent breaking the structure of the page.

### Before
<img width="1173" alt="screen shot 2016-06-06 at 11 15 56 am" src="https://cloud.githubusercontent.com/assets/12573921/15827068/11478540-2bd8-11e6-9ade-41d30c2cf8f5.png">

### After
<img width="1266" alt="screen shot 2016-06-06 at 11 14 42 am" src="https://cloud.githubusercontent.com/assets/12573921/15827073/177e9b10-2bd8-11e6-954e-2a17c71a7746.png">


Closes issue #1215 