### PR TITLE
Removed limitation on the upper bound of grade scheme element

### DIFF
--- a/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
@@ -7,12 +7,13 @@
   controller: ($scope) ->
     this.lowest_points = (modelValue, viewValue) ->
       if (modelValue < $scope.element.highest_points || $scope.element.highest_points == '')
-        GradeSchemeElementsService.update_scheme($scope.index, modelValue)
+        GradeSchemeElementsService.update_high_range($scope.index, modelValue)
         true
       else
         false
     this.highest_points = (modelValue, viewValue) ->
-      if (modelValue > $scope.element.lowest_points && modelValue < GradeSchemeElementsService.getTotalPoints())
+      if (modelValue > $scope.element.lowest_points || $scope.element.lowest_points == '' )
+        GradeSchemeElementsService.update_low_range($scope.index, modelValue)
         true
       else
         false
@@ -30,5 +31,4 @@
   require: ['^gradeSchemeRanges', '^ngModel']
   restrict: 'C'
   link: (scope, elm, attrs, ctrls) ->
-   ctrls[1].$validators.range = ctrls[0].highest_points
-    # create an on change binding
+    ctrls[1].$validators.range = ctrls[0].highest_points

--- a/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
@@ -6,17 +6,11 @@
   }
   controller: ($scope) ->
     this.lowest_points = (modelValue) ->
-      if (modelValue < $scope.element.highest_points || $scope.element.highest_points == '')
-        GradeSchemeElementsService.update_high_range($scope.index, modelValue)
-        true
-      else
-        false
+      GradeSchemeElementsService.isLowestPointValue($scope.element, $scope.index, modelValue)
+
     this.highest_points = (modelValue) ->
-      if (modelValue > $scope.element.lowest_points || $scope.element.lowest_points == '' )
-        GradeSchemeElementsService.update_low_range($scope.index, modelValue)
-        true
-      else
-        false
+      GradeSchemeElementsService.isHighestPointValue($scope.element, $scope.index, modelValue)
+
   templateUrl: 'ng_gradeSchemeRanges.html'
   link: (scope, elm, attrs, ctrl) ->
 ]

--- a/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
@@ -6,10 +6,18 @@
   }
   controller: ($scope) ->
     this.lowest_points = (modelValue) ->
-      GradeSchemeElementsService.updatePreviousElementIfLower($scope.element, $scope.index, modelValue)
+      # update the previous grade scheme element if our lowest_points value has
+      # dropped below its highest_points value
+      #
+      GradeSchemeElementsService
+        .updatePreviousElementIfLower($scope.element, $scope.index, modelValue)
 
     this.highest_points = (modelValue) ->
-      GradeSchemeElementsService.updateNextElementIfHigher($scope.element, $scope.index, modelValue)
+      # update the next grade scheme element if our highest_points value has
+      # become greater than its lowest_points value
+      #
+      GradeSchemeElementsService
+        .updateNextElementIfHigher($scope.element, $scope.index, modelValue)
 
   templateUrl: 'ng_gradeSchemeRanges.html'
   link: (scope, elm, attrs, ctrl) ->

--- a/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
@@ -5,13 +5,13 @@
     element: '=ngModel'
   }
   controller: ($scope) ->
-    this.lowest_points = (modelValue, viewValue) ->
+    this.lowest_points = (modelValue) ->
       if (modelValue < $scope.element.highest_points || $scope.element.highest_points == '')
         GradeSchemeElementsService.update_high_range($scope.index, modelValue)
         true
       else
         false
-    this.highest_points = (modelValue, viewValue) ->
+    this.highest_points = (modelValue) ->
       if (modelValue > $scope.element.lowest_points || $scope.element.lowest_points == '' )
         GradeSchemeElementsService.update_low_range($scope.index, modelValue)
         true

--- a/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/GradeSchemeDirectives.js.coffee
@@ -6,10 +6,10 @@
   }
   controller: ($scope) ->
     this.lowest_points = (modelValue) ->
-      GradeSchemeElementsService.isLowestPointValue($scope.element, $scope.index, modelValue)
+      GradeSchemeElementsService.updatePreviousElementIfLower($scope.element, $scope.index, modelValue)
 
     this.highest_points = (modelValue) ->
-      GradeSchemeElementsService.isHighestPointValue($scope.element, $scope.index, modelValue)
+      GradeSchemeElementsService.updateNextElementIfHigher($scope.element, $scope.index, modelValue)
 
   templateUrl: 'ng_gradeSchemeRanges.html'
   link: (scope, elm, attrs, ctrl) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -33,14 +33,14 @@
       if(index != elements.length + 1)
         elements[index - 1].lowest_points = newValue+1
 
-    isLowestPointValue = (element, index, modelValue) ->
+    updatePreviousElementIfLower = (element, index, modelValue) ->
       if (modelValue < element.highest_points || element.highest_points == '')
         update_high_range(index, modelValue)
         true
       else
         false
 
-    isHighestPointValue = (element, index, modelValue) ->
+    updateNextElementIfHigher = (element, index, modelValue) ->
       if (modelValue > element.lowest_points || element.lowest_points == '' )
         update_low_range(index, modelValue)
         true
@@ -76,8 +76,8 @@
         checkLowRange: checkLowRange
         update_high_range: update_high_range
         update_low_range: update_low_range
-        isLowestPointValue: isLowestPointValue
-        isHighestPointValue: isHighestPointValue
+        updatePreviousElementIfLower: updatePreviousElementIfLower
+        updateNextElementIfHigher: updateNextElementIfHigher
         getTotalPoints: getTotalPoints
         elements: elements
         remove: remove

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -7,11 +7,11 @@
       deletedIds.push(elements.splice(index, 1)[0].id)
 
     addNew = (index) ->
-      elements.splice(index+1, 0, {
+      elements.splice(index + 1, 0, {
         letter: ''
         level: ''
         lowest_points: ''
-        highest_points: elements[index].lowest_points-1
+        highest_points: elements[index].lowest_points - 1
       })
 
     addFirst = () ->
@@ -26,12 +26,12 @@
       (value < elements[parseInt(index)].highest_points)
 
     update_high_range = (index, newValue) ->
-      if(index != elements.length-1)
-        elements[index+1].highest_points = newValue-1
+      if(index != elements.length - 1)
+        elements[index + 1].highest_points = newValue-1
 
     update_low_range = (index, newValue) ->
-      if(index != elements.length+1)
-        elements[index-1].lowest_points = newValue+1
+      if(index != elements.length + 1)
+        elements[index - 1].lowest_points = newValue+1
 
     getGradeSchemeElements = ()->
       $http.get('/grade_scheme_elements/mass_edit.json').success((response) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -29,6 +29,20 @@
       if(index != elements.length - 1)
         elements[index + 1].highest_points = newValue-1
 
+    isLowestPointValue = (element, index, modelValue) ->
+      if (modelValue < element.highest_points || element.highest_points == '')
+        update_high_range(index, modelValue)
+        true
+      else
+        false
+
+    isHighestPointValue = (element, index, modelValue) ->
+      if (modelValue > element.lowest_points || element.lowest_points == '' )
+        update_low_range(index, modelValue)
+        true
+      else
+        false
+
     update_low_range = (index, newValue) ->
       if(index != elements.length + 1)
         elements[index - 1].lowest_points = newValue+1

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -33,6 +33,10 @@
       if(index != elements.length + 1)
         elements[index - 1].lowest_points = newValue+1
 
+    # this method will update the previous grade scheme element in the
+    # collection if its lowest_points value is lower than the highest points
+    # value for the previous element
+    #
     updatePreviousElementIfLower = (element, index, modelValue) ->
       if (modelValue < element.highest_points || element.highest_points == '')
         update_high_range(index, modelValue)
@@ -40,6 +44,10 @@
       else
         false
 
+    # this method will update the subsequent grade scheme element in the
+    # collection if its highest_points value is greater than the lowest points
+    # value for the subsequent element
+    #
     updateNextElementIfHigher = (element, index, modelValue) ->
       if (modelValue > element.lowest_points || element.lowest_points == '' )
         update_low_range(index, modelValue)

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -29,6 +29,10 @@
       if(index != elements.length - 1)
         elements[index + 1].highest_points = newValue-1
 
+    update_low_range = (index, newValue) ->
+      if(index != elements.length + 1)
+        elements[index - 1].lowest_points = newValue+1
+
     isLowestPointValue = (element, index, modelValue) ->
       if (modelValue < element.highest_points || element.highest_points == '')
         update_high_range(index, modelValue)
@@ -42,10 +46,6 @@
         true
       else
         false
-
-    update_low_range = (index, newValue) ->
-      if(index != elements.length + 1)
-        elements[index - 1].lowest_points = newValue+1
 
     getGradeSchemeElements = ()->
       $http.get('/grade_scheme_elements/mass_edit.json').success((response) ->
@@ -76,6 +76,8 @@
         checkLowRange: checkLowRange
         update_high_range: update_high_range
         update_low_range: update_low_range
+        isLowestPointValue: isLowestPointValue
+        isHighestPointValue: isHighestPointValue
         getTotalPoints: getTotalPoints
         elements: elements
         remove: remove

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -25,9 +25,13 @@
     checkLowRange = (value, index) ->
       (value < elements[parseInt(index)].highest_points)
 
-    update_scheme = (index, newValue) ->
+    update_high_range = (index, newValue) ->
       if(index != elements.length-1)
         elements[index+1].highest_points = newValue-1
+
+    update_low_range = (index, newValue) ->
+      if(index != elements.length+1)
+        elements[index-1].lowest_points = newValue+1
 
     getGradeSchemeElements = ()->
       $http.get('/grade_scheme_elements/mass_edit.json').success((response) ->
@@ -56,7 +60,8 @@
         getGradeSchemeElements: getGradeSchemeElements
         postGradeSchemeElements: postGradeSchemeElements
         checkLowRange: checkLowRange
-        update_scheme: update_scheme
+        update_high_range: update_high_range
+        update_low_range: update_low_range
         getTotalPoints: getTotalPoints
         elements: elements
         remove: remove

--- a/app/assets/javascripts/angular/templates/ng_gradeSchemeRanges.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeSchemeRanges.html.haml
@@ -1,4 +1,4 @@
 %span.form_label Low Point Threshold
 %input.low-range{:type => 'number','index' => '{{index}}','name' => 'lowest_points', 'ng-model' => 'element.lowest_points'}
 %span.form_label High Point Threshold
-%input.high-range{:type => 'number', 'name' => 'highest_points', 'ng-model' => 'element.highest_points', 'ng-disabled' => 'index > 0'}
+%input.high-range{:type => 'number', 'index' => '{{index}}','name' => 'highest_points', 'ng-model' => 'element.highest_points' }


### PR DESCRIPTION
This bugfix addresses the grade scheme element form rejecting point values that are higher than 1) is set on the Course model, or 2) the total sum of assignments created. Because the grading scheme is often entered far before all of the assignments are in, this is key to the UX feeling functional. It also adds the ability to edit the highest_points value, and for changes here to smartly update the lowest bounds of the above grade scheme element.