### PR TITLE
bugfix angular criterion creation

### DIFF
--- a/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
@@ -6,7 +6,8 @@
 
   $scope.savedCriterionCount = 0
 
-  $scope.init = (assignmentId, pointTotal)->
+  $scope.init = (rubricId, assignmentId, pointTotal)->
+    $scope.rubricId = rubricId
     $scope.assignmentId = assignmentId
     $scope.pointTotal = parseInt(pointTotal)
     $scope.services()

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -7,7 +7,7 @@
 .pageContent
   = render "layouts/alerts"
 
-  #rubric(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@assignment.id}, #{@assignment.point_total})")
+  #rubric(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@rubric.id}, #{@assignment.id}, #{@assignment.point_total})")
 
     #points-overview-floating(ng-cloak ng-hide="angular.element('#points-overview').isOnscreen()")
       %h4#points-legend


### PR DESCRIPTION
Reverts the removal of the rubric id from this commit: https://github.com/UM-USElab/gradecraft-development/commit/3071078f40e1f0b65f772192b119b77673c0d6ce

This is still needed because Angular passes the value down to other files, even though it isn't used in the controller itself.