### PR TITLE
fixes calculation bug when no grades earned

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
@@ -15,7 +15,6 @@
   # multiply points by the student's assignment type weight if weighted
   # points is optional, defaults to total_points for Assignment Type
   weightedPoints = (assignmentType, points)->
-    points = points || assignmentType.total_points
     if assignmentType.student_weightable
       if assignmentType.student_weight > 0
         points = points * assignmentType.student_weight
@@ -27,7 +26,7 @@
     weightedPoints(assignmentType, assignmentType.final_points_for_student)
 
   maxPossiblePoints = (assignmentType)->
-    total = weightedPoints(assignmentType)
+    total = weightedPoints(assignmentType, assignmentType.total_points)
     if assignmentType.is_capped
       total = if total > assignmentType.total_points then assignmentType.total_points else total
     total


### PR DESCRIPTION
This fixes a bug in the predictor graph that would occur if no grades have yet been earned. The issue stemmed from the js `or` assignment when points were zero

##### js:
<img width="103" alt="screen shot 2016-07-08 at 7 02 06 pm" src="https://cloud.githubusercontent.com/assets/1138350/16703785/7bccf420-453e-11e6-8643-7b94e5dea310.png">

##### ruby:
<img width="232" alt="screen shot 2016-07-08 at 7 02 32 pm" src="https://cloud.githubusercontent.com/assets/1138350/16703795/8ee6aea2-453e-11e6-9ae5-67758e0d564a.png">
