### PR TITLE
set timeout and wait for badges before criteria

### DIFF
--- a/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.js.coffee
@@ -12,10 +12,21 @@
     $scope.pointTotal = parseInt(pointTotal)
     $scope.services()
 
+
   $scope.services = () ->
+    # because getting Criteria requires badges from $scope
+    # we need to wait until the badges are created before
+    # making this call.
+    queCriteriaAfterBadges = ()->
+      if (RubricService.badgesAvailable() == false)
+        window.setTimeout(queCriteriaAfterBadges, 100)
+      else
+        RubricService.getCriteria($scope.assignmentId, $scope)
+
     promises = [
-      RubricService.getBadges()
-      RubricService.getCriteria($scope.assignmentId, $scope)]
+      RubricService.getBadges(),
+      queCriteriaAfterBadges()
+      ]
     $q.all(promises)
 
   # distill key/value pairs for criterion ids and relative order

--- a/app/assets/javascripts/angular/factories/Level.js.coffee
+++ b/app/assets/javascripts/angular/factories/Level.js.coffee
@@ -5,7 +5,12 @@
       @id = attrs.id or null
       @criterion = criterion
       @badges = {}
+
+      # This call requires that badges are fully loaded!
+      # There is a timeout in the RubricCtrl to accomodate this,
+      # without it badges are not guaranteed.
       @availableBadges = angular.copy($scope.courseBadges)
+
       @selectedBadge = ""
       @id = if attrs.id then attrs.id else null
 

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -1,5 +1,10 @@
 @gradecraft.factory 'RubricService', ['CourseBadge', 'Criterion', 'CriterionGrade', '$http', (CourseBadge, Criterion, CriterionGrade, $http) ->
 
+  _badgesAvailable = false
+
+  badgesAvailable = ()->
+    _badgesAvailable
+
   pointsPossible = 0
   thresholdPoints = 0
   assignment = {}
@@ -59,6 +64,7 @@
         courseBadge = new CourseBadge(badge.attributes)
         badges[badge.id] = courseBadge
       )
+      _badgesAvailable = true
     )
 
   getGrade = (assignment)->
@@ -133,6 +139,7 @@
     points
 
   return {
+      badgesAvailable: badgesAvailable,
       getCriteria: getCriteria,
       getCriterionGrades: getCriterionGrades,
       getBadges: getBadges,


### PR DESCRIPTION
There are better ways of doing this, but it would require extracting $scope from the Angular Level factory, which would not be easy.

Instead, this solution waits until the badges are fully loaded until making the api call for criteria. When the levels are constructed, we are guaranteed that the badges already exist on scope.