### PR TITLE
2344 see details link

### DIFF
--- a/app/assets/stylesheets/_dashboard.sass
+++ b/app/assets/stylesheets/_dashboard.sass
@@ -306,6 +306,8 @@ ul.badge-grid
   align-items: center
   @media (max-width: $media-small-max)
     display: block
+  p
+    margin: 0
 
 .event-image
   float: left

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -14,10 +14,11 @@
               .event-image
                 %img{:src => event.media }
             - if event.description.present?
-              .event-description
-                = sanitize(event.description, :tags=>['a', 'strong', 'em', 'ul', 'ol', 'li', 'p', 'br']).truncate(200, :separator => " ").html_safe
-          .see-details-link
-            = link_to "See the Details", event
+              .event-details
+                .event-description
+                  = sanitize(event.description, :tags=>['a', 'strong', 'em', 'ul', 'ol', 'li', 'p', 'br']).truncate(200, :separator => " ").html_safe
+                .see-details-link
+                  = link_to "See the Details", event
           %ul.assignments-due
             - presenter.assignments_due_on(event).each do |assignment|
               - if assignment.visible_for_student?(current_student)

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -10,16 +10,15 @@
         %p.event-date= glyph(:calendar) + presenter.dates_for(event)
         .slide-body
           .event-information
-            .event-image
-              %img{:src => event.media }
+            - if event.media.present?
+              .event-image
+                %img{:src => event.media }
             - if event.description.present?
               .event-description
                 = sanitize(event.description, :tags=>['a', 'strong', 'em', 'ul', 'ol', 'li', 'p', 'br']).truncate(200, :separator => " ").html_safe
-                = link_to "See the Details", event
+          .see-details-link
+            = link_to "See the Details", event
           %ul.assignments-due
             - presenter.assignments_due_on(event).each do |assignment|
               - if assignment.visible_for_student?(current_student)
                 %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.strftime("%H:%M%p") }
-    .event-slide.last-slide
-      .slide-body
-        .dashboard-message This class is over!


### PR DESCRIPTION
This PR prevents html safe input from users breaking the "See the details" link under the event description in upcoming events module. Also included is a quick fix for the "no upcoming events" slide.

### Without event pic
![screen shot 2016-08-26 at 11 24 27 am](https://cloud.githubusercontent.com/assets/12573921/18011180/05a67950-6b82-11e6-9410-af0e664fe3ee.png)

### With event pic
![screen shot 2016-08-26 at 11 39 43 am](https://cloud.githubusercontent.com/assets/12573921/18011182/06e9503a-6b82-11e6-9ce9-ce14e282916c.png)
