### PR TITLE
redirect preview logout to student path

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -57,7 +57,7 @@ class UserSessionsController < ApplicationController
     faculty = User.find(impersonating_agent_id)
     auto_login(faculty)
     delete_impersonating_agent
-    redirect_to root_url
+    redirect_to students_path
   end
 
   def destroy


### PR DESCRIPTION
This will redirect an exit from student preview mode back to the students index page.