### PR TITLE
Added rake task to update AssignmentType max_points to 0

### DIFF
--- a/lib/tasks/assignment_types.rake
+++ b/lib/tasks/assignment_types.rake
@@ -1,0 +1,6 @@
+namespace :assignment_types do
+  desc "Set all assignment types with a max_points value of nil to zero"
+  task update_max_points: :environment do
+    AssignmentType.where("max_points IS NULL").update_all(max_points: 0)
+  end
+end


### PR DESCRIPTION
In preparation for merging the migration to add 'null: false' requirements to AssignmentType fields, we need to deal with the 231 records that current have nil values here. 

I have confirmed that all of the other columns we're adding limitations to do not have any records with nil values. 