### PR TITLE
1519 submit next

### DIFF
--- a/app/controllers/assignments/students_controller.rb
+++ b/app/controllers/assignments/students_controller.rb
@@ -1,6 +1,7 @@
 class Assignments::StudentsController < ApplicationController
   before_filter :ensure_staff?
 
+  # POST /assignments/:assignment_id/students/:student_id/grade
   def grade
     grade = Grade.find_or_create params[:assignment_id], params[:student_id]
     redirect_to edit_grade_path grade

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -37,7 +37,18 @@ class GradesController < ApplicationController
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end
 
-      path = session[:return_to] || assignment_path(grade.assignment)
+      if params[:redirect_to_grade_next].present?
+        next_submission = grade.assignment.submissions.ungraded.first
+        if next_submission.present?
+          grade = Grade.find_or_create next_submission.assignment.id, next_submission.student.id
+          path =  edit_grade_path grade
+        else
+          path = assignment_path(grade.assignment)
+        end
+      else
+        path = session[:return_to] || assignment_path(grade.assignment)
+      end
+
       redirect_to path,
         notice: "#{grade.student.name}'s #{grade.assignment.name} was successfully updated"
     else # failure

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -180,12 +180,7 @@ class GradesController < ApplicationController
   end
 
   def path_for_next_grade(grade)
-    if grade.assignment.accepts_submissions?
-      next_submission = grade.assignment.submissions.ungraded.first
-      next_student = next_submission.student if next_submission.present?
-    else
-      next_student = grade.assignment.next_ungraded_student(grade.student)
-    end
+    next_student = grade.assignment.next_ungraded_student(grade.student)
 
     if next_student.present?
       return edit_grade_path(

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -184,7 +184,7 @@ class GradesController < ApplicationController
       next_submission = grade.assignment.submissions.ungraded.first
       next_student = next_submission.student if next_submission.present?
     else
-      next_student = grade.assignment.ungraded_students.first
+      next_student = grade.assignment.next_ungraded_student(grade.student)
     end
 
     if next_student.present?

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -181,13 +181,9 @@ class GradesController < ApplicationController
 
   def path_for_next_grade(grade)
     next_student = grade.assignment.next_ungraded_student(grade.student)
-
-    if next_student.present?
-      return edit_grade_path(
-        Grade.find_or_create(grade.assignment.id, next_student.id)
-      )
-    else
-      return assignment_path(grade.assignment)
-    end
+    return assignment_path(grade.assignment) unless next_student.present?
+    return edit_grade_path(
+      Grade.find_or_create(grade.assignment.id, next_student.id)
+    )
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -65,7 +65,14 @@ module Gradable
     predicted_earned_grades.predicted_to_be_done.count
   end
 
-  def ungraded_students
-    course.students - User.find(grades.graded.pluck(:student_id))
+  def ungraded_students(ids_to_include=[])
+    course.students.order_by_name -
+      (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
+  end
+
+  def next_ungraded_student(student)
+    us = ungraded_students([student.id])
+    i = us.map(&:id).index(student.id)
+    i && i < us.length - 1 ? us[i + 1] : nil
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -70,8 +70,16 @@ module Gradable
       (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
   end
 
+  def ungraded_students_with_submissions(ids_to_include=[])
+    ungraded_students(ids_to_include) & User.find(submissions.pluck(:student_id))
+  end
+
   def next_ungraded_student(student)
-    us = ungraded_students([student.id])
+    if accepts_submissions?
+      us = ungraded_students_with_submissions([student.id])
+    else
+      us = ungraded_students([student.id])
+    end
     i = us.map(&:id).index(student.id)
     i && i < us.length - 1 ? us[i + 1] : nil
   end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -76,11 +76,11 @@ module Gradable
 
   def next_ungraded_student(student)
     if accepts_submissions?
-      us = ungraded_students_with_submissions([student.id])
+      ungraded_students = ungraded_students_with_submissions([student.id])
     else
-      us = ungraded_students([student.id])
+      ungraded_students = ungraded_students([student.id])
     end
-    i = us.map(&:id).index(student.id)
-    i && i < us.length - 1 ? us[i + 1] : nil
+    i = ungraded_students.map(&:id).index(student.id)
+    i && i < ungraded_students.length - 1 ? ungraded_students[i + 1] : nil
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -64,4 +64,8 @@ module Gradable
   def predicted_count
     predicted_earned_grades.predicted_to_be_done.count
   end
+
+  def ungraded_students
+    course.students - User.find(grades.graded.pluck(:student_id))
+  end
 end

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -55,8 +55,8 @@
           .submit-buttons
             %ul
               %li= submit_tag "#{grade.persisted? && grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
-              - if grade.assignment.accepts_submissions? && !grade.is_graded?
-                %li= submit_tag "Submit and Grade Next", name: "redirect_to_grade_next", class: "button"
+              - if !grade.is_graded?
+                %li= submit_tag "Submit and Grade Next", name: "redirect_to_next_grade", class: "button"
               %li= link_to glyph("times-circle") + "Cancel", assignment_path(grade.assignment), class: "button"
 
         %section

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -55,7 +55,7 @@
           .submit-buttons
             %ul
               %li= submit_tag "#{grade.persisted? && grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
-              - if !grade.is_graded?
+              - unless grade.is_graded?
                 %li= submit_tag "Submit and Grade Next", name: "redirect_to_next_grade", class: "button"
               %li= link_to glyph("times-circle") + "Cancel", assignment_path(grade.assignment), class: "button"
 

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -55,6 +55,8 @@
           .submit-buttons
             %ul
               %li= submit_tag "#{grade.persisted? && grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
+              - if grade.assignment.accepts_submissions? && !grade.is_graded?
+                %li= submit_tag "Submit and Grade Next", name: "redirect_to_grade_next", class: "button"
               %li= link_to glyph("times-circle") + "Cancel", assignment_path(grade.assignment), class: "button"
 
         %section

--- a/app/views/grades/standard_edit/_raw_points_grading_fields.html.haml
+++ b/app/views/grades/standard_edit/_raw_points_grading_fields.html.haml
@@ -1,5 +1,5 @@
 .raw-score
-  = f.label :raw_points, "Raw Points (#{assignment.full_points} Points Possible)"
+  = f.label :raw_points, "Raw Points (#{points assignment.full_points} Points Possible)"
   = f.text_field :raw_points,
     default: assignment.full_points,
     label: "Score",

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -136,8 +136,10 @@ describe GradesController do
       end
 
       context "when redirect_to_next_grade is included in params" do
-        it "redirects to grade the next ungraded student when not accepting submissions"  , focus: true  do
-          next_student = create(:student_course_membership, course: @assignment.course).user
+        it "redirects to grade the next ungraded student when not accepting submissions" do
+          next_student = create(
+            :student_course_membership, course: @assignment.course,
+            user: create(:user,last_name: "Zzz")).user
           @assignment.update(accepts_submissions: false)
 
           put :update, { id: @grade.id, grade: { raw_points: 12345, status: "Graded"}, redirect_to_next_grade: true}

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -135,6 +135,15 @@ describe GradesController do
         expect(response).to redirect_to(login_path)
       end
 
+      it "redirects to next submission if requested" do
+        submission_2 = create :submission, assignment: @assignment
+        put :update, { id: @grade.id, grade: { raw_points: 12345}, redirect_to_grade_next: true}
+        expect(response).to redirect_to(edit_grade_path(
+          Grade.where(
+            student: submission_2.student,
+            assignment: submission_2.assignment).first))
+      end
+
       it "redirects on failure" do
         allow_any_instance_of(Grade).to receive(:update_attributes).and_return false
         put :update, { id: @grade.id, grade: { full_points: 100 }}

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -136,26 +136,29 @@ describe GradesController do
       end
 
       context "when redirect_to_next_grade is included in params" do
-        it "redirects to grade the next ungraded student when not accepting submissions" do
-          next_student = create(
+        before do
+          @next_student = create(
             :student_course_membership, course: @assignment.course,
             user: create(:user,last_name: "Zzz")).user
-          @assignment.update(accepts_submissions: false)
+        end
 
+        it "creates and redirects to grade the next ungraded student when not accepting submissions" do
+          @assignment.update(accepts_submissions: false)
           put :update, { id: @grade.id, grade: { raw_points: 12345, status: "Graded"}, redirect_to_next_grade: true}
           expect(response).to redirect_to(edit_grade_path(
             Grade.where(
-              student: next_student,
+              student: @next_student,
               assignment: @assignment).first)
           )
         end
 
-        it "redirects to grade the next submission when accepting submissions" do
-          submission_2 = create :submission, assignment: @assignment
+        it "creates and redirects to grade the next student with submission" do
+          create :submission, assignment: @assignment, student: @student
+          create :submission, assignment: @assignment, student: @next_student
           put :update, { id: @grade.id, grade: { raw_points: 12345 }, redirect_to_next_grade: true}
           expect(response).to redirect_to(edit_grade_path(
             Grade.where(
-              student: submission_2.student,
+              student: @next_student,
               assignment: @assignment).first)
           )
         end

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -129,17 +129,11 @@ describe GradesController do
         expect(@grade.reload.score).to eq(nil)
       end
 
-      it "returns to assignment show page on simple submit" do
-        session[:return_to] = login_path
-        put :update, { id: @grade.id, grade: { raw_points: 12345 }}
-        expect(response).to redirect_to(assignment_path(@grade.assignment))
-      end
-
-      context "when redirect_to_next_grade is included in params" do
+      context "when grading a series of students" do
         before do
           @next_student = create(
             :student_course_membership, course: @assignment.course,
-            user: create(:user,last_name: "Zzz")).user
+            user: create(:user, last_name: "Zzz")).user
         end
 
         it "creates and redirects to grade the next ungraded student when not accepting submissions" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -822,6 +822,19 @@ describe Assignment do
     end
   end
 
+  describe "ungraded_students" do
+    before { subject.save }
+
+    it "returns all students for course who are not graded for this assignment" do
+      s1 = create(:student_course_membership, course: subject.course).user
+      s2 = create(:student_course_membership, course: subject.course).user
+      s3 = create(:student_course_membership, course: subject.course).user
+      subject.grades.create student_id: s1.id, raw_points: 8, status: "Graded"
+      subject.grades.create student_id: s2.id, raw_points: 5, status: "In Progress"
+      expect(subject.ungraded_students.count).to eq(2)
+    end
+  end
+
   describe "#soon?" do
     it "is not soon if there is no due date" do
       subject.due_at = nil

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -823,15 +823,40 @@ describe Assignment do
   end
 
   describe "ungraded_students" do
-    before { subject.save }
-
-    it "returns all students for course who are not graded for this assignment" do
+    before do
+      subject.save
       s1 = create(:student_course_membership, course: subject.course).user
       s2 = create(:student_course_membership, course: subject.course).user
       s3 = create(:student_course_membership, course: subject.course).user
       subject.grades.create student_id: s1.id, raw_points: 8, status: "Graded"
       subject.grades.create student_id: s2.id, raw_points: 5, status: "In Progress"
-      expect(subject.ungraded_students.count).to eq(2)
+    end
+
+    it "returns all students without a 'Graded' grade for the assignment" do
+     expect(subject.ungraded_students.count).to eq(2)
+    end
+  end
+
+  describe "next_ungraded_student" do
+    before { subject.save }
+
+    %w"Zenith Apex Middleton".each do |username|
+      let!(username.downcase.to_sym) do
+        create(:student_course_membership, course: subject.course,
+          user: create(:user,last_name: username)).user
+      end
+    end
+
+    it "returns the next student by last name" do
+      expect(subject.next_ungraded_student(middleton).last_name).to eq("Zenith")
+    end
+
+    it "returns nil for the last student" do
+      expect(subject.next_ungraded_student(zenith)).to be_nil
+    end
+
+    it "returns nil for student not in the list" do
+      expect(subject.next_ungraded_student(create(:user))).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR adds a "Submit and Grade Next" button on the Grade edit form, to allow Professors to cycle through the students needing grading rather than constantly return to the Assignment index page.

<img width="383" alt="screen shot 2016-09-01 at 3 50 42 pm" src="https://cloud.githubusercontent.com/assets/1138350/18182027/160b37fc-705c-11e6-821a-2f1fb73935be.png">

The logic is a follows: 

If there are submissions for the assignment, "Next" will be the next student, ordered alphabetically, with a submission for the assignment without a grade(status: "Graded").

If the assignment does not accept submissions, "Next" will be the next student, ordered alphabetically, without a grade(status: "Graded")

Both cases return to the index page on the last student.

Running through the students alphabetically and not looping ensures that clicking "S&G Next" when submitting an "In Progress" grade does not return to the current grade edit page.

When editing a "Graded" grade with the form, the button does not appear.
