### PR TITLE
2172 refresh canvas assignments

### DIFF
--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -46,6 +46,23 @@ class Assignments::ImportersController < ApplicationController
     end
   end
 
+  # POST /assignments/importers/:importer_provider_id/assignments/:id/refresh
+  def refresh_assignment
+    provider_name = params[:importer_provider_id]
+    assignment = Assignment.find(params[:id])
+
+    result = Services::ImportsLMSAssignments.refresh provider_name,
+      authorization(provider_name).access_token, assignment
+
+    if result.success?
+      flash[:notice] = "You have successfully refreshed #{assignment.name} from #{provider_name.capitalize}"
+    else
+      flash[:alert] = result.message
+    end
+
+    redirect_to assignment_path(assignment)
+  end
+
   private
 
   def syllabus

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -55,7 +55,7 @@ class Assignments::ImportersController < ApplicationController
       authorization(provider_name).access_token, assignment
 
     if result.success?
-      flash[:notice] = "You have successfully refreshed #{assignment.name} from #{provider_name.capitalize}"
+      flash[:notice] = "You have successfully updated #{assignment.name} from #{provider_name.capitalize}"
     else
       flash[:alert] = result.message
     end

--- a/app/importers/assignment_importers/canvas_assignment_importer.rb
+++ b/app/importers/assignment_importers/canvas_assignment_importer.rb
@@ -45,6 +45,7 @@ class CanvasAssignmentImporter
       provider_resource_id: provider_resource_id)
     imported.assignment = assignment
     imported.provider_data = provider_data
+    imported.last_imported_at = DateTime.now
     imported.save
   end
 end

--- a/app/importers/assignment_importers/canvas_assignment_importer.rb
+++ b/app/importers/assignment_importers/canvas_assignment_importer.rb
@@ -11,12 +11,8 @@ class CanvasAssignmentImporter
   def import(course, assignment_type_id)
     unless assignments.nil?
       assignments.each do |canvas_assignment|
-        assignment = course.assignments.build name: canvas_assignment["name"],
-          description: canvas_assignment["description"],
-          due_at: canvas_assignment["due_at"],
-          full_points: canvas_assignment["points_possible"],
-          assignment_type_id: assignment_type_id
-        assignment.pass_fail = true if canvas_assignment["grading_type"] == "pass_fail"
+        assignment = self.class.import_row course.assignments.build, canvas_assignment
+        assignment.assignment_type_id = assignment_type_id
 
         if assignment.save
           link_imported canvas_assignment["id"],
@@ -31,6 +27,15 @@ class CanvasAssignmentImporter
     end
 
     self
+  end
+
+  def self.import_row(assignment, canvas_assignment)
+    assignment.name = canvas_assignment["name"]
+    assignment.description = canvas_assignment["description"]
+    assignment.due_at = canvas_assignment["due_at"]
+    assignment.full_points = canvas_assignment["points_possible"]
+    assignment.pass_fail = true if canvas_assignment["grading_type"] == "pass_fail"
+    assignment
   end
 
   private

--- a/app/importers/assignment_importers/canvas_assignment_importer.rb
+++ b/app/importers/assignment_importers/canvas_assignment_importer.rb
@@ -19,7 +19,9 @@ class CanvasAssignmentImporter
         assignment.pass_fail = true if canvas_assignment["grading_type"] == "pass_fail"
 
         if assignment.save
-          link_imported canvas_assignment["id"], assignment
+          link_imported canvas_assignment["id"],
+            { course_id: canvas_assignment["course_id"] },
+            assignment
           successful << assignment
         else
           unsuccessful << { data: canvas_assignment,
@@ -33,10 +35,11 @@ class CanvasAssignmentImporter
 
   private
 
-  def link_imported(provider_resource_id, assignment)
+  def link_imported(provider_resource_id, provider_data, assignment)
     imported = ImportedAssignment.find_or_initialize_by(provider: :canvas,
       provider_resource_id: provider_resource_id)
     imported.assignment = assignment
+    imported.provider_data = provider_data
     imported.save
   end
 end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -4,6 +4,7 @@ require_relative "imports_lms_assignments/refresh_assignment"
 require_relative "imports_lms_assignments/retrieves_imported_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignments"
+require_relative "imports_lms_assignments/updates_imported_timestamp"
 
 module Services
   class ImportsLMSAssignments
@@ -23,7 +24,8 @@ module Services
       with(provider: provider, access_token: access_token, assignment: assignment).reduce(
         Actions::RetrievesImportedAssignment,
         Actions::RetrievesLMSAssignment,
-        Actions::RefreshAssignment
+        Actions::RefreshAssignment,
+        Actions::UpdatesImportedTimestamp
       )
     end
   end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -1,5 +1,6 @@
 require "light-service"
 require_relative "imports_lms_assignments/imports_lms_assignments"
+require_relative "imports_lms_assignments/retrieves_imported_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignments"
 
 module Services
@@ -13,6 +14,12 @@ module Services
            assignment_type_id: assignment_type_id).reduce(
              Actions::RetrievesLMSAssignments,
              Actions::ImportsLMSAssignments
+      )
+    end
+
+    def self.refresh(provider, access_token, assignment)
+      with(provider: provider, access_token: access_token, assignment: assignment).reduce(
+        Actions::RetrievesImportedAssignment
       )
     end
   end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -1,6 +1,7 @@
 require "light-service"
 require_relative "imports_lms_assignments/imports_lms_assignments"
 require_relative "imports_lms_assignments/retrieves_imported_assignment"
+require_relative "imports_lms_assignments/retrieves_lms_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignments"
 
 module Services
@@ -19,7 +20,8 @@ module Services
 
     def self.refresh(provider, access_token, assignment)
       with(provider: provider, access_token: access_token, assignment: assignment).reduce(
-        Actions::RetrievesImportedAssignment
+        Actions::RetrievesImportedAssignment,
+        Actions::RetrievesLMSAssignment
       )
     end
   end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -1,5 +1,6 @@
 require "light-service"
 require_relative "imports_lms_assignments/imports_lms_assignments"
+require_relative "imports_lms_assignments/refresh_assignment"
 require_relative "imports_lms_assignments/retrieves_imported_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignments"
@@ -21,7 +22,8 @@ module Services
     def self.refresh(provider, access_token, assignment)
       with(provider: provider, access_token: access_token, assignment: assignment).reduce(
         Actions::RetrievesImportedAssignment,
-        Actions::RetrievesLMSAssignment
+        Actions::RetrievesLMSAssignment,
+        Actions::RefreshAssignment
       )
     end
   end

--- a/app/services/imports_lms_assignments/refresh_assignment.rb
+++ b/app/services/imports_lms_assignments/refresh_assignment.rb
@@ -1,19 +1,21 @@
+require "active_support"
+require_relative "../../importers/assignment_importers"
+
 module Services
   module Actions
     class RefreshAssignment
       extend LightService::Action
+      extend ActiveSupport::Inflector
 
-      expects :assignment, :lms_assignment
+      expects :assignment, :lms_assignment, :provider
 
       executed do |context|
         assignment = context.assignment
         lms_assignment = context.lms_assignment
+        provider = context.provider
 
-        assignment.name = lms_assignment["name"]
-        assignment.description = lms_assignment["description"]
-        assignment.due_at = lms_assignment["due_at"]
-        assignment.full_points = lms_assignment["points_possible"]
-        assignment.pass_fail = true if lms_assignment["grading_type"] == "pass_fail"
+        importer_class = constantize("#{camelize(provider)}AssignmentImporter")
+        assignment = importer_class.import_row assignment, lms_assignment
         assignment.save
       end
     end

--- a/app/services/imports_lms_assignments/refresh_assignment.rb
+++ b/app/services/imports_lms_assignments/refresh_assignment.rb
@@ -1,0 +1,21 @@
+module Services
+  module Actions
+    class RefreshAssignment
+      extend LightService::Action
+
+      expects :assignment, :lms_assignment
+
+      executed do |context|
+        assignment = context.assignment
+        lms_assignment = context.lms_assignment
+
+        assignment.name = lms_assignment["name"]
+        assignment.description = lms_assignment["description"]
+        assignment.due_at = lms_assignment["due_at"]
+        assignment.full_points = lms_assignment["points_possible"]
+        assignment.pass_fail = true if lms_assignment["grading_type"] == "pass_fail"
+        assignment.save
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_assignments/retrieves_imported_assignment.rb
+++ b/app/services/imports_lms_assignments/retrieves_imported_assignment.rb
@@ -1,0 +1,22 @@
+module Services
+  module Actions
+    class RetrievesImportedAssignment
+      extend LightService::Action
+
+      expects :assignment, :provider
+      promises :imported_assignment
+
+      executed do |context|
+        assignment = context.assignment
+        provider = context.provider
+
+        context.imported_assignment =
+          ImportedAssignment.where(assignment_id: assignment.id, provider: provider).first
+
+        if context.imported_assignment.nil?
+          context.fail! "Assignment was not imported from #{provider.capitalize}", 422
+        end
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
@@ -19,7 +19,7 @@ module Services
         syllabus = ActiveLMS::Syllabus.new provider, access_token
         begin
           context.lms_assignment = syllabus.assignment course_id, assignment_id
-        rescue Exception => e
+        rescue StandardError => e
           context.fail! e.message
         end
       end

--- a/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
@@ -1,0 +1,28 @@
+require "active_lms"
+
+module Services
+  module Actions
+    class RetrievesLMSAssignment
+      extend LightService::Action
+
+      expects :access_token, :imported_assignment, :provider
+      promises :lms_assignment
+
+      executed do |context|
+        provider = context.provider
+        access_token = context.access_token
+        course_id = context.imported_assignment.provider_data[:course_id]
+        assignment_id = context.imported_assignment.provider_resource_id
+
+        context.lms_assignment = nil
+
+        syllabus = ActiveLMS::Syllabus.new provider, access_token
+        begin
+          context.lms_assignment = syllabus.assignment course_id, assignment_id
+        rescue Exception => e
+          context.fail! e.message
+        end
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
@@ -11,7 +11,7 @@ module Services
       executed do |context|
         provider = context.provider
         access_token = context.access_token
-        course_id = context.imported_assignment.provider_data[:course_id]
+        course_id = context.imported_assignment.provider_data["course_id"]
         assignment_id = context.imported_assignment.provider_resource_id
 
         context.lms_assignment = nil

--- a/app/services/imports_lms_assignments/updates_imported_timestamp.rb
+++ b/app/services/imports_lms_assignments/updates_imported_timestamp.rb
@@ -1,0 +1,13 @@
+module Services
+  module Actions
+    class UpdatesImportedTimestamp
+      extend LightService::Action
+
+      expects :imported_assignment
+
+      executed do |context|
+        context.imported_assignment.update_attribute :last_imported_at, DateTime.now
+      end
+    end
+  end
+end

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -17,6 +17,11 @@
         - else
           %li.hide-for-small= link_to glyph("file-zip-o") + "Download All Submissions", submissions_exports_path(assignment_id: presenter.assignment.id), method: :post
 
+      - unless presenter.assignment.imported_assignment.nil?
+        %li.hide-for-small
+          = link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+            = glyph(:refresh)
+            = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
       %li.hide-for-small
         %a{:href => assignment_grades_importers_path(presenter.assignment) }
           = glyph(:upload)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ GradeCraft::Application.routes.draw do
       get "/courses/:id/assignments", to: :assignments, as: :assignments
       post "/courses/:id/assignments/import", to: :assignments_import,
         as: :assignments_import
+      post "/assignments/:id/refresh", to: :refresh_assignment, as: :refresh_assignment
     end
   end
 

--- a/db/migrate/20160906203536_add_provider_data_to_imported_assignments.rb
+++ b/db/migrate/20160906203536_add_provider_data_to_imported_assignments.rb
@@ -1,0 +1,5 @@
+class AddProviderDataToImportedAssignments < ActiveRecord::Migration
+  def change
+    add_column :imported_assignments, :provider_data, :hstore
+  end
+end

--- a/db/migrate/20160907000216_add_last_imported_at_to_imported_assignments.rb
+++ b/db/migrate/20160907000216_add_last_imported_at_to_imported_assignments.rb
@@ -1,0 +1,5 @@
+class AddLastImportedAtToImportedAssignments < ActiveRecord::Migration
+  def change
+    add_column :imported_assignments, :last_imported_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830154453) do
+ActiveRecord::Schema.define(version: 20160906203536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -476,6 +476,7 @@ ActiveRecord::Schema.define(version: 20160830154453) do
     t.string   "provider_resource_id", null: false
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
+    t.hstore   "provider_data"
   end
 
   add_index "imported_assignments", ["assignment_id"], name: "index_imported_assignments_on_assignment_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160906203536) do
+ActiveRecord::Schema.define(version: 20160907000216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -477,6 +477,7 @@ ActiveRecord::Schema.define(version: 20160906203536) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.hstore   "provider_data"
+    t.datetime "last_imported_at"
   end
 
   add_index "imported_assignments", ["assignment_id"], name: "index_imported_assignments_on_assignment_id", using: :btree

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -22,6 +22,10 @@ module ActiveLMS
       provider.courses
     end
 
+    def assignment(course_id, assignment_id)
+      provider.assignment(course_id, assignment_id)
+    end
+
     def assignments(course_id, assignment_ids=nil)
       provider.assignments(course_id, assignment_ids)
     end

--- a/spec/controllers/assignments/importers_controller_spec.rb
+++ b/spec/controllers/assignments/importers_controller_spec.rb
@@ -7,6 +7,8 @@ describe Assignments::ImportersController do
   let(:professor_membership) { create :professor_course_membership, course: course }
   let(:provider) { :canvas }
 
+  before { allow(controller).to receive(:current_course).and_return course }
+
   describe "GET courses" do
     context "as a professor" do
       before { login_user(professor) }
@@ -51,7 +53,6 @@ describe Assignments::ImportersController do
 
       before do
         login_user(professor)
-        allow(controller).to receive(:current_course).and_return course
         allow(Services::ImportsLMSAssignments).to receive(:import).and_return result
       end
 
@@ -89,6 +90,59 @@ describe Assignments::ImportersController do
     context "as a student" do
       it "redirects to the root url" do
         post :assignments_import, importer_provider_id: provider, id: course_id
+
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+
+  describe "POST #refresh_assignment" do
+    let(:assignment) { create :assignment, course: course }
+
+    context "as a professor" do
+      let(:access_token) { "BLAH" }
+      let(:result) { double(:result, success?: true, message: "") }
+      let!(:user_authorization) do
+        create :user_authorization, :canvas, user: professor, access_token: access_token,
+          expires_at: 2.days.from_now
+      end
+
+      before { login_user(professor) }
+
+      it "updates the assignment from the provider details" do
+        expect(Services::ImportsLMSAssignments).to \
+          receive(:refresh).with(provider.to_s, access_token, assignment).and_return result
+
+        post :refresh_assignment, importer_provider_id: provider, id: assignment.id
+      end
+
+      it "redirects back to the assignment show view and displays a notice" do
+        allow(Services::ImportsLMSAssignments).to receive(:refresh).and_return result
+
+        post :refresh_assignment, importer_provider_id: provider, id: assignment.id
+
+        expect(response).to redirect_to(assignment_path(assignment))
+        expect(flash[:notice]).to \
+          eq "You have successfully refreshed #{assignment.name} from Canvas"
+      end
+
+      context "for an assignment that was not imported" do
+        it "redirects back to the assignment show view and displays an alert" do
+          allow(result).to receive_messages(success?: false,
+                                            message: "This was not imported")
+          allow(Services::ImportsLMSAssignments).to receive(:refresh).and_return result
+
+          post :refresh_assignment, importer_provider_id: provider, id: assignment.id
+
+          expect(response).to redirect_to(assignment_path(assignment))
+          expect(flash[:alert]).to eq "This was not imported"
+        end
+      end
+    end
+
+    context "as a student" do
+      it "redirects to the root url" do
+        post :refresh_assignment, importer_provider_id: provider, id: assignment.id
 
         expect(response).to redirect_to root_path
       end

--- a/spec/controllers/assignments/importers_controller_spec.rb
+++ b/spec/controllers/assignments/importers_controller_spec.rb
@@ -123,7 +123,7 @@ describe Assignments::ImportersController do
 
         expect(response).to redirect_to(assignment_path(assignment))
         expect(flash[:notice]).to \
-          eq "You have successfully refreshed #{assignment.name} from Canvas"
+          eq "You have successfully updated #{assignment.name} from Canvas"
       end
 
       context "for an assignment that was not imported" do

--- a/spec/factories/imported_assignment_factory.rb
+++ b/spec/factories/imported_assignment_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :imported_assignment do
     association :assignment
     sequence(:provider_resource_id) {|n| "ASSIGNMENT_#{n}" }
+    sequence(:provider_data) { |n| { course_id: "COURSE_#{n}" }}
 
     trait :canvas do
       provider :canvas

--- a/spec/factories/imported_assignment_factory.rb
+++ b/spec/factories/imported_assignment_factory.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :imported_assignment do
+    association :assignment
+    sequence(:provider_resource_id) {|n| "ASSIGNMENT_#{n}" }
+
+    trait :canvas do
+      provider :canvas
+    end
+  end
+end

--- a/spec/factories/imported_assignment_factory.rb
+++ b/spec/factories/imported_assignment_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :imported_assignment do
     association :assignment
     sequence(:provider_resource_id) {|n| "ASSIGNMENT_#{n}" }
-    sequence(:provider_data) { |n| { course_id: "COURSE_#{n}" }}
+    sequence(:provider_data) { |n| { "course_id" => "COURSE_#{n}" }}
 
     trait :canvas do
       provider :canvas

--- a/spec/importers/assignment_importers/canvas_assignment_importer_spec.rb
+++ b/spec/importers/assignment_importers/canvas_assignment_importer_spec.rb
@@ -16,6 +16,7 @@ describe CanvasAssignmentImporter do
       let(:canvas_assignment) do
         {
           id: canvas_assignment_id,
+          course_id: 123,
           name: "This is an assignment from Canvas",
           description: "This is the description",
           due_at: "2012-07-01T23:59:00-06:00",
@@ -66,6 +67,7 @@ describe CanvasAssignmentImporter do
         expect(imported_assignment.provider).to eq "canvas"
         expect(imported_assignment.provider_resource_id).to \
           eq canvas_assignment_id
+        expect(imported_assignment.provider_data).to eq({ "course_id" => "123" })
       end
 
       it "contains a successful row if the assignment is valid" do

--- a/spec/importers/assignment_importers/canvas_assignment_importer_spec.rb
+++ b/spec/importers/assignment_importers/canvas_assignment_importer_spec.rb
@@ -68,6 +68,8 @@ describe CanvasAssignmentImporter do
         expect(imported_assignment.provider_resource_id).to \
           eq canvas_assignment_id
         expect(imported_assignment.provider_data).to eq({ "course_id" => "123" })
+        expect(imported_assignment.last_imported_at).to \
+          be_within(1.second).of(DateTime.now)
       end
 
       it "contains a successful row if the assignment is valid" do

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -17,6 +17,23 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
     end
   end
 
+  describe "#assignment" do
+    subject { described_class.new access_token }
+
+    it "retrieves the assignment for the id from the api" do
+      body = { name: "This is a published assignment" }
+      stub_request(:get,
+                   "https://canvas.instructure.com/api/v1/courses/123/assignments/456")
+        .with(query: { "access_token" => access_token })
+        .to_return(status: 200, body: body.to_json,
+                   headers: {})
+
+      assignment = subject.assignment(123, 456)
+
+      expect(assignment["name"]).to eq "This is a published assignment"
+    end
+  end
+
   describe "#assignments" do
     subject { described_class.new access_token }
 

--- a/spec/lib/active_lms/syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus_spec.rb
@@ -15,6 +15,15 @@ describe ActiveLMS::Syllabus do
     end
   end
 
+  describe "#assignment" do
+    subject { described_class.new :canvas, access_token }
+
+    it "delegates to the provider" do
+      expect(subject.provider).to receive(:assignment).with(123, 456)
+      subject.assignment(123, 456)
+    end
+  end
+
   describe "#assignments" do
     subject { described_class.new :canvas, access_token }
 

--- a/spec/services/imports_lms_assignments/refresh_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/refresh_assignment_spec.rb
@@ -15,19 +15,27 @@ describe Services::Actions::RefreshAssignment do
       grading_type: "points"
     }.stringify_keys
   end
+  let(:provider) { :canvas }
 
   it "expects the assignment to refresh" do
-    expect { described_class.execute lms_assignment: lms_assignment }.to \
-      raise_error LightService::ExpectedKeysNotInContextError
+    expect { described_class.execute lms_assignment: lms_assignment, provider: provider }
+      .to raise_error LightService::ExpectedKeysNotInContextError
   end
 
   it "expects the lms assignment details to refresh with" do
-    expect { described_class.execute assignment: assignment }.to \
+    expect { described_class.execute assignment: assignment, provider: provider }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the provider to import the row with" do
+    expect { described_class.execute assignment: assignment,
+             lms_assignment: lms_assignment }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
   it "updates the assignment details" do
-    result = described_class.execute assignment: assignment, lms_assignment: lms_assignment
+    result = described_class.execute assignment: assignment,
+      lms_assignment: lms_assignment, provider: provider
 
     expect(result.assignment).to_not be_changed
     expect(result.assignment.name).to eq "This is an assignment from Canvas"

--- a/spec/services/imports_lms_assignments/refresh_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/refresh_assignment_spec.rb
@@ -1,0 +1,38 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_assignments/refresh_assignment"
+
+describe Services::Actions::RefreshAssignment do
+  let(:assignment) { create :assignment }
+  let(:lms_assignment) do
+    {
+      id: "ASSIGNMENT_ID",
+      course_id: 123,
+      name: "This is an assignment from Canvas",
+      description: "This is the description",
+      due_at: "2012-07-01T23:59:00-06:00",
+      points_possible: 123,
+      grading_type: "points"
+    }.stringify_keys
+  end
+
+  it "expects the assignment to refresh" do
+    expect { described_class.execute lms_assignment: lms_assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the lms assignment details to refresh with" do
+    expect { described_class.execute assignment: assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "updates the assignment details" do
+    result = described_class.execute assignment: assignment, lms_assignment: lms_assignment
+
+    expect(result.assignment).to_not be_changed
+    expect(result.assignment.name).to eq "This is an assignment from Canvas"
+    expect(result.assignment.description).to eq "This is the description"
+    expect(result.assignment.due_at).to eq DateTime.new(2012, 7, 1, 23, 59, 0, "-6")
+    expect(result.assignment.full_points).to eq 123
+  end
+end

--- a/spec/services/imports_lms_assignments/retrieves_imported_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/retrieves_imported_assignment_spec.rb
@@ -1,0 +1,33 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_assignments/retrieves_imported_assignment"
+
+describe Services::Actions::RetrievesImportedAssignment do
+  let(:assignment) { create :assignment }
+  let(:provider) { "canvas" }
+
+  it "expects a provider to retrieve the imported assignment for" do
+    expect { described_class.execute assignment: assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects an assignment to retrieve the imported assignment for" do
+    expect { described_class.execute provider: provider }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "retrieves the imported assignment" do
+    imported_assignment = create :imported_assignment, provider: provider,
+      assignment: assignment
+
+    result = described_class.execute assignment: assignment, provider: provider
+
+    expect(result.imported_assignment).to eq imported_assignment
+  end
+
+  it "fails the context if the assignment was not previously imported" do
+    result = described_class.execute assignment: assignment, provider: provider
+
+    expect(result).to_not be_success
+  end
+end

--- a/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
@@ -29,7 +29,7 @@ describe Services::Actions::RetrievesLMSAssignment do
     expect(ActiveLMS::Syllabus).to \
       receive(:new).with(provider, access_token).and_call_original
     expect_any_instance_of(ActiveLMS::Syllabus).to \
-      receive(:assignment).with(imported_assignment.provider_data[:course_id],
+      receive(:assignment).with(imported_assignment.provider_data["course_id"],
                                 imported_assignment.provider_resource_id)
         .and_return ({ name: "Assignment 1" })
 
@@ -41,7 +41,7 @@ describe Services::Actions::RetrievesLMSAssignment do
 
   it "fails the context if the assignment cannot be found" do
     allow_any_instance_of(ActiveLMS::Syllabus).to \
-      receive(:assignment).with(imported_assignment.provider_data[:course_id],
+      receive(:assignment).with(imported_assignment.provider_data["course_id"],
                                 imported_assignment.provider_resource_id)
       .and_raise("Resource not found")
 

--- a/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
@@ -1,0 +1,54 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_assignments/retrieves_lms_assignment"
+
+describe Services::Actions::RetrievesLMSAssignment do
+  let(:access_token) { "TOKEN" }
+  let(:imported_assignment) { create :imported_assignment, provider: provider }
+  let(:provider) { "canvas" }
+
+  it "expects the provider to retrieve the assignment from" do
+    expect { described_class.execute access_token: access_token,
+             imported_assignment: imported_assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the access token to use to retrieve the assignment" do
+    expect { described_class.execute provider: provider,
+             imported_assignment: imported_assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the imported assignment to use to retrieve the lms assignment" do
+    expect { described_class.execute access_token: access_token,
+             provider: provider }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "retrieves the assignment details from the lms provider" do
+    expect(ActiveLMS::Syllabus).to \
+      receive(:new).with(provider, access_token).and_call_original
+    expect_any_instance_of(ActiveLMS::Syllabus).to \
+      receive(:assignment).with(imported_assignment.provider_data[:course_id],
+                                imported_assignment.provider_resource_id)
+        .and_return ({ name: "Assignment 1" })
+
+    result = described_class.execute access_token: access_token,
+      imported_assignment: imported_assignment, provider: provider
+
+    expect(result.lms_assignment[:name]).to eq "Assignment 1"
+  end
+
+  it "fails the context if the assignment cannot be found" do
+    allow_any_instance_of(ActiveLMS::Syllabus).to \
+      receive(:assignment).with(imported_assignment.provider_data[:course_id],
+                                imported_assignment.provider_resource_id)
+      .and_raise("Resource not found")
+
+    result = described_class.execute access_token: access_token,
+      imported_assignment: imported_assignment, provider: provider
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "Resource not found"
+  end
+end

--- a/spec/services/imports_lms_assignments/updates_imported_timestamp_spec.rb
+++ b/spec/services/imports_lms_assignments/updates_imported_timestamp_spec.rb
@@ -1,0 +1,19 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_assignments/updates_imported_timestamp"
+
+describe Services::Actions::UpdatesImportedTimestamp do
+  let(:imported_assignment) { create :imported_assignment, :canvas }
+
+  it "expects the imported assignment to use to update" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "updates the imported timestamp" do
+    result = described_class.execute imported_assignment: imported_assignment
+
+    expect(result.imported_assignment.last_imported_at).to \
+      be_within(1.second).of(DateTime.now)
+  end
+end

--- a/spec/services/imports_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments_spec.rb
@@ -36,6 +36,11 @@ describe Services::ImportsLMSAssignments do
   describe ".refresh" do
     let(:assignment) { create :assignment }
 
+    before do
+      # do not call the API
+      allow_any_instance_of(ActiveLMS::Syllabus).to receive(:assignment).and_return {}
+    end
+
     it "retrieves the imported assignment from the database" do
       expect(Services::Actions::RetrievesImportedAssignment).to \
         receive(:execute).and_call_original
@@ -50,7 +55,12 @@ describe Services::ImportsLMSAssignments do
       described_class.refresh provider, access_token, assignment
     end
 
-    xit "updates the assignment details in the database"
+    it "updates the assignment details in the database" do
+      expect(Services::Actions::RefreshAssignment).to \
+        receive(:execute).and_call_original
+
+      described_class.refresh provider, access_token, assignment
+    end
   end
 end
 

--- a/spec/services/imports_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments_spec.rb
@@ -2,13 +2,14 @@ require "active_record_spec_helper"
 require "./app/services/imports_lms_assignments"
 
 describe Services::ImportsLMSAssignments do
+  let(:access_token) { "TOKEN" }
+  let(:provider) { :canvas }
+
   describe ".import" do
-    let(:access_token) { "TOKEN" }
     let(:assignment_ids) { ["ASSIGNMENT_1", "ASSIGNMENT_2"] }
     let(:assignment_type) { create :assignment_type, course: course }
     let(:course) { create :course }
     let(:course_id) { "COURSE_ID" }
-    let(:provider) { :canvas }
 
     before do
       # do not call the API
@@ -30,6 +31,20 @@ describe Services::ImportsLMSAssignments do
       described_class.import provider, access_token, course_id, assignment_ids, course,
         assignment_type.id
     end
+  end
+
+  describe ".refresh" do
+    let(:assignment) { create :assignment }
+
+    it "retrieves the imported assignment from the database" do
+      expect(Services::Actions::RetrievesImportedAssignment).to \
+        receive(:execute).and_call_original
+
+      described_class.refresh provider, access_token, assignment
+    end
+
+    xit "retrieves the assignment details from the lms provider"
+    xit "updates the assignment details in the database"
   end
 end
 

--- a/spec/services/imports_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments_spec.rb
@@ -43,7 +43,13 @@ describe Services::ImportsLMSAssignments do
       described_class.refresh provider, access_token, assignment
     end
 
-    xit "retrieves the assignment details from the lms provider"
+    it "retrieves the assignment details from the lms provider" do
+      expect(Services::Actions::RetrievesLMSAssignment).to \
+        receive(:execute).and_call_original
+
+      described_class.refresh provider, access_token, assignment
+    end
+
     xit "updates the assignment details in the database"
   end
 end

--- a/spec/services/imports_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments_spec.rb
@@ -61,6 +61,13 @@ describe Services::ImportsLMSAssignments do
 
       described_class.refresh provider, access_token, assignment
     end
+
+    it "updates the imported timestamp" do
+      expect(Services::Actions::UpdatesImportedTimestamp).to \
+        receive(:execute).and_call_original
+
+      described_class.refresh provider, access_token, assignment
+    end
   end
 end
 


### PR DESCRIPTION
This allows any imported assignment to be "synced" with it's provider so that changes that occurred on the provider (e.g. canvas) are updated with the assignment in GradeCraft.

A few additional table changes to `imported_assignments` were needed.

1. A `provider_data` was added to specify additional data needed to retrieve the assignment on the canvas site. `course_id` is needed to retrieve a single assignment and so that is stored.
2. A `last_imported_at` timestamp was added to mark the date/time an assignment was last imported. This will be used when "syncing" the data back and forth.

Closes #2172