### PR TITLE
load first assignment in predictor side panel on init

### DIFF
--- a/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/PredictorCtrl.js.coffee
@@ -1,6 +1,6 @@
 # Manages Loading all assets for the Predictor Page on init
 
-@gradecraft.controller 'PredictorCtrl', ['$scope', '$q', 'PredictorService', ($scope, $q, PredictorService) ->
+@gradecraft.controller 'PredictorCtrl', ['$scope', '$q', 'PredictorService', 'StudentPanelService', ($scope, $q, PredictorService, StudentPanelService) ->
 
   $scope.loading = true
 
@@ -8,6 +8,7 @@
     $scope.student_id = student_id
     $scope.services().then(()->
       $scope.loading = false
+      StudentPanelService.changeFocusArticle(PredictorService.assignments[0])
     )
 
   $scope.services = ()->


### PR DESCRIPTION
This PR loads the first assignment from the array into the student side panel. Since the predictor takes some time to load all assets, I have kept the info "hint" in place, until the assignments have loaded.

I noticed that something recently changed on master which has broken assignment types position ordering -- with the sample data "Grade Settings" is no longer the first type to show on the `/syllabus` or `/predictor`. This may through you for a loop during review of this PR, since the first assignment is in this AT. I will submit a separate issue to address this.

![screen shot 2016-08-22 at 4 12 10 pm](https://cloud.githubusercontent.com/assets/1138350/17869923/58a530f8-6883-11e6-9d4e-e480ddef1bc8.png)

closes #2315 