### PR TITLE
Styled preview bar

### DIFF
--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -38,16 +38,6 @@ body
   padding: 1rem
   background-color: $color-white
 
-.mainContainer.viewing-student > .mainContent 
-  padding-top: 5.5rem
-  @media (max-width: $media-small-max)
-    padding-top: 3.5rem
-
-  h3.pagetitle
-    display: none
-  .predictor-graph
-    top: 134px
-
 .student > .mainContent
   padding-top: 2.2rem
   @media (max-width: $media-small-max)
@@ -122,15 +112,24 @@ a:hover + .display_on_hover
   position: absolute
   margin-left: -240px
 
+.preview-bar
+  padding: 1rem 1rem .75rem
+
 .the-nav.preview-mode
   background-color: $color-orange-1
+  .course_semester
+    color: $color-white
 
-.the-nav .release-preview-link
+.the-nav .release-preview-link a
   float: left
   color: white
-  font-size: 1.25rem
-  margin-left: 10%
-  margin: 10px 0 0 10%
+  font-size: .95rem
+  margin: 7px 0 0 12%
+  background-color: $color-blue-3
+  padding: .25rem
+  border-radius: $global-radius
+  &:hover 
+    background-color: $color-blue-2
 
 @media (min-width: $media-medium-max)
   .panel .row

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -56,9 +56,6 @@ $card-margin-1 : 3px
 .staff #predictor-graph-section
   margin-bottom: 0.75rem
 
-.staff .viewing-student > .predictor-graph
-  top: 134px
-
 #predictor-graph-svg
   width: 100%
   height: 140px

--- a/app/assets/stylesheets/_topbar.sass
+++ b/app/assets/stylesheets/_topbar.sass
@@ -164,7 +164,7 @@ ul.subnav.logged-out
     color: $color-white
     background-color: $color-blue-2
   .the-nav > .nav > li:hover > a.no-hover
-    background-color: $color-blue-1
+    background-color: transparent
     color: $color-white
   .the-nav > .nav > li:hover .subnav
     display: block

--- a/app/assets/stylesheets/_typography.sass
+++ b/app/assets/stylesheets/_typography.sass
@@ -74,19 +74,6 @@ hr
   text-transform: normal
   background-color: $color-blue-2
 
-h2.profileTitle
-  position: fixed
-  text-transform: uppercase
-  width: 100%
-  max-width: 1248px
-  display: block
-  color: $color-black
-  padding: .25rem .5rem
-  font-size: 1.8rem
-  background-color: $color-blue-4
-  box-sizing: border-box
-  z-index: 30
-
 /** Page Title **/
 h3.pagetitle
   text-transform: uppercase

--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -1,4 +1,5 @@
-%h3.pagetitle Dashboard
+- if current_user_is_student?
+  %h3.pagetitle Dashboard
 
 .pageContent
 

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -2,10 +2,10 @@
   / Staff-only sidebar navigation
   = render partial: "layouts/navigation/staff_subnav"
 
-.mainContainer{role: "main", :class => current_student.present? ? "viewing-student staff" : "staff"}
+.mainContainer{role: "main", class: "staff"}
 
   - if current_student.present?
-    %h2.profileTitle= current_student.name
+    %h3.pagetitle= current_student.name
 
   / Page content
   .mainContent= render partial: "layouts/content"

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -1,3 +1,4 @@
-= render "layouts/alerts"
+.preview-bar
+  .right= link_to glyph(:eye) + "Preview GradeCraft as #{presenter.student.first_name}", student_preview_path(presenter.student), class: "button"
 
 #dashboard-timeline= render partial: "info/dashboard/student_dashboard", locals: { presenter: presenter }


### PR DESCRIPTION
This PR adds a "Preview as..." button to the student show page:

<img width="1184" alt="screen shot 2016-08-25 at 12 29 45 pm" src="https://cloud.githubusercontent.com/assets/234276/17977417/a844e00c-6abf-11e6-857c-de69e7fdacf3.png">

And slightly refines the style of the preview bar to have a more clickable exit: 
<img width="1436" alt="screen shot 2016-08-25 at 12 29 53 pm" src="https://cloud.githubusercontent.com/assets/234276/17977420/a9f2f88a-6abf-11e6-96fc-f1574d7b97b9.png">
