### PR TITLE
refinements to predictor text input field

### DIFF
--- a/app/assets/javascripts/angular/directives/modelIntConverter.js.coffee
+++ b/app/assets/javascripts/angular/directives/modelIntConverter.js.coffee
@@ -14,6 +14,7 @@
 
       ngModelController.$formatters.push((data)->
         #convert data to string for view
+        return "" if isNaN(data)
         return data.toString()
       )
   }

--- a/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
@@ -122,9 +122,7 @@
 
       # points below threshold revert to zero
       scope.pointsSnappedToThreshold = (points)->
-        if isNaN(points)
-          return 0
-        else if scope.pointsAreBelowThreshold(points)
+        if scope.pointsAreBelowThreshold(points)
           return 0
         else
           return points
@@ -138,6 +136,7 @@
 
 
       scope.snapAndSave = (points)->
+        points = if isNaN(points) then 0 else points
         scope.snap(points)
         scope.save()
 

--- a/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
@@ -122,28 +122,42 @@
 
       # points below threshold revert to zero
       scope.pointsSnappedToThreshold = (points)->
-        if scope.pointsAreBelowThreshold(points)
+        if isNaN(points)
+          return 0
+        else if scope.pointsAreBelowThreshold(points)
           return 0
         else
           return points
 
-      scope.snapAndSave = (points)->
+      scope.snap = (points)->
         points = scope.pointsSnappedToRange(points)
         points = scope.pointsSnappedToScoreLevel(points)
         points = scope.pointsSnappedToThreshold(points)
         scope.updateArticle(points)
         scope.updateSlider(points)
-        scope.save()
 
+
+      scope.snapAndSave = (points)->
+        scope.snap(points)
+        scope.save()
 
       #---------------- DIRECT INPUT FIELD ------------------------------------#
 
+      # snap and persist input value on blur
       scope.registerInput = ()->
         scope.inputMode("TEXT_INPUT")
 
         # Wait for the current $apply in progress to complete
         setTimeout ( ->
           scope.snapAndSave(scope.article.prediction.predicted_points)
+        ), 125
+
+      # register and snap updates while typing in the input field
+      scope.registerInputChanging = ()->
+        scope.inputMode("TEXT_INPUT")
+
+        setTimeout ( ->
+          scope.snap(scope.article.prediction.predicted_points)
         ), 125
 
 

--- a/app/assets/javascripts/angular/templates/predictor/components/slider.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/components/slider.html.haml
@@ -1,6 +1,6 @@
 .grade{'id'=>'assignment-{{article.id}}-level'}
   .value
-    %input.predicted-points.model-int-converter{'smart-number'=>'', 'ng-blur'=>'registerInput()', 'ng-model'=>'article.prediction.predicted_points', 'pu-elastic-input'=>""}
+    %input.predicted-points.model-int-converter{'smart-number'=>'', 'ng-change'=>'registerInputChanging()', 'ng-blur'=>'registerInput()', 'ng-model'=>'article.prediction.predicted_points', 'pu-elastic-input'=>""}
     %span.divider=" / "
     %span.full-points {{article.full_points | number}}
   .name


### PR DESCRIPTION
This PR finesses the predictor input field for a better UX.  

issues addressed:
  * Deleting all text returns "NaN" via SmartNumber
  * The slider only updates to the text input on blur, so the interaction feels unnatural.

I have added separate `on-change` and `on-blur` events to the slider input field. They both trigger the same update sequence, but the Ajax update only happens on blur.

This results in real time "idiot-checking": empty fields and negative numbers revert to a zero, numbers above the threshold revert to the max points.  

Please let me know if any particular change feels too aggressive to be handled in real-time, and we can probably tweak the code to wait until blur to make the change.