### PR TITLE
Production rake fix

### DIFF
--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -11,12 +11,12 @@ namespace :grades do
 
   desc "Update all of the graded_at dates to the updated_at for the grades"
   task update_graded_at: :environment do
-    Grade.find_each(batch_size: 500) { |g| g.update_column(:graded_at, g.graded_at) }
+    Grade.where("(predicted_score > 0 OR predicted_score IS NULL) AND graded_at IS NULL").update_all("graded_at=updated_at")
   end
 
   desc "Transfer the predictions off existing grades"
   task transfer_predictions: :environment do
-    Grade.where("predicted_score > 0").each do |grade|
+    Grade.where("predicted_score > 0").find_each(batch_size: 500) do |grade|
       prediction = PredictedEarnedGrade.find_or_create_by(
         assignment_id: grade.assignment.id,
         student_id: grade.student.id

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -14,6 +14,11 @@ namespace :grades do
     Grade.where("(predicted_score > 0 OR predicted_score IS NULL) AND graded_at IS NULL").update_all("graded_at=updated_at")
   end
 
+  desc "Update grades without a final score to use raw score"
+  task update_final_score: :environment do
+    Grade.where("final_score is NULL and raw_score is not NULL").update_all("final_score=raw_score")
+  end
+
   desc "Transfer the predictions off existing grades"
   task transfer_predictions: :environment do
     Grade.where("predicted_score > 0").find_each(batch_size: 500) do |grade|


### PR DESCRIPTION
This PR fixes the two grade tasks that need to be run on production, and adds a third.

`update_graded_at` has been changed (thanks @jwright) and should be rerun

`transfer_predictions` has been changed to run in batches

`update_final_score` was added and needs to be run in anticipation of value-points-score name changes. ( _This replaces [PR#2039](https://github.com/UM-USElab/gradecraft-development/pull/2039)_).