### PR TITLE
update view spec to match changes

### DIFF
--- a/spec/views/grades/_standard_edit_spec.rb
+++ b/spec/views/grades/_standard_edit_spec.rb
@@ -24,7 +24,7 @@ describe "grades/_standard_edit" do
   describe "when an assignment has point values" do
     it "renders the points possible when incomplete" do
       render
-      assert_select "label", text: "Raw Points (#{@assignment.full_points} Points Possible)", count: 1
+      assert_select "label", text: "Raw Points (#{points @assignment.full_points} Points Possible)", count: 1
     end
   end
 


### PR DESCRIPTION
This fixes a spec that was breaking due to a change in the view (adding commas into the presentation of full points for the assignment).