### PR TITLE
2310 miscellaneous layout fixes

### DIFF
--- a/app/assets/stylesheets/_badges.sass
+++ b/app/assets/stylesheets/_badges.sass
@@ -100,9 +100,10 @@ button#remove-badges, button#add-badges
 
 .grade-badge,
 .badge-index-section .badge-icon-container
-  float: left
+  display: inline-block
   margin: 1rem
   position: relative
+  vertical-align: top
 
   img
     width: 80px

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -43,7 +43,7 @@ $card-margin-1 : 3px
   height: 140px
 
 .predictor-graph
-  width: 100%
+  width: calc(100% - 401px)
   max-width: 1099px
   position: fixed
   top: 80px

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -44,7 +44,7 @@ $card-margin-1 : 3px
 
 .predictor-graph
   width: 100%
-  max-width: 1100px
+  max-width: 1099px
   position: fixed
   top: 80px
   background-color: $color-white
@@ -67,7 +67,7 @@ $card-margin-1 : 3px
     path, line
       fill: none
       stroke: black
-      shape-rendering: scripEdges;
+      shape-rendering: scripEdges
     text
       font-size: $predictor-font-size-4
   #svg-graph-points-earned

--- a/app/assets/stylesheets/_student_sidebar.sass
+++ b/app/assets/stylesheets/_student_sidebar.sass
@@ -7,6 +7,8 @@
 #student-main-column
   width: auto
   overflow: hidden
+  min-height: 100%
+  border-right: 1px solid $color-grey-6
   
 .student-panel
   width: 400px
@@ -15,8 +17,6 @@
   position: relative
   font-weight: 300
   z-index: 18
-  // top: 2.3rem
-  border-left: 1px solid $color-grey-6
   .align-box
     width: 100px
     height: 100px
@@ -33,7 +33,6 @@
   #student-panel-widget, .student-panel-article
     z-index: 50
     position: fixed
-    // top: 80px
     width: 400px
   h2
     text-transform: uppercase

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,6 +1,6 @@
 = content_nav_for Badge if !current_student
 
-%h3.pagetitle= presenter.title if !current_student
+%h3.pagetitle= presenter.title
 
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff? && !presenter.view_student_context?
 


### PR DESCRIPTION
This PR fixes the border on the student side panel and the badge page layout when the badge name is long by using inline-block rather that floating.

This closes #2310 and #2307 