### PR TITLE
Feature/1328 rubric upload

### DIFF
--- a/app/assets/javascripts/angular/directives/gradeFileUpload.js.coffee
+++ b/app/assets/javascripts/angular/directives/gradeFileUpload.js.coffee
@@ -8,7 +8,7 @@
       element.bind('change', ()->
         scope.$apply(()->
           model.assign(scope, element[0].files)
-          RubricService.postGradeFiles(RubricService.grade, element[0].files)
+          RubricService.postGradeFiles(element[0].files)
         );
       );
     };

--- a/app/assets/javascripts/angular/directives/gradeFileUpload.js.coffee
+++ b/app/assets/javascripts/angular/directives/gradeFileUpload.js.coffee
@@ -1,0 +1,15 @@
+# adapted from https://uncorkedstudios.com/blog/multipartformdata-file-upload-with-angularjs
+@gradecraft.directive('gradeFileUpload', ['$parse', 'RubricService', ($parse, RubricService)->
+  return {
+    restrict: 'A',
+    link: (scope, element, attrs)->
+      model = $parse(attrs.gradeFileUpload)
+
+      element.bind('change', ()->
+        scope.$apply(()->
+          model.assign(scope, element[0].files)
+          RubricService.postGradeFiles(RubricService.grade, element[0].files)
+        );
+      );
+    };
+]);

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -74,15 +74,12 @@
         window.location = returnURL
     ).error(
       (data)->
-        if data.errors.length
-          console.log(data.errors[0].detail)
+        console.log(data)
     )
 
 
 
   postGradeFiles = (grade, files)->
-    console.log("Uploading:");
-    console.dir(files)
     fd = new FormData();
     angular.forEach(files, (file, index)->
       fd.append("grade_files[]", file)
@@ -98,8 +95,7 @@
         console.log(data)
     ).error(
       (data)->
-        if data.errors.length
-          console.log(data.errors[0].detail)
+        console.log(data)
     )
 
   thresholdPoints = ()->

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -79,7 +79,7 @@
 
 
 
-  postGradeFiles = (grade, files)->
+  postGradeFiles = (files)->
     fd = new FormData();
     angular.forEach(files, (file, index)->
       fd.append("grade_files[]", file)

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -78,6 +78,30 @@
           console.log(data.errors[0].detail)
     )
 
+
+
+  postGradeFiles = (grade, files)->
+    console.log("Uploading:");
+    console.dir(files)
+    fd = new FormData();
+    angular.forEach(files, (file, index)->
+      fd.append("grade_files[]", file)
+    )
+
+    $http.post(
+      "/api/grades/#{grade.id}/grade_files",
+      fd,
+      transformRequest: angular.identity,
+      headers: { 'Content-Type': undefined }
+    ).success(
+      (data)->
+        console.log(data)
+    ).error(
+      (data)->
+        if data.errors.length
+          console.log(data.errors[0].detail)
+    )
+
   thresholdPoints = ()->
     thresholdPoints
 
@@ -94,6 +118,7 @@
       getBadges: getBadges,
       getGrade: getGrade,
       putRubricGradeSubmission: putRubricGradeSubmission,
+      postGradeFiles: postGradeFiles,
       assignment: assignment,
       badges: badges,
       criteria: criteria,

--- a/app/controllers/api/grades/grade_files_controller.rb
+++ b/app/controllers/api/grades/grade_files_controller.rb
@@ -5,7 +5,11 @@ class API::Grades::GradeFilesController < ApplicationController
   # POST /api/grades/:grade_id/grade_files
   def create
     grade = Grade.find(params[:grade_id])
-    grade.add_grade_files(*params[:grade_files])
+
+    params[:grade_files].each do |f|
+      grade.grade_files << GradeFile.create(file: f, filename: f.original_filename[0..49], grade_id: grade.id)
+    end
+
     render json: { message: "success uploading grade files"}
   end
 end

--- a/app/controllers/api/grades/grade_files_controller.rb
+++ b/app/controllers/api/grades/grade_files_controller.rb
@@ -1,0 +1,11 @@
+class API::Grades::GradeFilesController < ApplicationController
+
+  before_filter :ensure_staff?
+
+  # POST /api/grades/:grade_id/grade_files
+  def create
+    grade = Grade.find(params[:grade_id])
+    grade.add_grade_files(*params[:grade_files])
+    render json: { message: "success uploading grade files"}
+  end
+end

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -93,6 +93,11 @@
         %textarea(ng-model="grade.adjustment_points_feedback" froala="froalaOptions")
     .clear
 
+    .feedback-upload
+      %input(type="file" multiple="true" grade-file-upload="feedbackFiles")
+    .clear
+    %br
+
     .summary_feedback
       %h3.text-right Overall Feedback
       %textarea(ng-model="grade.feedback" froala="froalaSummaryOptions")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ GradeCraft::Application.routes.draw do
       resources :earned_badges, only: :create, module: :grades do
         delete :delete_all, on: :collection
       end
+      resources :grade_files, only: [:create], module: :grades
     end
     resources :grade_scheme_elements, only: :index
     resources :levels, only: :update

--- a/spec/controllers/api/grades/grade_files_controller_spec.rb
+++ b/spec/controllers/api/grades/grade_files_controller_spec.rb
@@ -1,0 +1,28 @@
+require "rails_spec_helper"
+
+describe API::Grades::GradeFilesController do
+  let(:world) { World.create.with(:course, :student, :assignment, :grade) }
+  let(:professor) { create(:professor_course_membership, course: world.course).user }
+
+  context "as professor" do
+    before(:each) { login_user(professor) }
+
+    describe "POST create" do
+      it "adds upload file to grade" do
+        grade_file = fixture_file("Too long, strange characters, and Spaces (In) Name.jpg", "img/jpg")
+        post :create, grade_id: world.grade.id, grade_files: [grade_file], format: :json
+        expect(world.grade.grade_files.count).to eq(1)
+      end
+    end
+  end
+
+  context "as student" do
+    before(:each) { login_user(world.student) }
+
+    describe "POST create" do
+      it "is a protected route" do
+        expect(post :create, grade_id: world.grade.id, format: :json).to redirect_to(:root)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to upload files attached to Rubric Grades, similar to the existing file upload available on the normal grading form.

The rubric grading form is handled through angular, so the multi-file upload will not work as it does with a standard form. Instead we upload the files in advance of submission, on change to the file input field.