### PR TITLE
1521 count top grades only

### DIFF
--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -95,6 +95,10 @@ class AssignmentType < ActiveRecord::Base
                   .where(assignment_type: self)
   end
 
+  def count_grades_for(student)
+    grades_for(student).count
+  end
+
   def score_for_student(student)
     grades_for(student).pluck("score").sum || 0
   end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -50,6 +50,7 @@ class Grade < ActiveRecord::Base
   after_destroy :save_student_and_team_scores
 
   scope :completion, -> { where(order: "assignments.due_at ASC", joins: :assignment) }
+  scope :order_by_highest_score, -> { order("score DESC") }
 
   scope :excluded_from_course_score, -> { where excluded_from_course_score: true }
   scope :included_in_course_score, -> { where excluded_from_course_score: false }

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -20,6 +20,12 @@
       .form_label{id: "txtMaxPoints"} Is there a cap on how many points students can earn through this category (Set to 0 if not)? If you fill this in, students will not be able to earn more than this amount.
 
     .form-item
+      / Do only X number of highest grades count?
+      = f.label :top_grades_counted, :label => "Count Highest Grades"
+      = f.text_field :top_grades_counted, data: { autonumeric: true, "m-dec" => "0" }
+      .form_label{id: "assignment_type_top_grades_counted"} Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here.
+
+    .form-item
       = f.label :student_weightable, "Student Weighted"
       = f.check_box :student_weightable, {"aria-describedby" => "txtStudentWeighted"}
       .form_label{id: "txtStudentWeighted"} Do students decide how much this #{term_for :assignment} type will count towards their grade?

--- a/app/views/students/syllabus/_assignments.haml
+++ b/app/views/students/syllabus/_assignments.haml
@@ -11,6 +11,10 @@
       #{assignment_type.try(:name)} • #{ points assignment_type.visible_score_for_student(presenter.student) }/#{ points assignment_type.total_points_for_student(presenter.student) }
 
     .assignment-type-container
+      - if assignment_type.is_capped?
+        .italic This #{ (term_for :assignment_type).downcase } is capped at #{ points assignment_type.max_points } points.
+      - if assignment_type.count_only_top_grades?
+        .italic You have completed #{ assignment_type.count_grades_for(current_student) } #{ (term_for :assignments).downcase } in this category. Your top #{ assignment_type.top_grades_counted } grades count towards your course score.
       - if assignment_type.description?
         %p.description= raw assignment_type.description
 

--- a/db/migrate/20160624165722_add_top_count_to_assignment_type.rb
+++ b/db/migrate/20160624165722_add_top_count_to_assignment_type.rb
@@ -1,0 +1,5 @@
+class AddTopCountToAssignmentType < ActiveRecord::Migration
+  def change
+    add_column :assignment_types, :top_grades_counted, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160617095018) do
+ActiveRecord::Schema.define(version: 20160624165722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20160617095018) do
     t.integer  "course_id",                          null: false
     t.boolean  "student_weightable", default: false, null: false
     t.integer  "position",                           null: false
+    t.integer  "top_grades_counted",    default: 0,  null: false
   end
 
   create_table "assignments", force: :cascade do |t|


### PR DESCRIPTION
This PR adds a feature that allows instructors to declare a maximum number of grades that count from a single assignment type and properly totals the student's course score. 