### PR TITLE
Check for mailto links when checking for external links

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -57,8 +57,10 @@ module LinkHelper
     def external?
       return false if self.uri.blank?
       uri = URI(self.uri)
-      !uri.relative? && !uri.host.end_with?("gradecraft.com") &&
-        !uri.host.end_with?("localhost")
+      uri.scheme == "mailto" ||
+        (!uri.relative? &&
+         !uri.host.end_with?("gradecraft.com") &&
+         !uri.host.end_with?("localhost"))
     rescue URI::InvalidURIError
       false
     end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -87,6 +87,11 @@ describe LinkHelper do
       link = "gradecraft.com"
       expect(helper.external_link?(link)).to eq false
     end
+
+    it "is external if it's a mailto link" do
+      link = "mailto:test@example.com"
+      expect(helper.external_link?(link)).to eq true
+    end
   end
 
   describe "#omission_link_to" do


### PR DESCRIPTION
Checks for mailto links within the external link helper. This helper returns `true` for mailto links to identify them as external.

Closes #2095