### PR TITLE
fix score levels on grade form

### DIFF
--- a/app/assets/javascripts/angular/factories/AssignmentScoreLevel.js.coffee
+++ b/app/assets/javascripts/angular/factories/AssignmentScoreLevel.js.coffee
@@ -3,7 +3,7 @@
 
     constructor: (attrs) ->
       @id = attrs.id
-      @value = attrs.value
+      @value = attrs.points
       @formatted_value = null
       @name = attrs.name
       @assignment_id = attrs.assignment_id


### PR DESCRIPTION
Update ASL `value` to `points` to reflect db model changes. Keep this.value since it is a form field "value" attribute

closes #2270