### PR TITLE
Fix Analytics Exports

### DIFF
--- a/app/analytics_exports/course_event_export.rb
+++ b/app/analytics_exports/course_event_export.rb
@@ -5,6 +5,7 @@ class CourseEventExport
 
   set_schema  username: :username,
               role: :user_role,
+              user_id: :user_id,
               page: :page,
               date_time: lambda { |event| event.created_at.to_formatted_s(:db) }
 

--- a/app/analytics_exports/course_event_export.rb
+++ b/app/analytics_exports/course_event_export.rb
@@ -6,7 +6,6 @@ class CourseEventExport
   set_schema  username: :username,
               role: :user_role,
               page: :page,
-              action: :page_name,
               date_time: lambda { |event| event.created_at.to_formatted_s(:db) }
 
   def schema_records_for_role(role)
@@ -27,9 +26,5 @@ class CourseEventExport
 
   def page(event, index)
     event.try(:page) || "[n/a]"
-  end
-
-  def page_name(event, index)
-    nil
   end
 end

--- a/app/analytics_exports/course_predictor_export.rb
+++ b/app/analytics_exports/course_predictor_export.rb
@@ -5,7 +5,9 @@ class CoursePredictorExport
 
   set_schema username: :username,
              role: :user_role,
+             user_id: :user_id,
              assignment: :assignment_name,
+             assignment_id: :assignment_id,
              prediction: :predicted_points,
              possible: :possible_points,
              date_time: lambda { |event| event.created_at.to_formatted_s(:db) }

--- a/app/analytics_exports/course_predictor_export.rb
+++ b/app/analytics_exports/course_predictor_export.rb
@@ -7,8 +7,8 @@ class CoursePredictorExport
              role: :user_role,
              student_profile: :student_profile,
              assignment: :assignment_name,
-             prediction: :score,
-             possible: :possible,
+             prediction: :predicted_points,
+             possible: :possible_points,
              date_time: lambda { |event| event.created_at.to_formatted_s(:db) }
 
   def schema_records_for_role(role)
@@ -38,7 +38,7 @@ class CoursePredictorExport
 
   def assignment_name(event, index)
     return "[assignment id: nil]" unless event.respond_to? :assignment_id
-    assignment_id = event.assignment_id
+    assignment_id = event.assignment_id.to_i
     @assignment_names[assignment_id] || "[assignment id: #{assignment_id}]"
   end
 

--- a/app/analytics_exports/course_predictor_export.rb
+++ b/app/analytics_exports/course_predictor_export.rb
@@ -5,7 +5,6 @@ class CoursePredictorExport
 
   set_schema username: :username,
              role: :user_role,
-             student_profile: :student_profile,
              assignment: :assignment_name,
              prediction: :predicted_points,
              possible: :possible_points,
@@ -40,9 +39,5 @@ class CoursePredictorExport
     return "[assignment id: nil]" unless event.respond_to? :assignment_id
     assignment_id = event.assignment_id.to_i
     @assignment_names[assignment_id] || "[assignment id: #{assignment_id}]"
-  end
-
-  def student_profile(event, index)
-    nil
   end
 end

--- a/app/analytics_exports/course_user_aggregate_export.rb
+++ b/app/analytics_exports/course_user_aggregate_export.rb
@@ -5,6 +5,7 @@ class CourseUserAggregateExport
 
   set_schema username: :username,
              role: :user_role,
+             user_id: :user_id,
              total_pageviews: :pageviews,
              total_logins: :logins,
              total_predictor_events: :predictor_events,

--- a/app/analytics_exports/course_user_aggregate_export.rb
+++ b/app/analytics_exports/course_user_aggregate_export.rb
@@ -59,4 +59,8 @@ class CourseUserAggregateExport
   def predictor_sessions(user, i)
     @user_predictor_sessions[user.id]
   end
+
+  def user_id(user, i)
+    user.id
+  end
 end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -186,7 +186,9 @@ class AnalyticsController < ApplicationController
   def export
     respond_to do |format|
       format.zip do
-        export_dir = Dir.mktmpdir
+        # let's create a directory to save our exported files to
+        export_dir = FileUtils.mkdir File.join(Dir.mktmpdir, current_course.courseno)
+
         export_filename = "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }.zip"
         id = current_course.id
 

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -243,6 +243,7 @@ class AnalyticsController < ApplicationController
           export_filepath = File.join(output_dir, export_filename)
           Archive::Zip.archive(export_filepath, export_dir)
           send_file export_filepath
+
         ensure
           FileUtils.remove_entry_secure export_dir
         end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -203,7 +203,7 @@ class AnalyticsController < ApplicationController
 
           user_predictor_pageviews =
             CourseUserPagePageview.data(:all_time, nil, {
-            course_id: id, page: "/dashboard#predictor"
+            course_id: id, page: /predictor/
             })
 
           user_logins = CourseUserLogin.data(:all_time, nil, {
@@ -239,7 +239,7 @@ class AnalyticsController < ApplicationController
             export.new(data).generate_csv export_dir
           end
 
-          output_dir = Dir.mktmpdir
+          output_dir = Dir.mktmpdir(current_course.courseno)
           export_filepath = File.join(output_dir, export_filename)
           Archive::Zip.archive(export_filepath, export_dir)
           send_file export_filepath

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -188,7 +188,6 @@ class AnalyticsController < ApplicationController
       format.zip do
         export_dir = Dir.mktmpdir
         export_zip "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }", export_dir do
-
           id = current_course.id
 
           events = Analytics::Event.where(course_id: id)
@@ -231,8 +230,12 @@ class AnalyticsController < ApplicationController
             assignments: assignments
           }
 
-          Analytics.configuration.exports[:course].each do |export|
-            export.new(data).generate_csv Dir.mktmpdir
+          [
+            CourseEventExport,
+            CoursePredictorExport,
+            CourseUserAggregateExport
+          ].each do |export|
+            export.new(data).generate_csv export_dir
           end
         end
       end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -187,7 +187,7 @@ class AnalyticsController < ApplicationController
     respond_to do |format|
       format.zip do
         export_dir = Dir.mktmpdir
-        export_filename = "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }"
+        export_filename = "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }.zip"
         id = current_course.id
 
         begin
@@ -245,7 +245,7 @@ class AnalyticsController < ApplicationController
           send_file export_filepath
 
         ensure
-          FileUtils.remove_entry_secure export_dir
+          FileUtils.remove_entry_secure export_dir, output_dir
         end
       end
     end

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -189,51 +189,51 @@ class AnalyticsController < ApplicationController
         export_dir = Dir.mktmpdir
         export_zip "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }", export_dir do
 
-          (Role.all + ["total"]).each do |role|
-            role_subdir = File.join(export_dir,role.pluralize)
-            id = current_course.id
-            events = Analytics::Event.where(course_id: id)
-            predictor_events =
-              Analytics::Event.where(course_id: id, event_type: "predictor")
-            user_pageviews = CourseUserPageview.data(:all_time, nil, {
-              course_id: id
-              },
-              { page: "_all" })
-            user_predictor_pageviews =
-              CourseUserPagePageview.data(:all_time, nil, {
-              course_id: id, page: "/dashboard#predictor"
-              })
-            user_logins = CourseUserLogin.data(:all_time, nil, {
-              course_id: id
-              })
+          id = current_course.id
 
-            user_ids = events.collect(&:user_id).compact.uniq
-            assignment_ids = events.select {
-              |event| event.respond_to? :assignment_id
-            }.collect(&:assignment_id).compact.uniq
-            users = User.where(id: user_ids).select(:id, :username)
-            assignments =
-              Assignment.where(id: assignment_ids).select(:id, :name)
+          events = Analytics::Event.where(course_id: id)
 
-            data = {
-              events: events,
-              predictor_events: predictor_events,
-              user_pageviews: user_pageviews[:results],
-              user_predictor_pageviews: user_predictor_pageviews[:results],
-              user_logins: user_logins[:results],
-              users: users,
-              assignments: assignments
-            }
-            Analytics.configuration.exports[:course].each do |export|
-              exp = export.new(data)
-              if role == "total"
-                exp.generate_csv(role_subdir)
-              else
-                exp.generate_csv(role_subdir,
-                nil, exp.schema_records_for_role(role))
-              end
-            end
-          end # each role
+          predictor_events =
+            Analytics::Event.where(course_id: id, event_type: "predictor")
+
+          user_pageviews = CourseUserPageview.data(:all_time, nil, {
+            course_id: id
+            },
+            { page: "_all" })
+
+          user_predictor_pageviews =
+            CourseUserPagePageview.data(:all_time, nil, {
+            course_id: id, page: "/dashboard#predictor"
+            })
+
+          user_logins = CourseUserLogin.data(:all_time, nil, {
+            course_id: id
+            })
+
+          user_ids = events.collect(&:user_id).compact.uniq
+
+          assignment_ids = events.select {
+            |event| event.respond_to? :assignment_id
+          }.collect(&:assignment_id).compact.uniq
+
+          users = User.where(id: user_ids).select(:id, :username)
+
+          assignments =
+            Assignment.where(id: assignment_ids).select(:id, :name)
+
+          data = {
+            events: events,
+            predictor_events: predictor_events,
+            user_pageviews: user_pageviews[:results],
+            user_predictor_pageviews: user_predictor_pageviews[:results],
+            user_logins: user_logins[:results],
+            users: users,
+            assignments: assignments
+          }
+
+          Analytics.configuration.exports[:course].each do |export|
+            export.new(data).generate_csv Dir.mktmpdir
+          end
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -99,29 +99,6 @@ class ApplicationController < ActionController::Base
     return not_authenticated unless current_user_is_admin?
   end
 
-  # To use: First create the temp directory you will be generating files in.
-  # A copy of the directory will be created as a zip download, and the tempdir
-  # will be deleted.
-  #
-  # example:
-  #   export_dir = Dir.mktmpdir
-  #   export_zip "my_zip", export_dir do
-  #     open( "#{export_dir}/my_file.txt",'w' ) do |f|
-  #       f.puts ...
-  #     end
-  #   end
-  #
-  def export_zip(export_name, temp_dir, &file_creation)
-    begin
-      file_creation.call
-      zip_data = ZipUtils::Zip.new(temp_dir)
-      send_data(zip_data, type: "application/zip",
-        filename: "#{export_name}.zip")
-    ensure
-      FileUtils.remove_entry_secure temp_dir
-    end
-  end
-
   def save_referer
     session[:return_to] = request.referer
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,7 +115,7 @@ class ApplicationController < ActionController::Base
     begin
       file_creation.call
       zip_data = ZipUtils::Zip.new(temp_dir)
-      send_data(zip_data.zipstring, type: "application/zip",
+      send_data(zip_data, type: "application/zip",
         filename: "#{export_name}.zip")
     ensure
       FileUtils.remove_entry_secure temp_dir

--- a/config/initializers/analytics.rb
+++ b/config/initializers/analytics.rb
@@ -24,12 +24,4 @@ Analytics.configure do |config|
       CourseUserLogin
     ]
   }
-
-  config.exports = {
-    course: [
-      CourseEventExport,
-      CoursePredictorExport,
-      CourseUserAggregateExport
-    ]
-  }
 end

--- a/lib/analytics/export.rb
+++ b/lib/analytics/export.rb
@@ -34,13 +34,15 @@ module Analytics::Export
             puts "    => column #{column.inspect}, value #{value.inspect}"
             h[column] = recs.each_with_index.map do |record, i|
               print "\r       record #{i} of #{total_records} (#{(i*100.0/total_records).round}%)" if i % 5 == 0 || i == (total_records - 1)
+
               if value.respond_to? :call
                 value.call(record)
               elsif record.respond_to? value
                 record.send(value)
               else
-                self.send(value, record, i)
+                self.send(value, record, i) if self.respond_to? value
               end
+
             end
           end
           puts "\n       Done. Elapsed time: #{elapsed} seconds"

--- a/lib/analytics/export.rb
+++ b/lib/analytics/export.rb
@@ -62,7 +62,7 @@ module Analytics::Export
 
     file_name ||= "#{self.class.name.underscore}.csv"
 
-    CSV.open(File.join(path, file_name), "wb") do |csv|
+    CSV.open(File.join(path, file_name), "w") do |csv|
       # Write header row
       csv << self.class.schema.keys
 

--- a/lib/analytics/export.rb
+++ b/lib/analytics/export.rb
@@ -57,9 +57,7 @@ module Analytics::Export
 
   def generate_csv(path, file_name=nil, schema_record_set=nil)
     schema_recs = schema_record_set || self.schema_records
-    unless File.exists?(path) && File.directory?(path)
-      FileUtils.mkdir_p(path)
-    end
+
     file_name ||= "#{self.class.name.underscore}.csv"
 
     CSV.open(File.join(path, file_name), "wb") do |csv|


### PR DESCRIPTION
The thrust of this PR is that the analytics export process was broken in multiple places and @chcholman needed this to be fixed to be able to generate a working export in order to continue work on her dissertation.

This PR should be considered a patch of the existing code to be used to get the existing analytics export implementation into a working state, and not a long-term design solution for the analytics export suite. Additional issues #2118, #2128, #2129, #2130, #2131, and #2132 have been created to incrementally issue enhancements to the overall functionality of the analytics export suite.

Some points of interest here:

- the `CourseEventExport` and `CoursePredictorExport` were using outdated method names for referencing predicted points and possible points values, and additionally had some unimplemented placeholder columns that were generating blank columns on the export CSV.

- the `AnalyticsController#export` method was generating one batch of files for each role and additionally a batch of files for all roles, which meant that all of the events were being queried for at least 9 times. Large lecture classes of 300+ students were taking over half an hour to complete an export.

- exports were persisting files on disk but not using s3fs, meaning that a docker container shift mid-export could destroy any already-exported data.

- CSV files were being concatenated rather than written individually in-place, so each CSV file was dumped into one master CSV file rather than being written individually.

Additionally please note that no additional spec files have been added to support this code -- these will come in with the pending issues once further refactoring is performed on the players involved.

**Note also** that this has been tested against multiple courses in production and it seems that any bugs related to data malformations have been ironed out.