### PR TITLE
Strip leading and trailing whitespace

### DIFF
--- a/app/importers/student_importer.rb
+++ b/app/importers/student_importer.rb
@@ -16,6 +16,7 @@ class StudentImporter
   def import(course=nil)
     if file
       CSV.foreach(file, headers: true, skip_blanks: true) do |csv|
+        strip_whitespace csv
         row = UserRow.new csv
 
         team = find_or_create_team row, course
@@ -60,6 +61,10 @@ class StudentImporter
     return if row.team_name.blank?
     team = Team.find_by_course_and_name course.id, row.team_name
     team ||= Team.create course_id: course.id, name: row.team_name
+  end
+
+  def strip_whitespace(row)
+    row.each_with_index { |field, index| row[index].strip! if row[index] }
   end
 
   class UserRow

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -148,9 +148,10 @@ describe UsersController do
       it "renders the results from the import" do
         post :upload, file: file
         expect(response).to render_template :import_results
-        expect(response.body).to include "2 Students Imported Successfully"
+        expect(response.body).to include "3 Students Imported Successfully"
         expect(response.body).to include "jimmy@example.com"
         expect(response.body).to include "robert@example.com"
+        expect(response.body).to include "whitespace@example.com"
       end
 
       it "renders any errors that have occured" do

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,3 +1,4 @@
 First Name,Last Name,Username,Email,Team Name
+  leading,trailing  ,whitespace, whitespace@example.com , ,
 Robert,Plant,robert,robert@example.com,
 Jimmy,Page,jimmy,jimmy@example.com,Zeppelin


### PR DESCRIPTION
When importing users via csv, strip leading and trailing whitespace prior to processing

Fixes #2097