### PR TITLE
remove create grades dependency for predictor

### DIFF
--- a/app/serializers/predicted_assignment_serializer.rb
+++ b/app/serializers/predicted_assignment_serializer.rb
@@ -15,7 +15,9 @@ class PredictedAssignmentSerializer < SimpleDelegator
   def grade
     if @grade.nil?
       if student.present?
-        grade = Grade.find_or_create(assignment.id, student.id)
+        grade = Grade.where(
+          assignment_id: assignment.id,
+          student_id: student.id).first || NullGrade.new
       else
         grade = NullGrade.new
       end

--- a/spec/serializers/predicted_assignment_serializer_spec.rb
+++ b/spec/serializers/predicted_assignment_serializer_spec.rb
@@ -11,12 +11,6 @@ describe PredictedAssignmentSerializer do
   end
 
   describe "#grade" do
-    it "creates a grade if it does not have one for the assignment" do
-      current_time = DateTime.now
-      grade = subject.grade
-      expect(Grade.find(grade.attributes[:id]).created_at).to be > current_time
-    end
-
     it "returns the grade if one already exists for the user and assignment" do
       existing_grade = Grade.create(assignment: assignment, student: user)
       expect(subject.grade.attributes[:id]).to eq existing_grade.id


### PR DESCRIPTION
This PR removes the need for grades to be created for predictor display. I would like to remove the need for Null objects entirely (handle json without nested objects from within the front end) but while we have them this is the easiest way to accomplish this.