### PR TITLE
Refactor views for consistent partial rendering

### DIFF
--- a/app/views/analytics/index.html.haml
+++ b/app/views/analytics/index.html.haml
@@ -2,11 +2,11 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "analytics/buttons"
 
 .pageContent
 
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %h4.subtitle Interactions
 

--- a/app/views/analytics/staff.html.haml
+++ b/app/views/analytics/staff.html.haml
@@ -2,10 +2,10 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "analytics/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %h4.subtitle Interactions
   / Event counts

--- a/app/views/analytics/students.html.haml
+++ b/app/views/analytics/students.html.haml
@@ -2,10 +2,10 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "analytics/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %h4.subtitle Interactions
   / Event counts

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -9,6 +9,6 @@
       %li= link_to_unless_current glyph(:plus) + "New Announcement", new_announcement_path
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
-  = render "list"
+  = render partial: "announcements/list"

--- a/app/views/announcements/new.html.haml
+++ b/app/views/announcements/new.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "announcements/form"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -9,7 +9,7 @@
       %li= link_to_unless_current glyph(:plus) + 'New Announcement', new_announcement_path
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %p
     %strong Course:

--- a/app/views/assignment_types/all_grades.html.haml
+++ b/app/views/assignment_types/all_grades.html.haml
@@ -2,10 +2,10 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "assignment_types/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   = team_filter(@teams) if @teams.present?
 

--- a/app/views/assignment_types/edit.html.haml
+++ b/app/views/assignment_types/edit.html.haml
@@ -2,7 +2,7 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "assignment_types/buttons"
 
 .pageContent
-  = render "form"
+  = render partial: "assignment_types/form"

--- a/app/views/assignment_types/index.html.haml
+++ b/app/views/assignment_types/index.html.haml
@@ -2,10 +2,10 @@
 
 %h3.pagetitle#tableCaption= @title
 
-= render "buttons"
+= render partial: "assignment_types/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %table.dynatable{"aria-describedby" => "tableCaption"}
     %thead

--- a/app/views/assignment_types/new.html.haml
+++ b/app/views/assignment_types/new.html.haml
@@ -2,7 +2,7 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "assignment_types/buttons"
 
 .pageContent
-  = render "form"
+  = render partial: "assignment_types/form"

--- a/app/views/assignment_types/show.html.haml
+++ b/app/views/assignment_types/show.html.haml
@@ -2,11 +2,11 @@
 
 %h3.pagetitle#pageCaption= @title
 
-= render "buttons"
+= render partial: "assignment_types/buttons"
 
 .pageContent
 
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %table.dynatable{"aria-describedby" => "tableCaption"}
     %thead

--- a/app/views/assignments/_description_and_downloads.haml
+++ b/app/views/assignments/_description_and_downloads.haml
@@ -12,7 +12,7 @@
   .italic= "Due: #{presenter.assignment.due_at}" if presenter.assignment.due_at?
 
   - if presenter.assignment_accepting_submissions?(current_student)
-    .no-bullet= render "students/submissions", assignment: presenter.assignment
+    .no-bullet= render partial: "students/submissions", locals: { assignment: presenter.assignment }
 
   - if presenter.student_logged?(current_user)
     = render partial: "assignments/self_log_form", locals: { student: current_student, assignment: presenter.assignment }
@@ -29,7 +29,7 @@
     - if presenter.group_assignment?
       %hr.dotted
       - if @group.present?
-        = render "groups/status_display", group: @group
+        = render partial: "groups/status_display", locals: { group: @group }
         Your #{term_for :group} for this #{term_for :assignment}:
         %ul
           - @group.students.each do |student|

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -183,11 +183,11 @@
       %script(id="unlock-condition-template" type="text/x-template")
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: "form-inline", child_index: "child_index" do |ucf|
-            = render "layouts/unlock_condition_fields", f: ucf
+            = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
       - presenter.assignment.unlock_conditions.each do |condition|
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, condition, class: "form-inline" do |ucf|
-            = render "layouts/unlock_condition_fields", f: ucf
+            = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
     = link_to "Add a Condition", "#", class: "add-unlock-condition button"
 
   %section
@@ -197,11 +197,11 @@
       %script(id="assignment-score-level-template" type="text/x-template")
         %fieldset.assignment-score-level
           = f.simple_fields_for :assignment_score_levels, AssignmentScoreLevel.new, class: "form-inline", child_index: "child_index" do |slf|
-            = render "assignment_score_level_fields", f: slf
+            = render partial: "assignment_score_level_fields", locals: { f: slf }
       - presenter.assignment.assignment_score_levels.order_by_value.each do |assignment_score_level|
         %fieldset.assignment-score-level
           = f.simple_fields_for :assignment_score_levels, assignment_score_level, class: "form-inline" do |slf|
-            = render "assignment_score_level_fields", f: slf
+            = render partial: "assignment_score_level_fields", locals: { f: slf }
     = link_to "Add a Level", "#", class: "add-assignment-score-level button"
 
   %section

--- a/app/views/assignments/_show_instructor.haml
+++ b/app/views/assignments/_show_instructor.haml
@@ -35,6 +35,6 @@
       - if presenter.has_persisted_grades?
         .ui-tabs-panel#tabt4{role: "tabpanel", "aria-hidden" => false }
           - if presenter.group_assignment?
-            -# = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
+            = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
           - else
             = render partial: "grades/analytics/instructor_analytics", locals: { presenter: presenter }

--- a/app/views/assignments/_show_instructor.haml
+++ b/app/views/assignments/_show_instructor.haml
@@ -3,10 +3,10 @@
 %h3.pagetitle= presenter.title
 
 // Button bar at the top of the page
-= render "buttons", presenter: presenter
+= render partial: "buttons", locals: { presenter: presenter }
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   #tabs.ui-tabs.ui-widget
     %ul.ui-tabs-nav{role: "tablist"}
@@ -24,11 +24,10 @@
     #tabt1.ui-tabs-panel
       .ui-tabs-panel#tab.active{role: "tabpanel", "aria-hidden" => false }
         - if presenter.group_assignment?
-          = render "assignments/group/group_show", presenter: presenter
+          = render partial: "assignments/group/group_show", locals: { presenter: presenter }
         - else
-          = render "assignments/individual/individual_show", presenter: presenter
+          = render partial: "assignments/individual/individual_show", locals: { presenter: presenter }
       .ui-tabs-panel#tabt2{role: "tabpanel", "aria-hidden" => false }
-        = render "assignments/description_and_downloads", presenter: presenter
       - if presenter.grade_with_rubric?
         .ui-tabs-panel#tabt3{role: "tabpanel", "aria-hidden" => false }
           .tab-container
@@ -36,6 +35,6 @@
       - if presenter.has_persisted_grades?
         .ui-tabs-panel#tabt4{role: "tabpanel", "aria-hidden" => false }
           - if presenter.group_assignment?
-            = render "grades/analytics/group_analytics", presenter: presenter
+            -# = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
           - else
-            = render "grades/analytics/instructor_analytics", presenter: presenter
+            = render partial: "grades/analytics/instructor_analytics", locals: { presenter: presenter }

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= presenter.title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   #tabs.ui-tabs.ui-widget
     %ul.ui-tabs-nav{role: "tablist"}
@@ -33,9 +33,9 @@
           = render partial: "rubrics/components/rubric_table", locals: { rubric: presenter.rubric, presenter: presenter, student: current_student, include_grade_info: false }
       - if presenter.has_submission_for?(current_student)
         #tab3
-          = render "submissions/submission_content",
-              presenter: Submissions::ShowPresenter.new(id: presenter.submission_for_assignment(current_student).id,
-                assignment_id: presenter.assignment.id, course: current_course)
+          = render partial: "submissions/submission_content",
+              locals: { presenter: Submissions::ShowPresenter.new(id: presenter.submission_for_assignment(current_student).id,
+                assignment_id: presenter.assignment.id, course: current_course) }
         #history
           = history_timeline presenter.submission_grade_history(current_student)
       - if presenter.grades_available_for? current_student
@@ -44,6 +44,6 @@
         - if !presenter.hide_analytics?
           #tab5
             - if presenter.assignment.has_groups?
-              = render "grades/analytics/group_analytics", presenter: presenter
+              = render partial: "grades/analytics/group_analytics", locals: { presenter: presenter }
             - else
-              = render "grades/analytics/individual_analytics", presenter: presenter
+              = render partial: "grades/analytics/individual_analytics", locals: { presenter: presenter }

--- a/app/views/assignments/index.html.haml
+++ b/app/views/assignments/index.html.haml
@@ -14,7 +14,7 @@
         Review #{(term_for :assignment).titleize} Settings
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   .assignments
     - @assignment_types.each do |assignment_type|
@@ -42,7 +42,7 @@
                   %td.draggable
                     %i.fa.fa-arrows-v
                   %td= link_to assignment.name, assignment
-                  %td= render "index_icons", assignment: assignment
+                  %td= render partial: "index_icons", locals: { assignment: assignment }
                   %td= assignment.try(:due_at) || "Ongoing"
                   %td{:style => "display: none"}
                     - if assignment.due_at.present?

--- a/app/views/assignments/new.html.haml
+++ b/app/views/assignments/new.html.haml
@@ -2,7 +2,7 @@
 
 %h3.pagetitle= "New #{term_for :assignment}"
 
-= render partial: "buttons", locals: { presenter: presenter }
+= render partial: "assignments/buttons", locals: { presenter: presenter }
 
 .pageContent
-  = render partial: "form", locals: { presenter: presenter }
+  = render partial: "assignments/form", locals: { presenter: presenter }

--- a/app/views/assignments/settings.html.haml
+++ b/app/views/assignments/settings.html.haml
@@ -10,7 +10,7 @@
         New #{(term_for :assignment).titleize}
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   .assignments
     - @assignment_types.each do |assignment_type|

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -61,11 +61,11 @@
         %script(id="unlock-condition-template" type="text/x-template")
           %fieldset.unlock-condition
             = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: "form-inline", child_index: "child_index" do |ucf|
-              = render "layouts/unlock_condition_fields", f: ucf
+              = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
         - @badge.unlock_conditions.each do |condition|
           %fieldset.unlock-condition
             = f.simple_fields_for :unlock_conditions, condition, class: "form-inline" do |ucf|
-              = render "layouts/unlock_condition_fields", f: ucf
+              = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
       = link_to "Add a Condition", "#", class: "add-unlock-condition button"
 
   %section

--- a/app/views/badges/edit.html.haml
+++ b/app/views/badges/edit.html.haml
@@ -5,4 +5,4 @@
 = render partial: "badges/context_menu", locals: { badge: @badge, actions: [:see, :award, :quick_award]}
 
 .pageContent
-  = render "form"
+  = render partial: "badges/form"

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -5,7 +5,7 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff? && !presenter.view_student_context?
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %table.badge-index-table.second-row-header{:class => ("student-index" if presenter.view_student_context?)}
     %thead

--- a/app/views/badges/new.html.haml
+++ b/app/views/badges/new.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "badges/form"

--- a/app/views/badges/show.html.haml
+++ b/app/views/badges/show.html.haml
@@ -5,7 +5,7 @@
 = render partial: "badges/context_menu", locals: { badge: presenter.badge, actions: [:new, :edit, :award, :quick_award] } if current_user_is_staff?
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   = team_filter(presenter.teams) if current_course.has_teams? && current_user_is_staff?
 

--- a/app/views/challenge_grades/edit.html.haml
+++ b/app/views/challenge_grades/edit.html.haml
@@ -3,6 +3,6 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
-  = render partial: "form", locals: { form_path: challenge_grade_path(@challenge_grade) }
+  = render partial: "challenge_grades/form", locals: { form_path: challenge_grade_path(@challenge_grade) }

--- a/app/views/challenge_grades/show.html.haml
+++ b/app/views/challenge_grades/show.html.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %p
     %b #{(term_for :team).titleize}:

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -49,11 +49,11 @@
       %script(id="challenge-score-level-template" type="text/x-template")
         %fieldset.challenge-score-level
           = f.simple_fields_for :challenge_score_levels, ChallengeScoreLevel.new, class: "form-inline", child_index: "child_index" do |slf|
-            = render "challenge_score_level_fields", f: slf
+            = render partial: "challenge_score_level_fields", locals: { f: slf }
       - @challenge.challenge_score_levels.each do |challenge_score_level|
         %fieldset.challenge-score-level
           = f.simple_fields_for :challenge_score_levels, challenge_score_level, class: "form-inline" do |slf|
-            = render "challenge_score_level_fields", f: slf
+            = render partial: "challenge_score_level_fields", locals: { f: slf }
     = link_to "Add a Level", "#", class: "add-challenge-score-level button radius"
 
   %section

--- a/app/views/challenges/challenge_grades/mass_edit.html.haml
+++ b/app/views/challenges/challenge_grades/mass_edit.html.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   #massGrade
     = simple_form_for @challenge, method: :put, :url => mass_update_challenge_challenge_grades_path(@challenge) do |f|

--- a/app/views/challenges/edit.html.haml
+++ b/app/views/challenges/edit.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "challenges/form"

--- a/app/views/challenges/index.html.haml
+++ b/app/views/challenges/index.html.haml
@@ -11,9 +11,9 @@
           New #{(term_for :challenge).titleize}
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   - if current_user_is_staff?
-    = render "staff_index"
+    = render partial: "challenges/staff_index"
   - else
-    = render "student_index"
+    = render partial: "challenges/student_index"

--- a/app/views/challenges/new.html.haml
+++ b/app/views/challenges/new.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "challenges/form"

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -19,7 +19,7 @@
           Quick Grade
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   - if @challenge.challenge_files.present?
     %p
@@ -31,6 +31,6 @@
           = link_to "(Remove)", remove_uploads_path({ :model => "ChallengeFile", :upload_id => cf.id })
 
   - if current_user_is_staff?
-    = render "show_instructor"
+    = render partial: "challenges/show_instructor"
   - else
-    = render "show_student"
+    = render partial: "challenges/show_student"

--- a/app/views/courses/edit.html.haml
+++ b/app/views/courses/edit.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "courses/form"

--- a/app/views/courses/index.html.haml
+++ b/app/views/courses/index.html.haml
@@ -10,7 +10,7 @@
         New Course
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %table.dynatable{"aria-describedby" => "tableCaption"}
     %thead

--- a/app/views/courses/new.html.haml
+++ b/app/views/courses/new.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "courses/form"

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -10,7 +10,7 @@
         Edit
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   .panel
     %h4 THE BASICS

--- a/app/views/earned_badges/edit.html.haml
+++ b/app/views/earned_badges/edit.html.haml
@@ -3,6 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
-
-  = render "form"
+  = render partial: "earned_badges/form"

--- a/app/views/earned_badges/mass_edit.html.haml
+++ b/app/views/earned_badges/mass_edit.html.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   = team_filter(@teams) if current_course.has_teams?
 

--- a/app/views/earned_badges/new.html.haml
+++ b/app/views/earned_badges/new.html.haml
@@ -5,4 +5,4 @@
 .pageContent
   = render partial: "layouts/alerts"
 
-  = render partial: "challenge_grades/form"
+  = render partial: "earned_badges/form"

--- a/app/views/earned_badges/new.html.haml
+++ b/app/views/earned_badges/new.html.haml
@@ -3,6 +3,6 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
-  = render "form"
+  = render partial: "challenge_grades/form"

--- a/app/views/earned_badges/show.html.haml
+++ b/app/views/earned_badges/show.html.haml
@@ -10,7 +10,7 @@
         Edit
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %img{:src => @earned_badge.badge.try(:icon), :alt => @earned_badge.badge.try(:name), :width => "25", :height => "25"}
   %p

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "events/form"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -10,7 +10,7 @@
         New Event
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %table.dynatable
     %thead

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -3,4 +3,4 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "form"
+  = render partial: "events/form"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -14,7 +14,7 @@
         Edit
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %p
     %b Name:

--- a/app/views/exports/index.html.haml
+++ b/app/views/exports/index.html.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   %h2 Submissions Exports
   %br

--- a/app/views/grade_scheme_elements/index.html.haml
+++ b/app/views/grade_scheme_elements/index.html.haml
@@ -10,7 +10,7 @@
         Edit
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   / Grade Scheme Elements Table Display
   %table{"aria-describedby" => "tableCaption"}

--- a/app/views/grade_scheme_elements/mass_edit.html.haml
+++ b/app/views/grade_scheme_elements/mass_edit.html.haml
@@ -2,7 +2,7 @@
 %h3.pagetitle= @title
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   - if ! current_course.grade_scheme_elements.present?
     .italic Start by adding your highest level, and work your way down

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -27,7 +27,7 @@
       .form-item= f.association :students, :collection => current_course.students, as: :select, :label => "#{term_for :students}"
     .form_label{id: "txtStudentName"} Enter a fellow student's name to add them to this #{term_for :group}. Only one student needs to create the #{term_for :group}, after which all #{term_for :group} members will be able to submit work, see submitted materials, and see instructor grades and feedback.
 
-  = render "proposal_section", f: f
+  = render partial: "groups/proposal_section", locals: { f: f }
 
   .submit-buttons
     %ul

--- a/app/views/groups/_proposal_section.haml
+++ b/app/views/groups/_proposal_section.haml
@@ -4,7 +4,7 @@
       %script(id="proposal-template" type="text/x-template")
         %fieldset.proposal.callout.panel
           = f.simple_fields_for :proposals, Proposal.new, class: "form-inline", child_index: "child_index" do |pf|
-            = render "proposal_fields", f: pf
+            = render partial: "proposal_fields", locals: { f: pf }
       - i = 1
       - @group.proposals.order_by_creation_date.each do |proposal|
         %fieldset.proposal.panel

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -3,7 +3,7 @@
 %h3.pagetitle= @title
 
 - if current_user_is_staff?
-  = render "buttons"
+  = render partial: "groups/buttons"
 
 .pageContent
-  = render "form"
+  = render partial: "groups/form"

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -2,24 +2,24 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "groups/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
   - if @pending_groups.present?
     %h4.subtitle= "Pending #{term_for :groups}"
 
-    = render "groups_table", course: current_course, :groups => @pending_groups
+    = render partial: "groups/groups_table", locals: { course: current_course, :groups => @pending_groups }
 
   - if @rejected_groups.present?
 
     %h4.subtitle.fail= "Rejected #{term_for :groups}"
 
-    = render "groups_table", course: current_course, :groups => @rejected_groups
+    = render partial: "groups/groups_table", locals: { course: current_course, :groups => @rejected_groups }
 
   - if @approved_groups.present?
 
     %h4.subtitle.success= "Approved #{term_for :groups}"
 
-    = render "groups_table", course: current_course, :groups => @approved_groups
+    = render partial: "groups/groups_table", locals: { course: current_course, :groups => @approved_groups }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -5,7 +5,7 @@
 
 %h3.pagetitle= @title
 
-= render "buttons"
+= render partial: "groups/buttons"
 
 .pageContent
-  = render "form"
+  = render partial: "groups/form"

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -6,12 +6,12 @@
 %h3.pagetitle= @title
 
 - if current_user_is_staff?
-  = render "buttons"
+  = render partial: "groups/buttons"
 
 .pageContent
-  = render "layouts/alerts"
+  = render partial: "layouts/alerts"
 
-  = render "status_display", group: @group
+  = render partial: "status_display", locals: { group: @group }
 
   %h4
     Members:

--- a/app/views/info/dashboard.html.haml
+++ b/app/views/info/dashboard.html.haml
@@ -1,4 +1,4 @@
 - if current_user_is_staff? && ! current_course.assignments.present?
-  = render "course_creation_wizard"
+  = render partial: "course_creation_wizard"
 - else
-  #dashboard-timeline= render "#{current_user.role(current_course)}_dashboard"
+  #dashboard-timeline= render partial: "#{current_user.role(current_course)}_dashboard"

--- a/app/views/info/grading_status.html.haml
+++ b/app/views/info/grading_status.html.haml
@@ -5,10 +5,10 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "submissions_table", submission_type: "ungraded", subtitle: "Ungraded Submissions", submissions_by_assignment: @ungraded_submissions_by_assignment, count: ungraded_submissions_count_for(current_course), course: current_course
+  = render partial: "submissions_table", locals: { submission_type: "ungraded", subtitle: "Ungraded Submissions", submissions_by_assignment: @ungraded_submissions_by_assignment, count: ungraded_submissions_count_for(current_course), course: current_course }
 
-  = render "grades_table", grade_type: "unreleased", subtitle: "Unreleased Grades", grades_by_assignment: @unreleased_grades_by_assignment, count: unreleased_grades_count_for(current_course), course: current_course
+  = render partial: "grades_table", locals: { grade_type: "unreleased", subtitle: "Unreleased Grades", grades_by_assignment: @unreleased_grades_by_assignment, count: unreleased_grades_count_for(current_course), course: current_course }
 
-  = render "grades_table", grade_type: "in_progress", subtitle: "In Progress Grades", grades_by_assignment: @in_progress_grades_by_assignment, count: in_progress_grades_count_for(current_course), course: current_course
+  = render partial: "grades_table", locals: { grade_type: "in_progress", subtitle: "In Progress Grades", grades_by_assignment: @in_progress_grades_by_assignment, count: in_progress_grades_count_for(current_course), course: current_course }
 
-  = render "submissions_table", submission_type: "resubmissions", subtitle: "Resubmitted Submissions", submissions_by_assignment: @resubmissions_by_assignment, count: resubmission_count_for(current_course), course: current_course
+  = render partial: "submissions_table", locals: { submission_type: "resubmissions", subtitle: "Resubmitted Submissions", submissions_by_assignment: @resubmissions_by_assignment, count: resubmission_count_for(current_course), course: current_course }

--- a/app/views/info/top_10.html.haml
+++ b/app/views/info/top_10.html.haml
@@ -7,13 +7,13 @@
 
   %h4.subtitle Top 10
 
-  = render "students_table", course: current_course, :students => @top_ten_students
+  = render partial: "students_table", locals: { course: current_course, :students => @top_ten_students }
 
   - if @bottom_ten_students.present?
     %h4.subtitle Bottom 10
 
-    = render "students_table", course: current_course, :students => @bottom_ten_students
+    = render partial: "students_table", locals: { course: current_course, :students => @bottom_ten_students }
 
   - if current_course.teams.present?
     %h4.subtitle #{term_for :team} Overview
-    = render "teams_table", course: current_course, :teams => current_course.teams
+    = render partial: "teams_table", locals: { course: current_course, :teams => current_course.teams }

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -1,12 +1,12 @@
 .sidebar-container.hide-for-small.hide-for-medium
   / Staff-only sidebar navigation
-  = render "layouts/navigation/staff_subnav"
+  = render partial: "layouts/navigation/staff_subnav"
 
 .mainContainer.staff{role: "main"}
 
   - if current_student.present?
     = content_nav do
-      = render "students/student_profile_tabs"
+      = render partial: "students/student_profile_tabs"
 
   / Page content
-  .mainContent{ class: (@display_sidebar ? "student" : "") }= render "layouts/content"
+  .mainContent{ class: (@display_sidebar ? "student" : "") }= render partial: "layouts/content"

--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -1,5 +1,5 @@
 .mainContainer.student{role: "main"}
   / Display errors and notifications
   = content_nav do
-    = render "students/student_profile_tabs"
-  .student.mainContent= render "layouts/content"
+    = render partial: "students/student_profile_tabs"
+  .student.mainContent= render partial: "layouts/content"

--- a/app/views/layouts/_top_bar.haml
+++ b/app/views/layouts/_top_bar.haml
@@ -1,5 +1,5 @@
 - if ! current_user
-  = render "layouts/navigation/top_bar_logged_out"
+  = render partial: "layouts/navigation/top_bar_logged_out"
 - else
   #left-flyout-nav.layout-left-flyout
 
@@ -10,20 +10,20 @@
         %span.course_name= "#{current_course.name} "
         %span.course_semester= "#{current_course.try(:semester)} #{current_course.try(:year)}"
     - if current_user_is_student?
-      = render "students/student_profile_tabs"
+      = render partial: "students/student_profile_tabs"
       %hr
     - elsif current_user_is_staff?
-      = render "layouts/navigation/staff_subnav"
+      = render partial: "layouts/navigation/staff_subnav"
     %h5 Course Info
     %ul.course-info
-      = render "layouts/navigation/class_info"
+      = render partial: "layouts/navigation/class_info"
     %hr
     %h5 My Courses
     %ul.course-list
-      = render "layouts/navigation/course_list"
+      = render partial: "layouts/navigation/course_list"
     %hr
     %ul.account-info
-      = render "layouts/navigation/account_info"
+      = render partial: "layouts/navigation/account_info"
     %hr
 
   .layout-right-content
@@ -39,8 +39,8 @@
           %ul.nav.nav-pill.right
             %li.course-info-btn
               = link_to glyph('info-circle hidden-sm') + "Class Info", "#", title: "Quick information about #{current_course.name}", class: "section-title"
-              %ul.course-info-card= render "layouts/navigation/class_info"
-            = render "layouts/navigation/authenticated_nav"
+              %ul.course-info-card= render partial: "layouts/navigation/class_info"
+            = render partial: "layouts/navigation/authenticated_nav"
         %nav.mobile-nav.hide-for-large
           %a.btn-navbar-left.btn-navbar-navtoggle.btn-flyout-left-trigger
             %i.fa.fa-bars.fa-fw

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,24 +7,24 @@
       = current_course.try(:name) || "GradeCraft"
     = stylesheet_link_tag "application", "https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600"
     = stylesheet_link_tag "application", :media => "all"
-    = render "layouts/favicon"
+    = render partial: "layouts/favicon"
     = csrf_meta_tags
     = yield(:head)
 
   %body(class="#{body_class}")
-    = render "layouts/top_bar"
+    = render partial: "layouts/top_bar"
     - if current_user
       .inner-wrap.clearfix
         - if current_user_is_staff?
-          = render "layouts/staff"
+          = render partial: "layouts/staff"
         - else
-          = render "layouts/student"
+          = render partial: "layouts/student"
     - else
-      = render "layouts/public"
-    = render "layouts/help/uservoice"
+      = render partial: "layouts/public"
+    = render partial: "layouts/help/uservoice"
     .footer
-      = render "layouts/footer"
-    = render "layouts/background"
-    = render "layouts/google_analytics"
+      = render partial: "layouts/footer"
+    = render partial: "layouts/background"
+    = render partial: "layouts/google_analytics"
     = javascript_include_tag "application", "data-turbolinks-track" => true
     = yield(:scripts)

--- a/app/views/layouts/mailers/announcement_layout.html.haml
+++ b/app/views/layouts/mailers/announcement_layout.html.haml
@@ -5,7 +5,7 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= @email_title
     = render partial: "layouts/mailers/stylesheet"
-    
+
   %body{:bgcolor => "#f6f6f6"}
     / body
     %table.body-wrap

--- a/app/views/layouts/mailers/announcement_layout.html.haml
+++ b/app/views/layouts/mailers/announcement_layout.html.haml
@@ -4,7 +4,7 @@
     %meta{:content => "width=device-width", name: "viewport"}/
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= @email_title
-    = render "layouts/mailers/stylesheet"
+    = render partial: "layouts/mailers/stylesheet"
     
   %body{:bgcolor => "#f6f6f6"}
     / body
@@ -15,9 +15,9 @@
           / content
           .content
             %table
-              %tr= render "layouts/mailers/logo"
+              %tr= render partial: "layouts/mailers/logo"
               %tr
                 %td= yield
-              = render "layouts/mailers/social_media"
+              = render partial: "layouts/mailers/social_media"
     / footer
-    = render "layouts/mailers/footer"
+    -# = render partial: "layouts/mailers/footer"

--- a/app/views/layouts/mailers/announcement_layout.html.haml
+++ b/app/views/layouts/mailers/announcement_layout.html.haml
@@ -20,4 +20,4 @@
                 %td= yield
               = render partial: "layouts/mailers/social_media"
     / footer
-    -# = render partial: "layouts/mailers/footer"
+    = render partial: "layouts/mailers/footer"

--- a/app/views/layouts/mailers/exports_layout.html.haml
+++ b/app/views/layouts/mailers/exports_layout.html.haml
@@ -4,7 +4,7 @@
     %meta{:content => "width=device-width", name: "viewport"}/
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= @page_title rescue "GradeCraft Files Exported"
-    = render "layouts/mailers/stylesheet"
+    = render partial: "layouts/mailers/stylesheet"
 
   %body{:bgcolor => "#f6f6f6"}
     / body
@@ -15,11 +15,11 @@
           / content
           .content
             %table
-              %tr= render "layouts/mailers/logo"
+              %tr= render partial: "layouts/mailers/logo"
               %tr
                 %td
                   = yield
-              = render "layouts/mailers/social_media"
+              = render partial: "layouts/mailers/social_media"
 
     / footer
-    = render "layouts/mailers/footer"
+    = render partial: "layouts/mailers/footer"

--- a/app/views/layouts/mailers/notification_layout.html.haml
+++ b/app/views/layouts/mailers/notification_layout.html.haml
@@ -4,7 +4,7 @@
     %meta{:content => "width=device-width", name: "viewport"}/
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title= @page_title rescue "GradeCraft Notification"
-    = render "layouts/mailers/stylesheet"
+    = render partial: "layouts/mailers/stylesheet"
 
   %body{:bgcolor => "#f6f6f6"}
     / body
@@ -15,11 +15,11 @@
           / content
           .content
             %table
-              %tr= render "layouts/mailers/logo"
+              %tr= render partial: "layouts/mailers/logo"
               %tr
                 %td
                   = yield
-              = render "layouts/mailers/social_media"
+              = render partial: "layouts/mailers/social_media"
 
     / footer
-    = render "layouts/mailers/footer"
+    = render partial: "layouts/mailers/footer"

--- a/app/views/layouts/navigation/_authenticated_nav.haml
+++ b/app/views/layouts/navigation/_authenticated_nav.haml
@@ -3,7 +3,7 @@
     My Courses
     %i.fa.fa-caret-down.hidden-sm
   %ul.subnav#course-list
-    = render "layouts/navigation/course_list"
+    = render partial: "layouts/navigation/course_list"
 %li.dropdown.my-account       
   %a.section-title{:href => "#", :title => "My account management"} 
     - if current_user.avatar_file_name.present?
@@ -11,4 +11,4 @@
     = current_user.public_name
     %i.fa.fa-caret-down.hidden-2m
   %ul.subnav#account-info
-    = render "layouts/navigation/account_info"
+    = render partial: "layouts/navigation/account_info"

--- a/app/views/layouts/navigation/_staff_subnav.haml
+++ b/app/views/layouts/navigation/_staff_subnav.haml
@@ -1,4 +1,4 @@
 .sidebar
   %nav.sr-only Staff navigation
   %ul#staff-navigation.staff-sidenav{role: "navigation", "aria-labeledby" => "staff-navigation"}
-    = render "layouts/navigation/staff_subnav_links"
+    = render partial: "layouts/navigation/staff_subnav_links"

--- a/app/views/layouts/navigation/_top_bar_logged_out.haml
+++ b/app/views/layouts/navigation/_top_bar_logged_out.haml
@@ -8,7 +8,7 @@
               = image_tag "gradecraft_logo.png", :width => "150", :class => "logo-home"
               = image_tag "GradeCraft_Logo_Mark_RGB.png", :width => "30", :class => "gc-mark"
         %ul.nav.nav-pill.right.public-nav
-          = render "layouts/navigation/public_nav"
-        = render "layouts/navigation/login_nav"
+          = render partial: "layouts/navigation/public_nav"
+        = render partial: "layouts/navigation/login_nav"
         %a.btn-public-nav
           %i.fa.fa-bars.fa-fw

--- a/app/views/pages/brand_and_style_guidelines.html.haml
+++ b/app/views/pages/brand_and_style_guidelines.html.haml
@@ -1,7 +1,7 @@
 .page
   .hero-section
     %h1 Brand & Style Guidelines
-    %ul.public-subnav= render "subnav"
+    %ul.public-subnav= render partial: "pages/subnav"
   .main-section
     .main-section-content
       %ul

--- a/app/views/pages/features.html.haml
+++ b/app/views/pages/features.html.haml
@@ -13,8 +13,8 @@
 
         #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
           .ui-tabs-panel#tab.active{role: "tabpanel", "aria-hidden" => false }
-            = render "instructor_features"
+            = render partial: "pages/instructor_features"
           .ui-tabs-panel#tabt2{role: "tabpanel", "aria-hidden" => false }
-            = render "student_features"
+            = render partial: "pages/student_features"
 
-= render "newsletter_signup"
+= render partial: "pages/newsletter_signup"

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -99,4 +99,4 @@
           View examples
           = glyph("long-arrow-right")
 
-= render "newsletter_signup"
+= render partial: "pages/newsletter_signup"

--- a/app/views/pages/press.html.haml
+++ b/app/views/pages/press.html.haml
@@ -1,11 +1,11 @@
 .page
 	.hero-section
 		%h1 Press & Awards
-		%ul.public-subnav= render "subnav"
+		%ul.public-subnav= render partial: "pages/subnav"
 	.main-section
 		.main-section-content
 			%h2.title.bold Awards
-			%ul= render "awards"
+			%ul= render partial: "pages/awards"
 			%br
 			%h2.title.bold Press
-			%ul= render "articles"
+			%ul= render partial: "pages/articles"

--- a/app/views/pages/research.html.haml
+++ b/app/views/pages/research.html.haml
@@ -1,7 +1,7 @@
 .page
   .hero-section
     %h1 Research
-    %ul.public-subnav= render "subnav"
+    %ul.public-subnav= render partial: "pages/subnav"
   .main-section
     .main-section-content
       %p The GradeCraft team  engages in research focused on the design and use of gameful learning. Our work supports the creation of knowledge and tools that improve GradeCraft, improve our ability to support gameful pedagogy, and contribute to the larger community working towards educational improvement.

--- a/app/views/pages/team.html.haml
+++ b/app/views/pages/team.html.haml
@@ -1,7 +1,7 @@
 .page
   .hero-section
     %h1 Our Team
-    %ul.public-subnav= render "subnav"
+    %ul.public-subnav= render partial: "pages/subnav"
   .main-section
     .main-section-content
       = image_tag "gradecraft-team.jpg", :class => "team-photo"

--- a/app/views/passwords/new.html.haml
+++ b/app/views/passwords/new.html.haml
@@ -1,4 +1,4 @@
 %section.forgot-password
   %h2 Forgot Your Password?
   %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.
-  = render "reset_form"
+  = render partial: "passwords/reset_form"

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -35,11 +35,11 @@
       .rubric-container.divider(ng-repeat="criterion in criteria")
         .order-label {{$index + 1}}
         .criterion(name="criterionForm" ng-form ng-submit="criterion.create()" ng-class="{saved: criterion.isSaved()}" ng-animate="{enter: 'animate-enter', leave: 'animate-leave'}")
-          = render "rubrics/new_criterion"
+          = render partial: "rubrics/new_criterion"
         .level-container
           .level-wrapper
             .level(name="levelForm" ng-repeat="level in criterion.levels" ng-form ng-submit="level.create()" ng-class="{saved: level.isSaved(), nocredit: level.noCredit, 'level-meets-expectations': level.pointsMeetExpectations()}")
-              = render "rubrics/new_level"
+              = render partial: "rubrics/new_level"
         %button.add-level(name="newLevel" ng-click="criterion.insertLevel()" ng-show="criterion.isSaved()")
           + Level
 

--- a/app/views/students/flagged.html.haml
+++ b/app/views/students/flagged.html.haml
@@ -4,4 +4,4 @@
 
 .pageContent
   = render "layouts/alerts"
-  = render "students_table", course: current_course, :students => @students
+  = render partial: "students/students_table", locals: { course: current_course, :students => @students }

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -10,4 +10,4 @@
   = team_filter(@teams) if current_course.has_teams?
 
   / Display the table of course students, their leaderboard display, their team affiation, their score and their grade
-  = render "students_table", course: current_course, :students => @students
+  = render partial: "students/students_table", locals: { course: current_course, :students => @students }

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -3,5 +3,5 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "students/syllabus/assignments", presenter: presenter
-  = render "students/syllabus/challenges"
+  = render partial: "students/syllabus/assignments", locals: { presenter: presenter }
+  = render partial: "students/syllabus/challenges"

--- a/app/views/students/syllabus.haml
+++ b/app/views/students/syllabus.haml
@@ -3,5 +3,5 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "students/syllabus/assignments", presenter: presenter
-  = render "students/syllabus/challenges"
+  = render partial: "students/syllabus/assignments", locals: { presenter: presenter }
+  = render partial: "students/syllabus/challenges"

--- a/app/views/students/syllabus/_assignment_table.haml
+++ b/app/views/students/syllabus/_assignment_table.haml
@@ -11,17 +11,17 @@
   - if presenter.assignment_visible?(assignment)
     %tr
       %td= link_to assignment.name, assignment_path(assignment) if presenter.name_visible?(assignment)
-      %td= render "students/syllabus/components/assignment_icons", presenter: presenter, assignment: assignment
+      %td= render partial: "students/syllabus/components/assignment_icons", locals: { presenter: presenter, assignment: assignment }
       %td
         - if presenter.points_visible?(assignment)
           - if assignment.pass_fail?
-            = render "grades/components/pass_fail", presenter: presenter, assignment: assignment
+            = render partial: "grades/components/pass_fail", locals: { presenter: presenter, assignment: assignment }
           - else
             // Checking to see if this assignment type is student weightable
-            = render "grades/components/score", grade: presenter.grade_for(assignment), assignment_type: assignment_type, assignment: assignment
+            = render partial: "grades/components/score", locals: { grade: presenter.grade_for(assignment), assignment_type: assignment_type, assignment: assignment }
           - if current_user_is_student?
-            = render "grades/components/prediction", grade: presenter.grade_for(assignment)
-      %td= render "students/syllabus/components/due_at", assignment: assignment
+            = render partial: "grades/components/prediction", locals: { grade: presenter.grade_for(assignment) }
+      %td= render partial: "students/syllabus/components/due_at", locals: { assignment: assignment }
       %td
         %span
           - if presenter.open?(assignment)
@@ -30,19 +30,19 @@
         .right
           %ul.button-bar
             / Grade Management /
-            = render "students/syllabus/components/grade_buttons", presenter: presenter, assignment: assignment
+            = render partial: "students/syllabus/components/grade_buttons", locals: { presenter: presenter, assignment: assignment }
 
             / Exclude Grade Feature /
-            = render "students/syllabus/components/exclude_buttons", presenter: presenter, assignment: assignment
+            = render partial: "students/syllabus/components/exclude_buttons", locals: { presenter: presenter, assignment: assignment }
 
             / Groups /
             - if assignment.has_groups?
-              = render "students/syllabus/components/group_buttons", presenter: presenter, assignment: assignment
+              = render partial: "students/syllabus/components/group_buttons", locals: { presenter: presenter, assignment: assignment }
 
             / Submissions /
             - if presenter.submittable?(assignment)
-              = render "students/syllabus/components/submission_buttons", presenter: presenter, assignment: assignment
+              = render partial: "students/syllabus/components/submission_buttons", locals: { presenter: presenter, assignment: assignment }
 
             / Manual Unlock /
             - if current_user_is_staff?
-              = render "students/syllabus/components/manual_unlock", presenter: presenter, assignment: assignment
+              = render partial: "students/syllabus/components/manual_unlock", locals: { presenter: presenter, assignment: assignment }

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -16,4 +16,4 @@
 
       // Display the assignments for each assignment type in a responsive table, below header.
       %table.default_assignments_dynatable.dynatable
-        = render "students/syllabus/assignment_table", presenter: presenter, assignment_type: assignment_type
+        = render partial: "students/syllabus/assignment_table", locals: { presenter: presenter, assignment_type: assignment_type }

--- a/app/views/students/teams.html.haml
+++ b/app/views/students/teams.html.haml
@@ -4,14 +4,14 @@
   = render "layouts/alerts"
 
   %h4.italic.not_bold
-    = render "teams/leaderboard"
+    = render partial: "teams/leaderboard"
     - if @team.present?
       - if current_course.in_team_leaderboard? || @team.in_team_leaderboard?
-        = render "teams/in_team_rankings", team: @team
+        = render partial: "teams/in_team_rankings", locals: { team: @team }
 
       %h4.subtitle Your #{term_for :team} (#{@team.name}) has earned #{points @team.challenge_grade_score } points
       - if @team.banner.present?
         %img.clear{:src => @team.banner, :height => 200 }
 
     - if current_course.challenges.present?
-      = render "challenges/student_index"
+      = render partial: "challenges/student_index"

--- a/app/views/submissions/_submission_content.haml
+++ b/app/views/submissions/_submission_content.haml
@@ -1,14 +1,14 @@
 // Allow students to edit the submission if that's still possible
-= render "submissions/components/edit", presenter: presenter if presenter.open_for_editing?
+= render partial: "submissions/components/edit", locals: { presenter: presenter } if presenter.open_for_editing?
 
 // Displaying when the assignment was submitted and if it was late/resubmitted
-= render "submissions/components/dates_and_state", presenter: presenter
+= render partial: "submissions/components/dates_and_state", locals: { presenter: presenter }
 
 // Displaying the link to the submission if there is one
-= render "submissions/components/links", presenter: presenter if presenter.submission.link?
+= render partial: "submissions/components/links", locals: { presenter: presenter } if presenter.submission.link?
 
 // Display file attachments if present
-= render "submissions/components/files", presenter: presenter if presenter.submission.submission_files.present?
+= render partial: "submissions/components/files", locals: { presenter: presenter } if presenter.submission.submission_files.present?
 
 // Display submission comment if the student wrote one
-= render "submissions/components/feedback", presenter: presenter if presenter.submission.text_comment?
+= render partial: "submissions/components/feedback", locals: { presenter: presenter } if presenter.submission.text_comment?

--- a/app/views/teams/edit.html.haml
+++ b/app/views/teams/edit.html.haml
@@ -7,4 +7,4 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "form"
+  = render partial: "teams/form"

--- a/app/views/teams/index.html.haml
+++ b/app/views/teams/index.html.haml
@@ -7,5 +7,5 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "leaderboard"
-  = render "stats"
+  = render partial: "teams/leaderboard"
+  = render partial: "teams/stats"

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -7,4 +7,4 @@
 .pageContent
   = render "layouts/alerts"
 
-  = render "form"
+  = render partial: "teams/form"

--- a/app/views/user_sessions/new.html.haml
+++ b/app/views/user_sessions/new.html.haml
@@ -4,10 +4,10 @@
   #login-form
     %h2 Login
     %p
-    = render "form"
+    = render partial: "user_sessions/form"
   #password-forgot
     %h2 Forgot Your Password?
     %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
-    = render "passwords/reset_form"
+    = render partial: "passwords/reset_form"
 
     .small * This will not work if you use a @umich email address to log in. You must reset your password through the UM system.

--- a/app/views/users/_gradecraft_user_form.html.haml
+++ b/app/views/users/_gradecraft_user_form.html.haml
@@ -14,4 +14,4 @@
       = f.label :display_name
       = f.text_field :display_name
   = render partial: "courses", locals: { form: f }
-  = render "submit_buttons"
+  = render partial: "users/submit_buttons"

--- a/app/views/users/_internal_user_form.html.haml
+++ b/app/views/users/_internal_user_form.html.haml
@@ -19,4 +19,4 @@
         = label_tag :send_welcome, "Send welcome email"
         = check_box_tag :send_welcome, "1", true
   = render partial: "courses", locals: { form: f }
-  = render "submit_buttons"
+  = render partial: "users/submit_buttons"


### PR DESCRIPTION
When I started this refactor, I was looking for all occurrences of `render "<partial>"`. A large portion of these are the `render "layouts/alerts"` at the top of almost all views. These are particularly time consuming to test. And since they are repeated in most views, this got me thinking about refactoring at a different level: to DRY up the views and move the things that most view are doing individually up to the layouts. I created #2035 to define that work.

I completed refactoring of the non-alerts calls to render partials, so this PR includes refactoring of some of the alerts calls, but not all.