### PR TITLE
Fix issues with student import

### DIFF
--- a/app/importers/student_importer.rb
+++ b/app/importers/student_importer.rb
@@ -103,8 +103,7 @@ class StudentImporter
         last_name: last_name,
         email: email,
         username: username,
-        password: password,
-        team_name: team_name
+        password: password
       }
     end
   end

--- a/app/importers/student_importer.rb
+++ b/app/importers/student_importer.rb
@@ -50,7 +50,9 @@ class StudentImporter
     user ||= Services::CreatesNewUser
       .create(row.to_h.merge(internal: internal_students), send_welcome)[:user]
 
-    user.course_memberships.create(course_id: course.id, role: "student") if course && user.valid?
+    if course && user.valid? && !user.is_student?(course)
+      user.course_memberships.create(course_id: course.id, role: "student")
+    end
     user
   end
 

--- a/spec/importers/student_importer_spec.rb
+++ b/spec/importers/student_importer_spec.rb
@@ -28,6 +28,13 @@ describe StudentImporter do
           expect(user.course_memberships.first.role).to eq "student"
         end
 
+        it "does not create the student membership if it already exists" do
+          user = User.create first_name: "Jimmy", last_name: "Page",
+              email: "jimmy@example.com", username: "jimmy", password: "blah"
+          user.course_memberships.create course_id: course.id, role: "student"
+          expect { subject.import course }.to_not raise_error
+        end
+
         it "adds the students to the team if the team exists" do
           subject.import course
           expect(team.name).to eq "Zeppelin"
@@ -47,6 +54,7 @@ describe StudentImporter do
           expect(team.name).to eq "Zeppelin"
           expect(team.students.first.email).to eq "jimmy@example.com"
         end
+
         it "does not add the student to the team if a team is not specified" do
           subject.import course
           user = User.unscoped.first


### PR DESCRIPTION
I could not replicate the issue of a missing reference. I was able to do it once but that was because I modified the server on development and I did not restart it and Rails does not autoload the classes in `/app/importers`. Once I restarted the server, everything was fine. In addition, this line also exists: https://github.com/UM-USElab/gradecraft-development/blob/master/app/importers/student_importer.rb#L2 and so it should be ok.

@chcholman Did the error you reported happen on production?

I did notice an issue with the importer however in that it always tries and creates a student relationship. This commit checks to see if the course membership exists before trying to create it.