### PR TITLE
Styled form validation error messages

### DIFF
--- a/app/assets/stylesheets/_forms.sass
+++ b/app/assets/stylesheets/_forms.sass
@@ -150,6 +150,11 @@ ul.accepts_submission_types
   color: $color-white
   padding: .3rem .7rem
 
+error
+  color: $color-red-1
+  font-weight: bold
+  padding-left: .5rem
+
 .inline-list > li > *
   display: block
   width: 100%

--- a/config/initializers/simple_form_foundation.rb
+++ b/config/initializers/simple_form_foundation.rb
@@ -8,7 +8,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label_input
-    b.use :error, wrap_with: { tag: :small }
+    b.use :error, wrap_with: { tag: :error }
 
     # Uncomment the following line to enable hints. The line is commented out by default since Foundation
     # does't provide styles for hints. You will need to provide your own CSS styles for hints.


### PR DESCRIPTION
This PR adds styling to highlight fields that fail form validation with a red bold appearance:
<img width="629" alt="screen shot 2016-06-09 at 9 50 43 pm" src="https://cloud.githubusercontent.com/assets/234276/15952157/977d0854-2e8c-11e6-8871-f0dcca93aafc.png">
