### PR TITLE
predictor sliders with relaxed snapping

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/slider.js.coffee
@@ -127,17 +127,20 @@
         else
           return points
 
-      scope.snap = (points)->
+      # Only snaps that we want to fire while live updates
+      # are coming from the input field
+      scope.liveSnap = (points)->
+        points = scope.pointsSnappedToRange(points)
+        scope.updateArticle(points)
+        scope.updateSlider(points)
+
+      scope.snapAndSave = (points)->
+        points = if isNaN(points) then 0 else points
         points = scope.pointsSnappedToRange(points)
         points = scope.pointsSnappedToScoreLevel(points)
         points = scope.pointsSnappedToThreshold(points)
         scope.updateArticle(points)
         scope.updateSlider(points)
-
-
-      scope.snapAndSave = (points)->
-        points = if isNaN(points) then 0 else points
-        scope.snap(points)
         scope.save()
 
       #---------------- DIRECT INPUT FIELD ------------------------------------#
@@ -156,7 +159,7 @@
         scope.inputMode("TEXT_INPUT")
 
         setTimeout ( ->
-          scope.snap(scope.article.prediction.predicted_points)
+          scope.liveSnap(scope.article.prediction.predicted_points)
         ), 125
 
 


### PR DESCRIPTION
### The Problem:

![fail](https://cloud.githubusercontent.com/assets/1138350/18324847/9246c6ce-750c-11e6-8e5f-5b0e2b887ab3.gif)

There appeared to be a bug on production where a level slider would not progress past zero unless the slider was first pulled over to the right.

We found this particular assignment had a level set at zero. With the live snapping in place on the slider input, it would drag the slider back down to zero before enough digits could be entered to pass the threshold for this level value.

I found this was also the behavior on a level with a threshold -- the threshold would in effect snap a value back to zero before it could be fully entered.

### The Solution: 

This PR relaxes the snapping checks that are in place during a live update to an input field.  Min and Max snapping still occurs, but level and threshold checks are only run once the user clicks out of the field.

![pass](https://cloud.githubusercontent.com/assets/1138350/18325056/9ec4ca30-750d-11e6-995b-94a140338ac9.gif)

Please check that this interaction feels intuitive, and still provides enough feedback to the user while typing. 

closes #2382