### PR TITLE
2207 import canvas grade

### DIFF
--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -50,8 +50,8 @@ class Grades::ImportersController < ApplicationController
     @provider_name = params[:importer_provider_id]
 
     @result = Services::ImportsLMSGrades.import @provider_name,
-      authorization(@provider_name).access_token, params[:id], params[:grade_ids],
-      params[:assignment_id], current_user
+      authorization(@provider_name).access_token, params[:id], params[:assignment_ids],
+      params[:grade_ids], params[:assignment_id], current_user
 
     if @result.success?
       render :grades_import_results

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -48,15 +48,15 @@ class Grades::ImportersController < ApplicationController
   # POST /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades_import
   def grades_import
     @provider_name = params[:importer_provider_id]
+    @assignment = Assignment.find params[:assignment_id]
 
     @result = Services::ImportsLMSGrades.import @provider_name,
       authorization(@provider_name).access_token, params[:id], params[:assignment_ids],
-      params[:grade_ids], params[:assignment_id], current_user
+      params[:grade_ids], @assignment.id, current_user
 
     if @result.success?
       render :grades_import_results
     else
-      @assignment = Assignment.find params[:assignment_id]
       @grades = syllabus.grades(params[:id], params[:assignment_ids])
 
       render :grades, alert: @result.message

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -51,7 +51,7 @@ class Grades::ImportersController < ApplicationController
 
     @result = Services::ImportsLMSGrades.import @provider_name,
       authorization(@provider_name).access_token, params[:id], params[:grade_ids],
-      params[:assignment_id]
+      params[:assignment_id], current_user
 
     if @result.success?
       render :grades_import_results
@@ -84,7 +84,8 @@ class Grades::ImportersController < ApplicationController
       redirect_to assignment_grades_importer_path(@assignment, params[:importer_provider_id]),
         notice: "File is missing"
     else
-      @result = GradeImporter.new(params[:file].tempfile).import(current_course, @assignment)
+      @result = CSVGradeImporter.new(params[:file].tempfile)
+        .import(current_course, @assignment)
 
       grade_ids = @result.successful.map(&:id)
       enqueue_multiple_grade_update_jobs(grade_ids)

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -1,4 +1,5 @@
 require "active_lms"
+require_relative "../../services/imports_lms_grades"
 
 class Grades::ImportersController < ApplicationController
   include OAuthProvider
@@ -37,11 +38,29 @@ class Grades::ImportersController < ApplicationController
     @courses = syllabus.courses
   end
 
-  # GET /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades
+  # POST /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades
   def grades
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
     @grades = syllabus.grades(params[:id], params[:assignment_ids])
+  end
+
+  # POST /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades_import
+  def grades_import
+    @provider_name = params[:importer_provider_id]
+
+    @result = Services::ImportsLMSGrades.import @provider_name,
+      authorization(@provider_name).access_token, params[:id], params[:grade_ids],
+      params[:assignment_id]
+
+    if @result.success?
+      render :grades_import_results
+    else
+      @assignment = Assignment.find params[:assignment_id]
+      @grades = syllabus.grades(params[:id], params[:assignment_ids])
+
+      render :grades, alert: @result.message
+    end
   end
 
   # GET /assignments/:assignment_id/grades/importers

--- a/app/importers/grade_importers.rb
+++ b/app/importers/grade_importers.rb
@@ -1,0 +1,2 @@
+require_relative "grade_importers/canvas_grade_importer"
+

--- a/app/importers/grade_importers.rb
+++ b/app/importers/grade_importers.rb
@@ -1,2 +1,3 @@
 require_relative "grade_importers/canvas_grade_importer"
+require_relative "grade_importers/csv_grade_importer"
 

--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -1,0 +1,33 @@
+class CanvasGradeImporter
+  attr_reader :successful, :unsuccessful
+  attr_accessor :grades
+
+  def initialize(grades)
+    @grades = grades
+    @successful = []
+    @unsuccessful = []
+  end
+
+  def import(assignment_id, syllabus)
+    unless grades.nil?
+      grades.each do |canvas_grade|
+        user = find_user canvas_grade["user_id"], syllabus
+        grade = Grade.new assignment_id: assignment_id,
+          student_id: user.try(:id),
+          raw_points: canvas_grade["score"]
+        grade.save
+      end
+    end
+
+    self
+  end
+
+  private
+
+  def find_user(user_id, syllabus)
+    canvas_user = syllabus.user(user_id)
+    if canvas_user
+      User.find_by_insensitive_email(canvas_user["primary_email"])
+    end
+  end
+end

--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -32,9 +32,9 @@ class CanvasGradeImporter
 
   def find_user(user_id, syllabus)
     canvas_user = syllabus.user(user_id)
-    if canvas_user
-      User.find_by_insensitive_email(canvas_user["primary_email"])
-    end
+    return nil if canvas_user.nil?
+
+    User.find_by_insensitive_email(canvas_user["primary_email"])
   end
 
   def link_imported(provider_resource_id, grade)

--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -1,6 +1,6 @@
 require "csv"
 
-class GradeImporter
+class CSVGradeImporter
   attr_reader :successful, :unsuccessful, :unchanged
   attr_accessor :file
 

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -14,6 +14,7 @@ class Grade < ActiveRecord::Base
   belongs_to :group, polymorphic: true, touch: true # Optional
   belongs_to :graded_by, class_name: "User", touch: true
 
+  has_one :imported_grade, dependent: :destroy
   has_many :earned_badges, dependent: :destroy
 
   has_many :badges, through: :earned_badges
@@ -96,16 +97,16 @@ class Grade < ActiveRecord::Base
   end
 
   def check_unlockables
-    if self.assignment.is_a_condition? 
+    if self.assignment.is_a_condition?
       self.assignment.unlock_keys.map(&:unlockable).each do |unlockable|
         unlockable.check_unlock_status(student)
       end
     end
-    if self.assignment_type.is_a_condition? 
+    if self.assignment_type.is_a_condition?
       self.assignment_type.unlock_keys.map(&:unlockable).each do |unlockable|
         unlockable.check_unlock_status(student)
       end
-    end  
+    end
   end
 
   def excluded_by

--- a/app/models/imported_grade.rb
+++ b/app/models/imported_grade.rb
@@ -1,0 +1,3 @@
+class ImportedGrade < ActiveRecord::Base
+  belongs_to :grade
+end

--- a/app/services/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades.rb
@@ -12,8 +12,7 @@ module Services
            assignment_ids: assignment_ids, grade_ids: grade_ids,
            assignment_id: assignment_id, user: user).reduce(
              Actions::RetrievesLMSGrades,
-             Actions::ImportsLMSGrades
-      )
+             Actions::ImportsLMSGrades)
     end
   end
 end

--- a/app/services/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades.rb
@@ -1,6 +1,17 @@
+require "light-service"
+require_relative "imports_lms_grades/imports_lms_grades"
+require_relative "imports_lms_grades/retrieves_lms_grades"
+
 module Services
   class ImportsLMSGrades
+    extend LightService::Organizer
+
     def self.import(provider, access_token, course_id, grade_ids, assignment_id)
+      with(provider: provider, access_token: access_token, course_id: course_id,
+           grade_ids: grade_ids, assignment_id: assignment_id).reduce(
+             Actions::RetrievesLMSGrades,
+             Actions::ImportsLMSGrades
+      )
     end
   end
 end

--- a/app/services/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades.rb
@@ -1,0 +1,6 @@
+module Services
+  class ImportsLMSGrades
+    def self.import(provider, access_token, course_id, grade_ids, assignment_id)
+    end
+  end
+end

--- a/app/services/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades.rb
@@ -6,9 +6,11 @@ module Services
   class ImportsLMSGrades
     extend LightService::Organizer
 
-    def self.import(provider, access_token, course_id, grade_ids, assignment_id)
+    def self.import(provider, access_token, course_id, assignment_ids, grade_ids,
+                    assignment_id, user)
       with(provider: provider, access_token: access_token, course_id: course_id,
-           grade_ids: grade_ids, assignment_id: assignment_id).reduce(
+           assignment_ids: assignment_ids, grade_ids: grade_ids,
+           assignment_id: assignment_id, user: user).reduce(
              Actions::RetrievesLMSGrades,
              Actions::ImportsLMSGrades
       )

--- a/app/services/imports_lms_grades/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades/imports_lms_grades.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class ImportsLMSGrades
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_grades/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades/imports_lms_grades.rb
@@ -1,9 +1,29 @@
+require "active_lms"
+require_relative "../../importers/grade_importers"
+
 module Services
   module Actions
     class ImportsLMSGrades
       extend LightService::Action
+      extend ActiveSupport::Inflector
+
+      expects :assignment_id, :grades, :provider, :user
+      promises :import_result
 
       executed do |context|
+        assignment_id = context.assignment_id
+        grades = context.grades
+        provider = context.provider
+        user = context.user
+        authorization = UserAuthorization.for(user, provider)
+
+        context.import_result = nil
+        unless authorization.nil?
+          klass = constantize("#{camelize(provider)}GradeImporter")
+          syllabus = ActiveLMS::Syllabus.new provider,
+            authorization.access_token
+          context.import_result = klass.new(grades).import assignment_id, syllabus
+        end
       end
     end
   end

--- a/app/services/imports_lms_grades/retrieves_lms_grades.rb
+++ b/app/services/imports_lms_grades/retrieves_lms_grades.rb
@@ -1,9 +1,22 @@
+require "active_lms"
+
 module Services
   module Actions
     class RetrievesLMSGrades
       extend LightService::Action
 
+      expects :access_token, :assignment_ids, :course_id, :grade_ids, :provider
+      promises :grades
+
       executed do |context|
+        provider = context.provider
+        access_token = context.access_token
+        assignment_ids = context.assignment_ids
+        course_id = context.course_id
+        grade_ids = context.grade_ids
+
+        syllabus = ActiveLMS::Syllabus.new provider, access_token
+        context.grades = syllabus.grades course_id, assignment_ids, grade_ids
       end
     end
   end

--- a/app/services/imports_lms_grades/retrieves_lms_grades.rb
+++ b/app/services/imports_lms_grades/retrieves_lms_grades.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class RetrievesLMSGrades
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/views/grades/importers/_grade_row.html.haml
+++ b/app/views/grades/importers/_grade_row.html.haml
@@ -6,3 +6,6 @@
   %td= lms_user_match?(user["primary_email"], current_course) ? "Yes" : "No"
   %td= grade["score"]
   %td= Time.new(grade["graded_at"]).strftime("%A, %B %d %Y") unless grade["graded_at"].nil?
+  %td.center
+    - if lms_user_match?(user["primary_email"], current_course)
+      = check_box_tag "grade_ids[]", grade["id"], false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-grades-command']" }

--- a/app/views/grades/importers/_grade_row.html.haml
+++ b/app/views/grades/importers/_grade_row.html.haml
@@ -5,4 +5,4 @@
   %td= user["primary_email"]
   %td= lms_user_match?(user["primary_email"], current_course) ? "Yes" : "No"
   %td= grade["score"]
-  %td= grade["graded_at"]
+  %td= Time.new(grade["graded_at"]).strftime("%A, %B %d %Y") unless grade["graded_at"].nil?

--- a/app/views/grades/importers/grades.html.haml
+++ b/app/views/grades/importers/grades.html.haml
@@ -13,7 +13,8 @@
         =link_to "modify your assignment selection", assignment_grades_importer_assignments_path(@assignment, @provider_name, params[:id])
         to find grades to import.
   -else
-    = form_tag "#" do
+    = form_tag assignment_grades_importer_grades_import_path(@assignment, :canvas, params[:id]) do
+      = hidden_field_tag :assignment_ids, params[:assignment_ids]
       %table.dynatable.no-table-header
         %thead
           %tr

--- a/app/views/grades/importers/grades.html.haml
+++ b/app/views/grades/importers/grades.html.haml
@@ -14,7 +14,8 @@
         to find grades to import.
   -else
     = form_tag assignment_grades_importer_grades_import_path(@assignment, :canvas, params[:id]) do
-      = hidden_field_tag :assignment_ids, params[:assignment_ids]
+      - params[:assignment_ids].each do |assignment_id|
+        = hidden_field_tag "assignment_ids[]", assignment_id
       %table.dynatable.no-table-header
         %thead
           %tr

--- a/app/views/grades/importers/grades.html.haml
+++ b/app/views/grades/importers/grades.html.haml
@@ -13,17 +13,24 @@
         =link_to "modify your assignment selection", assignment_grades_importer_assignments_path(@assignment, @provider_name, params[:id])
         to find grades to import.
   -else
-    %table.dynatable.no-table-header
-      %thead
-        %tr
-          %th{scope: "col"} Course
-          %th{scope: "col"} Assignment
-          %th{scope: "col"} Student Name
-          %th{scope: "col"} Student Email
-          %th{scope: "col"} Gradecraft Match?
-          %th{scope: "col"} Score
-          %th{scope: "col"} Graded At
-      %tbody
-        - @grades.each do |grade|
-          = render partial: "grade_row", locals: { grade: grade,
-                                                   user: lms_user(@syllabus, grade["user_id"])}
+    = form_tag "#" do
+      %table.dynatable.no-table-header
+        %thead
+          %tr
+            %th{scope: "col"} Course
+            %th{scope: "col"} Assignment
+            %th{scope: "col"} Student Name
+            %th{scope: "col"} Student Email
+            %th{scope: "col"} Gradecraft Match?
+            %th{scope: "col"} Score
+            %th{scope: "col"} Graded At
+            %th{"data-dynatable-no-sort" => "true"}
+              %button.button.select-all= "Check"
+              %button.button.select-none= "Uncheck"
+        %tbody
+          - @grades.each do |grade|
+            = render partial: "grade_row", locals: { grade: grade,
+                                                     user: lms_user(@syllabus, grade["user_id"])}
+      .submit-buttons
+        .right
+          %p= submit_tag "Import Selected Grades for #{@assignment.name}", class: "button disabled", disabled: true, data: { behavior: "selected-grades-command" }

--- a/app/views/grades/importers/grades_import_results.html.haml
+++ b/app/views/grades/importers/grades_import_results.html.haml
@@ -1,0 +1,36 @@
+= content_nav_for Course, ["Import Grades", assignment_grades_importers_path(@assignment)], @provider_name.capitalize
+
+
+%h3.pagetitle= "#{@provider_name.capitalize} Grade Import Results"
+
+.pageContent
+  = render "layouts/alerts"
+
+  - unless @result.import_result.unsuccessful.empty?
+    %h4.subtitle
+      = "#{@result.import_result.unsuccessful.count} #{"Grade".pluralize(@result.import_result.unsuccessful.count)} Not Imported"
+    %table.dynatable
+      %thead
+        %tr
+          %th Data
+          %th Error(s)
+      %tbody
+        - @result.import_result.unsuccessful.each do |row|
+          %tr
+            %td= row[:data]
+            %td= row[:errors]
+
+  %h4.subtitle
+    = "#{@result.import_result.successful.count} #{"Grade".pluralize(@result.import_result.successful.count)} Imported Successfully"
+  %table.dynatable
+    %thead
+      %tr
+        %th Assignment
+        %th Raw Points
+        %th Score
+    %tbody
+      - @result.import_result.successful.each do |grade|
+        %tr
+          %td= link_to grade.assignment.name, assignment_path(grade.assignment)
+          %td= points grade.raw_points
+          %td= grade.score

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,6 +13,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "LMS"
   inflect.acronym "LTI"
   inflect.acronym "API"
+  inflect.acronym "CSV"
   inflect.acronym "OAuth"
   inflect.irregular "criterion", "criteria"
   inflect.irregular "TA", "TA"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ GradeCraft::Application.routes.draw do
         get :courses
         get "/courses/:id/assignments", to: :assignments, as: :assignments
         post "/courses/:id/grades", to: :grades, as: :grades
+        post "/courses/:id/grades/import", to: :grades_import, as: :grades_import
       end
     end
 

--- a/db/migrate/20160830154453_create_imported_grades.rb
+++ b/db/migrate/20160830154453_create_imported_grades.rb
@@ -1,0 +1,11 @@
+class CreateImportedGrades < ActiveRecord::Migration
+  def change
+    create_table :imported_grades do |t|
+      t.references :grade, index: true, foreign_key: true
+      t.string :provider
+      t.string :provider_resource_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818022703) do
+ActiveRecord::Schema.define(version: 20160830154453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -480,6 +480,16 @@ ActiveRecord::Schema.define(version: 20160818022703) do
 
   add_index "imported_assignments", ["assignment_id"], name: "index_imported_assignments_on_assignment_id", using: :btree
 
+  create_table "imported_grades", force: :cascade do |t|
+    t.integer  "grade_id"
+    t.string   "provider"
+    t.string   "provider_resource_id"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "imported_grades", ["grade_id"], name: "index_imported_grades_on_grade_id", using: :btree
+
   create_table "level_badges", force: :cascade do |t|
     t.integer  "level_id"
     t.integer  "badge_id"
@@ -825,6 +835,7 @@ ActiveRecord::Schema.define(version: 20160818022703) do
   add_foreign_key "flagged_users", "users", column: "flagged_id"
   add_foreign_key "flagged_users", "users", column: "flagger_id"
   add_foreign_key "imported_assignments", "assignments"
+  add_foreign_key "imported_grades", "grades"
   add_foreign_key "secure_tokens", "courses"
   add_foreign_key "secure_tokens", "users"
   add_foreign_key "user_authorizations", "users"

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -26,8 +26,8 @@ module ActiveLMS
       provider.assignments(course_id, assignment_ids)
     end
 
-    def grades(course_id, assignment_ids)
-      provider.grades(course_id, assignment_ids)
+    def grades(course_id, assignment_ids, grade_ids=nil)
+      provider.grades(course_id, assignment_ids, grade_ids)
     end
 
     def user(id)

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -48,13 +48,20 @@ module ActiveLMS
       assignment
     end
 
-    def grades(course_id, assignment_ids)
+    def grades(course_id, assignment_ids, grade_ids=nil)
       grades = []
       params = { assignment_ids: assignment_ids,
                  student_ids: "all",
                  include: ["assignment", "course", "user"] }
       client.get_data("/courses/#{course_id}/students/submissions", params) do |data|
-        grades += data
+        if grade_ids.nil?
+          grades += data
+        else
+          filtered_ids = [grade_ids].flatten.uniq.compact
+          data.select { |grade| filtered_ids.include?(grade["id"]) }.each do |grade|
+            grades << grade
+          end
+        end
       end
       grades
     end

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -1,17 +1,127 @@
 require "canvas"
 
+# Internal: Provides communication between Canvas to satisfy the Syllabus
+# signature methods in order to retrieve data from the Canvas LMS.
+#
+# This should not be used directly. This is used as a specific adapter for
+# ActiveLMS::Syllabus.
 module ActiveLMS
   class CanvasSyllabus
+    # Internal: Initializes a CanvasSyllabus
+    #
+    # access_token - A String that holds the Canvas access token to connect to
+    # the Canvas API.
     def initialize(access_token)
       @client = Canvas::API.new(access_token)
     end
 
+    # Internal: Retrieves a single course from the Canvas API.
+    #
+    # id - A String representing the course id from the Canvas API.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/courses/:id
+    #
+    # Returns a Hash representing a single Course.
+    #
+    # {
+    #   "id": 370663,
+    #   "sis_course_id": null,
+    #   "integration_id": null,
+    #   "name": "InstructureCon 2012",
+    #   "course_code": "INSTCON12",
+    #   "workflow_state": "available",
+    #   "account_id": 81259,
+    #   "root_account_id": 81259,
+    #   "enrollment_term_id": 34,
+    #   "grading_standard_id": 25,
+    #   "start_at": "2012-06-01T00:00:00-06:00",
+    #   "end_at": "2012-09-01T00:00:00-06:00",
+    #   "enrollments": null,
+    #   "total_students": 32,
+    #   "calendar": null,
+    #   "default_view": "feed",
+    #   "syllabus_body": "<p>syllabus html goes here</p>",
+    #   "needs_grading_count": 17,
+    #   "term": null,
+    #   "course_progress": null,
+    #   "apply_assignment_group_weights": true,
+    #   "permissions": {"create_discussion_topic":true,"create_announcement":true},
+    #   "is_public": true,
+    #   "is_public_to_auth_users": true,
+    #   "public_syllabus": true,
+    #   "public_description": "Come one, come all to InstructureCon 2012!",
+    #   "storage_quota_mb": 5,
+    #   "storage_quota_used_mb": 5,
+    #   "hide_final_grades": false,
+    #   "license": "Creative Commons",
+    #   "allow_student_assignment_edits": false,
+    #   "allow_wiki_comments": false,
+    #   "allow_student_forum_attachments": false,
+    #   "open_enrollment": true,
+    #   "self_enrollment": false,
+    #   "restrict_enrollments_to_course_dates": false,
+    #   "course_format": "online",
+    #   "access_restricted_by_date": false,
+    #   "time_zone": "America/Denver"
+    # }
     def course(id)
       course = nil
       client.get_data("/courses/#{id}") { |data| course = data }
       course
     end
 
+    # Internal: Retrieves all the courses assigned to as a teacher from
+    # the Canvas API.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/courses?enrollment_type=teacher
+    #
+    # Returns an Array of Hashes representing multiple courses.
+    #
+    # [{
+    #   "id": 370663,
+    #   "sis_course_id": null,
+    #   "integration_id": null,
+    #   "name": "InstructureCon 2012",
+    #   "course_code": "INSTCON12",
+    #   "workflow_state": "available",
+    #   "account_id": 81259,
+    #   "root_account_id": 81259,
+    #   "enrollment_term_id": 34,
+    #   "grading_standard_id": 25,
+    #   "start_at": "2012-06-01T00:00:00-06:00",
+    #   "end_at": "2012-09-01T00:00:00-06:00",
+    #   "enrollments": null,
+    #   "total_students": 32,
+    #   "calendar": null,
+    #   "default_view": "feed",
+    #   "syllabus_body": "<p>syllabus html goes here</p>",
+    #   "needs_grading_count": 17,
+    #   "term": null,
+    #   "course_progress": null,
+    #   "apply_assignment_group_weights": true,
+    #   "permissions": {"create_discussion_topic":true,"create_announcement":true},
+    #   "is_public": true,
+    #   "is_public_to_auth_users": true,
+    #   "public_syllabus": true,
+    #   "public_description": "Come one, come all to InstructureCon 2012!",
+    #   "storage_quota_mb": 5,
+    #   "storage_quota_used_mb": 5,
+    #   "hide_final_grades": false,
+    #   "license": "Creative Commons",
+    #   "allow_student_assignment_edits": false,
+    #   "allow_wiki_comments": false,
+    #   "allow_student_forum_attachments": false,
+    #   "open_enrollment": true,
+    #   "self_enrollment": false,
+    #   "restrict_enrollments_to_course_dates": false,
+    #   "course_format": "online",
+    #   "access_restricted_by_date": false,
+    #   "time_zone": "America/Denver"
+    # }]
     def courses
       @courses || begin
         @courses = []
@@ -22,6 +132,77 @@ module ActiveLMS
       @courses
     end
 
+    # Internal: Retrieves all the assignments for a specific course from
+    # the Canvas API.
+    #
+    # id - A String representing the course id from the Canvas API.
+    # assignment_ids - An Array of ids that can filter out the assignments
+    # there were retrieved.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/courses/:id/assignments
+    #
+    # Returns an Array of Hashes representing multiple assignments.
+    #
+    # [{
+    #   "id": 4,
+    #   "name": "some assignment",
+    #   "description": "<p>Do the following:</p>...",
+    #   "created_at": "2012-07-01T23:59:00-06:00",
+    #   "updated_at": "2012-07-01T23:59:00-06:00",
+    #   "due_at": "2012-07-01T23:59:00-06:00",
+    #   "lock_at": "2012-07-01T23:59:00-06:00",
+    #   "unlock_at": "2012-07-01T23:59:00-06:00",
+    #   "has_overrides": true,
+    #   "all_dates": null,
+    #   "course_id": 123,
+    #   "html_url": "https://...",
+    #   "submissions_download_url": ".../courses/:course_id/assignments/:id/submissions",
+    #  "assignment_group_id": 2,
+    #  "allowed_extensions": ["docx", "ppt"],
+    #  "turnitin_enabled": true,
+    #  "turnitin_settings": null,
+    #  "grade_group_students_individually": false,
+    #  "external_tool_tag_attributes": null,
+    #  "peer_reviews": false,
+    #  "automatic_peer_reviews": false,
+    #  "peer_review_count": 0,
+    #  "peer_reviews_assign_at": "2012-07-01T23:59:00-06:00",
+    #  "group_category_id": 1,
+    #  "needs_grading_count": 17,
+    #  "needs_grading_count_by_section": [{
+    #     "section_id":"123456",
+    #     "needs_grading_count":5 }],
+    #  "position": 1,
+    #  "post_to_sis": true,
+    #  "integration_id": "12341234",
+    #  "integration_data": "12341234",
+    #  "muted": null,
+    #  "points_possible": 12,
+    #  "submission_types": ["online_text_entry"],
+    #  "grading_type": "points",
+    #  "grading_standard_id": null,
+    #  "published": true,
+    #  "unpublishable": false,
+    #  "only_visible_to_overrides": false,
+    #  "locked_for_user": false,
+    #  "lock_info": null,
+    #  "lock_explanation": "This assignment is locked until September 1 at 12:00am",
+    #  "quiz_id": 620,
+    #  "anonymous_submissions": false,
+    #  "discussion_topic": null,
+    #  "freeze_on_copy": false,
+    #  "frozen": false,
+    #  "frozen_attributes": ["title"],
+    #  "submission": null,
+    #  "use_rubric_for_grading": true,
+    #  "rubric_settings": "{"points_possible"=>12}",
+    #  "rubric": null,
+    #  "assignment_visibility": [137, 381, 572],
+    #  "overrides": null,
+    #  "omit_from_final_grade": true
+    # }]
     def assignments(course_id, assignment_ids=nil)
       assignments = []
 
@@ -40,6 +221,76 @@ module ActiveLMS
       assignments
     end
 
+    # Internal: Retrieves the assignments for a specific course and assignment from
+    # the Canvas API.
+    #
+    # course_id - A String representing the course id from the Canvas API.
+    # assignment_id - A String representing the assignment id from the Canvas API.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/courses/:course_id/assignments/:id
+    #
+    # Returns a Hashes representing an assignments.
+    #
+    # {
+    #   "id": 4,
+    #   "name": "some assignment",
+    #   "description": "<p>Do the following:</p>...",
+    #   "created_at": "2012-07-01T23:59:00-06:00",
+    #   "updated_at": "2012-07-01T23:59:00-06:00",
+    #   "due_at": "2012-07-01T23:59:00-06:00",
+    #   "lock_at": "2012-07-01T23:59:00-06:00",
+    #   "unlock_at": "2012-07-01T23:59:00-06:00",
+    #   "has_overrides": true,
+    #   "all_dates": null,
+    #   "course_id": 123,
+    #   "html_url": "https://...",
+    #   "submissions_download_url": ".../courses/:course_id/assignments/:id/submissions",
+    #  "assignment_group_id": 2,
+    #  "allowed_extensions": ["docx", "ppt"],
+    #  "turnitin_enabled": true,
+    #  "turnitin_settings": null,
+    #  "grade_group_students_individually": false,
+    #  "external_tool_tag_attributes": null,
+    #  "peer_reviews": false,
+    #  "automatic_peer_reviews": false,
+    #  "peer_review_count": 0,
+    #  "peer_reviews_assign_at": "2012-07-01T23:59:00-06:00",
+    #  "group_category_id": 1,
+    #  "needs_grading_count": 17,
+    #  "needs_grading_count_by_section": [{
+    #     "section_id":"123456",
+    #     "needs_grading_count":5 }],
+    #  "position": 1,
+    #  "post_to_sis": true,
+    #  "integration_id": "12341234",
+    #  "integration_data": "12341234",
+    #  "muted": null,
+    #  "points_possible": 12,
+    #  "submission_types": ["online_text_entry"],
+    #  "grading_type": "points",
+    #  "grading_standard_id": null,
+    #  "published": true,
+    #  "unpublishable": false,
+    #  "only_visible_to_overrides": false,
+    #  "locked_for_user": false,
+    #  "lock_info": null,
+    #  "lock_explanation": "This assignment is locked until September 1 at 12:00am",
+    #  "quiz_id": 620,
+    #  "anonymous_submissions": false,
+    #  "discussion_topic": null,
+    #  "freeze_on_copy": false,
+    #  "frozen": false,
+    #  "frozen_attributes": ["title"],
+    #  "submission": null,
+    #  "use_rubric_for_grading": true,
+    #  "rubric_settings": "{"points_possible"=>12}",
+    #  "rubric": null,
+    #  "assignment_visibility": [137, 381, 572],
+    #  "overrides": null,
+    #  "omit_from_final_grade": true
+    # }
     def assignment(course_id, assignment_id)
       assignment = nil
       client.get_data("/courses/#{course_id}/assignments/#{assignment_id}") do |data|
@@ -48,6 +299,42 @@ module ActiveLMS
       assignment
     end
 
+    # Internal: Retrieves all the grades for a specific course and assignments from
+    # the Canvas API.
+    #
+    # course_id - A String representing the course id from the Canvas API.
+    # assignment_ids - An Array of ids that can filter out the assignments
+    # there were retrieved.
+    # grade_ids - An array of ids that can filter out the grades that were retrieved.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/courses/:id/students/submission
+    #
+    # Returns an Array of Hashes representing multiple grades.
+    #
+    # [{
+    #   "assignment_id": 23,
+    #   "assignment": "Assignment",
+    #   "course": "Course",
+    #   "attempt": 1,
+    #   "body": "There are three factors too...",
+    #   "grade": "A-",
+    #   "grade_matches_current_submission": true,
+    #   "html_url": "http://example.com/courses/255/assignments/543/submissions/134",
+    #   "preview_url": ".../courses/255/assignments/543/submissions/134?preview=1",
+    #   "score": 13.5,
+    #   "submission_comments": null,
+    #   "submission_type": "online_text_entry",
+    #   "submitted_at": "2012-01-01T01:00:00Z",
+    #   "url": null,
+    #   "user_id": 134,
+    #   "grader_id": 86,
+    #   "user": "User",
+    #   "late": false,
+    #   "assignment_visible": true,
+    #   "excused": true
+    # }]
     def grades(course_id, assignment_ids, grade_ids=nil)
       grades = []
       params = { assignment_ids: assignment_ids,
@@ -66,6 +353,33 @@ module ActiveLMS
       grades
     end
 
+    # Internal: Retrieves single user from the Canvas API.
+    #
+    # id - A String representing the user id from the Canvas API.
+    #
+    # Examples
+    #
+    # GET: http://instructure.com/api/v1/users/:id/profile
+    #
+    # Returns an Array of Hashes representing multiple grades.
+    #
+    # {
+    #   "id": 2,
+    #  "name": "Sheldon Cooper",
+    #  "sortable_name": "Cooper, Sheldon",
+    #  "short_name": "Shelly",
+    #  "sis_user_id": "SHEL93921",
+    #  "sis_import_id": 18,
+    #  "sis_login_id": null,
+    #  "integration_id": "ABC59802",
+    #  "login_id": "sheldon@caltech.example.com",
+    #  "avatar_url": ".../gravatar.com/avatar/d8cb8c8cd40ddf0cd05241443a591868?s=80&r=g",
+    #  "enrollments": null,
+    #  "email": "sheldon@caltech.example.com",
+    #  "locale": "tlh",
+    #  "time_zone": "America/Denver",
+    #  "bio": "I like the Muppets."
+    # }
     def user(id)
       user = nil
       client.get_data("/users/#{id}/profile") { |data| user = data }

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -57,8 +57,8 @@ module ActiveLMS
         if grade_ids.nil?
           grades += data
         else
-          filtered_ids = [grade_ids].flatten.uniq.compact
-          data.select { |grade| filtered_ids.include?(grade["id"]) }.each do |grade|
+          filtered_ids = [grade_ids].flatten.uniq.compact.map(&:to_s)
+          data.select { |grade| filtered_ids.include?(grade["id"].to_s) }.each do |grade|
             grades << grade
           end
         end

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -26,8 +26,10 @@ module ActiveLMS
       assignments = []
 
       if assignment_ids.nil?
-        client.get_data("/courses/#{course_id}/assignments", published: true) do |data|
-          assignments += data
+        client.get_data("/courses/#{course_id}/assignments") do |data|
+          data.select { |assignment| assignment["published"] }.each do |assignment|
+            assignments << assignment
+          end
         end
       else
         [assignment_ids].flatten.uniq.compact.each do |assignment_id|

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -107,7 +107,7 @@ describe Grades::ImportersController do
       it "imports the selected grades" do
         expect(Services::ImportsLMSGrades).to \
           receive(:import).with("canvas", access_token, course_id,
-                                grade_ids, world.assignment.id.to_s)
+                                grade_ids, world.assignment.id.to_s, professor)
             .and_return result
 
         post :grades_import, importer_provider_id: "canvas",

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -5,10 +5,10 @@ describe Grades::ImportersController do
   before { allow(controller).to receive(:current_course).and_return world.course }
 
   context "as a professor" do
-    before do
-      membership = create :professor_course_membership, course: world.course
-      login_user membership.user
-    end
+    let(:membership) { create :professor_course_membership, course: world.course }
+    let(:professor) { membership.user }
+
+    before { login_user professor }
 
     describe "GET download" do
       it "returns sample csv data" do
@@ -61,6 +61,76 @@ describe Grades::ImportersController do
 
           expect(flash[:notice]).to eq("File is missing")
           expect(response).to redirect_to(assignment_grades_importer_path(world.assignment, :csv))
+        end
+      end
+    end
+
+    describe "GET courses" do
+      context "without an existing authentication" do
+        it "redirects to authorize with canvas" do
+          get :courses, assignment_id: world.assignment.id, importer_provider_id: :canvas
+
+          expect(response).to redirect_to "/auth/canvas"
+        end
+      end
+
+      context "with an expired authentication" do
+        let(:access_token) { "BLAH" }
+        let!(:user_authorization) do
+          create :user_authorization, :canvas, user: professor, access_token: access_token,
+            expires_at: 2.days.ago
+        end
+
+        it "retrieves a refresh token" do
+          allow_any_instance_of(ActiveLMS::Syllabus).to receive(:courses).and_return []
+          expect_any_instance_of(UserAuthorization).to receive(:refresh!)
+
+          get :courses, assignment_id: world.assignment.id, importer_provider_id: :canvas
+        end
+      end
+    end
+
+    describe "POST grades_import" do
+      let(:access_token) { "BLAH" }
+      let(:course_id) { "COURSE_ID" }
+      let(:grade_ids) { ["GRADE1", "GRADE2"] }
+      let(:result) { double(:result, success?: true, message: "") }
+      let!(:user_authorization) do
+        create :user_authorization, :canvas, user: professor, access_token: access_token,
+          expires_at: 2.days.from_now
+      end
+
+      before do
+        allow(Services::ImportsLMSGrades).to receive(:import).and_return result
+      end
+
+      it "imports the selected grades" do
+        expect(Services::ImportsLMSGrades).to \
+          receive(:import).with("canvas", access_token, course_id,
+                                grade_ids, world.assignment.id.to_s)
+            .and_return result
+
+        post :grades_import, importer_provider_id: "canvas",
+          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+      end
+
+      it "renders the results" do
+        post :grades_import, importer_provider_id: "canvas",
+          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+
+        expect(response).to render_template :grades_import_results
+      end
+
+      context "with an invalid result" do
+        it "re-renders the template with the error" do
+          allow(result).to receive(:success?).and_return false
+          syllabus = double(course: {}, grades: [])
+          allow(controller).to receive(:syllabus).and_return syllabus
+
+          post :grades_import, importer_provider_id: "canvas",
+            assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+
+          expect(response).to render_template :grades
         end
       end
     end

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -92,6 +92,7 @@ describe Grades::ImportersController do
 
     describe "POST grades_import" do
       let(:access_token) { "BLAH" }
+      let(:assignment_ids) { ["ASSIGNMENT_1"] }
       let(:course_id) { "COURSE_ID" }
       let(:grade_ids) { ["GRADE1", "GRADE2"] }
       let(:result) { double(:result, success?: true, message: "") }
@@ -107,16 +108,19 @@ describe Grades::ImportersController do
       it "imports the selected grades" do
         expect(Services::ImportsLMSGrades).to \
           receive(:import).with("canvas", access_token, course_id,
-                                grade_ids, world.assignment.id.to_s, professor)
+                                assignment_ids, grade_ids, world.assignment.id.to_s,
+                                professor)
             .and_return result
 
         post :grades_import, importer_provider_id: "canvas",
-          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids,
+          assignment_ids: assignment_ids
       end
 
       it "renders the results" do
         post :grades_import, importer_provider_id: "canvas",
-          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+          assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids,
+          assignment_ids: assignment_ids
 
         expect(response).to render_template :grades_import_results
       end
@@ -128,7 +132,8 @@ describe Grades::ImportersController do
           allow(controller).to receive(:syllabus).and_return syllabus
 
           post :grades_import, importer_provider_id: "canvas",
-            assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids
+            assignment_id: world.assignment.id, id: course_id, grade_ids: grade_ids,
+            assignment_ids: assignment_ids
 
           expect(response).to render_template :grades
         end

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -108,7 +108,7 @@ describe Grades::ImportersController do
       it "imports the selected grades" do
         expect(Services::ImportsLMSGrades).to \
           receive(:import).with("canvas", access_token, course_id,
-                                assignment_ids, grade_ids, world.assignment.id.to_s,
+                                assignment_ids, grade_ids, world.assignment.id,
                                 professor)
             .and_return result
 

--- a/spec/importers/grade_importers/canvas_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/canvas_grade_importer_spec.rb
@@ -1,0 +1,42 @@
+require "active_record_spec_helper"
+require "./app/importers/grade_importers/canvas_grade_importer"
+
+describe CanvasGradeImporter do
+  describe "#import" do
+    it "returns empty results if there are no canvas grades" do
+      result = described_class.new(nil).import(nil, nil)
+
+      expect(result.successful).to be_empty
+      expect(result.unsuccessful).to be_empty
+    end
+
+    context "with some canvas grades" do
+      let(:assignment) { create :assignment }
+      let(:canvas_grade) do
+        {
+          id: canvas_grade_id,
+          score: 98.0,
+          user_id: "USER_1"
+        }.stringify_keys
+      end
+      let(:canvas_user) do
+        {
+          primary_email: user.email
+        }.stringify_keys
+      end
+      let(:canvas_grade_id) { "GRADE_1" }
+      let(:grade) { Grade.unscoped.last }
+      let(:syllabus) { double(:syllabus, user: canvas_user) }
+      let(:user) { create :user }
+      subject { described_class.new([canvas_grade]) }
+
+      it "creates the grade" do
+        expect { subject.import(assignment.id, syllabus) }.to \
+          change { Grade.count }.by 1
+        expect(grade.assignment).to eq assignment
+        expect(grade.student).to eq user
+        expect(grade.raw_points).to eq 98
+      end
+    end
+  end
+end

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -1,9 +1,11 @@
-require "rails_spec_helper"
+require "active_record_spec_helper"
+require "./lib/quote_helper"
+require "./app/importers/grade_importers/csv_grade_importer"
 
-describe GradeImporter do
+describe CSVGradeImporter do
   describe "#import" do
     it "returns empty results when there is no file" do
-      result = GradeImporter.new(nil).import
+      result = described_class.new(nil).import
       expect(result.successful).to be_empty
       expect(result.unsuccessful).to be_empty
     end
@@ -12,7 +14,7 @@ describe GradeImporter do
       let(:file) { fixture_file "grades.csv", "text/csv" }
       let(:course) { create :course }
       let(:assignment) { create :assignment, course: course }
-      subject { GradeImporter.new(file.tempfile) }
+      subject { described_class.new(file.tempfile) }
 
       context "with a student not in the file" do
         let(:student) { create :user }

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -20,16 +20,18 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
   describe "#assignments" do
     subject { described_class.new access_token }
 
-    it "retrieves the assignments for the course from the api" do
+    it "retrieves the published assignments for the course from the api" do
+      body = [{ name: "This is a published assignment", published: true },
+              { name: "This is an unpublished assignment", published: false }]
       stub_request(:get, "https://canvas.instructure.com/api/v1/courses/123/assignments")
-        .with(query: { "published" => "true", "access_token" => access_token })
-        .to_return(status: 200, body: [{ name: "This is an assignment" }].to_json,
+        .with(query: { "access_token" => access_token })
+        .to_return(status: 200, body: body.to_json,
                    headers: {})
 
       assignments = subject.assignments(123)
 
       expect(assignments.count).to eq 1
-      expect(assignments.first["name"]).to eq "This is an assignment"
+      expect(assignments.first["name"]).to eq "This is a published assignment"
     end
 
     context "for specific ids" do

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -110,20 +110,42 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
   end
 
   describe "#grades" do
+    let(:assignment_ids) { [456, 789] }
+    let!(:stub) do
+      stub_request(:get,
+          "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
+        .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
+                       "include" => ["assignment", "course", "user"],
+                       "access_token" => access_token })
+        .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
+    end
     subject { described_class.new access_token }
 
     it "retrieves the grades from the api" do
-      stub_request(:get,
-          "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
-        .with(query: { "assignment_ids" => [456, 789], "student_ids" => "all",
-                       "include" => ["assignment", "course", "user"],
-                       "access_token" => access_token })
-        .to_return(status: 200, body: [{ score: 87 }].to_json, headers: {})
-
-      grades = subject.grades(123, [456, 789])
+      grades = subject.grades(123, assignment_ids)
 
       expect(grades.count).to eq 1
       expect(grades.first["score"]).to eq 87
+    end
+
+    context "for specific ids" do
+      it "filters out a single id" do
+        grades = subject.grades(123, assignment_ids, 456)
+
+        expect(grades.first["id"]).to eq 456
+      end
+
+      it "does not duplicate the grades for double grade ids" do
+        grades = subject.grades(123, assignment_ids, [456, 456])
+
+        expect(grades.count).to eq 1
+      end
+
+      it "filters out the grade ids" do
+        grades = subject.grades(123, assignment_ids, [123])
+
+        expect(grades).to be_empty
+      end
     end
   end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -130,7 +130,7 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
 
     context "for specific ids" do
       it "filters out a single id" do
-        grades = subject.grades(123, assignment_ids, 456)
+        grades = subject.grades(123, assignment_ids, "456")
 
         expect(grades.first["id"]).to eq 456
       end

--- a/spec/lib/active_lms/syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus_spec.rb
@@ -46,7 +46,7 @@ describe ActiveLMS::Syllabus do
     subject { described_class.new :canvas, access_token }
 
     it "delegates to the provider" do
-      expect(subject.provider).to receive(:grades).with(123, [456, 789])
+      expect(subject.provider).to receive(:grades).with(123, [456, 789], nil)
       subject.grades(123, [456, 789])
     end
   end

--- a/spec/services/imports_lms_grades/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades/imports_lms_grades_spec.rb
@@ -1,0 +1,56 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_grades/imports_lms_grades"
+
+describe Services::Actions::ImportsLMSGrades do
+  let(:assignment) { create :assignment }
+  let(:grade) { Grade.unscoped.last }
+  let(:grades) { [{ "id" => "GRADE_1", "score" => 97 }] }
+  let(:provider) { :canvas }
+  let(:user) { create :user }
+
+  it "expects grades to import" do
+    expect { described_class.execute assignment_id: assignment.id,
+             provider: provider, user: user }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects an assignment id to create the grades for" do
+    expect { described_class.execute grades: grades, provider: provider, user: user }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects a provider to create the correct importer object" do
+    expect { described_class.execute assignment_id: assignment.id, grades: grades,
+             user: user }.to raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects a user to find the grade information for" do
+    expect { described_class.execute assignment_id: assignment.id, grades: grades,
+             provider: provider }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  context "with a user authorization" do
+    let!(:user_authorization) { create :user_authorization, user: user,
+                                provider: provider, access_token: "BLAH" }
+
+    it "creates the grades" do
+      allow_any_instance_of(ActiveLMS::Syllabus).to \
+        receive(:user).and_return({ "primary_email" => user.email })
+      result = described_class.execute assignment_id: assignment.id,
+        grades: grades, provider: provider, user: user
+
+      expect(result.import_result.successful.count).to eq 1
+    end
+  end
+
+  context "without a user authorization" do
+    it "does not create the grade" do
+      result = described_class.execute assignment_id: assignment.id,
+          grades: grades, provider: provider, user: user
+
+      expect(result.import_result).to be_nil
+    end
+  end
+end

--- a/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
@@ -1,0 +1,52 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_grades/retrieves_lms_grades"
+
+describe Services::Actions::RetrievesLMSGrades do
+  let(:access_token) { "TOKEN" }
+  let(:assignment_ids) { ["ASSIGNMENT_1", "ASSIGNMENT_2"] }
+  let(:course_id) { "COURSE_ID" }
+  let(:grade_ids) { ["GRADE_1", "GRADE_2"] }
+  let(:provider) { "canvas" }
+
+  it "expects the provider to retrieve the grades from" do
+    expect { described_class.execute access_token: access_token, course_id: course_id,
+             assignment_ids: assignment_ids, grade_ids: grade_ids }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the access token to use to retrieve the grades" do
+    expect { described_class.execute provider: provider, course_id: course_id,
+             assignment_ids: assignment_ids, grade_ids: grade_ids }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the provider's course id to retrieve the grades from" do
+    expect { described_class.execute provider: provider, access_token: access_token,
+             assignment_ids: assignment_ids, grade_ids: grade_ids }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the provider's assignment ids to retrieve the grades from" do
+    expect { described_class.execute provider: provider, access_token: access_token,
+             course_id: course_id, grade_ids: grade_ids }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the provider's grade ids to retrieve the grades from" do
+    expect { described_class.execute provider: provider, access_token: access_token,
+             course_id: course_id, assignment_ids: assignment_ids }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "retrieves the grade details from the lms provider" do
+    expect(ActiveLMS::Syllabus).to \
+      receive(:new).with(provider, access_token).and_call_original
+    expect_any_instance_of(ActiveLMS::Syllabus).to \
+      receive(:grades).with(course_id, assignment_ids, grade_ids)
+        .and_return [{ grade: "A+" }, { grade: "D-" }]
+
+    result = described_class.execute provider: provider, access_token: access_token,
+      course_id: course_id, assignment_ids: assignment_ids, grade_ids: grade_ids
+  end
+end

--- a/spec/services/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades_spec.rb
@@ -1,0 +1,26 @@
+require "active_record_spec_helper"
+require "./app/services/imports_lms_grades"
+
+describe Services::ImportsLMSGrades do
+  describe ".import" do
+    let(:access_token) { "TOKEN" }
+    let(:assignment) { create :assignment }
+    let(:course_id) { "COURSE_ID" }
+    let(:grade_ids) { ["GRADE_1", "GRADE_2"] }
+    let(:provider) { :canvas }
+
+    it "retrieves the grade details from the lms provider" do
+      expect(Services::Actions::RetrievesLMSGrades).to \
+        receive(:execute).and_call_original
+
+      described_class.import provider, access_token, course_id, grade_ids, assignment.id
+    end
+
+    it "imports the grades" do
+      expect(Services::Actions::ImportsLMSGrades).to \
+        receive(:execute).and_call_original
+
+      described_class.import provider, access_token, course_id, grade_ids, assignment.id
+    end
+  end
+end

--- a/spec/services/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades_spec.rb
@@ -5,22 +5,31 @@ describe Services::ImportsLMSGrades do
   describe ".import" do
     let(:access_token) { "TOKEN" }
     let(:assignment) { create :assignment }
+    let(:assignment_ids) { ["ASSIGNMENT_1"] }
     let(:course_id) { "COURSE_ID" }
     let(:grade_ids) { ["GRADE_1", "GRADE_2"] }
     let(:provider) { :canvas }
+    let(:user) { create :user }
+
+    before do
+      # do not call the API
+      allow_any_instance_of(ActiveLMS::Syllabus).to receive(:grades).and_return []
+    end
 
     it "retrieves the grade details from the lms provider" do
       expect(Services::Actions::RetrievesLMSGrades).to \
         receive(:execute).and_call_original
 
-      described_class.import provider, access_token, course_id, grade_ids, assignment.id
+      described_class.import provider, access_token, course_id, assignment_ids,
+        grade_ids, assignment.id, user
     end
 
     it "imports the grades" do
       expect(Services::Actions::ImportsLMSGrades).to \
         receive(:execute).and_call_original
 
-      described_class.import provider, access_token, course_id, grade_ids, assignment.id
+      described_class.import provider, access_token, course_id, assignment_ids,
+        grade_ids, assignment.id, user
     end
   end
 end


### PR DESCRIPTION
Allows a professor to select grades to be imported for an assignment. The student email must exist for the user to be able to select that grade.

The grade import mimics the assignment import. There is a service that performs the data gathering and then an importer object to actually take the data from Canvas and import the data into GradeCraft.

Currently only the following fields are imported from the [Canvas submission object](https://canvas.instructure.com/doc/api/submissions.html#submissions).

* Canvas `score` -> GradeCraft `raw_points`

These scores are assigned to the current `assignment` for the `student` that matches the Canvas user's email address.

Closes #2207 