### PR TITLE
sanitize text before truncating in course event module

### DIFF
--- a/app/views/students/dashboard/_dashboard_course_events.haml
+++ b/app/views/students/dashboard/_dashboard_course_events.haml
@@ -16,5 +16,5 @@
             %img{:src => event.media }
           .event-description
             %p
-              = (truncate event.description, :length => 200, :omission => "...", :escape => false)
+              = truncate(sanitize(event.description, :tags => %w(br a)), :length => 200, :omission => "...")
               = link_to "Read More", event


### PR DESCRIPTION
Strip everything but breaks and links from course event snippet description shown in course event module BEFORE truncating so we don't truncate in the middle of an HTML tag and break the page.