### PR TITLE
2173 update canvas assignments

### DIFF
--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -63,6 +63,13 @@ class Assignments::ImportersController < ApplicationController
     redirect_to assignment_path(assignment)
   end
 
+  # POST /assignments/importers/:importer_provider_id/assignments/:id/update
+  def update_assignment
+    assignment = Assignment.find(params[:id])
+
+    redirect_to assignment_path(assignment)
+  end
+
   private
 
   def syllabus

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -65,7 +65,17 @@ class Assignments::ImportersController < ApplicationController
 
   # POST /assignments/importers/:importer_provider_id/assignments/:id/update
   def update_assignment
+    provider_name = params[:importer_provider_id]
     assignment = Assignment.find(params[:id])
+
+    result = Services::ImportsLMSAssignments.update provider_name,
+      authorization(provider_name).access_token, assignment
+
+    if result.success?
+      flash[:notice] = "You have successfully updated #{assignment.name} on #{provider_name.capitalize}"
+    else
+      flash[:alert] = result.message
+    end
 
     redirect_to assignment_path(assignment)
   end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -28,5 +28,8 @@ module Services
         Actions::UpdatesImportedTimestamp
       )
     end
+
+    def self.update(provider, access_token, assignment)
+    end
   end
 end

--- a/app/services/imports_lms_assignments.rb
+++ b/app/services/imports_lms_assignments.rb
@@ -5,6 +5,7 @@ require_relative "imports_lms_assignments/retrieves_imported_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignment"
 require_relative "imports_lms_assignments/retrieves_lms_assignments"
 require_relative "imports_lms_assignments/updates_imported_timestamp"
+require_relative "imports_lms_assignments/updates_lms_assignment"
 
 module Services
   class ImportsLMSAssignments
@@ -30,6 +31,10 @@ module Services
     end
 
     def self.update(provider, access_token, assignment)
+      with(provider: provider, access_token: access_token, assignment: assignment).reduce(
+        Actions::RetrievesImportedAssignment,
+        Actions::UpdatesLMSAssignment
+      )
     end
   end
 end

--- a/app/services/imports_lms_assignments/updates_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/updates_lms_assignment.rb
@@ -1,0 +1,32 @@
+require "active_lms"
+
+module Services
+  module Actions
+    class UpdatesLMSAssignment
+      extend LightService::Action
+
+      expects :access_token, :imported_assignment, :provider
+      promises :lms_assignment
+
+      executed do |context|
+        provider = context.provider
+        access_token = context.access_token
+        course_id = context.imported_assignment.provider_data["course_id"]
+        assignment_id = context.imported_assignment.provider_resource_id
+        assignment = context.imported_assignment.assignment
+        params = { assignment: { name: assignment.name }}
+
+        context.lms_assignment = nil
+
+        syllabus = ActiveLMS::Syllabus.new provider, access_token
+        begin
+        context.lms_assignment = syllabus.update_assignment course_id,
+          assignment_id,
+          params
+        rescue StandardError => e
+          context.fail! e.message
+        end
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_assignments/updates_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/updates_lms_assignment.rb
@@ -14,7 +14,12 @@ module Services
         course_id = context.imported_assignment.provider_data["course_id"]
         assignment_id = context.imported_assignment.provider_resource_id
         assignment = context.imported_assignment.assignment
-        params = { assignment: { name: assignment.name }}
+        params = { assignment: { name: assignment.name,
+                                 description: assignment.description,
+                                 due_at: assignment.due_at.nil? ? nil :
+                                         assignment.due_at.iso8601,
+                                 points_possible: assignment.full_points }}
+        params[:assignment].merge!(grading_type: "pass_fail") if assignment.pass_fail?
 
         context.lms_assignment = nil
 

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -22,6 +22,10 @@
           = link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
             = glyph(:refresh)
             = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
+        %li.hide-for-small
+          = link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+            = glyph(:refresh)
+            = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
       %li.hide-for-small
         %a{:href => assignment_grades_importers_path(presenter.assignment) }
           = glyph(:upload)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ GradeCraft::Application.routes.draw do
       post "/courses/:id/assignments/import", to: :assignments_import,
         as: :assignments_import
       post "/assignments/:id/refresh", to: :refresh_assignment, as: :refresh_assignment
+      post "/assignments/:id/update", to: :update_assignment, as: :update_assignment
     end
   end
 

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -34,6 +34,10 @@ module ActiveLMS
       provider.grades(course_id, assignment_ids, grade_ids)
     end
 
+    def update_assignment(course_id, assignment_id, params)
+      provider.update_assignment(course_id, assignment_id, params)
+    end
+
     def user(id)
       provider.user(id)
     end

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -353,6 +353,15 @@ module ActiveLMS
       grades
     end
 
+    def update_assignment(course_id, assignment_id, params)
+      assignment = nil
+      client.set_data(
+        "/courses/#{course_id}/assignments/#{assignment_id}", :put, params) do |data|
+          assignment = data
+      end
+        assignment
+    end
+
     # Internal: Retrieves single user from the Canvas API.
     #
     # id - A String representing the user id from the Canvas API.

--- a/lib/canvas/api.rb
+++ b/lib/canvas/api.rb
@@ -23,6 +23,15 @@ module Canvas
       end
     end
 
+    def set_data(path="/", method=:post, params={})
+      url = "#{self.class.base_uri}#{path}"
+      response = self.class.send method, url, body: params.to_json,
+        headers: { "Content-Type" => "application/json" },
+        query: { access_token: access_token }
+      raise ResponseError.new(response) unless response.success?
+      yield response.parsed_response if block_given?
+    end
+
     private
 
     def get_next_url(resp)

--- a/lib/canvas/response_error.rb
+++ b/lib/canvas/response_error.rb
@@ -3,7 +3,7 @@ module Canvas
     def initialize(response)
       body = response.parsed_response
       errors = body["errors"]
-      super errors.first["message"] unless errors.nil?
+      super errors.first["message"] unless errors.nil? || errors.empty?
     end
   end
 end

--- a/spec/controllers/assignments/importers_controller_spec.rb
+++ b/spec/controllers/assignments/importers_controller_spec.rb
@@ -148,4 +148,27 @@ describe Assignments::ImportersController do
       end
     end
   end
+
+  describe "POST #update_assignment" do
+    let(:assignment) { create :assignment, course: course }
+
+    context "as a professor" do
+      before { login_user(professor) }
+
+      xit "updates the canvas assignment from the assignment details"
+      xit "redirects back to the assignment show view and displays a notice"
+
+      context "for an assignment that was not imported" do
+        xit "redirects back to the assignment show view and displays an alert"
+      end
+    end
+
+    context "as a student" do
+      it "redirects to the root url" do
+        post :update_assignment, importer_provider_id: provider, id: assignment.id
+
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
 end

--- a/spec/controllers/assignments/importers_controller_spec.rb
+++ b/spec/controllers/assignments/importers_controller_spec.rb
@@ -153,13 +153,43 @@ describe Assignments::ImportersController do
     let(:assignment) { create :assignment, course: course }
 
     context "as a professor" do
+      let(:access_token) { "BLAH" }
+      let(:result) { double(:result, success?: true, message: "") }
+      let!(:user_authorization) do
+        create :user_authorization, :canvas, user: professor, access_token: access_token,
+          expires_at: 2.days.from_now
+      end
+
       before { login_user(professor) }
 
-      xit "updates the canvas assignment from the assignment details"
-      xit "redirects back to the assignment show view and displays a notice"
+      it "updates the canvas assignment from the assignment details" do
+        expect(Services::ImportsLMSAssignments).to \
+          receive(:update).with(provider.to_s, access_token, assignment).and_return result
+
+        post :update_assignment, importer_provider_id: provider, id: assignment.id
+      end
+
+      it "redirects back to the assignment show view and displays a notice" do
+        allow(Services::ImportsLMSAssignments).to receive(:update).and_return result
+
+        post :update_assignment, importer_provider_id: provider, id: assignment.id
+
+        expect(response).to redirect_to(assignment_path(assignment))
+        expect(flash[:notice]).to \
+          eq "You have successfully updated #{assignment.name} on Canvas"
+      end
 
       context "for an assignment that was not imported" do
-        xit "redirects back to the assignment show view and displays an alert"
+        it "redirects back to the assignment show view and displays an alert" do
+          allow(result).to receive_messages(success?: false,
+                                            message: "This was not updated")
+          allow(Services::ImportsLMSAssignments).to receive(:update).and_return result
+
+          post :update_assignment, importer_provider_id: provider, id: assignment.id
+
+          expect(response).to redirect_to(assignment_path(assignment))
+          expect(flash[:alert]).to eq "This was not updated"
+        end
       end
     end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -166,6 +166,24 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
     end
   end
 
+  describe "#update_assignment" do
+    subject { described_class.new access_token }
+
+    it "updates the assignment for the id from the api" do
+      request = { assignment: { name: "This is a published assignment" }}
+      body = { id: "123", name: "This is a published assignment" }
+      stub_request(:put,
+                   "https://canvas.instructure.com/api/v1/courses/123/assignments/456")
+        .with(query: { "access_token" => access_token }, body: request.to_json)
+        .to_return(status: 200, body: body.to_json,
+                   headers: {})
+
+      assignment = subject.update_assignment(123, 456, request)
+
+      expect(assignment["name"]).to eq "This is a published assignment"
+    end
+  end
+
   describe "#user" do
     subject { described_class.new access_token }
 

--- a/spec/lib/active_lms/syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus_spec.rb
@@ -60,6 +60,15 @@ describe ActiveLMS::Syllabus do
     end
   end
 
+  describe "#update_assignment" do
+    subject { described_class.new :canvas, access_token }
+
+    it "delegates to the provider" do
+      expect(subject.provider).to receive(:update_assignment).with(123, 456, {})
+      subject.update_assignment(123, 456, {})
+    end
+  end
+
   describe "#user" do
     subject { described_class.new :canvas, access_token }
 

--- a/spec/services/imports_lms_assignments/updates_lms_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/updates_lms_assignment_spec.rb
@@ -28,7 +28,12 @@ describe Services::Actions::UpdatesLMSAssignment do
   end
 
   it "updates the lms assignment" do
-    params = { name: assignment.name }
+    params = {
+      name: assignment.name,
+      description: assignment.description,
+      due_at: assignment.due_at,
+      points_possible: assignment.full_points
+    }
     expect(ActiveLMS::Syllabus).to \
       receive(:new).with(provider, access_token).and_call_original
     expect_any_instance_of(ActiveLMS::Syllabus).to \

--- a/spec/services/imports_lms_assignments/updates_lms_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/updates_lms_assignment_spec.rb
@@ -1,0 +1,59 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/imports_lms_assignments/updates_lms_assignment"
+
+describe Services::Actions::UpdatesLMSAssignment do
+  let(:access_token) { "TOKEN" }
+  let(:assignment) { create :assignment }
+  let(:imported_assignment) { create :imported_assignment, assignment: assignment,
+                              provider: provider }
+  let(:provider) { "canvas" }
+
+  it "expects the provider to update the assignment on" do
+    expect { described_class.execute access_token: access_token,
+             imported_assignment: imported_assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the access token to use to update the assignment" do
+    expect { described_class.execute provider: provider,
+             imported_assignment: imported_assignment }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects the imported assignment to use to update the lms assignment" do
+    expect { described_class.execute access_token: access_token,
+             provider: provider }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "updates the lms assignment" do
+    params = { name: assignment.name }
+    expect(ActiveLMS::Syllabus).to \
+      receive(:new).with(provider, access_token).and_call_original
+    expect_any_instance_of(ActiveLMS::Syllabus).to \
+      receive(:update_assignment).with(imported_assignment.provider_data["course_id"],
+                                imported_assignment.provider_resource_id,
+                                { assignment: params })
+        .and_return (params)
+
+    result = described_class.execute access_token: access_token,
+      imported_assignment: imported_assignment, provider: provider
+
+    expect(result.lms_assignment[:name]).to eq assignment.name
+  end
+
+  it "fails the context if the assignment cannot be found" do
+    allow_any_instance_of(ActiveLMS::Syllabus).to \
+      receive(:update_assignment).with(imported_assignment.provider_data["course_id"],
+                                       imported_assignment.provider_resource_id,
+                                       hash_including(:assignment))
+      .and_raise("Resource not found")
+
+    result = described_class.execute access_token: access_token,
+      imported_assignment: imported_assignment, provider: provider
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "Resource not found"
+  end
+end

--- a/spec/services/imports_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments_spec.rb
@@ -69,5 +69,29 @@ describe Services::ImportsLMSAssignments do
       described_class.refresh provider, access_token, assignment
     end
   end
+
+  describe ".update" do
+    let(:assignment) { create :assignment }
+
+    before do
+      # do not call the API
+      allow_any_instance_of(ActiveLMS::Syllabus).to \
+        receive(:update_assignment).and_return {}
+    end
+
+    it "retrieves the imported assignment from the database" do
+      expect(Services::Actions::RetrievesImportedAssignment).to \
+        receive(:execute).and_call_original
+
+      described_class.update provider, access_token, assignment
+    end
+
+    it "updates the assignment details on the provider" do
+      expect(Services::Actions::UpdatesLMSAssignment).to \
+        receive(:execute).and_call_original
+
+      described_class.update provider, access_token, assignment
+    end
+  end
 end
 


### PR DESCRIPTION
This PR allows an assignment to be updated on Canvas from GradeCraft. This is in preperation of the syncing task (#2174). Since we store when an assignment was last updated and when an assignment was last imported, we can now sync any changes between GradeCraft and Canvas.

The buttons on the `assignment#show` view now have the ability to update from Canvas or update to Canvas.

<img width="1241" alt="screen shot 2016-09-08 at 10 05 16 am" src="https://cloud.githubusercontent.com/assets/35017/18352414/57e068dc-75ac-11e6-85ce-9e940321c71f.png">

I am not crazy about this interface. I am starting to think that we need a new tab for imported assignments. This would allow the user to view when the last time an assignment was imported and the last time it was exported to Canvas. They would also be able to turn on/off sync when #2174 was completed. I'd love some thoughts around this.

Closes #2173 