### PR TITLE
better clickable sections in predictor

### DIFF
--- a/app/assets/javascripts/angular/directives/CollapsableSections.js.coffee
+++ b/app/assets/javascripts/angular/directives/CollapsableSections.js.coffee
@@ -8,7 +8,7 @@
   restrict : 'C',
   link: (scope, elm, attrs) ->
     elm.bind('click', (event)->
-      if angular.element(event.target).hasClass('collapse-arrow')
+      unless angular.element(event.target).is('.coins, .coin-slot, .coin-stack, .coin-remove-icon, .coin-add-icon')
         elm.siblings().toggleClass('collapsed')
         elm.toggleClass('collapsed')
     )

--- a/app/assets/javascripts/angular/templates/predictor/assignment_types.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/assignment_types.html.haml
@@ -1,29 +1,28 @@
 %div{'ng-repeat' => 'assignmentType in assignmentTypes'}
-  %section.predictor-section{'ng-if'=>'assignmentTypeHasAssignments(assignmentType)', 'ng-class'=>'{"with-weights": assignmentType.student_weightable}'}
-    .collapse-toggler
-      .collapse-arrow
-      .predictor-section-title{'ng-class'=>'{"status-max-points": assignmentTypeAtMaxPoints(assignmentType)}'}
-        .predictor-section-title-name
-          {{assignmentType.name}}
-        .weighted-max-possible-points{{'article'=>'assignmentType'}}
-        .predictor-section-title-predicted-points{{'ng-class'=>'{"weightable":assignmentType.student_weightable}'}}
-          .predictor-unweighted-point-total
-            {{assignmentTypePointTotal(assignmentType,false,true,true) | number}}
+  %section.predictor-section.collapse-toggler{'ng-if'=>'assignmentTypeHasAssignments(assignmentType)', 'ng-class'=>'{"with-weights": assignmentType.student_weightable}'}
+    .collapse-arrow
+    .predictor-section-title{'ng-class'=>'{"status-max-points": assignmentTypeAtMaxPoints(assignmentType)}'}
+      .predictor-section-title-name
+        {{assignmentType.name}}
+      .weighted-max-possible-points{{'article'=>'assignmentType'}}
+      .predictor-section-title-predicted-points{{'ng-class'=>'{"weightable":assignmentType.student_weightable}'}}
+        .predictor-unweighted-point-total
+          {{assignmentTypePointTotal(assignmentType,false,true,true) | number}}
 
-          .predictor-section-title-weights{{'ng-if'=>'assignmentType.student_weightable'}}
-            .predictor-title-right-span x
-            .weights-coin-widget{{'article'=>'assignmentType'}}
-            .predictor-title-right-span.left-padded =
-            .predictor-weighted-point-total
-              {{assignmentTypePointTotal(assignmentType,true,true,true) | number}}
+        .predictor-section-title-weights{{'ng-if'=>'assignmentType.student_weightable'}}
+          .predictor-title-right-span x
+          .weights-coin-widget{{'article'=>'assignmentType'}}
+          .predictor-title-right-span.left-padded =
+          .predictor-weighted-point-total
+            {{assignmentTypePointTotal(assignmentType,true,true,true) | number}}
 
-          .predictor-excess-points{'ng-if'=>'assignmentTypeAtMaxPoints(assignmentType)'}
-            .assignment-type-tooltip.icon
-              %a
-                %i.fa.fa-fw.fa-exclamation-circle
-              .display_on_hover.hover-style
-                You've predicted {{assignmentTypePointExcess(assignmentType) | number}} more points than you are allowed to earn for this {{termFor("assignmentType")}}!
+        .predictor-excess-points{'ng-if'=>'assignmentTypeAtMaxPoints(assignmentType)'}
+          .assignment-type-tooltip.icon
+            %a
+              %i.fa.fa-fw.fa-exclamation-circle
+            .display_on_hover.hover-style
+              You've predicted {{assignmentTypePointExcess(assignmentType) | number}} more points than you are allowed to earn for this {{termFor("assignmentType")}}!
 
-    .collapsable.predictor-articles
-      %article.predictor-article{'ng-repeat' => 'assignment in assignments | filter:{assignment_type_id: assignmentType.id}:true', 'article'=>'assignment'}
+  .collapsable.predictor-articles
+    %article.predictor-article{'ng-repeat' => 'assignment in assignments | filter:{assignment_type_id: assignmentType.id}:true', 'article'=>'assignment'}
   .clear

--- a/app/assets/javascripts/angular/templates/predictor/badges.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/badges.html.haml
@@ -1,11 +1,10 @@
-%section.predictor-section{'ng-if'=>'badges.length > 0'}
-  .collapse-toggler.clear
-    .collapse-arrow
-    .predictor-section-title
-      .predictor-section-title-name
-        {{termFor("badges")}}
-      .predictor-section-title-predicted-points.badges
-        {{badgesPredictedPoints() | number}}
+%section.predictor-section.collapse-toggler{'ng-if'=>'badges.length > 0'}
+  .collapse-arrow
+  .predictor-section-title
+    .predictor-section-title-name
+      {{termFor("badges")}}
+    .predictor-section-title-predicted-points.badges
+      {{badgesPredictedPoints() | number}}
 
-  .collapsable.predictor-articles
-    %article.predictor-article{'ng-repeat' => 'badge in badges', 'article'=>'badge'}
+.collapsable.predictor-articles
+  %article.predictor-article{'ng-repeat' => 'badge in badges', 'article'=>'badge'}

--- a/app/assets/javascripts/angular/templates/predictor/challenges.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/challenges.html.haml
@@ -1,13 +1,12 @@
-%section.predictor-section{'ng-if'=>'challenges.length > 0'}
-  .collapse-toggler.clear
-    .collapse-arrow
-    .predictor-section-title
-      .predictor-section-title-name
-        {{termFor("challenges")}}
-      .predictor-section-title-max-points=" {{challengesFullPoints() | number}} Possible Points"
-      .predictor-section-title-predicted-points
-        {{challengesPredictedPoints() | number}}
+%section.predictor-section.collapse-toggler{'ng-if'=>'challenges.length > 0'}
+  .collapse-arrow
+  .predictor-section-title
+    .predictor-section-title-name
+      {{termFor("challenges")}}
+    .predictor-section-title-max-points=" {{challengesFullPoints() | number}} Possible Points"
+    .predictor-section-title-predicted-points
+      {{challengesPredictedPoints() | number}}
 
-  .collapsable.predictor-articles
-    %article.predictor-article{'ng-repeat' => 'challenge in challenges', 'article'=>'challenge'}
+.collapsable.predictor-articles
+  %article.predictor-article{'ng-repeat' => 'challenge in challenges', 'article'=>'challenge'}
 

--- a/app/assets/javascripts/angular/templates/predictor/main.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/main.html.haml
@@ -14,18 +14,16 @@
       .predictor-graph
       #predictor-post-graph-spacer
 
-    #predictor-main-header{'ng-class'=>'{"with-weights": weightsAvailable()}'}
-
-      .collapse-all-toggler
-        .collapse-arrow.outdent
-        .predictor-section-title
-          .predictor-section-title-predicted-points{'ng-if'=>'weightsAvailable()'}
-            .predictor-title-right-span
-              Unused {{termFor("weights")}} :
-            .predictor-section-title-weights
-              .coin-stack
-                .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
-                .coin-stack-count {{unusedWeightsRange().length}}
+    #predictor-main-header.collapse-all-toggler{'ng-class'=>'{"with-weights": weightsAvailable()}'}
+      .collapse-arrow.outdent
+      .predictor-section-title
+        .predictor-section-title-predicted-points{'ng-if'=>'weightsAvailable()'}
+          .predictor-title-right-span
+            Unused {{termFor("weights")}} :
+          .predictor-section-title-weights
+            .coin-stack
+              .coin{'ng-repeat' => 'coin in unusedWeightsRange()'}
+              .coin-stack-count {{unusedWeightsRange().length}}
 
     .predictor-section-assignment-types
 


### PR DESCRIPTION
this PR places the `.collapse-toggler, .collapse-all-toggler` classes on the entire bar sections in the predictor, and only disables the action for the divs responsible to weights. This results in a cleaner Haml nesting and a better UX. win. win.