### PR TITLE
Fix momentum scroll iphone

### DIFF
--- a/app/assets/stylesheets/_login.sass
+++ b/app/assets/stylesheets/_login.sass
@@ -3,8 +3,6 @@
 
 .login
   padding: 3rem 1rem
-  width: calc(100% - 2.5rem)
-  height: calc(100% - 280px)
 
   .alert-bkg
     margin-left: -1rem
@@ -16,12 +14,13 @@
     padding: .75rem
 
   #login-form, #password-forgot
-    padding: 1rem
+    padding: 2rem 1rem
     border-left: 10px solid $color-white
     border-radius: $global-radius
-    width: 45.5%
-    height: 200px
-    float: left
+    width: 40%
+    display: inline-block
+    vertical-align: top
+    box-sizing: border-box
 
     input.button, input.input
       width: 10rem
@@ -30,6 +29,7 @@
 
   #login-form
     background-color: lighten($color-green-2, 10%)
+    padding-bottom: 4rem
 
   #password-forgot
     margin-left: 1rem
@@ -37,29 +37,25 @@
 
 @media (max-width: $media-medium-max)
   .login
-    padding: 1rem 0
-  #login-form, #password-forgot
-    position: relative
-    width: 100% !important
-    clear: both
-    height: auto !important
-    border-radius: 0 !important
-    padding-top: .5rem
-    padding-bottom: 3rem
-    border-bottom: 1px solid $color-white
-    margin: 0 !important
-    input
-      width: 90%
-      clear: both
-      margin-bottom: .5rem
+    padding: 3rem
 
-    .small, p
-      width: 80%
+    #login-form, #password-forgot
+      width: 100%
+      display: block
+      border-radius: 0 !important
+      margin: 0 auto
+      border: 0
+      input
+        width: 80%
+        margin-bottom: .5rem
+      input.button
+        display: block
 
-  #password-forgot
-    padding: 1rem
-    margin-left: 0
-    border: 0
+    #password-forgot
+      margin: 1rem auto
+
+    #login-form
+      padding: 2rem 1rem
 
 @media (max-width: $media-small-max)
   .login

--- a/app/assets/stylesheets/_signup.sass
+++ b/app/assets/stylesheets/_signup.sass
@@ -40,7 +40,6 @@ section.pilot
 @media (max-width: $media-small-max)
   section.pilot
     padding: .5em 1em
-    margin-top: 45px
 
   .center-items
     display: block

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -397,6 +397,9 @@ ul.subnav.logged-out
 
 .noscroll
   overflow: hidden
+  height: 100%
+  width: 100%
+  position: fixed
 
 .course-info-btn
   text-decoration: none

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -230,7 +230,8 @@ ul.subnav.logged-out
     width: 280px
     height: 100%
     z-index: 100
-    overflow: auto
+    overflow-y: auto
+    -webkit-overflow-scrolling: touch
     left: -280px
 
     ul

--- a/app/presenters/students/dashboard_course_info_presenter.rb
+++ b/app/presenters/students/dashboard_course_info_presenter.rb
@@ -13,7 +13,7 @@ class Students::DashboardCourseInfoPresenter < Showtime::Presenter
 
   def has_info?
     if student
-      has_student_info? && has_course_info?
+      has_student_info? || has_course_info?
     else
       has_course_info?
     end

--- a/app/views/layouts/_top_bar.haml
+++ b/app/views/layouts/_top_bar.haml
@@ -8,25 +8,25 @@
         %span.course= "#{current_course.courseno} "
         %span.course_name= "#{current_course.name} "
         %span.course_semester= "#{current_course.try(:semester)} #{current_course.try(:year)}"
-    - if current_user_is_student?
-      = render partial: "students/student_profile_tabs"
-    - elsif current_user_is_staff?
-      = render partial: "layouts/navigation/staff_subnav"
-    %hr
-    - if presenter.has_info?
-      %a.course-info-btn-mobile
-        %h5 Course Info
-        = glyph("chevron-down")
-      %ul.course-info
-        = render partial: "layouts/navigation/class_info"
+      - if current_user_is_student?
+        = render partial: "students/student_profile_tabs"
+      - elsif current_user_is_staff?
+        = render partial: "layouts/navigation/staff_subnav"
       %hr
-    %h5 My Courses
-    %ul.course-list
-      = render partial: "layouts/navigation/course_list"
-    %hr
-    %ul.account-info
-      = render partial: "layouts/navigation/account_info"
-    %hr
+      - if presenter.has_info?
+        %a.course-info-btn-mobile
+          %h5 Course Info
+          = glyph("chevron-down")
+        %ul.course-info
+          = render partial: "layouts/navigation/class_info"
+        %hr
+      %h5 My Courses
+      %ul.course-list
+        = render partial: "layouts/navigation/course_list"
+      %hr
+      %ul.account-info
+        = render partial: "layouts/navigation/account_info"
+      %hr
 
   .layout-right-content
     %header

--- a/app/views/layouts/_top_bar.haml
+++ b/app/views/layouts/_top_bar.haml
@@ -10,15 +10,16 @@
         %span.course_semester= "#{current_course.try(:semester)} #{current_course.try(:year)}"
     - if current_user_is_student?
       = render partial: "students/student_profile_tabs"
-      %hr
     - elsif current_user_is_staff?
       = render partial: "layouts/navigation/staff_subnav"
-    %a.course-info-btn-mobile
-      %h5 Course Info
-      = glyph("chevron-down")
-    %ul.course-info
-      = render partial: "layouts/navigation/class_info"
     %hr
+    - if presenter.has_info?
+      %a.course-info-btn-mobile
+        %h5 Course Info
+        = glyph("chevron-down")
+      %ul.course-info
+        = render partial: "layouts/navigation/class_info"
+      %hr
     %h5 My Courses
     %ul.course-list
       = render partial: "layouts/navigation/course_list"


### PR DESCRIPTION
This PR adds the ability for iPhones to utilize momentum scroll when scrolling through the mobile menu inside the application. Also fixed in the PR is an issue where login form page was breaking sticky footer structure and fixes the course info `has_info?` method for students by changing the and statement to an or statement. I also added the logic to hide the course info if none exists to the mobile menu.