### PR TITLE
fix scope on predicted earned grade

### DIFF
--- a/app/models/predicted_earned_grade.rb
+++ b/app/models/predicted_earned_grade.rb
@@ -4,7 +4,7 @@ class PredictedEarnedGrade < ActiveRecord::Base
 
   scope :predicted_to_be_done, -> { where("predicted_points > 0")}
   scope :for_course, ->(course) do
-    joins(:assignments).where(assignments: {course_id: course.id})
+    joins(:assignment).where(assignments: {course_id: course.id})
   end
   scope :for_student, ->(student) { where(student_id: student.id) }
 

--- a/spec/models/predicted_earned_grade_spec.rb
+++ b/spec/models/predicted_earned_grade_spec.rb
@@ -3,36 +3,36 @@ require "active_record_spec_helper"
 describe PredictedEarnedGrade do
 
   before do
-    @predicted_earned_challenge = create(:predicted_earned_challenge)
+    @predicted_earned_grade = create(:predicted_earned_grade)
   end
 
-  subject { @predicted_earned_challenge }
+  subject { @predicted_earned_grade }
 
   it { is_expected.to respond_to("student_id")}
-  it { is_expected.to respond_to("challenge_id")}
+  it { is_expected.to respond_to("assignment_id")}
   it { is_expected.to respond_to("predicted_points")}
 
   it { is_expected.to be_valid }
 
   describe ".for_course" do
-    it "returns all predicted earned challenges for a specific course" do
+    it "returns all predicted earned grades for a specific course" do
       course = create(:course)
-      course_predicted_challenge = create(:predicted_earned_challenge,
-                                    challenge: create(:challenge, course: course))
-      another_predicted_challenge = create(:predicted_earned_challenge)
-      results = PredictedEarnedChallenge.for_course(course)
-      expect(results).to eq [course_predicted_challenge]
+      course_predicted_grade = create(:predicted_earned_grade,
+                                    assignment: create(:assignment, course: course))
+      another_predicted_grade = create(:predicted_earned_grade)
+      results = PredictedEarnedGrade.for_course(course)
+      expect(results).to eq [course_predicted_grade]
     end
   end
 
   describe ".for_student" do
-    it "returns all predicted earned challenges for a specific student" do
+    it "returns all predicted earned grades for a specific student" do
       student = create(:user)
-      student_predicted_challenge = create(:predicted_earned_challenge,
+      student_predicted_grade = create(:predicted_earned_grade,
                                            student: student)
-      another_predicted_challenge = create(:predicted_earned_challenge)
-      results = PredictedEarnedChallenge.for_student(student)
-      expect(results).to eq [student_predicted_challenge]
+      another_predicted_grade = create(:predicted_earned_grade)
+      results = PredictedEarnedGrade.for_student(student)
+      expect(results).to eq [student_predicted_grade]
     end
   end
 end


### PR DESCRIPTION
This pr fixed the `for_course` scope for predicted earned grades, and the specs for this model. These specs did not catch the error because they were testing PEChallenges, not PEGrades.