### PR TITLE
additional methods for null objects for challenges

### DIFF
--- a/app/models/null_grade.rb
+++ b/app/models/null_grade.rb
@@ -79,6 +79,14 @@ class NullGrade
   def student
     NullStudent.new
   end
+
+  def team
+    NullTeam.new
+  end
+
+  def challenge
+    NullAssignment.new
+  end
 end
 
 class NullAssignment

--- a/app/models/null_student.rb
+++ b/app/models/null_student.rb
@@ -41,6 +41,22 @@ class NullStudentGrades
     self
   end
 
+  def student_visible(*)
+    self
+  end
+
+  def not_nil(*)
+    self
+  end
+
+  def included_in_course_score(*)
+    self
+  end
+
+  def pluck(*)
+    []
+  end
+
   def first
     NullGrade.new
   end
@@ -53,6 +69,14 @@ class NullTeam
 
   def challenge_grades
     NullStudentGrades.new
+  end
+
+  def course
+    NullCourse.new
+  end
+
+  def course_id
+    0
   end
 end
 


### PR DESCRIPTION
Viewing the Generic Predictor for courses with Challenges currently fails in the following methods :

`AssignmentType#grades_for for challenges`
`AssignmentType#final_points_for_student`
`ChallengeGradeProctor#viewable?`

To replicate or verify changes:

  * Login as a professor
  * verify api calls:
    * `/api/predicted_earned_challenges`
    * `/api/assignment_types`
  * verify predictor:
    * localhost:5000/predictor
