### PR TITLE
1970 record grade modifier

### DIFF
--- a/app/controllers/api/criterion_grades_controller.rb
+++ b/app/controllers/api/criterion_grades_controller.rb
@@ -33,7 +33,7 @@ class API::CriterionGradesController < ApplicationController
 
   # PUT api/assignments/:assignment_id/students/:student_id/criterion_grade
   def update
-    result = Services::CreatesGradeUsingRubric.create params
+    result = Services::CreatesGradeUsingRubric.create params, current_user
     if result.success?
       render json: {
         message: "Grade successfully saved", success: true },
@@ -63,7 +63,7 @@ class API::CriterionGradesController < ApplicationController
 
   # PUT api/assignments/:assignment_id/groups/:group_id/criterion_grade
   def group_update
-    result = Services::CreatesGroupGradesUsingRubric.create params
+    result = Services::CreatesGroupGradesUsingRubric.create params, current_user
     if result.success?
       render json: {
         message: "Grade successfully saved", success: true

--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -15,7 +15,7 @@ class API::GradesController < ApplicationController
   # POST api/grades/:grade_id
   def update
     grade = Grade.find(params[:id])
-    grade.assign_attributes(grade_params)
+    grade.assign_attributes(grade_params.merge(graded_by_id: current_user.id))
     grade.instructor_modified = true
     if grade.raw_points_changed?
       grade.graded_at = DateTime.now

--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -16,7 +16,6 @@ class API::GradesController < ApplicationController
   def update
     grade = Grade.find(params[:id])
     grade.assign_attributes(grade_params.merge(graded_by_id: current_user.id))
-    grade.instructor_modified = true
     if grade.raw_points_changed?
       grade.graded_at = DateTime.now
     end

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -140,7 +140,6 @@ class Assignments::GradesController < ApplicationController
         @grade.raw_points = @assignment.full_points
       end
 
-      @grade.instructor_modified = true
       @grade.graded_by_id = current_user.id
       @grade.status = "Graded"
 
@@ -167,7 +166,6 @@ class Assignments::GradesController < ApplicationController
   def assignment_params
     params.require(:assignment).permit grades_attributes: [:graded_by_id,
                                                            :graded_at,
-                                                           :instructor_modified,
                                                            :student_id,
                                                            :raw_points, :status,
                                                            :pass_fail_status,

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -141,6 +141,7 @@ class Assignments::GradesController < ApplicationController
       end
 
       @grade.instructor_modified = true
+      @grade.graded_by_id = current_user.id
       @grade.status = "Graded"
 
       if @grade.save
@@ -164,9 +165,12 @@ class Assignments::GradesController < ApplicationController
   private
 
   def assignment_params
-    params.require(:assignment).permit grades_attributes: [:graded_by_id, :graded_at,
-                                                           :instructor_modified, :student_id,
-                                                           :raw_points, :status, :pass_fail_status,
+    params.require(:assignment).permit grades_attributes: [:graded_by_id,
+                                                           :graded_at,
+                                                           :instructor_modified,
+                                                           :student_id,
+                                                           :raw_points, :status,
+                                                           :pass_fail_status,
                                                            :id]
   end
 

--- a/app/controllers/assignments/groups_controller.rb
+++ b/app/controllers/assignments/groups_controller.rb
@@ -35,7 +35,7 @@ class Assignments::GroupsController < ApplicationController
   private
 
   def grade_params
-    params.require(:grade).permit :graded_at, :group_id, :graded_by_id, :instructor_modified,
+    params.require(:grade).permit :graded_at, :group_id, :graded_by_id,
       :submission_id, :raw_points, :feedback, :status
   end
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -85,7 +85,7 @@ class Grades::ImportersController < ApplicationController
         notice: "File is missing"
     else
       @result = CSVGradeImporter.new(params[:file].tempfile)
-        .import(current_course, @assignment)
+        .import(current_course, @assignment, current_user)
 
       grade_ids = @result.successful.map(&:id)
       enqueue_multiple_grade_update_jobs(grade_ids)

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -33,8 +33,7 @@ class GradesController < ApplicationController
     grade = Grade.find params[:id]
 
     if grade.update_attributes grade_params.merge(graded_at: DateTime.now,
-                                                  graded_by_id: current_user.id,
-                                                  instructor_modified: true)
+                                                  graded_by_id: current_user.id)
       if GradeProctor.new(grade).viewable?
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end
@@ -136,7 +135,7 @@ class GradesController < ApplicationController
       :earned_badges_attributes, :excluded_by_id, :excluded_at, :excluded_from_course_score,
       :feedback, :feedback_read, :feedback_read_at, :feedback_reviewed, :feedback_reviewed_at,
       :final_points, :grade_file_ids, :grade_files_attributes, :graded_at, :graded_by_id,
-      :group_id, :group_type, :instructor_modified, :is_custom_value, :pass_fail_status,
+      :group_id, :group_type, :is_custom_value, :pass_fail_status,
       :full_points, :raw_points, :student_id, :submission_id, :task_id, :team_id, :status,
       grade_files_attributes: [:id, file: []]
   end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -32,7 +32,9 @@ class GradesController < ApplicationController
   def update
     grade = Grade.find params[:id]
 
-    if grade.update_attributes grade_params.merge(graded_at: DateTime.now, instructor_modified: true)
+    if grade.update_attributes grade_params.merge(graded_at: DateTime.now,
+                                                  graded_by_id: current_user.id,
+                                                  instructor_modified: true)
       if GradeProctor.new(grade).viewable?
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -37,7 +37,7 @@ class InfoController < ApplicationController
   # submissions in the system
   def grading_status
     @title = "Grading Status"
-    grades = current_course.grades.instructor_modified
+    grades = current_course.grades.grade_modified
     submissions = current_course.submissions.includes(:assignment, :grade, :student, :group, :submission_files)
     @ungraded_submissions_by_assignment = submissions.ungraded.group_by(&:assignment)
     @resubmissions_by_assignment = submissions.resubmitted.group_by(&:assignment)

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -18,7 +18,8 @@ class GradeExporter
       csv << headers + detail_headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
-        grade = NullGrade.new if grade.nil? || !(grade.instructor_modified? || grade.graded_or_released?)
+        grade = NullGrade.new if grade.nil? || !(grade.grade_modified? ||
+                                                 grade.graded_or_released?)
         submission = student.submission_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
                 student.email,

--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -55,7 +55,6 @@ class CSVGradeImporter
     grade.raw_points = row.grade
     grade.feedback = row.feedback
     grade.status = "Graded" if grade.status.nil?
-    grade.instructor_modified = true
     grade.graded_by_id = grader.id unless grader.nil?
     grade.graded_at = DateTime.now
   end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -44,7 +44,7 @@ class Grade < ActiveRecord::Base
 
   scope :excluded_from_course_score, -> { where excluded_from_course_score: true }
   scope :included_in_course_score, -> { where excluded_from_course_score: false }
-  scope :instructor_modified, -> { where instructor_modified: true }
+  scope :grade_modified, -> { where.not(graded_by_id: nil) }
   scope :positive, -> { where("score > 0")}
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }
@@ -67,8 +67,12 @@ class Grade < ActiveRecord::Base
       self.adjustment_points_feedback = nil
 
     self.adjustment_points = 0
-    self.feedback_read = self.feedback_reviewed = self.instructor_modified = false
+    self.feedback_read = self.feedback_reviewed = false
     save
+  end
+
+  def grade_modified?
+    !self.graded_by_id.nil?
   end
 
   def feedback_read!

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -35,7 +35,7 @@ class Assignments::Presenter < Showtime::Presenter
   def prediction_for(assignment)
     grade_for(assignment).predicted_points
   end
-  
+
   def positive_prediction_for?(assignment)
     grade_for(assignment).predicted_points > 0
   end
@@ -73,7 +73,7 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def has_reviewable_grades?
-    grades.instructor_modified.present?
+    grades.grade_modified.present?
   end
 
   def has_submission_for?(user)

--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -11,7 +11,6 @@ module Submissions::GradeHistory
       .remove("name" => "final_points")
       .remove("name" => "graded_at")
       .remove("name" => "graded_by_id")
-      .remove("name" => "instructor_modified")
       .remove("name" => "score")
       .remove("name" => "status")
       .remove("name" => "submission_id")

--- a/app/services/creates_grade/marks_as_graded.rb
+++ b/app/services/creates_grade/marks_as_graded.rb
@@ -3,11 +3,12 @@ module Services
     class MarksAsGraded
       extend LightService::Action
 
-      expects :grade
+      expects :grade, :user
 
       executed do |context|
         context[:grade].instructor_modified = true
         context[:grade].graded_at = DateTime.now
+        context[:grade].graded_by_id = context[:user].id
       end
     end
   end

--- a/app/services/creates_grade/marks_as_graded.rb
+++ b/app/services/creates_grade/marks_as_graded.rb
@@ -6,7 +6,6 @@ module Services
       expects :grade, :user
 
       executed do |context|
-        context[:grade].instructor_modified = true
         context[:grade].graded_at = DateTime.now
         context[:grade].graded_by_id = context[:user].id
       end

--- a/app/services/creates_grade_using_rubric.rb
+++ b/app/services/creates_grade_using_rubric.rb
@@ -16,8 +16,8 @@ module Services
 
     aliases raw_params: :attributes
 
-    def self.create(raw_params)
-      with(raw_params: raw_params)
+    def self.create(raw_params, user)
+      with(raw_params: raw_params, user: user)
         .reduce(
           Actions::VerifiesAssignmentStudent,
           Actions::BuildsCriterionGrades,

--- a/app/services/creates_group_grades_using_rubric.rb
+++ b/app/services/creates_group_grades_using_rubric.rb
@@ -5,8 +5,8 @@ module Services
   class CreatesGroupGradesUsingRubric
     extend LightService::Organizer
 
-    def self.create(raw_params)
-      with(raw_params: raw_params)
+    def self.create(raw_params, user)
+      with(raw_params: raw_params, user: user)
         .reduce(
           Actions::IteratesCreatesGradeUsingRubric
         )

--- a/app/services/group_services/iterates_creates_grade_using_rubric.rb
+++ b/app/services/group_services/iterates_creates_grade_using_rubric.rb
@@ -5,7 +5,7 @@ module Services
     class IteratesCreatesGradeUsingRubric
       extend LightService::Action
 
-      expects :raw_params
+      expects :raw_params, :user
 
       executed do |context|
         begin
@@ -15,11 +15,12 @@ module Services
           next context
         end
 
+        user = context[:user]
         group.students.each do |student|
           params = context[:raw_params].deep_dup
           params["student_id"] = student.id
           params["group_id"] = group.id
-          context.add_to_context Services::CreatesGradeUsingRubric.create(params)
+          context.add_to_context Services::CreatesGradeUsingRubric.create(params, user)
         end
       end
     end

--- a/app/views/assignments/grades/index.html.haml
+++ b/app/views/assignments/grades/index.html.haml
@@ -12,7 +12,7 @@
   - if presenter.grade_with_rubric?
     - presenter.students_being_graded.each do |student|
       - grade_for_assignment = student.grade_for_assignment(presenter.assignment)
-      - if grade_for_assignment.present? && grade_for_assignment.instructor_modified?
+      - if grade_for_assignment.present? && grade_for_assignment.grade_modified?
         %h4.uppercase= student.name
         .left
           %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "

--- a/app/views/assignments/grades/mass_edit.html.haml
+++ b/app/views/assignments/grades/mass_edit.html.haml
@@ -30,7 +30,6 @@
                 = gf.hidden_field :graded_by_id, :value => current_user.id
                 - if !grade.status
                   = gf.hidden_field :status, :value => "Graded"
-                = gf.hidden_field :instructor_modified, :value => true
                 = gf.hidden_field :student_id
                 = label_tag do
                   // Checking to see if the grade is actually graded before setting the default value to 0

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -38,7 +38,7 @@
               %td= link_to student.name, student_path(student)
               - grade = group_presenter.grade_for(student)
               %td
-                - if grade.present? && grade.instructor_modified?
+                - if grade.present? && grade.grade_modified?
                   = points grade.final_points
               - if group_presenter.assignment.assignment_type.student_weightable?
                 %td

--- a/app/views/assignments/groups/_standard_edit.html.haml
+++ b/app/views/assignments/groups/_standard_edit.html.haml
@@ -1,7 +1,6 @@
 = simple_form_for :grade, :url => graded_assignment_group_path(@assignment, @group), :html => { :method => :put} do |f|
   = hidden_field_tag "group_id", @group.id
   = f.hidden_field :graded_by_id, :value => current_user.id
-  = f.hidden_field :instructor_modified, :value => true
   = f.hidden_field :submission_id, value: @submission_id
 
   Score:

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -11,18 +11,18 @@
     %td= link_to student.last_name, student_path(student)
     - if presenter.assignment.threshold_points?
       %td.raw-score
-        = points grade.raw_points if grade.instructor_modified?
+        = points grade.raw_points if grade.grade_modified?
     %td.status-or-score
       - if presenter.assignment.pass_fail?
-        = grade.try(:pass_fail_status) if grade.instructor_modified?
+        = grade.try(:pass_fail_status) if grade.grade_modified?
       - else
-        = points grade.final_points if grade.instructor_modified?
+        = points grade.final_points if grade.grade_modified?
 
     // If the student can weight the assignment type
     - if presenter.assignment_type.student_weightable?
       %td
         - if student.weighted_assignments?(current_course)
-          = points grade.score if grade.instructor_modified?
+          = points grade.score if grade.grade_modified?
         - else
           = "(not yet assigned)"
 
@@ -60,7 +60,7 @@
               /* Submission present - allow instructor to see it, and identify if it's a new submission or a resubmission. Icon represents if there are files attached. */
               %li= link_to glyph(:paperclip) + "See Submission", assignment_submission_path(presenter.assignment, submission.id), class: "button"
 
-          - if grade.instructor_modified?
+          - if grade.grade_modified?
             %li= link_to glyph(:eye) + "See Grade", grade_path(grade), class: "button"
             - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(submissions_for_assignment)
               %li= link_to glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"

--- a/db/migrate/20160902195541_remove_instructor_modified_from_grades.rb
+++ b/db/migrate/20160902195541_remove_instructor_modified_from_grades.rb
@@ -1,0 +1,5 @@
+class RemoveInstructorModifiedFromGrades < ActiveRecord::Migration
+  def change
+    remove_column :grades, :instructor_modified
+  end
+end

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -47,7 +47,6 @@
   # only used if :grades is true:
   grade_attributes: {
     raw_points: -> { rand(5000) },
-    instructor_modified: false,
     status: nil,
     feedback: nil,
     excluded_from_course_score: false
@@ -122,7 +121,6 @@ uncertainty! - Douglas Adams"
   grades: true,
   grade_attributes: {
     status: "Graded",
-    instructor_modified: true
   }
 }
 
@@ -157,8 +155,7 @@ to bed. ― J.K. Rowling"
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -194,8 +191,7 @@ of what it feels about education.― Harold Howe",
   assignment_score_levels: true,
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -228,8 +224,7 @@ life.― John Holt",
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -250,7 +245,6 @@ met. Grades have a raw_points of 15000",
   grades: true,
   grade_attributes: {
     status: "Graded",
-    instructor_modified: true,
     raw_points: -> { 15000 },
   }
 }
@@ -363,7 +357,6 @@ is for. Did you learn nothing from my chemistry class? - Walter H. White",
   grades: true,
   grade_attributes: {
     status: "Graded",
-    instructor_modified: true,
     raw_points: -> { 80000 },
     feedback: 'As Aristotle said, <strong>"The whole is greater than the sum \
 of its parts."</strong>'
@@ -548,9 +541,7 @@ positive, because they allow you to work off something.–Charles Gwathmey",
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: true,
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   },
   prediction: true,
   prediction_attributes: {
@@ -572,10 +563,8 @@ not added to total",
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: true,
     status: "Graded",
-    excluded_from_course_score: true,
-    instructor_modified: true
+    excluded_from_course_score: true
   },
   prediction: true,
   prediction_attributes: {
@@ -631,10 +620,8 @@ should not have a visible grade",
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: true,
     raw_points: -> { rand(15000) },
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   },
   prediction: true,
   prediction_attributes: {
@@ -701,7 +688,6 @@ accepts predictions.",
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: false,
     raw_points: -> { nil },
     status: nil,
   },
@@ -783,7 +769,6 @@ submissive, and so on -- because they're dysfunctional to the institutions. \
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: false,
     raw_points: -> { nil },
     status: nil,
   },
@@ -810,7 +795,6 @@ submissive, and so on -- because they're dysfunctional to the institutions. \
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: true,
     raw_points: -> { 15000 },
     status: "Graded"
   },
@@ -849,7 +833,6 @@ Ralph Waldo Emerson",
   },
   grades: true,
   grade_attributes: {
-    instructor_modified: false,
     raw_points: -> { nil },
     status: nil,
   },
@@ -889,7 +872,6 @@ to proceed with growing up. ― John Taylor Gatto",
   assignment_score_levels: true,
   grades: true,
   grade_attributes: {
-    instructor_modified: false,
     raw_points: -> { nil },
     status: nil,
   },
@@ -1227,7 +1209,6 @@ treated like money, to be put away in a bank for the future. ― Seymour Papert"
   grades: true,
   grade_attributes: {
     status: "Graded",
-    instructor_modified: true,
     raw_points: -> { 180000 },
     feedback: 'As George Washington Carver said, <strong>"Education is the key
       to unlock the golden door of freedom."</strong>'
@@ -1273,7 +1254,6 @@ in the end you’ll fall right into my trap. ― Sophia Nikolaidou",
   grades: true,
   grade_attributes: {
     status: "Graded",
-    instructor_modified: true,
     raw_points: -> { 180000 },
     feedback: 'As Winston Churchill said, <strong>"Continuous effort - not
       strength or intelligence - is the key to unlocking our potential.
@@ -1505,8 +1485,7 @@ the speed, and the route.― Jay Cross",
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -1534,8 +1513,7 @@ the speed, and the route.― Jay Cross",
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -1563,8 +1541,7 @@ the speed, and the route.― Jay Cross",
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }
 
@@ -1592,7 +1569,6 @@ the speed, and the route.― Jay Cross",
   },
   grades: true,
   grade_attributes: {
-    status: "Graded",
-    instructor_modified: true
+    status: "Graded"
   }
 }

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -1,14 +1,5 @@
 namespace :grades do
 
-  desc "Set all grades that have a status as being instructor_modified"
-
-  task update_instructor_modified: :environment do
-    puts "Setting grades as 'instructor_modified where a status exists..."
-    total_updated = Grade.where("status is not null").update_all(instructor_modified: true)
-    puts "Updated #{total_updated} grades with instructor_modified: true"
-    puts "DONE"
-  end
-
   desc "Update all of the graded_at dates to the updated_at for the grades"
   task update_graded_at: :environment do
     Grade.where("(predicted_score > 0 OR predicted_score IS NULL) AND graded_at IS NULL").update_all("graded_at=updated_at")

--- a/spec/controllers/api/grades_controller_spec.rb
+++ b/spec/controllers/api/grades_controller_spec.rb
@@ -37,14 +37,6 @@ describe API::GradesController do
         expect(world.grade.raw_points).to eq(20000)
       end
 
-      it "updates instructor modified to true" do
-        post :update, { id: world.grade.id, grade: {
-          raw_points: 20000, feedback: "good jorb!" }}
-
-        world.grade.reload
-        expect(world.grade.instructor_modified).to be_truthy
-      end
-
       it "updates the graded by id to the current user" do
         post :update, { id: world.grade.id, grade: {
           raw_points: 20000, feedback: "good jorb!" }}

--- a/spec/controllers/api/grades_controller_spec.rb
+++ b/spec/controllers/api/grades_controller_spec.rb
@@ -28,7 +28,9 @@ describe API::GradesController do
 
     describe "update" do
       it "updates feedback, status and raw score from params" do
-        post :update, { id: world.grade.id, grade: { raw_points: 20000, feedback: "good jorb!", status: "Graded" }}
+        post :update, { id: world.grade.id, grade: {
+          raw_points: 20000, feedback: "good jorb!", status: "Graded" }}
+
         world.grade.reload
         expect(world.grade.feedback).to eq("good jorb!")
         expect(world.grade.status).to eq("Graded")
@@ -36,14 +38,26 @@ describe API::GradesController do
       end
 
       it "updates instructor modified to true" do
-        post :update, { id: world.grade.id, grade: { raw_points: 20000, feedback: "good jorb!" }}
+        post :update, { id: world.grade.id, grade: {
+          raw_points: 20000, feedback: "good jorb!" }}
+
         world.grade.reload
         expect(world.grade.instructor_modified).to be_truthy
       end
 
+      it "updates the graded by id to the current user" do
+        post :update, { id: world.grade.id, grade: {
+          raw_points: 20000, feedback: "good jorb!" }}
+
+        world.grade.reload
+        expect(world.grade.graded_by_id).to eq professor.id
+      end
+
       it "timestamps the grade" do
         current_time = DateTime.now
-        post :update, { id: world.grade.id, grade: { raw_points: 20000, feedback: "good jorb!" }}
+        post :update, { id: world.grade.id, grade: {
+          raw_points: 20000, feedback: "good jorb!" }}
+
         expect(world.grade.reload.graded_at).to be > current_time
       end
     end

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -111,9 +111,8 @@ describe Assignments::GradesController do
     describe "PUT mass_update" do
       let(:grades_attributes) do
         { "#{@assignment.reload.grades.index(@grade)}" =>
-          { graded_by_id: @professor.id, instructor_modified: true,
-            student_id: @grade.student_id, raw_points: 1000, status: "Graded",
-            id: @grade.id
+          { graded_by_id: @professor.id, student_id: @grade.student_id,
+            raw_points: 1000, status: "Graded", id: @grade.id
           }
         }
       end

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -160,7 +160,7 @@ describe Assignments::GradesController do
 
     describe "POST self_log" do
       it "redirects back to the root" do
-        expect(post :self_log, assignment_id: @assignment.id ).to \
+        expect(post :self_log, assignment_id: @assignment.id).to \
           redirect_to(:root)
       end
     end
@@ -192,6 +192,13 @@ describe Assignments::GradesController do
           post :self_log, assignment_id: @assignment.id
           grade = @student.grade_for_assignment(@assignment)
           expect(grade.raw_points).to eq @assignment.full_points
+        end
+
+        it "marks the grade as graded by the student" do
+          post :self_log, assignment_id: @assignment.id
+
+          grade = @student.grade_for_assignment(@assignment)
+          expect(grade.graded_by_id).to eq @student.id
         end
 
         it "reports errors on failure to save" do

--- a/spec/controllers/assignments/groups_controller_spec.rb
+++ b/spec/controllers/assignments/groups_controller_spec.rb
@@ -43,8 +43,7 @@ describe Assignments::GroupsController do
         group.students << @student
         current_time = DateTime.now
         put :graded, assignment_id: @assignment.id, id: group.id,
-          grade: { graded_by_id: @professor.id, instructor_modified: true,
-                   raw_points: 1000, status: "Graded" }
+          grade: { graded_by_id: @professor.id, raw_points: 1000, status: "Graded" }
         expect(@grade.reload.raw_points).to eq 1000
         expect(@grade.group_id).to eq(group.id)
         expect(@grade.graded_at).to be > current_time

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -97,6 +97,12 @@ describe GradesController do
         expect(@grade.reload.graded_at).to be > current_time
       end
 
+      it "marks uses the current user as the graded by id" do
+        put :update, { id: @grade.id, grade: { raw_points: 12345 }}
+
+        expect(@grade.reload.graded_by_id).to eq @professor.id
+      end
+
       it "attaches the student submission" do
         submission = create :submission, assignment: @assignment, student: @student
         grade_params = { raw_points: 12345, submission_id: submission.id }

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -210,7 +210,6 @@ describe GradesController do
           feedback_read_at: Time.now,
           feedback_reviewed: true,
           feedback_reviewed_at: Time.now,
-          instructor_modified: true,
           graded_at: DateTime.now,
           status: "Graded"
         )

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -64,11 +64,13 @@ describe GradeExporter do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return double(:grade, graded_or_released?: false, score: 123,
-                             raw_points: 789, feedback: nil, graded_at: updated_at)
+                             raw_points: 789, feedback: nil, graded_at: updated_at,
+                             grade_modified?: true)
       allow(students[1]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return double :grade, graded_or_released?: true, score: 456,
-                             raw_points: 456, feedback: "Grrrrreat!", graded_at: updated_at
+                             raw_points: 456, feedback: "Grrrrreat!",
+                             graded_at: updated_at, grade_modified?: true
       allow(students[1]).to \
         receive(:submission_for_assignment).with(assignment)
           .and_return double(:submission, text_comment: "Hello there")
@@ -104,7 +106,7 @@ describe GradeExporter do
     it "does not include the grade if it has not been graded or released" do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
-          .and_return double(:grade, graded_or_released?: false)
+          .and_return double(:grade, graded_or_released?: false, grade_modified?: false)
       csv = CSV.new(subject.export_grades_with_detail(assignment, students)).read
       expect(csv[1][3]).to eq ""
     end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -63,12 +63,12 @@ describe GradeExporter do
       updated_at = DateTime.now
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
-          .and_return double(:grade, instructor_modified?: true, graded_or_released?: false,
-                              score: 123, raw_points: 789, feedback: nil, graded_at: updated_at)
+          .and_return double(:grade, graded_or_released?: false, score: 123,
+                             raw_points: 789, feedback: nil, graded_at: updated_at)
       allow(students[1]).to \
         receive(:grade_for_assignment).with(assignment)
-          .and_return double(:grade, instructor_modified?: false, graded_or_released?: true,
-                              score: 456, raw_points: 456, feedback: "Grrrrreat!", graded_at: updated_at)
+          .and_return double :grade, graded_or_released?: true, score: 456,
+                             raw_points: 456, feedback: "Grrrrreat!", graded_at: updated_at
       allow(students[1]).to \
         receive(:submission_for_assignment).with(assignment)
           .and_return double(:submission, text_comment: "Hello there")
@@ -104,7 +104,7 @@ describe GradeExporter do
     it "does not include the grade if it has not been graded or released" do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
-          .and_return double(:grade, instructor_modified?: false, graded_or_released?: false)
+          .and_return double(:grade, graded_or_released?: false)
       csv = CSV.new(subject.export_grades_with_detail(assignment, students)).read
       expect(csv[1][3]).to eq ""
     end

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -49,7 +49,6 @@ describe CSVGradeImporter do
           expect(grade.feedback).to eq "You did great!"
           expect(grade.status).to eq "Graded"
           expect(grade.graded_by_id).to eq user.id
-          expect(grade.instructor_modified).to eq true
           expect(result.successful.count).to eq 1
           expect(result.successful.last).to eq grade
         end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -80,7 +80,7 @@ describe Grade do
   describe "#clear_grade!" do
     subject  { create :released_grade, feedback: "You rock", feedback_read: true,
                feedback_read_at: DateTime.now, feedback_reviewed: true,
-               feedback_reviewed_at: DateTime.now, instructor_modified: true,
+               feedback_reviewed_at: DateTime.now,
                graded_at: DateTime.now, graded_by_id: 123 }
 
     it "clears the raw points" do
@@ -112,12 +112,6 @@ describe Grade do
       expect(subject.feedback_reviewed).to eq false
     end
 
-    it "clears the instructor modified" do
-      subject.clear_grade!
-
-      expect(subject.instructor_modified).to eq false
-    end
-
     it "removes any indication that it's been graded" do
       subject.clear_grade!
 
@@ -129,6 +123,29 @@ describe Grade do
       subject.clear_grade!
 
       expect(subject).to_not be_changed
+    end
+  end
+
+  describe ".grade_modified" do
+    it "returns all the grades that have been graded by someone" do
+      modified = create :grade, graded_by_id: 123
+      not_modified = create :grade, graded_by_id: nil
+
+      expect(described_class.grade_modified).to eq [modified]
+    end
+  end
+
+  describe "#grade_modified?" do
+    it "returns true if it has been graded by someone" do
+      subject.graded_by_id = 123
+
+      expect(subject).to be_grade_modified
+    end
+
+    it "returns false if it has not been graded by someone" do
+      subject.graded_by_id = nil
+
+      expect(subject).to_not be_grade_modified
     end
   end
 

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -258,9 +258,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student,
-                  raw_points: 100, status: nil, instructor_modified: false,
-                  graded_at: DateTime.now
-        )
+                  raw_points: 100, status: nil, graded_at: DateTime.now)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_value: 100)
@@ -271,9 +269,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student,
-                  raw_points: 100, status: "Graded", instructor_modified:
-                  true, graded_at: DateTime.now
-        )
+                  raw_points: 100, status: "Graded", graded_at: DateTime.now)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_date: (Date.today + 1)
@@ -285,9 +281,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student,
-                  raw_points: 100, status: "Graded", instructor_modified: true,
-                  graded_at: DateTime.now
-        )
+                  raw_points: 100, status: "Graded", graded_at: DateTime.now)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_date: (Date.today - 1)
@@ -299,9 +293,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, raw_points: 100,
-                  status: "Graded", instructor_modified: true,
-                  graded_at: DateTime.now
-        )
+                  status: "Graded", graded_at: DateTime.now)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_value: 100,
@@ -314,8 +306,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student,
-                  raw_points: 90, status: "Graded", instructor_modified: true
-        )
+                  raw_points: 90, status: "Graded")
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_value: 100,
@@ -328,9 +319,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, raw_points: 100,
-                  status: "Graded", instructor_modified: true,
-                  graded_at: DateTime.now
-        )
+                  status: "Graded", graded_at: DateTime.now)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Grade Earned", condition_value: 100,
@@ -345,8 +334,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, status: "Graded",
-                  instructor_modified: true, feedback_read: true
-        )
+                  feedback_read: true)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Feedback Read"
@@ -358,8 +346,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, status: "Graded",
-                  instructor_modified: true, feedback_read: false
-        )
+                  feedback_read: false)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Feedback Read"
@@ -371,9 +358,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, status: "Graded",
-                  instructor_modified: true, feedback_read: true,
-                  feedback_read_at: Date.today
-        )
+                  feedback_read: true, feedback_read_at: Date.today)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Feedback Read", condition_date: Date.today + 1
@@ -385,9 +370,7 @@ describe UnlockCondition do
         student = create(:user)
         create(
           :grade, assignment: assignment, student: student, status: "Graded",
-                  instructor_modified: true, feedback_read: true,
-                  feedback_read_at: Date.today
-        )
+                  feedback_read: true, feedback_read_at: Date.today)
         unlock_condition = UnlockCondition.new(
           condition_id: assignment.id, condition_type: "Assignment",
           condition_state: "Feedback Read", condition_date: Date.today - 1

--- a/spec/services/creates_grade/marks_as_graded_spec.rb
+++ b/spec/services/creates_grade/marks_as_graded_spec.rb
@@ -20,6 +20,5 @@ describe Services::Actions::MarksAsGraded do
     result = described_class.execute grade: grade, user: user
     expect(result[:grade].graded_at).to be_within(1.second).of(Time.now)
     expect(result[:grade].graded_by_id).to eq user.id
-    expect(result[:grade].instructor_modified).to be_truthy
   end
 end

--- a/spec/services/creates_grade/marks_as_graded_spec.rb
+++ b/spec/services/creates_grade/marks_as_graded_spec.rb
@@ -3,17 +3,23 @@ require "active_record_spec_helper"
 require "./app/services/creates_grade/marks_as_graded"
 
 describe Services::Actions::MarksAsGraded do
-
   let(:grade) { create :grade }
+  let(:user) { create :user }
 
   it "expect grade to be added to the context" do
-    expect { described_class.execute }.to \
+    expect { described_class.execute user: user }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects a user to be added to the context" do
+    expect { described_class.execute grade: grade }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
   it "adds attributes to the grade" do
-    result = described_class.execute grade: grade
+    result = described_class.execute grade: grade, user: user
     expect(result[:grade].graded_at).to be_within(1.second).of(Time.now)
+    expect(result[:grade].graded_by_id).to eq user.id
     expect(result[:grade].instructor_modified).to be_truthy
   end
 end

--- a/spec/services/creates_grade_using_rubric_spec.rb
+++ b/spec/services/creates_grade_using_rubric_spec.rb
@@ -1,59 +1,59 @@
 require "active_record_spec_helper"
-
 require "./app/services/creates_grade_using_rubric"
 
 describe Services::CreatesGradeUsingRubric do
   let(:params) { RubricGradePUT.new.params }
+  let(:user) { create :user }
 
   describe ".create" do
     it "confirms the student and assignment" do
       expect(Services::Actions::VerifiesAssignmentStudent).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "initializes new criterion grades" do
       expect(Services::Actions::BuildsCriterionGrades).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "saves criterion grades" do
       expect(Services::Actions::SavesCriterionGrades).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "initializes new grade from params" do
       expect(Services::Actions::BuildsGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "adds the submission id to the grade" do
       expect(Services::Actions::AssociatesSubmissionWithGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "marks grade as graded" do
       expect(Services::Actions::MarksAsGraded).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "saves the grade" do
       expect(Services::Actions::SavesGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "creates level badges" do
       expect(Services::Actions::BuildsEarnedLevelBadges).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "saves level badges" do
       expect(Services::Actions::SavesEarnedLevelBadges).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
 
     it "runs the grade updater job" do
       expect(Services::Actions::RunsGradeUpdaterJob).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, user
     end
   end
 end

--- a/spec/services/creates_group_grades_using_rubric_spec.rb
+++ b/spec/services/creates_group_grades_using_rubric_spec.rb
@@ -1,16 +1,18 @@
 require "active_record_spec_helper"
-
 require "./app/services/creates_group_grades_using_rubric"
 
 describe Services::CreatesGroupGradesUsingRubric do
-  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
+  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion,
+                                  :criterion_grade, :badge, :group) }
   let(:group_params) {{ "group_id" => world.group.id }}
   let(:params) { RubricGradePUT.new(world).params.merge group_params }
+  let(:user) { create :user }
 
   describe ".create" do
     it "interates through the students in a group" do
-      expect(Services::Actions::IteratesCreatesGradeUsingRubric).to receive(:execute).and_call_original
-      described_class.create params
+      expect(Services::Actions::IteratesCreatesGradeUsingRubric).to \
+        receive(:execute).and_call_original
+      described_class.create params, user
     end
   end
 end

--- a/spec/services/group_services/iterates_creates_grade_using_rubric_spec.rb
+++ b/spec/services/group_services/iterates_creates_grade_using_rubric_spec.rb
@@ -3,23 +3,26 @@ require "active_record_spec_helper"
 require "./app/services/group_services/iterates_creates_grade_using_rubric"
 
 describe Services::Actions::IteratesCreatesGradeUsingRubric do
-  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
+  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion,
+                                  :criterion_grade, :badge, :group) }
   let(:group_params) {{ "group_id" => world.group.id }}
   let(:raw_params) { RubricGradePUT.new(world).params.merge group_params }
+  let(:user) { create :user }
 
   it "fails if the group is not found" do
     raw_params["group_id"] = 1000
-    result = described_class.execute raw_params: raw_params
+    result = described_class.execute raw_params: raw_params, user: user
     expect(result.message).to eq("Unable to find group")
   end
 
   it "iterates over the students in group" do
-    expect(Services::CreatesGradeUsingRubric).to receive(:create).exactly(world.group.students.count).times.and_call_original
-    described_class.execute raw_params: raw_params
+    expect(Services::CreatesGradeUsingRubric).to \
+      receive(:create).exactly(world.group.students.count).times.and_call_original
+    described_class.execute raw_params: raw_params, user: user
   end
 
   it "adds the group id to the context" do
-    result = described_class.execute raw_params: raw_params
+    result = described_class.execute raw_params: raw_params, user: user
     expect(result[:attributes]["group_id"]).to eq(world.group.id)
   end
 end

--- a/spec/toolkits/models/assignments_toolkit.rb
+++ b/spec/toolkits/models/assignments_toolkit.rb
@@ -83,7 +83,7 @@ module Toolkits
       end
 
       def grade_student_for_active_assignment(student)
-        create(:grade, assignment: @assignment, student: student, feedback: "good jorb!", instructor_modified: true)
+        create(:grade, assignment: @assignment, student: student, feedback: "good jorb!")
       end
 
       def create_submission_for_student(student)

--- a/spec/views/assignments/student_index/_assignments_spec.rb
+++ b/spec/views/assignments/student_index/_assignments_spec.rb
@@ -167,7 +167,8 @@ describe "assignments/student_index/_assignments" do
       allow(view).to receive(:current_user_is_staff?).and_return(true)
       allow(view).to receive(:term_for).and_return("custom_term")
       assign(:students, [@student])
-      create(:grade, course: @course, instructor_modified: true, assignment: @assignment, student: @student, raw_points: 2000, status: "Released")
+      create(:grade, course: @course, assignment: @assignment, student: @student,
+             raw_points: 2000, status: "Released")
       render
       assert_select "a", text: "Edit Grade", count: 1
     end


### PR DESCRIPTION
This replaces the need for a `Grade#instructor_modified` column by just using the `graded_by_id` instead. This eliminates the need for two columns to be updated when a `Grade` is graded.

A method `grade_modified?` was added to `Grade` to be used for checking the existence of `graded_by_id` which replaces the `instructor_modified?` check.

Closes #1970 
