### PR TITLE
total predictions by AT to limit by caps

### DIFF
--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -138,7 +138,10 @@
 
   # Total points predicted for all assignments, badges, and challenges
   allPointsPredicted = ()->
-    total = assignmentsWeightedPredictedPoints()
+    total = 0
+    _.each(assignmentTypes, (assignmentType)->
+        total += assignmentTypePointTotal(assignmentType,true,true,true)
+      )
     total += badgesPredictedPoints()
     total += challengesPredictedPoints()
     total


### PR DESCRIPTION
This PR fixes the summation of predicted points in the predictor graph when there is a cap on the Assignment Type.

closes #2378