### PR TITLE
2428 mobile student rubric

### DIFF
--- a/app/assets/javascripts/assignments.js
+++ b/app/assets/javascripts/assignments.js
@@ -191,20 +191,30 @@ $('#class-analytics-toggle').change(function(){
   }
 });
 
-// Show only earned level on mobile for rubric grades regardless of previous selection
+// If screen is at mobile size, initialize slider for rubric feedback and destroy it when screen size is larger than mobile
 function rubricScreenSize() {
+  var $tabPanelContainer = $('.tab-panel-container');
+  // rather than testing window size which varies in browser, using MQ to hide level tabs on mobile
   if ($('.level-tabs').css('display') === 'none') {
-    $('.level-tab.earned').trigger('click');
-    $('.tab-panel-container').addClass('mobile-rubric-slider');
+    // Initialize slick slider on mobile for graded rubrics if not already initialized
+    if (!$tabPanelContainer.hasClass('slick-initialized')) {
+      $tabPanelContainer.each(function() {
+        var $thisSlider = $(this);
+
+        $thisSlider.slick({
+          prevArrow: '<a class="fa fa-caret-left previous rubric-slider-button"></a>',
+          nextArrow: '<a class="fa fa-caret-right next rubric-slider-button"></a>',
+          initialSlide: $thisSlider.data("start-index"),
+          adaptiveHeight: true, 
+          infinite: false
+        });
+      });
+    }
+  } else {
+    if ($tabPanelContainer.hasClass('slick-initialized')) {
+      $tabPanelContainer.slick("unslick");
+    }
   }
 }
 rubricScreenSize();
 $(window).resize(rubricScreenSize);
-
- // Initialize slick slider on mobile for graded rubrics
-$('.mobile-rubric-slider').slick({
-  prevArrow: '<a class="fa fa-caret-left previous rubric-slider-button"></a>',
-  nextArrow: '<a class="fa fa-caret-right next rubric-slider-button"></a>',
-  adaptiveHeight: true, 
-  infinite: false
-});

--- a/app/assets/javascripts/assignments.js
+++ b/app/assets/javascripts/assignments.js
@@ -193,9 +193,18 @@ $('#class-analytics-toggle').change(function(){
 
 // Show only earned level on mobile for rubric grades regardless of previous selection
 function rubricScreenSize() {
-  if ($('.level-tab').css('display') === 'none') {
+  if ($('.level-tabs').css('display') === 'none') {
     $('.level-tab.earned').trigger('click');
+    $('.tab-panel-container').addClass('mobile-rubric-slider');
   }
 }
 rubricScreenSize();
 $(window).resize(rubricScreenSize);
+
+ // Initialize slick slider on mobile for graded rubrics
+$('.mobile-rubric-slider').slick({
+  prevArrow: '<a class="fa fa-caret-left previous rubric-slider-button"></a>',
+  nextArrow: '<a class="fa fa-caret-right next rubric-slider-button"></a>',
+  adaptiveHeight: true, 
+  infinite: false
+});

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -333,14 +333,22 @@ button.meets-expectations-status.no-expectation
 #rubric-graded, #rubric-ungraded
   *
     font-weight: 300
-  h5
+  h4
     font-size: 1.1em
     text-transform: uppercase
-    font-weight: 400
-  h6
-    font-size: 1em
-    font-weight: 400
     margin: 0
+
+  h5
+    font-size: 1em
+    margin: 0
+
+  h6
+    font-size: 0.9em
+    margin: 0
+
+  h4, h5, h6
+    font-weight: 400
+
   section
     margin-bottom: 1rem
     &:last-child
@@ -414,8 +422,20 @@ button.meets-expectations-status.no-expectation
     font-size: 0.65rem
     font-style: italic
 
-  .earned-level-panel, .tab-panel
+  .meets-expectations-label
+    font-size: 0.8rem
+
+  .tab-panel-body
     padding: 0.5rem
+
+  .tab-panel-header
+    padding: 0.5rem 2rem
+    background-color: $color-grey-6
+    display: none
+    text-align: center
+    font-weight: 400
+    @media (max-width: $media-small-max)
+      display: block
 
   ul.badge-row
     height: auto
@@ -434,9 +454,14 @@ button.meets-expectations-status.no-expectation
       display: block
     &.earned
       background-color: lighten($color-green-1, 20%)
-    @media (max-width: $media-small-max)
-      display: block
-      padding: 0.25rem 1rem
+      .tab-panel-header
+        background-color: lighten($color-green-1, 20%)
+      @media (max-width: $media-small-max)
+        background-color: inherit
+
+  .slick-slide
+    padding: 0
+    display: block
 
   .rubric-slider-button
     position: absolute
@@ -445,14 +470,19 @@ button.meets-expectations-status.no-expectation
     cursor: pointer
     z-index: 1
     color: $color-blue-3
+    font-size: 1.2rem
     &:hover
       text-decoration: none
 
     &.next
-      right: 6px
+      right: 16px
 
     &.previous
-      left: 6px
+      left: 16px
+
+.class-analytics-toggle, .download-link
+  @media (max-width: $media-small-max)
+    display: none
 
 // label for class analytics toggle
 .class-analytics-label
@@ -468,7 +498,7 @@ button.meets-expectations-status.no-expectation
       border-bottom: 2px dashed $color-green-2
       position: relative
 
-  .meets-expectations-label, .meets-expectations-tag
+  .meets-expectations-tag
     font-size: 0.8rem
 
   .meets-expectations-tag

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -473,10 +473,10 @@ button.meets-expectations-status.no-expectation
     font-size: 1.2rem
     &:hover
       text-decoration: none
-
+    &.slick-disabled
+      display: none !important
     &.next
       right: 16px
-
     &.previous
       left: 16px
 
@@ -492,6 +492,7 @@ button.meets-expectations-status.no-expectation
 #rubric-ungraded
   .tab-panel
     border-bottom: 1px solid $color-grey-6
+    padding: 0.5rem
     &:last-child
       border-bottom: none
     &.meets-expectations-cutoff

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -369,6 +369,8 @@ button.meets-expectations-status.no-expectation
     display: -ms-flexbox
     display: flex
     margin: 0
+    @media (max-width: $media-small-max)
+      display: none
 
   .level-tab
     list-style-type: none
@@ -400,8 +402,6 @@ button.meets-expectations-status.no-expectation
       border-bottom: none
       &:hover
         background-color: lighten($color-green-1, 22%)
-    @media (max-width: $media-small-max)
-      display: none
 
   .level-name
     display: inline
@@ -434,6 +434,25 @@ button.meets-expectations-status.no-expectation
       display: block
     &.earned
       background-color: lighten($color-green-1, 20%)
+    @media (max-width: $media-small-max)
+      display: block
+      padding: 0.25rem 1rem
+
+  .rubric-slider-button
+    position: absolute
+    top: 10px
+    display: block
+    cursor: pointer
+    z-index: 1
+    color: $color-blue-3
+    &:hover
+      text-decoration: none
+
+    &.next
+      right: 6px
+
+    &.previous
+      left: 6px
 
 // label for class analytics toggle
 .class-analytics-label

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -7,4 +7,8 @@ module AssignmentsHelper
       end
     end
   end
+
+  def find_earned_rubric_grade(criterion, student_id)
+    criterion.levels.ordered.index{|level| level.earned_for?(student_id)}
+  end
 end

--- a/app/views/rubrics/components/_criteria_graded.haml
+++ b/app/views/rubrics/components/_criteria_graded.haml
@@ -19,6 +19,7 @@
           = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
           - if level.earned_for?(student.id)
             %section.grader-feedback
-              %h6 Comments
-              .level.level-comments.comments-box
-                = raw criterion.comments_for(student.id)
+              - if criterion.comments_for(student.id).present?
+                %h6 Comments
+                .level.level-comments.comments-box
+                  = raw criterion.comments_for(student.id)

--- a/app/views/rubrics/components/_criteria_graded.haml
+++ b/app/views/rubrics/components/_criteria_graded.haml
@@ -23,9 +23,8 @@
             %h5.level-name= "#{level.name}"
           .tab-panel-body
             = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
-            - if level.earned_for?(student.id)
+            - if level.earned_for?(student.id) && criterion.comments_for(student.id).present?
               %section.grader-feedback
-                - if criterion.comments_for(student.id).present?
-                  %h6 Comments
-                  .level.level-comments.comments-box
-                    = raw criterion.comments_for(student.id)
+                %h6 Comments
+                .level.level-comments.comments-box
+                  = raw criterion.comments_for(student.id)

--- a/app/views/rubrics/components/_criteria_graded.haml
+++ b/app/views/rubrics/components/_criteria_graded.haml
@@ -1,7 +1,7 @@
 - rubric.criteria.ordered.includes(levels: :level_badges).each_with_index do |criterion, cindex|
   .criterion{:id => "criterion-#{cindex}"}
     .criterion-heading
-      %h5.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
+      %h4.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
       %p.criterion-description= criterion.description
 
     %ul.level-tabs{:role => "tablist"}
@@ -13,13 +13,19 @@
           - if !level.hide_analytics?
             - unless level.criterion_grades(current_user).empty?
               %p.graded-students= "#{pluralize(level.criterion_grades(current_user).size, 'student')} earned this level"
+
     .tab-panel-container{"data-start-index" => find_earned_rubric_grade(criterion, student.id)}
       - criterion.levels.ordered.each_with_index do |level, lindex|
         .tab-panel{:class => ("earned selected" if level.earned_for?(student.id)), :id => "tab-#{cindex}-#{lindex}", :role => "tabpanel", "aria-labelledby" => "tab#{lindex+1}", "aria-selected" => (level.earned_for?(student.id) ? "true" : "false")}
-          = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
-          - if level.earned_for?(student.id)
-            %section.grader-feedback
-              - if criterion.comments_for(student.id).present?
-                %h6 Comments
-                .level.level-comments.comments-box
-                  = raw criterion.comments_for(student.id)
+          .tab-panel-header
+            - if level.earned_for?(student.id)
+              %span= glyph("check")
+            %h5.level-name= "#{level.name}"
+          .tab-panel-body
+            = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
+            - if level.earned_for?(student.id)
+              %section.grader-feedback
+                - if criterion.comments_for(student.id).present?
+                  %h6 Comments
+                  .level.level-comments.comments-box
+                    = raw criterion.comments_for(student.id)

--- a/app/views/rubrics/components/_criteria_graded.haml
+++ b/app/views/rubrics/components/_criteria_graded.haml
@@ -13,12 +13,12 @@
           - if !level.hide_analytics?
             - unless level.criterion_grades(current_user).empty?
               %p.graded-students= "#{pluralize(level.criterion_grades(current_user).size, 'student')} earned this level"
-
-    - criterion.levels.ordered.each_with_index do |level, lindex|
-      .tab-panel{:class => ("earned selected" if level.earned_for?(student.id)), :id => "tab-#{cindex}-#{lindex}", :role => "tabpanel", "aria-labelledby" => "tab#{lindex+1}", "aria-selected" => (level.earned_for?(student.id) ? "true" : "false")}
-        = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
-        - if level.earned_for?(student.id)
-          %section.grader-feedback
-            %h6 Comments
-            .level.level-comments.comments-box
-              = raw criterion.comments_for(student.id)
+    .tab-panel-container{"data-start-index" => find_earned_rubric_grade(criterion, student.id)}
+      - criterion.levels.ordered.each_with_index do |level, lindex|
+        .tab-panel{:class => ("earned selected" if level.earned_for?(student.id)), :id => "tab-#{cindex}-#{lindex}", :role => "tabpanel", "aria-labelledby" => "tab#{lindex+1}", "aria-selected" => (level.earned_for?(student.id) ? "true" : "false")}
+          = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
+          - if level.earned_for?(student.id)
+            %section.grader-feedback
+              %h6 Comments
+              .level.level-comments.comments-box
+                = raw criterion.comments_for(student.id)

--- a/app/views/rubrics/components/_level.haml
+++ b/app/views/rubrics/components/_level.haml
@@ -10,7 +10,7 @@
     %h6= "#{term_for :badges} Available"
     = render partial: "rubrics/components/level_badges", locals: { level: level }
 
-- elsif !level.level_badges(current_user).empty? && include_grade_info && level.earned_for?(student.id)
+- if !level.level_badges(current_user).empty? && include_grade_info && level.earned_for?(student.id)
   %section.badges-earned
     %h6= "#{term_for :badges} Earned"
     = render partial: "rubrics/components/level_badges", locals: { level: level }

--- a/app/views/rubrics/components/_level_heading.haml
+++ b/app/views/rubrics/components/_level_heading.haml
@@ -1,6 +1,6 @@
 - if current_student.present? && level.earned_for?(student.id)
-  %h6.level-name You earned 
-%h6.level-name= "#{level.name}: " "#{points level.points} Points"
+  %h5.level-name You earned 
+%h5.level-name= "#{level.name}: #{points level.points} Points"
 - if level.meets_expectations || level.above_expectations?
   %p.italic.meets-expectations-label Meets Expectations
 .level-description= level.description

--- a/app/views/rubrics/components/_rubric_table.haml
+++ b/app/views/rubrics/components/_rubric_table.haml
@@ -1,10 +1,11 @@
 .download-link= link_to glyph("file-excel-o") + "Download Rubric", export_assignment_rubric_path(presenter.assignment.id, format: :csv)
 
 - if include_grade_info
-  %h4.class-analytics-label Show class analytics
-  %label.rubric-switch-socket
-    %input#class-analytics-toggle{:type => "checkbox", :checked => true}
-    .rubric-switch-handle.round
+  .class-analytics-toggle
+    %h4.class-analytics-label Show class analytics
+    %label.rubric-switch-socket
+      %input#class-analytics-toggle{:type => "checkbox", :checked => true}
+      .rubric-switch-handle.round
 
   #rubric-graded
     = render partial: "rubrics/components/criteria_graded", locals: { rubric: rubric, student: student, include_grade_info: include_grade_info }


### PR DESCRIPTION
This PR adds a slider to the mobile version of graded rubric feedback that allows students/instructors to swipe or click through levels other than the one earned.

![screen shot 2016-09-22 at 1 12 37 pm](https://cloud.githubusercontent.com/assets/12573921/18758507/59f7a174-80c6-11e6-8ce9-9192cdef71c8.png)

