### PR TITLE
2190 Updates to Assignment Planner Module Functionality

### DIFF
--- a/app/assets/javascripts/student_dashboard.js
+++ b/app/assets/javascripts/student_dashboard.js
@@ -103,7 +103,6 @@ $('#course-planner').click(function() {
   $('.my-planner').hide();
 });
 
-
 //Find event with closest date
 if($("#dashboard-timeline").length) {
   $.ajax({

--- a/app/assets/javascripts/student_dashboard.js
+++ b/app/assets/javascripts/student_dashboard.js
@@ -97,7 +97,7 @@ $('#my-planner').click(function() {
    return $(this).find('a.starred').length === 0;
   }).css('display', 'none');
   if ($('.todo-list-assignments a.starred').length === 0) {
-    $('.my-planner-alert').toggleClass('hidden');
+    $('.my-planner-alert').removeClass('hidden');
   }
 });
 
@@ -105,7 +105,7 @@ $('#course-planner').click(function() {
   $('#course-planner, #my-planner').toggleClass("selected");
   $('.todo-list-assignments li').css('display', '');
   if ($('.todo-list-assignments a.starred').length === 0) {
-    $('.my-planner-alert').toggleClass('hidden');
+    $('.my-planner-alert').addClass('hidden');
   }
 });
 

--- a/app/assets/javascripts/student_dashboard.js
+++ b/app/assets/javascripts/student_dashboard.js
@@ -93,20 +93,14 @@ $(document).ready(function() {
 // Filter my planner items in "due this week" module
 $('#my-planner').click(function() {
   $('#course-planner, #my-planner').toggleClass("selected");
-  $('.todo-list-assignments li').filter(function() {
-   return $(this).find('a.starred').length === 0;
-  }).css('display', 'none');
-  if ($('.todo-list-assignments a.starred').length === 0) {
-    $('.my-planner-alert').removeClass('hidden');
-  }
+  $('.my-planner').show();
+  $('.course-planner').hide();
 });
 
 $('#course-planner').click(function() {
   $('#course-planner, #my-planner').toggleClass("selected");
-  $('.todo-list-assignments li').css('display', '');
-  if ($('.todo-list-assignments a.starred').length === 0) {
-    $('.my-planner-alert').addClass('hidden');
-  }
+  $('.course-planner').show();
+  $('.my-planner').hide();
 });
 
 

--- a/app/assets/javascripts/student_dashboard.js
+++ b/app/assets/javascripts/student_dashboard.js
@@ -93,14 +93,14 @@ $(document).ready(function() {
 // Filter my planner items in "due this week" module
 $('#my-planner').click(function() {
   $('#course-planner, #my-planner').toggleClass("selected");
-  $('.my-planner').show();
-  $('.course-planner').hide();
+  $('.my-planner-list').show();
+  $('.course-planner-list').hide();
 });
 
 $('#course-planner').click(function() {
   $('#course-planner, #my-planner').toggleClass("selected");
-  $('.course-planner').show();
-  $('.my-planner').hide();
+  $('.course-planner-list').show();
+  $('.my-planner-list').hide();
 });
 
 //Find event with closest date

--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -135,6 +135,8 @@ tbody
   &.selected
     border-bottom: 2px solid $color-blue-3
     color: $color-blue-3
+    pointer-events: none
+    cursor: default
 
 .notification-badge
   background-color: $color-red-1

--- a/app/assets/stylesheets/_student_dashboard.sass
+++ b/app/assets/stylesheets/_student_dashboard.sass
@@ -91,7 +91,7 @@
     padding: 2rem
     text-align: center
 
-  .my-planner
+  .my-planner-list
     display: none
 
   /* Styles the small version of the grading scheme */

--- a/app/assets/stylesheets/_student_dashboard.sass
+++ b/app/assets/stylesheets/_student_dashboard.sass
@@ -91,6 +91,9 @@
     padding: 2rem
     text-align: center
 
+  .my-planner
+    display: none
+
   /* Styles the small version of the grading scheme */
   .bar_magic
     border-radius: 5px

--- a/app/assets/stylesheets/_student_dashboard.sass
+++ b/app/assets/stylesheets/_student_dashboard.sass
@@ -91,7 +91,7 @@
     padding: 2rem
     text-align: center
 
-  .my-planner-list
+  .course-planner-list
     display: none
 
   /* Styles the small version of the grading scheme */

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -20,7 +20,7 @@ class InfoController < ApplicationController
 
   def timeline_events
     @events = Timeline.new(current_course).events_by_due_date
-    render(partial: "info/  timeline", handlers: [:jbuilder], formats: [:js])
+    render(partial: "info/timeline", handlers: [:jbuilder], formats: [:js])
   end
 
   def earned_badges

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -10,12 +10,17 @@ class InfoController < ApplicationController
   # Displays instructor dashboard, with or without Team Challenge dates
   def dashboard
     @events = Timeline.new(current_course).events_by_due_date
-    render :dashboard
+    render :dashboard, Students::DashboardCoursePlannerPresenter.build({
+      student: current_student,
+      assignments: current_course.assignments.chronological.includes(:assignment_type, :unlock_conditions),
+      course: current_course,
+      view_context: view_context
+    })
   end
 
   def timeline_events
     @events = Timeline.new(current_course).events_by_due_date
-    render(partial: "info/timeline", handlers: [:jbuilder], formats: [:js])
+    render(partial: "info/  timeline", handlers: [:jbuilder], formats: [:js])
   end
 
   def earned_badges

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -15,23 +15,23 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     properties[:assignments]
   end
 
-  def to_do_assignment?(assignment)
-    assignment.include_in_to_do? && assignment.visible_for_student?(student)
+  def to_do?(assignment)
+    assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(student)
   end
 
-  def assignment_available?(assignment)
+  def submittable?(assignment)
     assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
   end
 
-  def assignment_starred?(assignment)
+  def starred?(assignment)
     assignment.is_predicted_by_student?(student)
   end
 
-  def assignment_individual?(assignment)
-    assignment.is_individual?
+  def my_planner(assignment)
+    to_do?(assignment) && starred?(assignment)
   end
 
-  def assignment_submitted?
+  def submitted?(assignment)
     student.submission_for_assignment(assignment).present?
   end
 end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -42,4 +42,13 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
   def submitted?(assignment)
     student.submission_for_assignment(assignment).present?
   end
+
+  def empty_message(list_class)
+    assignment_term = course.assignment_term.downcase.pluralize
+    if list_class == "course-planner"
+      "You don't have any #{assignment_term} due in the next week!"
+    elsif list_class == "my-planner"
+      "You have not predicted any #{assignment_term}! Check out the grade predictor to add #{assignment_term} to this planner."
+    end
+  end
 end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -19,16 +19,16 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     assignment.include_in_to_do? && assignment.visible_for_student?(student)
   end
 
-  def assignment_available?
-    to_do_assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
+  def assignment_available?(assignment)
+    assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
   end
 
-  def assignment_starred?
-    assignment_available.is_predicted_by_student?(student)
+  def assignment_starred?(assignment)
+    assignment.is_predicted_by_student?(student)
   end
 
-  def assignment_individual?
-    assignment_available.is_individual?
+  def assignment_individual?(assignment)
+    assignment.is_individual?
   end
 
   def assignment_submitted?

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -54,17 +54,4 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
   def due_dates?
     assignments.any?{ |assignment| assignment.due_at? }
   end
-
-  def empty_message(list_class)
-    assignment_term = course.assignment_term.downcase.pluralize
-    if list_class == "course-planner-list"
-      if due_dates?
-        "You don't have any #{assignment_term} due in the next week!"
-      else
-        "This class has flexible assignment due dates. Check your course rules to learn when to turn in certain assignment."
-      end
-    elsif list_class == "my-planner-list"
-      "You have not predicted any #{assignment_term}! Check out the grade predictor to add #{assignment_term} to this planner."
-    end
-  end
 end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -15,6 +15,10 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     properties[:assignments]
   end
 
+  def to_do_assignments
+    assignments.select{ |assignment| assignment.include_in_to_do == true && assignment.visible_for_student?(student)== true && assignment.soon? == true }
+  end
+
   def to_do?(assignment)
     assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(student)
   end
@@ -27,8 +31,12 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     assignment.is_predicted_by_student?(student)
   end
 
-  def my_planner(assignment)
+  def my_planner?(assignment)
     to_do?(assignment) && starred?(assignment)
+  end
+
+  def my_planner_assignments
+    assignments.select{ |assignment| my_planner?(assignment) }
   end
 
   def submitted?(assignment)

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -15,20 +15,20 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     properties[:assignments]
   end
 
-  def to_do_assignments
-    assignments.select{ |assignment| assignment.include_in_to_do == true && assignment.visible_for_student?(student)== true && assignment.soon? == true }
-  end
-
   def to_do?(assignment)
-    assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(student)
+    assignment.include_in_to_do? && assignment.visible_for_student?(student)
   end
 
-  def submittable?(assignment)
-    assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
+  def to_do_assignments
+    assignments.select{ |assignment| to_do?(assignment) }
   end
 
-  def starred?(assignment)
-    assignment.is_predicted_by_student?(student)
+  def course_planner?(assignment)
+    to_do?(assignment) && assignment.soon?
+  end
+
+  def course_planner_assignments
+    assignments.select{ |assignment| course_planner?(assignment) }
   end
 
   def my_planner?(assignment)
@@ -37,6 +37,14 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
 
   def my_planner_assignments
     assignments.select{ |assignment| my_planner?(assignment) }
+  end
+
+  def submittable?(assignment)
+    assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
+  end
+
+  def starred?(assignment)
+    assignment.is_predicted_by_student?(student)
   end
 
   def submitted?(assignment)

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -1,0 +1,37 @@
+require "./lib/showtime"
+
+class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
+  include Showtime::ViewContext
+
+  def course
+    properties[:course]
+  end
+
+  def student
+    properties[:student]
+  end
+
+  def assignments
+    properties[:assignments]
+  end
+
+  def to_do_assignment?(assignment)
+    assignment.include_in_to_do? && assignment.visible_for_student?(student)
+  end
+
+  def assignment_available?
+    to_do_assignment.accepts_submissions? && assignment.is_unlocked_for_student?(student)
+  end
+
+  def assignment_starred?
+    assignment_available.is_predicted_by_student?(student)
+  end
+
+  def assignment_individual?
+    assignment_available.is_individual?
+  end
+
+  def assignment_submitted?
+    student.submission_for_assignment(assignment).present?
+  end
+end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -43,10 +43,18 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
     student.submission_for_assignment(assignment).present?
   end
 
+  def due_dates?
+    assignments.any?{ |assignment| assignment.due_at? }
+  end
+
   def empty_message(list_class)
     assignment_term = course.assignment_term.downcase.pluralize
     if list_class == "course-planner"
-      "You don't have any #{assignment_term} due in the next week!"
+      if due_dates?
+        "You don't have any #{assignment_term} due in the next week!"
+      else
+        "This class flexible assignment due dates. Check your course rules to learn when to turn in certain assignment."
+      end
     elsif list_class == "my-planner"
       "You have not predicted any #{assignment_term}! Check out the grade predictor to add #{assignment_term} to this planner."
     end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -49,13 +49,13 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
 
   def empty_message(list_class)
     assignment_term = course.assignment_term.downcase.pluralize
-    if list_class == "course-planner"
+    if list_class == "course-planner-list"
       if due_dates?
         "You don't have any #{assignment_term} due in the next week!"
       else
         "This class flexible assignment due dates. Check your course rules to learn when to turn in certain assignment."
       end
-    elsif list_class == "my-planner"
+    elsif list_class == "my-planner-list"
       "You have not predicted any #{assignment_term}! Check out the grade predictor to add #{assignment_term} to this planner."
     end
   end

--- a/app/presenters/students/dashboard_course_planner_presenter.rb
+++ b/app/presenters/students/dashboard_course_planner_presenter.rb
@@ -61,7 +61,7 @@ class Students::DashboardCoursePlannerPresenter < Showtime::Presenter
       if due_dates?
         "You don't have any #{assignment_term} due in the next week!"
       else
-        "This class flexible assignment due dates. Check your course rules to learn when to turn in certain assignment."
+        "This class has flexible assignment due dates. Check your course rules to learn when to turn in certain assignment."
       end
     elsif list_class == "my-planner-list"
       "You have not predicted any #{assignment_term}! Check out the grade predictor to add #{assignment_term} to this planner."

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -129,7 +129,7 @@
     .form-item
       = f.label :include_in_to_do, "Due this Week"
       = f.check_box :include_in_to_do
-      .form_label Can #{term_for :students} see this #{term_for :assignment} in the "Due this Week" panel?
+      .form_label Can #{term_for :students} see this #{term_for :assignment} in the "Course Events" panel?
 
     - if ! current_course.hide_analytics?
       .form-item

--- a/app/views/info/_student_dashboard.html.haml
+++ b/app/views/info/_student_dashboard.html.haml
@@ -5,4 +5,4 @@
   = render "layouts/alerts"
 
   #student-dashboard
-    = render "students/student_dashboard"
+    = render partial: "students/student_dashboard", locals: { presenter: presenter }

--- a/app/views/info/dashboard.html.haml
+++ b/app/views/info/dashboard.html.haml
@@ -1,4 +1,4 @@
 - if current_user_is_staff? && ! current_course.assignments.present?
   = render partial: "course_creation_wizard"
 - else
-  #dashboard-timeline= render partial: "#{current_user.role(current_course)}_dashboard"
+  #dashboard-timeline= render partial: "#{current_user.role(current_course)}_dashboard", locals: { presenter: presenter }

--- a/app/views/students/_student_dashboard.html.haml
+++ b/app/views/students/_student_dashboard.html.haml
@@ -1,5 +1,5 @@
 .col-30
-  .panel.todo.dashboard-module= render partial: "students/dashboard/dashboard_to_do_list"
+  .panel.todo.dashboard-module= render partial: "students/dashboard/dashboard_to_do_list", locals: { presenter: presenter }
 
 .col-40
   - if @events.present?

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -1,9 +1,9 @@
 .text-center
   .card-header
-    %h3 Due This Week
+    %h3 #{term_for :assignment} Planner
   .card-body#todo-list
     .planner-filter.clearfix
       = link_to "My Planner", "#", class: "filter-button button selected", id: "my-planner"
       = link_to "Course Planner", "#", class: "filter-button button", id: "course-planner"
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments, list_class: "course-planner-list" }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.course_planner_assignments, list_class: "course-planner-list" }
     = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments, list_class: "my-planner-list" }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -5,5 +5,5 @@
     .planner-filter.clearfix
       = link_to "Course Planner", "#", class: "filter-button button selected", id: "course-planner"
       = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments, list_class: "course-planner" }
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments, list_class: "my-planner" }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments, list_class: "course-planner-list" }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments, list_class: "my-planner-list" }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -5,4 +5,5 @@
     .planner-filter.clearfix
       = link_to "Course Planner", "#", class: "filter-button button selected", id: "course-planner"
       = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -8,9 +8,9 @@
     %ul.todo-list-assignments
       - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
         - presenter.assignments.each do |assignment|
-          - if presenter.to_do_assignment?
-            %li{:class => assignment.is_predicted_by_student?(current_student) ? "assignment-item starred" : "assignment-item"}
-              - if assignment.accepts_submissions? && assignment.is_unlocked_for_student?(current_student)
+          - if assignment.soon? && presenter.to_do_assignment?(assignment)
+            %li{:class => presenter.assignment_starred?(assignment) ? "assignment-item starred" : "assignment-item"}
+              - if presenter.assignment_available?(assignment)
                 - if assignment.is_individual?
                   .right= render "students/submissions", assignment: assignment
                 - else

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -7,8 +7,8 @@
       = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
     %ul.todo-list-assignments
       - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
-        - current_course.assignments.chronological.includes(:assignment_type, :unlock_conditions).each do |assignment|
-          - if assignment.soon? && assignment.include_in_to_do? && assignment.visible_for_student?(current_student)
+        - presenter.assignments.each do |assignment|
+          - if presenter.to_do_assignment?
             %li{:class => assignment.is_predicted_by_student?(current_student) ? "assignment-item starred" : "assignment-item"}
               - if assignment.accepts_submissions? && assignment.is_unlocked_for_student?(current_student)
                 - if assignment.is_individual?

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -5,34 +5,4 @@
     .planner-filter.clearfix
       = link_to "Course Planner", "#", class: "filter-button button selected", id: "course-planner"
       = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
-    %ul.todo-list-assignments
-      - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
-        - presenter.assignments.each do |assignment|
-          - if presenter.to_do?(assignment)
-            %li{:class => presenter.starred?(assignment) ? "assignment-item starred" : "assignment-item"}
-              - if presenter.submittable?(assignment)
-                - if assignment.is_individual?
-                  .right= render "students/submissions", assignment: assignment
-                - else
-                  .right= render "students/group_submissions", assignment: assignment, group: current_student.group_for_assignment(assignment)
-              - if presenter.starred?(assignment)
-                %a.starred
-                  %i.fa.fa-star.fa-fw.yellow
-                .display_on_hover.hover-style
-                  You have included this #{term_for :assignment} in your grade prediction
-              - if presenter.submitted?(assignment)
-                %span.strikethrough.assignment-name= link_to "#{assignment.try(:name)}", assignment
-                .small.uppercase= "#{assignment.assignment_type.name}"
-              - else
-                - if assignment.name_visible_for_student?(current_student)
-                  %span.bold.assignment-name= link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
-                - else
-                  %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
-                  %span.italic= "You must unlock this #{term_for :assignment } to learn more about it"
-                .small.uppercase= "#{assignment.assignment_type.name}"
-                .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
-    .my-planner-alert.hidden
-      %p
-        You have not predicted any #{(term_for :assignments).downcase}! Check out the
-        = link_to 'grade predictor', predictor_path 
-        to add #{(term_for :assignments).downcase} to this planner.
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -5,5 +5,5 @@
     .planner-filter.clearfix
       = link_to "Course Planner", "#", class: "filter-button button selected", id: "course-planner"
       = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments }
-    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments, list_class: "course-planner" }
+    = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments, list_class: "my-planner" }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -3,7 +3,7 @@
     %h3 Due This Week
   .card-body#todo-list
     .planner-filter.clearfix
-      = link_to "Course Planner", "#", class: "filter-button button selected", id: "course-planner"
-      = link_to "My Planner", "#", class: "filter-button button", id: "my-planner"
+      = link_to "My Planner", "#", class: "filter-button button selected", id: "my-planner"
+      = link_to "Course Planner", "#", class: "filter-button button", id: "course-planner"
     = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.to_do_assignments, list_class: "course-planner-list" }
     = render partial: "students/dashboard/dashboard_to_do_list_items", locals: { presenter: presenter, assignment_list: presenter.my_planner_assignments, list_class: "my-planner-list" }

--- a/app/views/students/dashboard/_dashboard_to_do_list.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list.haml
@@ -8,19 +8,19 @@
     %ul.todo-list-assignments
       - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
         - presenter.assignments.each do |assignment|
-          - if assignment.soon? && presenter.to_do_assignment?(assignment)
-            %li{:class => presenter.assignment_starred?(assignment) ? "assignment-item starred" : "assignment-item"}
-              - if presenter.assignment_available?(assignment)
+          - if presenter.to_do?(assignment)
+            %li{:class => presenter.starred?(assignment) ? "assignment-item starred" : "assignment-item"}
+              - if presenter.submittable?(assignment)
                 - if assignment.is_individual?
                   .right= render "students/submissions", assignment: assignment
                 - else
                   .right= render "students/group_submissions", assignment: assignment, group: current_student.group_for_assignment(assignment)
-              - if assignment.is_predicted_by_student?(current_student)
+              - if presenter.starred?(assignment)
                 %a.starred
                   %i.fa.fa-star.fa-fw.yellow
                 .display_on_hover.hover-style
                   You have included this #{term_for :assignment} in your grade prediction
-              - if current_student.submission_for_assignment(assignment).present?
+              - if presenter.submitted?(assignment)
                 %span.strikethrough.assignment-name= link_to "#{assignment.try(:name)}", assignment
                 .small.uppercase= "#{assignment.assignment_type.name}"
               - else

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -26,4 +26,12 @@
           .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
   - if assignment_list.empty?
     %li.my-planner-alert
-      = presenter.empty_message(list_class)
+      - if list_class == "course-planner-list"
+        - if presenter.due_dates?
+          You don't have any #{(term_for :assignment).downcase} due in the next week!
+        - else
+          This class has flexible assignment due dates. Check your course rules to learn when to turn in certain assignment.
+      - elsif list_class == "my-planner-list"
+        You have not predicted any #{(term_for :assignment).downcase}! Check out the 
+        = link_to "grade predictor", predictor_path
+        to add #{(term_for :assignment).downcase} to this planner.

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -11,7 +11,7 @@
           %a.starred
             %i.fa.fa-star.fa-fw.yellow
           .display_on_hover.hover-style
-            You have included this #{term_for :assignment} in your grade prediction
+            You have included this #{(term_for :assignment).downcase} in your grade prediction
         - if presenter.submitted?(assignment)
           %span.strikethrough.assignment-name= link_to "#{assignment.try(:name)}", assignment
           .small.uppercase= "#{assignment.assignment_type.name}"
@@ -20,11 +20,9 @@
             %span.bold.assignment-name= link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
           - else
             %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
-            %span.italic= "You must unlock this #{term_for :assignment } to learn more about it"
+            %span.italic= "You must unlock this #{(term_for :assignment).downcase} to learn more about it"
           .small.uppercase= "#{assignment.assignment_type.name}"
           .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
-.my-planner-alert.hidden
-  %p
-    You have not predicted any #{(term_for :assignments).downcase}! Check out the
-    = link_to 'grade predictor', predictor_path 
-    to add #{(term_for :assignments).downcase} to this planner.
+  - if assignment_list.empty?
+    %li.my-planner-alert
+      = presenter.empty_message(list_class)

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -1,0 +1,30 @@
+%ul.todo-list-assignments
+  - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
+    - presenter.to_do_assignments.each do |assignment|
+      %li{:class => presenter.starred?(assignment) ? "assignment-item starred" : "assignment-item"}
+        - if presenter.submittable?(assignment)
+          - if assignment.is_individual?
+            .right= render "students/submissions", assignment: assignment
+          - else
+            .right= render "students/group_submissions", assignment: assignment, group: current_student.group_for_assignment(assignment)
+        - if presenter.starred?(assignment)
+          %a.starred
+            %i.fa.fa-star.fa-fw.yellow
+          .display_on_hover.hover-style
+            You have included this #{term_for :assignment} in your grade prediction
+        - if presenter.submitted?(assignment)
+          %span.strikethrough.assignment-name= link_to "#{assignment.try(:name)}", assignment
+          .small.uppercase= "#{assignment.assignment_type.name}"
+        - else
+          - if assignment.name_visible_for_student?(current_student)
+            %span.bold.assignment-name= link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
+          - else
+            %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
+            %span.italic= "You must unlock this #{term_for :assignment } to learn more about it"
+          .small.uppercase= "#{assignment.assignment_type.name}"
+          .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
+.my-planner-alert.hidden
+  %p
+    You have not predicted any #{(term_for :assignments).downcase}! Check out the
+    = link_to 'grade predictor', predictor_path 
+    to add #{(term_for :assignments).downcase} to this planner.

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -1,4 +1,4 @@
-%ul.todo-list-assignments.list_class
+%ul{:class => "todo-list-assignments #{list_class}"}
   - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
     - assignment_list.each do |assignment|
       %li{:class => presenter.starred?(assignment) ? "assignment-item starred" : "assignment-item"}

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -1,6 +1,6 @@
-%ul.todo-list-assignments
+%ul.todo-list-assignments.list_class
   - cache multi_cache_key :student_dashboard_todo_list, current_student, current_course do
-    - presenter.to_do_assignments.each do |assignment|
+    - assignment_list.each do |assignment|
       %li{:class => presenter.starred?(assignment) ? "assignment-item starred" : "assignment-item"}
         - if presenter.submittable?(assignment)
           - if assignment.is_individual?

--- a/app/views/students/dashboard/_dashboard_to_do_list_items.haml
+++ b/app/views/students/dashboard/_dashboard_to_do_list_items.haml
@@ -22,6 +22,7 @@
             %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
             %span.italic= "You must unlock this #{(term_for :assignment).downcase} to learn more about it"
           .small.uppercase= "#{assignment.assignment_type.name}"
+        - if assignment.due_at?.present?
           .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
   - if assignment_list.empty?
     %li.my-planner-alert

--- a/spec/views/info/dashboard_spec.rb
+++ b/spec/views/info/dashboard_spec.rb
@@ -1,7 +1,15 @@
 # encoding: utf-8
 require "rails_spec_helper"
 
-describe "info/dashboard" do
+describe "info/dashboard", focus: true do
+
+  let(:view_context) { double(:view_context, current_user: @student_1) }
+  let(:presenter) { Students::DashboardCoursePlannerPresenter.build({
+    student: @student_1,
+    assignments: @assignments,
+    course: @course,
+    view_context: view_context
+  })}
 
   before(:all) do
     @course = create(:course_accepting_groups)

--- a/spec/views/info/dashboard_spec.rb
+++ b/spec/views/info/dashboard_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "rails_spec_helper"
 
-describe "info/dashboard"
+describe "info/dashboard" do
 
   let(:view_context) { double(:view_context, current_user: @student_1) }
   let(:presenter) { Students::DashboardCoursePlannerPresenter.new({

--- a/spec/views/info/dashboard_spec.rb
+++ b/spec/views/info/dashboard_spec.rb
@@ -36,6 +36,7 @@ describe "info/dashboard" do
 
   before(:each) do
     allow(view).to receive(:current_course).and_return(@course)
+    allow(view).to receive(:presenter).and_return presenter
   end
 
   context "as a professor" do

--- a/spec/views/info/dashboard_spec.rb
+++ b/spec/views/info/dashboard_spec.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "rails_spec_helper"
 
-describe "info/dashboard", focus: true do
+describe "info/dashboard"
 
   let(:view_context) { double(:view_context, current_user: @student_1) }
   let(:presenter) { Students::DashboardCoursePlannerPresenter.new({

--- a/spec/views/info/dashboard_spec.rb
+++ b/spec/views/info/dashboard_spec.rb
@@ -4,7 +4,7 @@ require "rails_spec_helper"
 describe "info/dashboard", focus: true do
 
   let(:view_context) { double(:view_context, current_user: @student_1) }
-  let(:presenter) { Students::DashboardCoursePlannerPresenter.build({
+  let(:presenter) { Students::DashboardCoursePlannerPresenter.new({
     student: @student_1,
     assignments: @assignments,
     course: @course,


### PR DESCRIPTION
This PR changes the way filtering was implemented on the "Due this Week" (now "Assignment Planner") module on the student dashboard in order to accommodate courses with no due dates and times when no assignments showed in the pane due to nothing being due in the next week. 

Now, "My Planner" shows a list of ALL predicted assignments, regardless of due date and "Course Planner" shows all available assignments due in the next 7 days. Messages show when lists are empty with prompts to take appropriate action in the app (i.e. students are reminded to use the grade predictor when no assignments are shows in "My Planner")

## What's Next
Filtering will be made more robust in the next PR to add the ability for students to quickly toggle to view what's due in 2 weeks, 1 month and last week.

Closes #2190 