### PR TITLE
Fix remove grade

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -51,25 +51,14 @@ class GradesController < ApplicationController
   # This is the method used when faculty delete a grade
   # it preserves the predicted grade
   def remove
-    @grade = Grade.find(params[:id])
-    @grade.raw_points = nil
-    @grade.status = nil
-    @grade.feedback = nil
-    @grade.feedback_read = false
-    @grade.feedback_read_at = nil
-    @grade.feedback_reviewed = false
-    @grade.feedback_reviewed_at = nil
-    @grade.instructor_modified = false
-    @grade.graded_at = nil
+    grade = Grade.find(params[:id])
 
-    @grade.update_attributes(grade_params)
-
-    if @grade.save
-      score_recalculator(@grade.student)
-      redirect_to @grade.assignment,
-        notice: "#{ @grade.student.name }'s #{ @grade.assignment.name } grade was successfully deleted."
+    if grade.clear_grade!
+      score_recalculator(grade.student)
+      redirect_to grade.assignment,
+        notice: "#{grade.student.name}'s #{grade.assignment.name} grade was successfully deleted."
     else
-      redirect_to @grade.assignment, notice:  @grade.errors.full_messages, status: 400
+      redirect_to grade.assignment, notice: grade.errors.full_messages, status: 400
     end
   end
 

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -61,6 +61,16 @@ class Grade < ActiveRecord::Base
     Grade.where(student_id: student_ids, assignment_id: assignment_id)
   end
 
+  def clear_grade!
+    self.raw_points, self.status, self.feedback, self.feedback_read_at,
+      self.feedback_reviewed_at, self.graded_at, self.graded_by_id,
+      self.adjustment_points_feedback = nil
+
+    self.adjustment_points = 0
+    self.feedback_read = self.feedback_reviewed = self.instructor_modified = false
+    save
+  end
+
   def feedback_read!
     update_attributes feedback_read: true, feedback_read_at: DateTime.now
   end
@@ -96,16 +106,16 @@ class Grade < ActiveRecord::Base
   end
 
   def check_unlockables
-    if self.assignment.is_a_condition? 
+    if self.assignment.is_a_condition?
       self.assignment.unlock_keys.map(&:unlockable).each do |unlockable|
         unlockable.check_unlock_status(student)
       end
     end
-    if self.assignment_type.is_a_condition? 
+    if self.assignment_type.is_a_condition?
       self.assignment_type.unlock_keys.map(&:unlockable).each do |unlockable|
         unlockable.check_unlock_status(student)
       end
-    end  
+    end
   end
 
   def excluded_by

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -153,6 +153,18 @@ describe GradesController do
         post :remove, { id: @grade.id, grade: { full_points: 13 }}
         expect(response.status).to eq(400)
       end
+
+      it "preserves the grade but removes any indication that it was graded" do
+        expect_any_instance_of(Grade).to receive(:clear_grade!).and_call_original
+
+        post :remove, { id: @grade.id }
+      end
+
+      it "recalculates the grade's score" do
+        expect(controller).to receive(:score_recalculator).with(@grade.student)
+
+        post :remove, { id: @grade.id }
+      end
     end
 
     describe "POST exclude" do

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -77,6 +77,61 @@ describe Grade do
     end
   end
 
+  describe "#clear_grade!" do
+    subject  { create :released_grade, feedback: "You rock", feedback_read: true,
+               feedback_read_at: DateTime.now, feedback_reviewed: true,
+               feedback_reviewed_at: DateTime.now, instructor_modified: true,
+               graded_at: DateTime.now, graded_by_id: 123 }
+
+    it "clears the raw points" do
+      subject.clear_grade!
+
+      expect(subject.raw_points).to be_nil
+    end
+
+    it "clears the adjustment" do
+      subject.clear_grade!
+
+      expect(subject.adjustment_points).to eq 0
+      expect(subject.adjustment_points_feedback).to be_nil
+    end
+
+    it "clears the status" do
+      subject.clear_grade!
+
+      expect(subject.status).to be_nil
+    end
+
+    it "clears the feedback" do
+      subject.clear_grade!
+
+      expect(subject.feedback).to be_empty
+      expect(subject.feedback_read_at).to be_nil
+      expect(subject.feedback_reviewed_at).to be_nil
+      expect(subject.feedback_read).to eq false
+      expect(subject.feedback_reviewed).to eq false
+    end
+
+    it "clears the instructor modified" do
+      subject.clear_grade!
+
+      expect(subject.instructor_modified).to eq false
+    end
+
+    it "removes any indication that it's been graded" do
+      subject.clear_grade!
+
+      expect(subject.graded_at).to be_nil
+      expect(subject.graded_by_id).to be_nil
+    end
+
+    it "persists the grade changes" do
+      subject.clear_grade!
+
+      expect(subject).to_not be_changed
+    end
+  end
+
   describe "#raw_points" do
     it "converts raw_points from human readable strings" do
       subject.update(raw_points: "1,234")
@@ -176,7 +231,7 @@ describe Grade do
       expect(subject.full_points).to be 0
     end
   end
-  
+
   describe "#feedback_read!" do
     it "marks the grade as read" do
       subject.feedback_read!


### PR DESCRIPTION
Fixes an issue with strong parameters when removing the grade by a professor. This was caused because the `grades#remove` method does not receive a `grade` param and the strong parameters were requiring it.

I removed the need to call `update_attributes` since the view was not passing any additional params except for the `id` of the `Grade`.

I cleaned up the actual removal of the grade so that it moves the responsibility to the model where it should be and I cleared additional fields that were missed in the controller.

I added specs for the `grades#remove` controller method and the new `clear_grade!` method on `Grade`.