### PR TITLE
1846 - Fix released grades bug

### DIFF
--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -30,7 +30,7 @@ class HistoryFilter
       result = inclusions.inject(true) do |select, inclusion|
         history_item.changeset[inclusion] == options[inclusion]
       end
-      result &= yield(history_item) if block_given?
+      result &= yield(history_item, history) if block_given?
       result
     end
     clear_empty_changesets

--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -20,26 +20,26 @@ module Submissions::GradeHistory
       .remove("name" => "file")
       .remove("name" => "store_dir")
       .remove("name" => "id")
-      .transform do |history|
-        if history.version.item_type == "SubmissionFile"
-          history.changeset["event"] = "upload"
+      .transform do |history_item|
+        if history_item.version.item_type == "SubmissionFile"
+          history_item.changeset["event"] = "upload"
         end
       end
       .rename("SubmissionFile" => "Attachment")
-      .include do |history|
+      .include do |history_item, history|
         viewable = true
 
-        if history.changeset["object"] == "Grade" && only_student_visible_grades
-          version = history.version.reify
+        if history_item.changeset["object"] == "Grade" && only_student_visible_grades
+          version = history_item.version.reify
           viewable = GradeProctor.new(version).viewable?
 
           unless viewable
             # Make the change viewable if the grade was updated first but then
             # it was released. This displays the changeset where the grade was
             # updated
-            viewable = (history.changeset.keys.include?("raw_points") ||
-                        history.changeset.keys.include?("feedback")) &&
-                        history.version.event == "update" &&
+            viewable = (history_item.changeset.keys.include?("raw_points") ||
+                        history_item.changeset.keys.include?("feedback")) &&
+                        history_item.version.event == "update" &&
                         GradeProctor.new(grade).viewable?
           end
         end


### PR DESCRIPTION
Modify the grade history module to display the grade change version if the grade was released after it was updated.

This displays the version information if the current grade is viewable to the student and the changeset includes a `raw_points` change or a `feedback` change.

Fixes #1846 