### PR TITLE
Fixing errant spec fail

### DIFF
--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -116,7 +116,7 @@ describe Grade do
       assignment = create :assignment, release_necessary: true
       create :grade, assignment: assignment, status: "Graded"
 
-      expect(described_class.student_visible).to eq [graded_grade, released_grade]
+      expect(described_class.student_visible).to include(released_grade, graded_grade)
     end
   end
 


### PR DESCRIPTION
This PR fixes a sporadically failing spec that was checking student visible grades, and occasionally receiving them in a different order than the `eq` matcher wanted. By switching it to an `includes` check this should pass consistently.