### PR TITLE
Analytics Export Hotfix

### DIFF
--- a/app/analytics_exports/course_predictor_export.rb
+++ b/app/analytics_exports/course_predictor_export.rb
@@ -37,8 +37,9 @@ class CoursePredictorExport
   end
 
   def assignment_name(event, index)
-    @assignment_names[event.assignment_id] ||
-      "[assignment id: #{event.assignment_id}]"
+    return "[assignment id: nil]" unless event.respond_to? :assignment_id
+    assignment_id = event.assignment_id
+    @assignment_names[assignment_id] || "[assignment id: #{assignment_id}]"
   end
 
   def student_profile(event, index)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,14 +77,14 @@ ActiveRecord::Schema.define(version: 20160609215010) do
   add_index "assignment_type_weights", ["student_id", "assignment_type_id"], name: "index_weights_on_student_and_assignment_type", using: :btree
 
   create_table "assignment_types", force: :cascade do |t|
-    t.string   "name",             null: false
-    t.integer  "max_points",        default: 0, null: false
+    t.string   "name",                               null: false
+    t.integer  "max_points",         default: 0,     null: false
     t.text     "description"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.integer  "course_id",                    null: false
-    t.boolean  "student_weightable",       default: false, null: false
-    t.integer  "position", null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.integer  "course_id",                          null: false
+    t.boolean  "student_weightable", default: false, null: false
+    t.integer  "position",                           null: false
   end
 
   create_table "assignments", force: :cascade do |t|
@@ -235,65 +235,65 @@ ActiveRecord::Schema.define(version: 20160609215010) do
   add_index "course_memberships", ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
 
   create_table "courses", force: :cascade do |t|
-    t.string   "name",                              limit: 255
-    t.string   "courseno",                          limit: 255
-    t.string   "year",                              limit: 255
-    t.string   "semester",                          limit: 255
-    t.datetime "created_at",                                                                                                   null: false
-    t.datetime "updated_at",                                                                                                   null: false
-    t.boolean  "badge_setting",                                                         default: true
-    t.boolean  "team_setting",                                                          default: false
-    t.string   "user_term",                         limit: 255
-    t.string   "team_term",                         limit: 255
-    t.string   "homepage_message",                  limit: 255
-    t.boolean  "status",                                                                default: true
+    t.string   "name",                            limit: 255
+    t.string   "courseno",                        limit: 255
+    t.string   "year",                            limit: 255
+    t.string   "semester",                        limit: 255
+    t.datetime "created_at",                                                                                                 null: false
+    t.datetime "updated_at",                                                                                                 null: false
+    t.boolean  "badge_setting",                                                       default: true
+    t.boolean  "team_setting",                                                        default: false
+    t.string   "user_term",                       limit: 255
+    t.string   "team_term",                       limit: 255
+    t.string   "homepage_message",                limit: 255
+    t.boolean  "status",                                                              default: true
     t.boolean  "group_setting"
     t.datetime "weights_close_at"
     t.boolean  "team_roles"
-    t.string   "team_leader_term",                  limit: 255
-    t.string   "group_term",                        limit: 255
+    t.string   "team_leader_term",                limit: 255
+    t.string   "group_term",                      limit: 255
     t.boolean  "accepts_submissions"
     t.boolean  "teams_visible"
-    t.string   "weight_term",                       limit: 255
+    t.string   "weight_term",                     limit: 255
     t.boolean  "predictor_setting"
     t.integer  "max_group_size"
     t.integer  "min_group_size"
-    t.decimal  "default_weight",                                precision: 4, scale: 1, default: 1.0
-    t.string   "tagline",                           limit: 255
+    t.decimal  "default_weight",                              precision: 4, scale: 1, default: 1.0
+    t.string   "tagline",                         limit: 255
     t.boolean  "academic_history_visible"
-    t.string   "office",                            limit: 255
-    t.string   "phone",                             limit: 255
-    t.string   "class_email",                       limit: 255
-    t.string   "twitter_handle",                    limit: 255
-    t.string   "twitter_hashtag",                   limit: 255
-    t.string   "location",                          limit: 255
-    t.string   "office_hours",                      limit: 255
+    t.string   "office",                          limit: 255
+    t.string   "phone",                           limit: 255
+    t.string   "class_email",                     limit: 255
+    t.string   "twitter_handle",                  limit: 255
+    t.string   "twitter_hashtag",                 limit: 255
+    t.string   "location",                        limit: 255
+    t.string   "office_hours",                    limit: 255
     t.text     "meeting_times"
-    t.string   "media",                             limit: 255
-    t.string   "media_credit",                      limit: 255
-    t.string   "media_caption",                     limit: 255
-    t.string   "badge_term",                        limit: 255
-    t.string   "assignment_term",                   limit: 255
-    t.string   "challenge_term",                    limit: 255
+    t.string   "media",                           limit: 255
+    t.string   "media_credit",                    limit: 255
+    t.string   "media_caption",                   limit: 255
+    t.string   "badge_term",                      limit: 255
+    t.string   "assignment_term",                 limit: 255
+    t.string   "challenge_term",                  limit: 255
     t.text     "grading_philosophy"
     t.integer  "total_weights"
     t.integer  "max_weights_per_assignment_type"
     t.boolean  "character_profiles"
-    t.string   "lti_uid",                           limit: 255
+    t.string   "lti_uid",                         limit: 255
     t.boolean  "team_score_average"
     t.boolean  "team_challenges"
     t.integer  "max_assignment_types_weighted"
     t.integer  "point_total"
     t.boolean  "in_team_leaderboard"
-    t.boolean  "add_team_score_to_student",                                             default: false
+    t.boolean  "add_team_score_to_student",                                           default: false
     t.datetime "start_date"
     t.datetime "end_date"
-    t.string   "pass_term",                         limit: 255
-    t.string   "fail_term",                         limit: 255
+    t.string   "pass_term",                       limit: 255
+    t.string   "fail_term",                       limit: 255
     t.string   "syllabus"
     t.boolean  "hide_analytics"
     t.string   "character_names"
-    t.string   "time_zone",                                                             default: "Eastern Time (US & Canada)"
+    t.string   "time_zone",                                                           default: "Eastern Time (US & Canada)"
   end
 
   add_index "courses", ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree
@@ -435,8 +435,10 @@ ActiveRecord::Schema.define(version: 20160609215010) do
     t.integer  "adjustment_points",                      default: 0,     null: false
     t.text     "adjustment_points_feedback"
     t.boolean  "excluded_from_course_score",             default: false
-    t.datetime "excluded_at"
+    t.datetime "excluded_date"
+    t.integer  "excluded_by"
     t.integer  "excluded_by_id"
+    t.datetime "excluded_at"
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree
@@ -574,6 +576,17 @@ ActiveRecord::Schema.define(version: 20160609215010) do
 
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
+
+  create_table "shared_earned_badges", force: :cascade do |t|
+    t.integer  "course_id"
+    t.text     "student_name"
+    t.integer  "user_id"
+    t.string   "icon",         limit: 255
+    t.string   "name",         limit: 255
+    t.integer  "badge_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "student_academic_histories", force: :cascade do |t|
     t.integer "student_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,14 +77,14 @@ ActiveRecord::Schema.define(version: 20160609215010) do
   add_index "assignment_type_weights", ["student_id", "assignment_type_id"], name: "index_weights_on_student_and_assignment_type", using: :btree
 
   create_table "assignment_types", force: :cascade do |t|
-    t.string   "name",                               null: false
-    t.integer  "max_points",         default: 0,     null: false
+    t.string   "name",             null: false
+    t.integer  "max_points",        default: 0, null: false
     t.text     "description"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.integer  "course_id",                          null: false
-    t.boolean  "student_weightable", default: false, null: false
-    t.integer  "position",                           null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "course_id",                    null: false
+    t.boolean  "student_weightable",       default: false, null: false
+    t.integer  "position", null: false
   end
 
   create_table "assignments", force: :cascade do |t|
@@ -235,65 +235,65 @@ ActiveRecord::Schema.define(version: 20160609215010) do
   add_index "course_memberships", ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
 
   create_table "courses", force: :cascade do |t|
-    t.string   "name",                            limit: 255
-    t.string   "courseno",                        limit: 255
-    t.string   "year",                            limit: 255
-    t.string   "semester",                        limit: 255
-    t.datetime "created_at",                                                                                                 null: false
-    t.datetime "updated_at",                                                                                                 null: false
-    t.boolean  "badge_setting",                                                       default: true
-    t.boolean  "team_setting",                                                        default: false
-    t.string   "user_term",                       limit: 255
-    t.string   "team_term",                       limit: 255
-    t.string   "homepage_message",                limit: 255
-    t.boolean  "status",                                                              default: true
+    t.string   "name",                              limit: 255
+    t.string   "courseno",                          limit: 255
+    t.string   "year",                              limit: 255
+    t.string   "semester",                          limit: 255
+    t.datetime "created_at",                                                                                                   null: false
+    t.datetime "updated_at",                                                                                                   null: false
+    t.boolean  "badge_setting",                                                         default: true
+    t.boolean  "team_setting",                                                          default: false
+    t.string   "user_term",                         limit: 255
+    t.string   "team_term",                         limit: 255
+    t.string   "homepage_message",                  limit: 255
+    t.boolean  "status",                                                                default: true
     t.boolean  "group_setting"
     t.datetime "weights_close_at"
     t.boolean  "team_roles"
-    t.string   "team_leader_term",                limit: 255
-    t.string   "group_term",                      limit: 255
+    t.string   "team_leader_term",                  limit: 255
+    t.string   "group_term",                        limit: 255
     t.boolean  "accepts_submissions"
     t.boolean  "teams_visible"
-    t.string   "weight_term",                     limit: 255
+    t.string   "weight_term",                       limit: 255
     t.boolean  "predictor_setting"
     t.integer  "max_group_size"
     t.integer  "min_group_size"
-    t.decimal  "default_weight",                              precision: 4, scale: 1, default: 1.0
-    t.string   "tagline",                         limit: 255
+    t.decimal  "default_weight",                                precision: 4, scale: 1, default: 1.0
+    t.string   "tagline",                           limit: 255
     t.boolean  "academic_history_visible"
-    t.string   "office",                          limit: 255
-    t.string   "phone",                           limit: 255
-    t.string   "class_email",                     limit: 255
-    t.string   "twitter_handle",                  limit: 255
-    t.string   "twitter_hashtag",                 limit: 255
-    t.string   "location",                        limit: 255
-    t.string   "office_hours",                    limit: 255
+    t.string   "office",                            limit: 255
+    t.string   "phone",                             limit: 255
+    t.string   "class_email",                       limit: 255
+    t.string   "twitter_handle",                    limit: 255
+    t.string   "twitter_hashtag",                   limit: 255
+    t.string   "location",                          limit: 255
+    t.string   "office_hours",                      limit: 255
     t.text     "meeting_times"
-    t.string   "media",                           limit: 255
-    t.string   "media_credit",                    limit: 255
-    t.string   "media_caption",                   limit: 255
-    t.string   "badge_term",                      limit: 255
-    t.string   "assignment_term",                 limit: 255
-    t.string   "challenge_term",                  limit: 255
+    t.string   "media",                             limit: 255
+    t.string   "media_credit",                      limit: 255
+    t.string   "media_caption",                     limit: 255
+    t.string   "badge_term",                        limit: 255
+    t.string   "assignment_term",                   limit: 255
+    t.string   "challenge_term",                    limit: 255
     t.text     "grading_philosophy"
     t.integer  "total_weights"
     t.integer  "max_weights_per_assignment_type"
     t.boolean  "character_profiles"
-    t.string   "lti_uid",                         limit: 255
+    t.string   "lti_uid",                           limit: 255
     t.boolean  "team_score_average"
     t.boolean  "team_challenges"
     t.integer  "max_assignment_types_weighted"
     t.integer  "point_total"
     t.boolean  "in_team_leaderboard"
-    t.boolean  "add_team_score_to_student",                                           default: false
+    t.boolean  "add_team_score_to_student",                                             default: false
     t.datetime "start_date"
     t.datetime "end_date"
-    t.string   "pass_term",                       limit: 255
-    t.string   "fail_term",                       limit: 255
+    t.string   "pass_term",                         limit: 255
+    t.string   "fail_term",                         limit: 255
     t.string   "syllabus"
     t.boolean  "hide_analytics"
     t.string   "character_names"
-    t.string   "time_zone",                                                           default: "Eastern Time (US & Canada)"
+    t.string   "time_zone",                                                             default: "Eastern Time (US & Canada)"
   end
 
   add_index "courses", ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree
@@ -435,10 +435,8 @@ ActiveRecord::Schema.define(version: 20160609215010) do
     t.integer  "adjustment_points",                      default: 0,     null: false
     t.text     "adjustment_points_feedback"
     t.boolean  "excluded_from_course_score",             default: false
-    t.datetime "excluded_date"
-    t.integer  "excluded_by"
-    t.integer  "excluded_by_id"
     t.datetime "excluded_at"
+    t.integer  "excluded_by_id"
   end
 
   add_index "grades", ["assignment_id", "student_id"], name: "index_grades_on_assignment_id_and_student_id", unique: true, using: :btree
@@ -576,17 +574,6 @@ ActiveRecord::Schema.define(version: 20160609215010) do
 
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
-
-  create_table "shared_earned_badges", force: :cascade do |t|
-    t.integer  "course_id"
-    t.text     "student_name"
-    t.integer  "user_id"
-    t.string   "icon",         limit: 255
-    t.string   "name",         limit: 255
-    t.integer  "badge_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
 
   create_table "student_academic_histories", force: :cascade do |t|
     t.integer "student_id"

--- a/lib/analytics.rb
+++ b/lib/analytics.rb
@@ -1,9 +1,11 @@
+require "is_configurable"
+require_relative "analytics/configuration"
+require_relative "analytics/event"
+require_relative "analytics/aggregate"
+require_relative "analytics/data"
+require_relative "analytics/export"
+require_relative "analytics/login_event"
+
 module Analytics
   extend IsConfigurable
 end
-
-require_dependency "is_configurable"
-require_dependency "analytics/configuration"
-require_dependency "analytics/event"
-require_dependency "analytics/aggregate"
-require_dependency "analytics/data"

--- a/lib/analytics/event.rb
+++ b/lib/analytics/event.rb
@@ -1,3 +1,5 @@
+require "mongoid"
+
 class Analytics::Event
   include Mongoid::Document
   include Mongoid::Attributes::Dynamic

--- a/lib/analytics/export.rb
+++ b/lib/analytics/export.rb
@@ -1,93 +1,91 @@
-module Analytics
-  module Export
-    def self.included(base)
-      base.extend(ClassMethods)
-      base.class_eval do
-        attr_accessor :data
-      end
+module Analytics::Export
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.class_eval do
+      attr_accessor :data
     end
+  end
 
-    def initialize(loaded_data)
-      self.data = loaded_data
-    end
+  def initialize(loaded_data)
+    self.data = loaded_data
+  end
 
-    def filter(rows)
-      rows
-    end
+  def filter(rows)
+    rows
+  end
 
-    def records
-      @records ||= self.filter data[self.class.rows]
-    end
+  def records
+    @records ||= self.filter data[self.class.rows]
+  end
 
-    # {
-    #   username: ["blah", "blah2", "blah3"],
-    #   role: ["admin", "owner", "owner"], ...
-    # }
-    def schema_records(records_set=nil)
-      puts "  => generating schema records"
-      recs = records_set || self.records
+  # {
+  #   username: ["blah", "blah2", "blah3"],
+  #   role: ["admin", "owner", "owner"], ...
+  # }
+  def schema_records(records_set=nil)
+    puts "  => generating schema records"
+    recs = records_set || self.records
 
-      Hash.new { |hash, key| hash[key] = [] }.tap do |h|
-        total_records = recs.size
-        all_elapsed = Benchmark.realtime do
-          self.class.schema.each do |column, value|
-            elapsed = Benchmark.realtime do
-              puts "    => column #{column.inspect}, value #{value.inspect}"
-              h[column] = recs.each_with_index.map do |record, i|
-                print "\r       record #{i} of #{total_records} (#{(i*100.0/total_records).round}%)" if i % 5 == 0 || i == (total_records - 1)
-                if value.respond_to? :call
-                  value.call(record)
-                elsif record.respond_to? value
-                  record.send(value)
-                else
-                  self.send(value, record, i)
-                end
+    Hash.new { |hash, key| hash[key] = [] }.tap do |h|
+      total_records = recs.size
+      all_elapsed = Benchmark.realtime do
+        self.class.schema.each do |column, value|
+          elapsed = Benchmark.realtime do
+            puts "    => column #{column.inspect}, value #{value.inspect}"
+            h[column] = recs.each_with_index.map do |record, i|
+              print "\r       record #{i} of #{total_records} (#{(i*100.0/total_records).round}%)" if i % 5 == 0 || i == (total_records - 1)
+              if value.respond_to? :call
+                value.call(record)
+              elsif record.respond_to? value
+                record.send(value)
+              else
+                self.send(value, record, i)
               end
             end
-            puts "\n       Done. Elapsed time: #{elapsed} seconds"
           end
+          puts "\n       Done. Elapsed time: #{elapsed} seconds"
         end
-        puts "     Done. Elapsed time: #{all_elapsed} seconds"
       end
+      puts "     Done. Elapsed time: #{all_elapsed} seconds"
+    end
+  end
+
+  def filter_schema_records(&filter)
+    record_set = filter.call(self.records)
+    self.schema_records record_set
+  end
+
+  def generate_csv(path, file_name=nil, schema_record_set=nil)
+    schema_recs = schema_record_set || self.schema_records
+    unless File.exists?(path) && File.directory?(path)
+      FileUtils.mkdir_p(path)
+    end
+    file_name ||= "#{self.class.name.underscore}.csv"
+
+    CSV.open(File.join(path, file_name), "wb") do |csv|
+      # Write header row
+      csv << self.class.schema.keys
+
+      # Zip schema_records values from each key
+      schema_recs.values.transpose.each{ |record| csv << record }
+    end
+  end
+
+  module ClassMethods
+    def set_schema(schema_hash)
+      @schema = schema_hash
     end
 
-    def filter_schema_records(&filter)
-      record_set = filter.call(self.records)
-      self.schema_records record_set
+    def schema
+      @schema
     end
 
-    def generate_csv(path, file_name=nil, schema_record_set=nil)
-      schema_recs = schema_record_set || self.schema_records
-      unless File.exists?(path) && File.directory?(path)
-        FileUtils.mkdir_p(path)
-      end
-      file_name ||= "#{self.class.name.underscore}.csv"
-
-      CSV.open(File.join(path, file_name), "wb") do |csv|
-        # Write header row
-        csv << self.class.schema.keys
-
-        # Zip schema_records values from each key
-        schema_recs.values.transpose.each{ |record| csv << record }
-      end
+    def rows_by(collection)
+      @rows = collection
     end
 
-    module ClassMethods
-      def set_schema(schema_hash)
-        @schema = schema_hash
-      end
-
-      def schema
-        @schema
-      end
-
-      def rows_by(collection)
-        @rows = collection
-      end
-
-      def rows
-        @rows
-      end
+    def rows
+      @rows
     end
   end
 end

--- a/lib/analytics/export.rb
+++ b/lib/analytics/export.rb
@@ -1,91 +1,93 @@
-module Analytics::Export
-  def self.included(base)
-    base.extend(ClassMethods)
-    base.class_eval do
-      attr_accessor :data
+module Analytics
+  module Export
+    def self.included(base)
+      base.extend(ClassMethods)
+      base.class_eval do
+        attr_accessor :data
+      end
     end
-  end
 
-  def initialize(loaded_data)
-    self.data = loaded_data
-  end
+    def initialize(loaded_data)
+      self.data = loaded_data
+    end
 
-  def filter(rows)
-    rows
-  end
+    def filter(rows)
+      rows
+    end
 
-  def records
-    @records ||= self.filter data[self.class.rows]
-  end
+    def records
+      @records ||= self.filter data[self.class.rows]
+    end
 
-  # {
-  #   username: ["blah", "blah2", "blah3"],
-  #   role: ["admin", "owner", "owner"], ...
-  # }
-  def schema_records(records_set=nil)
-    puts "  => generating schema records"
-    recs = records_set || self.records
+    # {
+    #   username: ["blah", "blah2", "blah3"],
+    #   role: ["admin", "owner", "owner"], ...
+    # }
+    def schema_records(records_set=nil)
+      puts "  => generating schema records"
+      recs = records_set || self.records
 
-    Hash.new { |hash, key| hash[key] = [] }.tap do |h|
-      total_records = recs.size
-      all_elapsed = Benchmark.realtime do
-        self.class.schema.each do |column, value|
-          elapsed = Benchmark.realtime do
-            puts "    => column #{column.inspect}, value #{value.inspect}"
-            h[column] = recs.each_with_index.map do |record, i|
-              print "\r       record #{i} of #{total_records} (#{(i*100.0/total_records).round}%)" if i % 5 == 0 || i == (total_records - 1)
-              if value.respond_to? :call
-                value.call(record)
-              elsif record.respond_to? value
-                record.send(value)
-              else
-                self.send(value, record, i)
+      Hash.new { |hash, key| hash[key] = [] }.tap do |h|
+        total_records = recs.size
+        all_elapsed = Benchmark.realtime do
+          self.class.schema.each do |column, value|
+            elapsed = Benchmark.realtime do
+              puts "    => column #{column.inspect}, value #{value.inspect}"
+              h[column] = recs.each_with_index.map do |record, i|
+                print "\r       record #{i} of #{total_records} (#{(i*100.0/total_records).round}%)" if i % 5 == 0 || i == (total_records - 1)
+                if value.respond_to? :call
+                  value.call(record)
+                elsif record.respond_to? value
+                  record.send(value)
+                else
+                  self.send(value, record, i)
+                end
               end
             end
+            puts "\n       Done. Elapsed time: #{elapsed} seconds"
           end
-          puts "\n       Done. Elapsed time: #{elapsed} seconds"
         end
+        puts "     Done. Elapsed time: #{all_elapsed} seconds"
       end
-      puts "     Done. Elapsed time: #{all_elapsed} seconds"
-    end
-  end
-
-  def filter_schema_records(&filter)
-    record_set = filter.call(self.records)
-    self.schema_records record_set
-  end
-
-  def generate_csv(path, file_name=nil, schema_record_set=nil)
-    schema_recs = schema_record_set || self.schema_records
-    unless File.exists?(path) && File.directory?(path)
-      FileUtils.mkdir_p(path)
-    end
-    file_name ||= "#{self.class.name.underscore}.csv"
-
-    CSV.open(File.join(path, file_name), "wb") do |csv|
-      # Write header row
-      csv << self.class.schema.keys
-
-      # Zip schema_records values from each key
-      schema_recs.values.transpose.each{ |record| csv << record }
-    end
-  end
-
-  module ClassMethods
-    def set_schema(schema_hash)
-      @schema = schema_hash
     end
 
-    def schema
-      @schema
+    def filter_schema_records(&filter)
+      record_set = filter.call(self.records)
+      self.schema_records record_set
     end
 
-    def rows_by(collection)
-      @rows = collection
+    def generate_csv(path, file_name=nil, schema_record_set=nil)
+      schema_recs = schema_record_set || self.schema_records
+      unless File.exists?(path) && File.directory?(path)
+        FileUtils.mkdir_p(path)
+      end
+      file_name ||= "#{self.class.name.underscore}.csv"
+
+      CSV.open(File.join(path, file_name), "wb") do |csv|
+        # Write header row
+        csv << self.class.schema.keys
+
+        # Zip schema_records values from each key
+        schema_recs.values.transpose.each{ |record| csv << record }
+      end
     end
 
-    def rows
-      @rows
+    module ClassMethods
+      def set_schema(schema_hash)
+        @schema = schema_hash
+      end
+
+      def schema
+        @schema
+      end
+
+      def rows_by(collection)
+        @rows = collection
+      end
+
+      def rows
+        @rows
+      end
     end
   end
 end

--- a/spec/analytics_exports/course_predictor_export_spec.rb
+++ b/spec/analytics_exports/course_predictor_export_spec.rb
@@ -1,4 +1,4 @@
-require "analytics/export"
+require "analytics"
 require "./app/analytics_exports/course_predictor_export"
 
 describe CoursePredictorExport do

--- a/spec/analytics_exports/course_predictor_export_spec.rb
+++ b/spec/analytics_exports/course_predictor_export_spec.rb
@@ -1,0 +1,47 @@
+require "analytics/export"
+require "./app/analytics_exports/course_predictor_export"
+
+describe CoursePredictorExport do
+  subject { described_class.new export_data }
+  let(:export_data) do
+    { users: [], assignments: [] }
+  end
+
+  describe "#assignment_name" do
+    let(:result) { subject.assignment_name event, 20 }
+    let(:event) { double(:event) }
+
+    context "event has no assignment_id" do
+      it "says that no assignment id is present" do
+        expect(result).to eq "[assignment id: nil]"
+      end
+    end
+
+    context "event has an assignment_id" do
+      before(:each) do
+        allow(event).to receive(:assignment_id) { 50 }
+        subject.instance_variable_set(:@assignment_names, assignment_names)
+      end
+
+      context "the assignment_id exists in @assignment_names" do
+        let(:assignment_names) do
+          { 50 => "this assignment" }
+        end
+
+        it "returns the name for the assignment" do
+          expect(result).to eq "this assignment"
+        end
+      end
+
+      context "the assignment_id doesn't exist in @assignment_names" do
+        let(:assignment_names) do
+          { 33 => "some other assignment" }
+        end
+
+        it "returns a placeholder for the assignment name with the id" do
+          expect(result).to eq "[assignment id: 50]"
+        end
+      end
+    end
+  end
+end

--- a/spec/mongoid_spec_helper.rb
+++ b/spec/mongoid_spec_helper.rb
@@ -1,0 +1,1 @@
+Mongoid.load! "#{Rails.root}/config/mongoid.yml"

--- a/spec/mongoid_spec_helper.rb
+++ b/spec/mongoid_spec_helper.rb
@@ -1,1 +1,2 @@
+require "mongoid"
 Mongoid.load! "#{Rails.root}/config/mongoid.yml"

--- a/spec/performers/login_event_performer_spec.rb
+++ b/spec/performers/login_event_performer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_spec_helper'
 require "mongoid"
 require "mongoid_spec_helper"
 
-describe LoginEventPerformer, focus: true do
+describe LoginEventPerformer do
   subject { described_class.new }
 
   # these are the attributes needed to skip #setup so we can test methods

--- a/spec/performers/login_event_performer_spec.rb
+++ b/spec/performers/login_event_performer_spec.rb
@@ -1,13 +1,8 @@
-# require 'active_record_spec_helper'
-# require_relative '../../lib/is_configurable'
-# require_relative '../../lib/loggly_resque'
-# require_relative '../../lib/inheritable_ivars'
-# require_relative '../../lib/resque_job'
-# require_relative '../../app/performers/login_event_performer'
-
 require 'rails_spec_helper'
+require "mongoid"
+require "mongoid_spec_helper"
 
-describe LoginEventPerformer do
+describe LoginEventPerformer, focus: true do
   subject { described_class.new }
 
   # these are the attributes needed to skip #setup so we can test methods

--- a/spec/performers/login_event_performer_spec.rb
+++ b/spec/performers/login_event_performer_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_spec_helper'
-require "mongoid"
 require "mongoid_spec_helper"
 
 describe LoginEventPerformer do


### PR DESCRIPTION
This PR resolves the issue that was occurring with assignment_id being called on events that had no assignment_id method. I've added a spec for `CoursePredictorExport#assignment_name`, which is where this was coming from, to test all of the cases.

Additionally I've added a `mongoid_spec_helper` class in `/spec` to help with expressly loading the Mongoid config (it wasn't being recognized in some examples), and have tested this patch against the production dump of data for course #41 which is where this error occurred in the first place.

@acousticrobot or @chcholman please take a look at this when you get a chance.