### PR TITLE
passthrough for totaling methods on Graph directive

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/graph.js.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.js.coffee
@@ -12,6 +12,15 @@
 
     link: (scope, el, attr)->
 
+      scope.allPointsEarned = ()->
+        PredictorService.allPointsEarned()
+
+      scope.allPointsPredicted = ()->
+        PredictorService.allPointsPredicted()
+
+      scope.predictedGradeLevel = ()->
+        PredictorService.predictedGradeLevel()
+
       # Dertermine the bounds and the scale for postioning the graph elements
       scope.GraphsStats = ()->
         # add 10% to the graph above the highest grade


### PR DESCRIPTION
This is a quick bug-fix for the Predictor graph. These pass-through methods allow the total points calculations and Grade level to be available in the haml templates and not just within d3.