### PR TITLE
2052-mobile-table-adjustments

### DIFF
--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -113,6 +113,10 @@ tbody
         border-top-right-radius: $global-radius
         border-bottom-right-radius: $global-radius
 
+.quick-grade-button
+  display: inline-block
+  margin-bottom: 1rem
+
 .notification-badge
   background-color: $color-red-1
   border-radius: 10px

--- a/app/assets/stylesheets/_tables.sass
+++ b/app/assets/stylesheets/_tables.sass
@@ -63,7 +63,7 @@ i.missing_grade
   color: $color-grey-5
 
 .collapse-hidden
-  padding: .5rem 1.5rem
+  padding: .5rem
 
 .assignment-type-container
   padding: 0 1.5rem 1rem
@@ -130,9 +130,12 @@ i.missing_grade
     padding: 1px 2px
 
   tbody ul.button-bar li:not(:last-of-type) a.button
-    margin-right: .5rem
+    margin-right: .2rem
 
 @media (max-width: 800px)
+  tbody ul.button-bar li
+    margin-left: 0px
+
   .dynatable-sort-header
     pointer-events: none
 
@@ -180,7 +183,7 @@ i.missing_grade
         padding: .5em
         font-size: .85rem
 
-  table.no-button-bar 
+  table.no-button-bar
     tr:last-child
       .st-key
         display: table-cell

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -6,10 +6,10 @@
   %div{ class: "assignment-#{grade_type}"}
     %h4.assignment_name
       = link_to assignment.name, assignment
-      - if assignment.is_individual?
-        = link_to glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
-      - else
-        = link_to glyph(:check) + "Grade", assignment, class: "button"
+    - if assignment.is_individual?
+      = link_to glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button quick-grade-button"
+    - else
+      = link_to glyph(:check) + "Grade", assignment, class: "button quick-grade-button"
 
     = form_tag edit_status_assignment_grades_path(assignment), method: :get do
 

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -5,7 +5,7 @@
 - submissions_by_assignment.each do |assignment, submissions|
   %h4.assignment_name
     = link_to assignment.name, assignment
-    = link_to glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+  = link_to glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button quick-grade-button"
   %table.dynatable.no-table-header{"aria-describedby" => "ungradedTableCaption"}
     %thead
       %tr


### PR DESCRIPTION
This PR is a bit of cleanup of mobile table styles - mostly related to buttons in and around tables on mobile devices.

### Before
<img width="388" alt="quick-grade-button" src="https://cloud.githubusercontent.com/assets/12573921/15873770/338ca968-2cce-11e6-9cd5-c68e65f1d120.png">

<img width="315" alt="screen shot 2016-06-07 at 4 41 52 pm" src="https://cloud.githubusercontent.com/assets/12573921/15873936/d9f8b8dc-2cce-11e6-9441-f5a4d6892811.png">

### After
<img width="316" alt="screen shot 2016-06-07 at 4 42 01 pm" src="https://cloud.githubusercontent.com/assets/12573921/15873929/d2d2831c-2cce-11e6-8b6b-ad186f43ad07.png">

<img width="316" alt="screen shot 2016-06-07 at 4 43 21 pm" src="https://cloud.githubusercontent.com/assets/12573921/15873966/ffb39ad8-2cce-11e6-8c99-0792569313eb.png">

