### PR TITLE
max points zero for sample assignment types

### DIFF
--- a/db/samples/assignment_types.rb
+++ b/db/samples/assignment_types.rb
@@ -18,7 +18,7 @@
   attributes: {
     name: "Genric Assignment Type",
     description: nil,
-    max_points: nil,
+    max_points: 0,
     position: nil,
     student_weightable: false,
   }


### PR DESCRIPTION
A quick fix for sample data, now that assignment type max points cannot be nil