### PR TITLE
2239 remove default weight

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -23,7 +23,7 @@
     PredictorService.termFor(article)
 
   $scope.unusedWeightsRange = ()->
-   PredictorService.unusedWeightsRange()
+    PredictorService.unusedWeightsRange()
 
   $scope.weightsAvailable = ()->
     PredictorService.weightsAvailable()

--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -22,6 +22,8 @@
   $scope.termFor = (article)->
     PredictorService.termFor(article)
 
+  $scope.weights = PredictorService.weights
+
   $scope.unusedWeightsRange = ()->
     PredictorService.unusedWeightsRange()
 

--- a/app/assets/javascripts/angular/directives/WeightsDirectives.js.coffee
+++ b/app/assets/javascripts/angular/directives/WeightsDirectives.js.coffee
@@ -37,8 +37,6 @@
         @article.student_weight > 0
       scope.weightsOpen = ()->
         AssignmentTypeService.weights.open
-      scope.defaultMultiplier = ()->
-        AssignmentTypeService.weights.default_weight
   }
 ]
 

--- a/app/assets/javascripts/angular/directives/weights/weighted_earned_points.js.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weighted_earned_points.js.coffee
@@ -1,0 +1,17 @@
+# .weighted-earned_points
+
+# Manages the sum of a student's earned points for an assignment type, and
+# weights it with the current weight for that assignment type
+@gradecraft.directive 'weightedEarnedPoints', [ 'AssignmentTypeService', (AssignmentTypeService)->
+
+  return {
+    restrict: 'C'
+    scope: {
+      article: '='
+    }
+    templateUrl: 'weights/weighted_earned_points.html'
+    link: (scope, el, attr)->
+      scope.weightedEarnedPoints = ()->
+        AssignmentTypeService.weightedEarnedPoints(@article)
+  }
+]

--- a/app/assets/javascripts/angular/directives/weights/weighted_total_points.js.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weighted_total_points.js.coffee
@@ -1,0 +1,17 @@
+# .weighted-total-points
+
+# manages the sum of possible points for an assignment type, and weights it
+# with the current weight for that assignment type
+@gradecraft.directive 'weightedTotalPoints', [ 'AssignmentTypeService', (AssignmentTypeService)->
+
+  return {
+    restrict: 'C'
+    scope: {
+      article: '='
+    }
+    templateUrl: 'weights/weighted_total_points.html'
+    link: (scope, el, attr)->
+      scope.weightedTotalPoints = ()->
+        AssignmentTypeService.weightedTotalPoints(@article)
+  }
+]

--- a/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
@@ -28,6 +28,9 @@
         _.range(AssignmentTypeService.weights.unusedWeights())
       scope.usedWeights = ()->
         _.range(@article.student_weight)
+      # coin iterator for coins stacked behind the top coin
+      scope.coinBackStack = ()->
+        _.range(@article.student_weight - 1)
       scope.weightsAvailable = ()->
         if @article.student_weight < 1
           return false if AssignmentTypeService.weights.unusedTypes() < 1

--- a/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
@@ -1,12 +1,6 @@
 # .weights-coin-widget
 
 # Manages the coin interface for adding and removing weights from Assignment Types
-#
-# TODO: This directive was moved out of the Predictor Directives but the logic
-# has not been refactored. It would probably be good to move the methods and
-# model management from this directive into the AssignmentTypeService.
-# Let's wait until the default_weight has been removed from GC and then clean
-# this up during it's removal.
 @gradecraft.directive 'weightsCoinWidget', [ 'AssignmentTypeService', (AssignmentTypeService)->
 
   return {
@@ -18,29 +12,29 @@
     link: (scope, el, attr)->
       scope.termFor = (term)->
         AssignmentTypeService.termFor(term)
+
       scope.increment = ()->
         @article.student_weight += 1
         AssignmentTypeService.postAssignmentTypeWeight(@article.id,@article.student_weight)
       scope.decrement = ()->
         @article.student_weight -= 1
         AssignmentTypeService.postAssignmentTypeWeight(@article.id,@article.student_weight)
-      scope.unusedWeights = ()->
-        _.range(AssignmentTypeService.weights.unusedWeights())
-      scope.usedWeights = ()->
-        _.range(@article.student_weight)
+
+      scope.unusedWeightsRange = ()->
+        AssignmentTypeService.weights.unusedWeightsRange()
+
       # coin iterator for coins stacked behind the top coin
-      scope.coinBackStack = ()->
+      scope.coinBackStackRange = ()->
         _.range(@article.student_weight - 1)
-      scope.weightsAvailable = ()->
-        if @article.student_weight < 1
-          return false if AssignmentTypeService.weights.unusedTypes() < 1
-        if AssignmentTypeService.weights.max_weights_per_assignment_type
-          @article.student_weight < AssignmentTypeService.weights.max_weights_per_assignment_type && AssignmentTypeService.weights.unusedWeights() > 0
-        else
-          AssignmentTypeService.weights.unusedWeights() > 0
-      scope.hasWeights = ()->
-        @article.student_weight > 0
+
       scope.weightsOpen = ()->
         AssignmentTypeService.weights.open
+      scope.weightsAvailableForArticle = ()->
+        AssignmentTypeService.weightsAvailableForArticle(@article)
+
+      scope.hasWeights = ()->
+        @article.student_weight > 0
+
+
   }
 ]

--- a/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights_coin_widget.js.coffee
@@ -16,6 +16,8 @@
     }
     templateUrl: 'weights/coins.html'
     link: (scope, el, attr)->
+      scope.termFor = (term)->
+        AssignmentTypeService.termFor(term)
       scope.increment = ()->
         @article.student_weight += 1
         AssignmentTypeService.postAssignmentTypeWeight(@article.id,@article.student_weight)
@@ -37,37 +39,5 @@
         @article.student_weight > 0
       scope.weightsOpen = ()->
         AssignmentTypeService.weights.open
-  }
-]
-
-# manages the sum of possible points for an assignment type, and weights it
-# with the current weight for that assignment type
-@gradecraft.directive 'weightedTotalPoints', [ 'AssignmentTypeService', (AssignmentTypeService)->
-
-  return {
-    restrict: 'C'
-    scope: {
-      article: '='
-    }
-    templateUrl: 'weights/weighted_total_points.html'
-    link: (scope, el, attr)->
-      scope.weightedTotalPoints = ()->
-        AssignmentTypeService.weightedTotalPoints(@article)
-  }
-]
-
-# Manages the sum of a student's earned points for an assignment type, and
-# weights it with the current weight for that assignment type
-@gradecraft.directive 'weightedEarnedPoints', [ 'AssignmentTypeService', (AssignmentTypeService)->
-
-  return {
-    restrict: 'C'
-    scope: {
-      article: '='
-    }
-    templateUrl: 'weights/weighted_earned_points.html'
-    link: (scope, el, attr)->
-      scope.weightedEarnedPoints = ()->
-        AssignmentTypeService.weightedEarnedPoints(@article)
   }
 ]

--- a/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
@@ -8,7 +8,6 @@
   assignmentTypes = []
 
   weights = {
-    default_weight: 1,
     unusedWeights: ()->
       return 0
   }
@@ -22,7 +21,7 @@
       if assignmentType.student_weight > 0
         points = points * assignmentType.student_weight
       else
-        points = points * weights.default_weight
+        points
     points
 
   weightedEarnedPoints = (assignmentType)->
@@ -59,7 +58,6 @@
       weights.weights_close_at = res.meta.weights_close_at
       weights.max_weights_per_assignment_type = res.meta.max_weights_per_assignment_type
       weights.max_assignment_types_weighted = res.meta.max_assignment_types_weighted
-      weights.default_weight = res.meta.default_weight
 
       weights.unusedWeights = ()->
         used = 0

--- a/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
@@ -44,6 +44,15 @@
   weightsAvailable = ()->
     weights.unusedWeights() && weights.open
 
+  weightsAvailableForArticle = (article)->
+    if article.student_weight < 1
+      return false if weights.unusedTypes() < 1
+    if weights.max_weights_per_assignment_type
+      article.student_weight < weights.max_weights_per_assignment_type && weights.unusedWeights() > 0
+    else
+      weights.unusedWeights() > 0
+
+
   #----------------- API Calls ------------------------------------------------#
 
   getAssignmentTypes = (studentId)->
@@ -98,6 +107,7 @@
 
       unusedWeightsRange: unusedWeightsRange
       weightsAvailable: weightsAvailable
+      weightsAvailableForArticle: weightsAvailableForArticle
 
       getAssignmentTypes: getAssignmentTypes
       postAssignmentTypeWeight: postAssignmentTypeWeight

--- a/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
@@ -12,17 +12,19 @@
       return 0
   }
 
+  termFor = (article)->
+    GradeCraftAPI.termFor(article)
+
+
   #---------------- Assignment Type Point Calculations ------------------------#
 
   # multiply points by the student's assignment type weight if weighted
   # points is optional, defaults to total_points for Assignment Type
   weightedPoints = (assignmentType, points)->
     if assignmentType.student_weightable
-      if assignmentType.student_weight > 0
-        points = points * assignmentType.student_weight
-      else
-        points
-    points
+      points * assignmentType.student_weight
+    else
+      points
 
   weightedEarnedPoints = (assignmentType)->
     weightedPoints(assignmentType, assignmentType.final_points_for_student)
@@ -86,6 +88,7 @@
         )
 
   return {
+      termFor: termFor
       assignmentTypes: assignmentTypes
       weights: weights
 

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -55,7 +55,7 @@
   assignmentTypePointTotal = (assignmentType, includeWeights, includeCaps, includePredicted)->
     if includePredicted
       subset = assignmentsForAssignmentType(assignments,assignmentType.id)
-      total = assignmentsSubsetPredictedPoints(subset)
+      total = AssignmentService.assignmentsSubsetPredictedPoints(subset)
     else
       # Use weighted calculation sent from API
       total = weightedEarnedPoints(assignmentType)
@@ -64,6 +64,13 @@
       total = weightedPoints(assignmentType, total)
     if assignmentType.is_capped and includeCaps
       total = if total > assignmentType.total_points then assignmentType.total_points else total
+    total
+
+  assignmentsWeightedPredictedPoints = ()->
+    total = 0
+    _.each(assignmentTypes, (assignmentType)->
+      total += assignmentTypePointTotal(assignmentType, true, false, true)
+    )
     total
 
   # Total predicted points above and beyond the assignment type max points
@@ -85,12 +92,6 @@
 
   getAssignments= (studentId)->
     AssignmentService.getAssignments(studentId)
-
-  assignmentsSubsetPredictedPoints = (assignments)->
-   AssignmentService.assignmentsSubsetPredictedPoints(assignments)
-
-  assignmentsPredictedPoints = ()->
-   AssignmentService.assignmentsPredictedPoints()
 
   #------ BADGES --------------------------------------------------------------#
 
@@ -137,7 +138,7 @@
 
   # Total points predicted for all assignments, badges, and challenges
   allPointsPredicted = ()->
-    total = assignmentsPredictedPoints()
+    total = assignmentsWeightedPredictedPoints()
     total += badgesPredictedPoints()
     total += challengesPredictedPoints()
     total
@@ -208,8 +209,6 @@
 
       assignments: assignments
       getAssignments: getAssignments
-      assignmentsSubsetPredictedPoints: assignmentsSubsetPredictedPoints
-      assignmentsPredictedPoints: assignmentsPredictedPoints
 
       badges: badges
       getBadges: getBadges

--- a/app/assets/javascripts/angular/templates/predictor/main.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/main.html.haml
@@ -23,7 +23,9 @@
             .predictor-title-right-span
               Unused {{termFor("weights")}} :
             .predictor-section-title-weights
-              .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
+              .coin-stack
+                .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
+                .coin-stack-count {{unusedWeightsRange().length}}
 
     .predictor-section-assignment-types
 

--- a/app/assets/javascripts/angular/templates/predictor/main.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/main.html.haml
@@ -21,7 +21,7 @@
         .predictor-section-title
           .predictor-section-title-predicted-points{'ng-if'=>'weightsAvailable()'}
             .predictor-title-right-span
-              Unused {{termFor(weights)}} :
+              Unused {{termFor("weights")}} :
             .predictor-section-title-weights
               .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
 

--- a/app/assets/javascripts/angular/templates/weights/coins.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/coins.html.haml
@@ -1,5 +1,3 @@
-.predictor-default-weight.predictor-title-right-span.padded{'ng-if' => '! hasWeights()'} {{defaultMultiplier()}}
-
 .coins{{'ng-if'=>'weightsOpen()'}}
   .coin{{'ng-click'=>'decrement()', 'ng-repeat' => 'coin in usedWeights()'}}
     %i.coin-remove-icon.fa.fa-fw.fa-times-circle

--- a/app/assets/javascripts/angular/templates/weights/coins.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/coins.html.haml
@@ -1,8 +1,13 @@
 .coins{{'ng-if'=>'weightsOpen()'}}
-  .coin{{'ng-click'=>'decrement()', 'ng-repeat' => 'coin in usedWeights()'}}
-    %i.coin-remove-icon.fa.fa-fw.fa-times-circle
   .coin-slot{{'ng-click'=>'increment()', 'ng-if' => 'weightsAvailable()'}}
     %i.coin-add-icon.fa.fa-fw.fa-plus-circle
+
+  .coin-stack{{'ng-if' => 'article.student_weight'}}
+    .coin{{'ng-repeat'=>'coin in coinBackStack()'}}
+    .coin{{'ng-click'=>'decrement()'}}
+      .coin-stack-count {{article.student_weight}}
+      %i.coin-remove-icon.fa.fa-fw.fa-times-circle
+
   .no-coins-slot{{'ng-if' => 'usedWeights() == 0 && !weightsAvailable()'}} no {{termFor("weights")}}
 
 .coins{{'ng-if'=>'!weightsOpen()'}}

--- a/app/assets/javascripts/angular/templates/weights/coins.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/coins.html.haml
@@ -3,6 +3,7 @@
     %i.coin-remove-icon.fa.fa-fw.fa-times-circle
   .coin-slot{{'ng-click'=>'increment()', 'ng-if' => 'weightsAvailable()'}}
     %i.coin-add-icon.fa.fa-fw.fa-plus-circle
+  .no-coins-slot{{'ng-if' => 'usedWeights() == 0 && !weightsAvailable()'}} no {{termFor("weights")}}
 
 .coins{{'ng-if'=>'!weightsOpen()'}}
   .coin-non-interactive{{'ng-repeat' => 'coin in usedWeights()'}}

--- a/app/assets/javascripts/angular/templates/weights/coins.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/coins.html.haml
@@ -1,15 +1,16 @@
 .coins{{'ng-if'=>'weightsOpen()'}}
-  .coin-slot{{'ng-click'=>'increment()', 'ng-if' => 'weightsAvailable()'}}
+  .coin-slot{{'ng-click'=>'increment()', 'ng-if' => 'weightsAvailableForArticle()'}}
     %i.coin-add-icon.fa.fa-fw.fa-plus-circle
 
   .coin-stack{{'ng-if' => 'article.student_weight'}}
-    .coin{{'ng-repeat'=>'coin in coinBackStack()'}}
+    .coin{{'ng-repeat'=>'coin in coinBackStackRange()'}}
     .coin{{'ng-click'=>'decrement()'}}
       .coin-stack-count {{article.student_weight}}
       %i.coin-remove-icon.fa.fa-fw.fa-times-circle
 
-  .no-coins-slot{{'ng-if' => 'usedWeights() == 0 && !weightsAvailable()'}} no {{termFor("weights")}}
+  .no-coins-slot{{'ng-if' => '! hasWeights() && !weightsAvailableForArticle()'}} no {{termFor("weights")}}
 
 .coins{{'ng-if'=>'!weightsOpen()'}}
-  .coin-non-interactive{{'ng-repeat' => 'coin in usedWeights()'}}
+  .coin-stack
+    .coin-non-interactive{{'ng-repeat' => 'coin in usedWeightsRange()'}}
 

--- a/app/assets/javascripts/angular/templates/weights/main.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/main.html.haml
@@ -4,7 +4,10 @@
       .predictor-title-right-span
         Unused {{termFor("weights")}} :
       .predictor-section-title-weights
-        .coin{{'ng-repeat' => 'coin in unusedWeightsRange()'}}
+        .coin-stack
+          .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
+          .coin-stack-count {{unusedWeightsRange().length}}
+
 
 
 %div{'ng-repeat' => 'assignmentType in assignmentTypes'}

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -132,8 +132,6 @@ $card-margin-1 : 3px 0 5px 0
 
 #predictor-main-header
   background-color: $color-blue-1
-  .coin
-    margin-top: 2px
 .predictor-section
   background-color: $color-blue-2
   .coin
@@ -219,11 +217,25 @@ $card-margin-1 : 3px 0 5px 0
   .coins
     float: left
     padding: 0 10px 0 10px
-  .coin, .coin-non-interactive, .coin-slot
+  .coin-stack
     float: left
+    margin-left: 20px
+    position: relative
+    .coin-stack-count
+      position: absolute
+      color: $color-orange-1
+      left: -16px
+      top: -1px
+    &:hover .coin-stack-count
+      visibility: hidden
+  .coin, .coin-non-interactive, .coin-slot
+    float: right
     width: 25px
     height: 25px
     @include rounded-corners(14px)
+  .coin
+      margin: 2px 0 0 -23px
+  .coin-non-interactive, .coin-slot
     margin: 2px 0 0 2px
   .coin, .coin-non-interactive
     background-color: $color-yellow-1
@@ -244,10 +256,11 @@ $card-margin-1 : 3px 0 5px 0
     color: $color-blue-2
     margin: 1px 0 0 -3px
     visibility: hidden
-  .coin-slot:hover .coin-add-icon
-    visibility: visible
   .coin-slot:hover
-    background-color: $color-blue-3
+    border: 2px solid $color-orange-1
+    background-color: $color-yellow-1
+    .coin-add-icon
+      visibility: visible
   .no-coins-slot
     font-size: $predictor-font-size-3
     background-color: $color-blue-3

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -134,8 +134,6 @@ $card-margin-1 : 3px 0 5px 0
   background-color: $color-blue-1
 .predictor-section
   background-color: $color-blue-2
-  .coin
-    margin-top: -1px
 
 .collapse-arrow
   width: 0
@@ -250,7 +248,7 @@ $card-margin-1 : 3px 0 5px 0
     visibility: visible
   .coin-slot
     background-color: $color-blue-2
-    border: 2px solid $color-blue-4
+    border: 2px solid $color-orange-1
     @include transition(all, .5s, ease-out)
   .coin-add-icon
     color: $color-blue-2
@@ -268,6 +266,12 @@ $card-margin-1 : 3px 0 5px 0
     margin: 4px 0 0 10px
     border-radius: 6px
     line-height: normal
+
+#predictor-main-header .predictor-section-title-weights
+  .coin-stack
+    &:hover .coin-stack-count
+      visibility: visible
+
 
 
 // ARTICLES

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -248,6 +248,13 @@ $card-margin-1 : 3px 0 5px 0
     visibility: visible
   .coin-slot:hover
     background-color: $color-blue-3
+  .no-coins-slot
+    font-size: $predictor-font-size-3
+    background-color: $color-blue-3
+    padding: 2px 5px
+    margin: 4px 0 0 10px
+    border-radius: 6px
+    line-height: normal
 
 
 // ARTICLES

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -195,13 +195,6 @@ $card-margin-1 : 3px 0 5px 0
     padding: 0 0 0 10px
   &.left-padded
     padding: 0 10px 0 0
-  &.predictor-default-weight
-    font-size: $predictor-font-size-3
-    background-color: $color-blue-3
-    padding: 2px 5px
-    margin: 4px 0 0 10px
-    border-radius: 6px
-    line-height: normal
 
 .predictor-excess-points
   float: right

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -125,7 +125,7 @@ class Assignment < ActiveRecord::Base
   # Custom point total if the class has weighted assignments
   def full_points_for_student(student)
     return 0 unless full_points
-    (full_points * assignment_type.weight_for_student(student)).round
+    full_points * assignment_type.weight_for_student(student)
   end
 
   # Checking to see if an assignment is due soon

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -26,11 +26,10 @@ class AssignmentType < ActiveRecord::Base
     ModelCopier.new(self).copy(attributes: attributes, associations: [:assignments])
   end
 
-  # weights default to 1 if not weightable, and
-  # 0 if weightable but not weighted by the student
+  # weights default to 0 if weightable but not weighted by the student
   def weight_for_student(student)
     return 1 unless student_weightable?
-    weights.where(student: student).first.try(:weight) || 1
+    weights.where(student: student).first.try(:weight) || 0
   end
 
   def is_capped?
@@ -58,6 +57,7 @@ class AssignmentType < ActiveRecord::Base
     assignments.map{ |a| a.full_points || 0 }.sum
   end
 
+  # total points a student can earn for this assignment type
   def total_points_for_student(student)
     if max_points > 0
       max_points
@@ -71,11 +71,7 @@ class AssignmentType < ActiveRecord::Base
   end
 
   def weighted_total_for_student(student)
-    if weight_for_student(student) >= 1
-      (total_points * weight_for_student(student)).to_i
-    else
-      total_points
-    end
+    total_points * weight_for_student(student)
   end
 
   def visible_score_for_student(student)

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -30,7 +30,7 @@ class AssignmentType < ActiveRecord::Base
   # 0 if weightable but not weighted by the student
   def weight_for_student(student)
     return 1 unless student_weightable?
-    weights.where(student: student).first.try(:weight) || course.default_weight
+    weights.where(student: student).first.try(:weight) || 1
   end
 
   def is_capped?
@@ -74,7 +74,7 @@ class AssignmentType < ActiveRecord::Base
     if weight_for_student(student) >= 1
       (total_points * weight_for_student(student)).to_i
     else
-      (total_points * course.default_weight).to_i
+      total_points
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -56,7 +56,7 @@ class Course < ActiveRecord::Base
     :total_weights, :weights_close_at,
     :assignment_weight_type, :has_submissions, :teams_visible,
     :weight_term, :max_group_size, :min_group_size, :fail_term, :pass_term,
-    :max_weights_per_assignment_type, :assignments, :default_weight,
+    :max_weights_per_assignment_type, :assignments,
     :accepts_submissions, :tagline, :academic_history_visible, :office, :phone,
     :class_email, :twitter_handle, :twitter_hashtag, :location, :office_hours,
     :meeting_times, :assignment_term, :challenge_term, :badge_term, :grading_philosophy,
@@ -100,7 +100,6 @@ class Course < ActiveRecord::Base
   validates_numericality_of :total_weights, allow_blank: true
   validates_numericality_of :max_weights_per_assignment_type, allow_blank: true
   validates_numericality_of :max_assignment_types_weighted, allow_blank: true
-  validates_numericality_of :default_weight, allow_blank: true
   validates_numericality_of :full_points, allow_blank: true
 
   validates_format_of :twitter_hashtag, with: /\A[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)*\z/, allow_blank: true, length: { within: 3..20 }

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -151,7 +151,7 @@ class Grade < ActiveRecord::Base
   def calculate_score
     return nil unless raw_points.present?
     weighting = assignment_type.student_weightable? ? assignment_weight : 1
-    (final_points * weighting).round
+    final_points * weighting
   end
 
   # Calculate all stored points fields before save

--- a/app/views/api/assignment_types/index.json.jbuilder
+++ b/app/views/api/assignment_types/index.json.jbuilder
@@ -21,5 +21,4 @@ json.meta do
   json.weights_close_at current_course.try(:weights_close_at)
   json.max_weights_per_assignment_type current_course.max_weights_per_assignment_type
   json.max_assignment_types_weighted current_course.max_assignment_types_weighted
-  json.default_weight current_course.default_weight
 end

--- a/app/views/assignment_type_weights/index.html.haml
+++ b/app/views/assignment_type_weights/index.html.haml
@@ -16,9 +16,6 @@
           %li You may place up to #{current_course.max_weights_per_assignment_type} #{ ( term_for :weights).titleize } on a single #{ (term_for :assignment_type).downcase}
         - if current_course.max_assignment_types_weighted?
           %li You may work on up to #{ current_course.max_assignment_types_weighted} #{ (term_for :assignment_types).downcase}
-        - if current_course.default_weight
-          %li Any #{(term_for :assignment_types).downcase} you do not place #{ ( term_for :weights).titleize } on but have grades for will be multiplied by #{current_course.default_weight}. For example, this would adjust a 1000 point Essay to be worth #{ (1000 * current_course.default_weight).to_i } points.
-
 
     #weights-widget{"ng-app" => "gradecraft", "ng-init" => "init(#{params[:student_id]})", "ng-controller" => "WeightsCtrl", "ng-include" => true,  "src" => "'weights/main.html'"}
 

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -194,11 +194,6 @@
       .form_label{id: "txtMaxWeighted"} Is there a maximum number of assignment types they can weight?
 
     .form-item
-      = f.label :default_weight, "Default Weight"
-      = f.text_field :default_weight, {"aria-describedby" => "txtDefaultWeight"}
-      .form_label{id: "txtDefaultWeight"} What amount should the assignment types that the student doesn't select to boost be multiplied by?
-
-    .form-item
       = f.label :weight_term
       = f.text_field :weight_term, {"aria-describedby" => "txtWeightTerm"}
       .form_label{id: "txtWeightTerm"} What do you want to call these weights/multipliers?

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -141,6 +141,3 @@
     %p
       %b Multiplier/weight term:
       = @course.weight_term
-    %p
-      %b What amount should other (unselected) assignment types be multiplied by?
-      = @course.default_weight

--- a/app/views/grades/components/_score.haml
+++ b/app/views/grades/components/_score.haml
@@ -2,7 +2,7 @@
 - if GradeProctor.new(grade).viewable? && grade.final_points
   - if assignment_type.student_weightable?
     -# Checking to see if this student has weighted this assignment anything other than 1
-    - if (grade.student.weight_for_assignment_type(assignment_type) == 0 && current_course.default_weight != 1) || grade.student.weight_for_assignment_type(assignment_type) > 1
+    - grade.student.weight_for_assignment_type(assignment_type) > 1
       = "#{points grade.final_points} / #{ points assignment.full_points } points (Raw)"
       .bold= "#{ points grade.score } / #{points grade.full_points} points (Multiplied)"
     - else

--- a/app/views/grades/components/_score.haml
+++ b/app/views/grades/components/_score.haml
@@ -1,16 +1,10 @@
 -# Requires: grade, assignment, assignment_type
 - if GradeProctor.new(grade).viewable? && grade.final_points
   - if assignment_type.student_weightable?
-    -# Checking to see if this student has weighted this assignment anything other than 1
-    - grade.student.weight_for_assignment_type(assignment_type) > 1
-      = "#{points grade.final_points} / #{ points assignment.full_points } points (Raw)"
-      .bold= "#{ points grade.score } / #{points grade.full_points} points (Multiplied)"
-    - else
-      .bold= "#{points grade.final_points} / #{ points grade.full_points } points"
+    = "#{points grade.final_points} / #{ points assignment.full_points } points (Raw)"
+    .bold= "#{ points grade.score } / #{points grade.full_points} points (Multiplied)"
   - else
     .bold
       = "#{points grade.final_points} / #{points grade.full_points} points earned"
 - else
   .italic= "#{points assignment.full_points} points possible"
-
-

--- a/app/views/students/dashboard/_dashboard_assignment_weights.haml
+++ b/app/views/students/dashboard/_dashboard_assignment_weights.haml
@@ -22,5 +22,3 @@
         %li You may work on up to #{ current_course.max_assignment_types_weighted} #{ (term_for :assignment_types).downcase}
       - if current_course.weights_close_at.present?
         %li You must make your decision by <b>#{current_course.weights_close_at}</b>
-      - if current_course.default_weight.present?
-        %li Any #{(term_for :assignment_types).downcase} you do not place #{ ( term_for :weights).titleize } on but have grades for will be multiplied by #{current_course.default_weight}.

--- a/db/samples/courses.rb
+++ b/db/samples/courses.rb
@@ -215,7 +215,6 @@ education there is. ― Isaac Asimov",
     weight_attributes: {
       max_assignment_types_weighted: 2,
       max_weights_per_assignment_type: 4,
-      default_weight: 0.5,
     }
   }
 }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715152003) do
+ActiveRecord::Schema.define(version: 20160726143628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -232,14 +232,14 @@ ActiveRecord::Schema.define(version: 20160715152003) do
     t.string   "courseno",                        limit: 255
     t.string   "year",                            limit: 255
     t.string   "semester",                        limit: 255
-    t.datetime "created_at",                                                                                                 null: false
-    t.datetime "updated_at",                                                                                                 null: false
-    t.boolean  "badge_setting",                                                       default: true
-    t.boolean  "team_setting",                                                        default: false
+    t.datetime "created_at",                                                                         null: false
+    t.datetime "updated_at",                                                                         null: false
+    t.boolean  "badge_setting",                               default: true
+    t.boolean  "team_setting",                                default: false
     t.string   "user_term",                       limit: 255
     t.string   "team_term",                       limit: 255
     t.string   "homepage_message",                limit: 255
-    t.boolean  "status",                                                              default: true
+    t.boolean  "status",                                      default: true
     t.boolean  "group_setting"
     t.datetime "weights_close_at"
     t.boolean  "team_roles"
@@ -251,7 +251,6 @@ ActiveRecord::Schema.define(version: 20160715152003) do
     t.boolean  "predictor_setting"
     t.integer  "max_group_size"
     t.integer  "min_group_size"
-    t.decimal  "default_weight",                              precision: 4, scale: 1, default: 1.0
     t.string   "tagline",                         limit: 255
     t.boolean  "academic_history_visible"
     t.string   "office",                          limit: 255
@@ -278,7 +277,7 @@ ActiveRecord::Schema.define(version: 20160715152003) do
     t.integer  "max_assignment_types_weighted"
     t.integer  "full_points"
     t.boolean  "in_team_leaderboard"
-    t.boolean  "add_team_score_to_student",                                           default: false
+    t.boolean  "add_team_score_to_student",                   default: false
     t.datetime "start_date"
     t.datetime "end_date"
     t.string   "pass_term",                       limit: 255
@@ -286,7 +285,7 @@ ActiveRecord::Schema.define(version: 20160715152003) do
     t.string   "syllabus"
     t.boolean  "hide_analytics"
     t.string   "character_names"
-    t.string   "time_zone",                                                           default: "Eastern Time (US & Canada)"
+    t.string   "time_zone",                                   default: "Eastern Time (US & Canada)"
   end
 
   add_index "courses", ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree

--- a/spec/factories/course_factory.rb
+++ b/spec/factories/course_factory.rb
@@ -14,7 +14,6 @@ FactoryGirl.define do
       total_weights 6
       max_weights_per_assignment_type 4
       max_assignment_types_weighted 2
-      default_weight 3
     end
 
     factory :invalid_course do

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -133,7 +133,6 @@ describe AssignmentType do
     end
 
     it "returns the weighted total if the student has *not* assigned weight to it (point total * default weight)" do
-      world.course.default_weight = 0.5
       assignment_type.student_weightable = true
       assignment = create(:assignment, assignment_type: assignment_type, course: world.course, full_points: 100)
 

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -132,11 +132,11 @@ describe AssignmentType do
       expect(assignment_type.weighted_total_for_student(student)).to eq(300)
     end
 
-    it "returns the weighted total if the student has *not* assigned weight to it (point total * default weight)" do
+    it "returns zero for total if the student has *not* assigned weight to it" do
       assignment_type.student_weightable = true
       assignment = create(:assignment, assignment_type: assignment_type, course: world.course, full_points: 100)
 
-      expect(assignment_type.weighted_total_for_student(student)).to eq(50)
+      expect(assignment_type.weighted_total_for_student(student)).to eq(0)
     end
   end
 

--- a/spec/views/api/assignment_types/index_spec.rb
+++ b/spec/views/api/assignment_types/index_spec.rb
@@ -11,7 +11,6 @@ describe "api/assignment_types/index" do
       weights_close_at: Time.now,
       max_weights_per_assignment_type: 4,
       max_assignment_types_weighted: 2,
-      default_weight: 0.5
     )
     assignment_type = create(:assignment_type, course: @course, student_weightable: true, max_points: 1234)
     @assignment_types = [assignment_type]
@@ -51,6 +50,5 @@ describe "api/assignment_types/index" do
     expect(@course.weights_close_at.to_json).to include(@json["meta"]["weights_close_at"])
     expect(@json["meta"]["max_weights_per_assignment_type"]).to eq(@course.max_weights_per_assignment_type)
     expect(@json["meta"]["max_assignment_types_weighted"]).to eq(@course.max_assignment_types_weighted)
-    expect(@json["meta"]["default_weight"]).to eq(@course.default_weight)
   end
 end


### PR DESCRIPTION
This PR removes the `default_weight` calculations from a course (but leaves the field on the model for historical purposes). When an AssignmentType accepts weights, but a student has not placed any weights on it, all Grades for it's assignments have a zero score.

The UX remains for the most part the same. When weights are available, any AssignmentType that they can be added to indicates acceptance with a blue circle:

<img width="334" alt="screen shot 2016-07-27 at 2 27 05 pm" src="https://cloud.githubusercontent.com/assets/1138350/17187947/380ac742-5409-11e6-8604-5ea77e2ac313.png">

To explain the calculation when no more weights are available, or `max_assignment_types_weighted` has been reached, a "no weights" indicator will show up in the summation.

On the Predictor:

<img width="321" alt="screen shot 2016-07-27 at 2 27 23 pm" src="https://cloud.githubusercontent.com/assets/1138350/17187975/5667346e-5409-11e6-8c71-114e8c443b08.png">

On the weights page,

<img width="234" alt="screen shot 2016-07-27 at 2 27 51 pm" src="https://cloud.githubusercontent.com/assets/1138350/17188164/f25d65f0-5409-11e6-8a6c-939184bf55b2.png">

The recalculation of score on the grades looks good to me, but I would like it if someone else could test and confirm this, and that it displays correctly on all pages where grades are displayed in list form, since I don't know these pages well.

I'm also not sure if the display of zero'd out grades on the grades show pages is clear or not:

<img width="220" alt="screen shot 2016-07-27 at 2 57 27 pm" src="https://cloud.githubusercontent.com/assets/1138350/17188323/8602064e-540a-11e6-87f3-a0c0862dd8b1.png">

 