### PR TITLE
2053 team challenge show page

### DIFF
--- a/app/views/challenges/_show_instructor.haml
+++ b/app/views/challenges/_show_instructor.haml
@@ -13,6 +13,12 @@
           %th.center{"data-dynatable-no-sort" => "true" }
             %button.button.select-all= "Check All"
             %button.button.select-none= "Uncheck"
+
+    %h4.subtitle Description
+    .challenge-description
+      = raw @challenge.description
+
+    %h4.subtitle Scores
     %tbody
       - @teams.alpha.each do |team|
         - challenge_grade = @challenge.challenge_grades.find_by team: team

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -2,20 +2,21 @@
 .challenge-description
   = raw @challenge.description
 
-%h4.subtitle Scores
-%table.dynatable
-  %thead
-    %tr
-      %th= current_course.team_term
-      %th{ "data-dynatable-sorts" => "numericScore" } Score
-      - if @challenge.has_levels?
-        %th Level
-  %tbody
-    - @teams.alpha.each do |team|
-      - challenge_grade = @challenge.challenge_grades.find_by team: team
+- if @challenge.graded?
+  %h4.subtitle Scores
+  %table.dynatable
+    %thead
       %tr
-        %td= team.name
-        %td= points challenge_grade.score if challenge_grade
+        %th= current_course.team_term
+        %th{ "data-dynatable-sorts" => "numericScore" } Score
         - if @challenge.has_levels?
-          %td
-            = @challenge.grade_level(grade) if challenge_grade
+          %th Level
+    %tbody
+      - @teams.alpha.each do |team|
+        - challenge_grade = @challenge.challenge_grades.find_by team: team
+        %tr
+          %td= team.name
+          %td= points challenge_grade.score if challenge_grade
+          - if @challenge.has_levels?
+            %td
+              = @challenge.grade_level(grade) if challenge_grade

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -1,3 +1,8 @@
+%h4.subtitle Description
+.challenge-description
+  = raw @challenge.description
+
+%h4.subtitle Scores
 %table.dynatable
   %thead
     %tr

--- a/app/views/challenges/_staff_index.haml
+++ b/app/views/challenges/_staff_index.haml
@@ -12,7 +12,7 @@
       %th{ :style => "min-width: 220px" }
 
   %tbody
-    - @challenges.each do |challenge|
+    - @challenges.chronological.alphabetical.each do |challenge|
       %tr
         %td= link_to challenge.name, challenge
         %td= link_to "See Description", challenge

--- a/app/views/challenges/_staff_index.haml
+++ b/app/views/challenges/_staff_index.haml
@@ -15,7 +15,7 @@
     - @challenges.each do |challenge|
       %tr
         %td= link_to challenge.name, challenge
-        %td= raw challenge.description
+        %td= link_to "See Description", challenge
         %td= points challenge.point_total
         %td= challenge.due_at
         %td{:style => "display: none"}

--- a/app/views/challenges/_student_index.html.haml
+++ b/app/views/challenges/_student_index.html.haml
@@ -11,7 +11,7 @@
         %th Point total
 
   %tbody
-    - current_course.challenges.visible.includes(:challenge_files, :challenge_grades).each do |challenge|
+    - current_course.challenges.visible.chronological.includes(:challenge_files, :challenge_grades).each do |challenge|
       %tr
         %td
           - if challenge.graded?
@@ -19,7 +19,7 @@
           - else
             = challenge.name
         %td
-          %span= raw challenge.description
+          = link_to "See Description", challenge
 
           - if challenge.challenge_files.present?
             %b Attachments:

--- a/app/views/challenges/_student_index.html.haml
+++ b/app/views/challenges/_student_index.html.haml
@@ -11,7 +11,7 @@
         %th Point total
 
   %tbody
-    - current_course.challenges.visible.chronological.includes(:challenge_files, :challenge_grades).each do |challenge|
+    - current_course.challenges.visible.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
       %tr
         %td
           - if challenge.graded?


### PR DESCRIPTION
This PR displays descriptions for challenges on the show page rather than in a field in the table on the index page for both students and instructors. If scores are not present for student, show page hides the scores table. This solves formatting issues we were having with these tables on mobile as shown below.

### Before
<img width="309" alt="screen shot 2016-06-07 at 9 46 32 am" src="https://cloud.githubusercontent.com/assets/12573921/15859851/c111ad40-2c94-11e6-92c9-e870d1084d16.png">

### After
<img width="314" alt="screen shot 2016-06-07 at 9 50 22 am" src="https://cloud.githubusercontent.com/assets/12573921/15859988/49e5e712-2c95-11e6-959e-7060e9abb2f8.png">

<img width="319" alt="screen shot 2016-06-07 at 9 49 02 am" src="https://cloud.githubusercontent.com/assets/12573921/15859946/226a8a80-2c95-11e6-9600-db68dd52e230.png">

Closes issue #2053 