### PR TITLE
Removed three unused methods from the User model

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -677,21 +677,6 @@ describe User do
     end
   end
 
-  describe "#weight_count(course)" do
-    let(:student) { create :user }
-
-    before do
-      create(:course_membership, user: student, course: course)
-      create(:assignment_type_weight, student: student, course: course)
-      create(:assignment_type_weight, student: student, course: course)
-      create(:assignment_type_weight, student: student, course: course)
-    end
-
-    it "should return the summed weight count for a course, for a student" do
-      expect(student.weight_count(course)).to eq(3)
-    end
-  end
-
   describe "#group_for_assignment(assignment)" do
     let!(:create_group) { world.create_group }
     let(:group) { world.group }


### PR DESCRIPTION
This PR removes three unused methods from the `User` model - two related to auditing students, and one for weights. 