### PR TITLE
2185 - Format Course Numbers for Analytics Exports

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -204,8 +204,10 @@ class AnalyticsController < ApplicationController
         export_tmpdir = Dir.mktmpdir nil, s3fs_prefix
 
         # create a url-safe course number for the export's root directory
-        course_number = Formatter::Filename.new(current_course.courseno)
-                          .url_safe.filename
+        # be sure to replace forward-slashes with hyphens
+        course_number = Formatter::Filename.new(
+                          current_course.courseno.gsub(/\/+/,"-")
+                        ).url_safe.filename
 
         # create a named directory to generate the files in
         export_dir = FileUtils.mkdir \

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -203,8 +203,13 @@ class AnalyticsController < ApplicationController
         # create a working tmpdir for the export
         export_tmpdir = Dir.mktmpdir nil, s3fs_prefix
 
+        # format a name for the root directory of the export
+        formatted_course_number = current_course.courseno
+                                    .gsub(/ +/, "_").gsub(/\//, "-")
+
         # create a named directory to generate the files in
-        export_dir = FileUtils.mkdir File.join(export_tmpdir, current_course.courseno)
+        export_dir = FileUtils.mkdir \
+                       File.join(export_tmpdir, formatted_course_number)
 
         id = current_course.id
 
@@ -258,7 +263,8 @@ class AnalyticsController < ApplicationController
           end
 
           # this is going to be the downloaded filename of the final archive
-          export_filename = "#{ current_course.courseno }_anayltics_export_#{ Time.now.strftime('%Y-%m-%d') }.zip"
+          export_filename = "#{ formatted_course_number }_anayltics_export_" \
+                            "#{ Time.now.strftime('%Y-%m-%d') }.zip"
 
           # create a place to store our final archive, for now
           output_dir = Dir.mktmpdir nil, s3fs_prefix

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -203,13 +203,13 @@ class AnalyticsController < ApplicationController
         # create a working tmpdir for the export
         export_tmpdir = Dir.mktmpdir nil, s3fs_prefix
 
-        # format a name for the root directory of the export
-        formatted_course_number = current_course.courseno
-                                    .gsub(/ +/, "_").gsub(/\//, "-")
+        # create a url-safe course number for the export's root directory
+        course_number = Formatter::Filename.new(current_course.courseno)
+                          .url_safe.filename
 
         # create a named directory to generate the files in
         export_dir = FileUtils.mkdir \
-                       File.join(export_tmpdir, formatted_course_number)
+                       File.join(export_tmpdir, course_number)
 
         id = current_course.id
 
@@ -263,7 +263,7 @@ class AnalyticsController < ApplicationController
           end
 
           # this is going to be the downloaded filename of the final archive
-          export_filename = "#{ formatted_course_number }_anayltics_export_" \
+          export_filename = "#{ course_number }_anayltics_export_" \
                             "#{ Time.now.strftime('%Y-%m-%d') }.zip"
 
           # create a place to store our final archive, for now

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -206,12 +206,12 @@ class AnalyticsController < ApplicationController
         # create a url-safe course number for the export's root directory
         # be sure to replace forward-slashes with hyphens
         course_number = Formatter::Filename.new(
-                          current_course.courseno.gsub(/\/+/,"-")
-                        ).url_safe.filename
+          current_course.courseno.gsub(/\/+/,"-")
+        ).url_safe.filename
 
         # create a named directory to generate the files in
         export_dir = FileUtils.mkdir \
-                       File.join(export_tmpdir, course_number)
+          File.join(export_tmpdir, course_number)
 
         id = current_course.id
 

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -204,7 +204,9 @@ class AnalyticsController < ApplicationController
         export_tmpdir = Dir.mktmpdir nil, s3fs_prefix
 
         # create a url-safe course number for the export's root directory
-        # be sure to replace forward-slashes with hyphens
+        # be sure to replace forward-slashes with hyphens and ampersands
+        # with the word 'and'
+        #
         course_number = Formatter::Filename.new(
           current_course.courseno.gsub(/\/+/,"-").gsub("&", "and")
         ).url_safe.filename

--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -206,7 +206,7 @@ class AnalyticsController < ApplicationController
         # create a url-safe course number for the export's root directory
         # be sure to replace forward-slashes with hyphens
         course_number = Formatter::Filename.new(
-          current_course.courseno.gsub(/\/+/,"-")
+          current_course.courseno.gsub(/\/+/,"-").gsub("&", "and")
         ).url_safe.filename
 
         # create a named directory to generate the files in

--- a/lib/formatter/filename.rb
+++ b/lib/formatter/filename.rb
@@ -25,9 +25,9 @@ module Formatter
     #
     def url_safe
       self.filename = filename
-        .strip
-        .gsub(/[^\w_-]+/, "_") # strip out characters besides letters and digits
+        .gsub(/[^\w_-]+/, "_") # replace non alphanum characters with underscores
         .gsub(/[ _]+/, "_") # condense redundant underscores
+        .gsub(/^_+|_+$/, "") # remove leading or trailing underscores
       self
     end
 

--- a/lib/formatter/filename.rb
+++ b/lib/formatter/filename.rb
@@ -20,6 +20,17 @@ module Formatter
       self
     end
 
+    # just remove erroneous characters, strip out whitespace, and replace
+    # any other consecutive non-alphanum characters with a single underscore
+    #
+    def url_safe
+      self.filename = filename
+        .strip
+        .gsub(/[^\w_-]+/, "_") # strip out characters besides letters and digits
+        .gsub(/[ _]+/, "_") # condense redundant underscores
+      self
+    end
+
     def reset!
       self.filename = original_filename
     end

--- a/spec/lib/formatter/filename_spec.rb
+++ b/spec/lib/formatter/filename_spec.rb
@@ -62,6 +62,33 @@ describe Formatter::Filename do
     end
   end
 
+  describe "#url_safe" do
+    let(:result) { subject.url_safe }
+
+    # note that we can't access the filename directly from the #sanitize call
+    # because Formatter::Filename#sanitize returns the object rather than the
+    # resulting filename attribute
+
+    it "trims leading and trailing spaces" do
+      subject.filename = "     look-at-all-this-whitespace     "
+      expect(result.filename).to eq "look-at-all-this-whitespace"
+    end
+
+    it "replaces multiple spaces or underscores with single underscores" do
+      subject.filename = "roger___   ___went____to    the   mall"
+      expect(result.filename).to eq "roger_went_to_the_mall"
+    end
+
+    it "gets rid of url-unfriendly characters" do
+      subject.filename = "####TURTLES&&BRO####@$@$#@$@$#@$@$#@#"
+      expect(result.filename).to eq "TURTLES_BRO"
+    end
+
+    it "returns the Formatter::Filename instance" do
+      expect(result.class).to eq described_class
+    end
+  end
+
   describe "#reset!" do
     it "resets the @filename to the @original filename" do
       subject.original_filename = "the-real-filename"

--- a/spec/lib/formatter/filename_spec.rb
+++ b/spec/lib/formatter/filename_spec.rb
@@ -69,8 +69,8 @@ describe Formatter::Filename do
     # because Formatter::Filename#sanitize returns the object rather than the
     # resulting filename attribute
 
-    it "trims leading and trailing spaces" do
-      subject.filename = "     look-at-all-this-whitespace     "
+    it "trims leading and trailing spaces and underscores" do
+      subject.filename = "     look-at-all-this-whitespace____________"
       expect(result.filename).to eq "look-at-all-this-whitespace"
     end
 

--- a/spec/lib/formatter/filename_spec.rb
+++ b/spec/lib/formatter/filename_spec.rb
@@ -84,6 +84,10 @@ describe Formatter::Filename do
       expect(result.filename).to eq "TURTLES_BRO"
     end
 
+    # be sure to return the instance of Formatter::Filename so we can chain
+    # additional behaviors without having to continue invoking the instance
+    # itself as a variable
+    #
     it "returns the Formatter::Filename instance" do
       expect(result.class).to eq described_class
     end


### PR DESCRIPTION
The entire point of this PR is that we were using unformatted `Course#courseno` values to construct the filenames for `Analytics::Export` archives, but some of those `courseno` values have forward slashes and other characters that were breaking export filenames.

I've added a `#url_safe` method to the `Formatter::Filename` library as well to give us url-safe and therefore filename-safe output for strings, and then implemented that in the current process for performing analytics exports in `AnalyticsController#export`.