### PR TITLE
2441 autoprefixer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'angular-rails-templates', '~> 0.2.0'
 gem 'archive-zip', '~> 0.7.0'
 
 gem 'autonumeric-rails'
+gem 'autoprefixer-rails'
 gem 'aws-sdk', '~> 2'
 gem 's3_direct_upload'
 gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     arel (6.0.2)
     autonumeric-rails (1.9.37)
       jquery-rails (>= 2.0.2)
+    autoprefixer-rails (6.4.1.1)
+      execjs
     aws-sdk (2.2.6)
       aws-sdk-resources (= 2.2.6)
     aws-sdk-core (2.2.6)
@@ -688,6 +690,7 @@ DEPENDENCIES
   angularjs-rails (~> 1.4.2)
   archive-zip (~> 0.7.0)
   autonumeric-rails
+  autoprefixer-rails
   aws-sdk (~> 2)
   better_errors
   bullet
@@ -786,5 +789,8 @@ DEPENDENCIES
   wysiwyg-rails
   zeus
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/stylesheets/_buttons_and_icons.sass
+++ b/app/assets/stylesheets/_buttons_and_icons.sass
@@ -16,7 +16,7 @@
   background-color: $color-blue-3
   white-space: nowrap
   font-weight: 400
-  -webkit-appearance: none
+  appearance: none
 
   &:hover
     background-color: darken($color-blue-3, 10%)

--- a/app/assets/stylesheets/_collapse.sass
+++ b/app/assets/stylesheets/_collapse.sass
@@ -5,8 +5,6 @@ h3.collapse
   margin: 0
 
 h3.collapse.open a i.fa.fa-angle-double-right.fa-fw
-  -ms-transform: rotate(90deg)
-  -webkit-transform: rotate(90deg)
   transform: rotate(90deg)
 
 h3.collapse.open a

--- a/app/assets/stylesheets/_dashboard.sass
+++ b/app/assets/stylesheets/_dashboard.sass
@@ -2,14 +2,7 @@
 @import layout
 
 #student-dashboard, #instructor-dashboard
-  display: -webkit-box
-  display: -webkit-flex
-  display: -ms-flexbox
   display: flex
-  -webkit-box-orient: horizontal
-  -webkit-box-direction: normal
-  -webkit-flex-direction: row
-  -ms-flex-direction: row
   flex-direction: row
   @media (max-width: $media-small-max)
     flex-wrap: wrap
@@ -24,14 +17,7 @@
     width: 60%
 
   .flex-col-30, .flex-col-40, .flex-col-60
-    display: -webkit-box
-    display: -webkit-flex
-    display: -ms-flexbox
     display: flex
-    -webkit-box-orient: vertical
-    -webkit-box-direction: normal
-    -webkit-flex-direction: column
-    -ms-flex-direction: column
     flex-direction: column
     margin-right: 1rem
     @media (max-width: $media-medium-max)
@@ -44,40 +30,21 @@
       margin-right: 0
 
   .flex-column
-    display: -webkit-box
-    display: -webkit-flex
-    display: -ms-flexbox
     display: flex
-    -webkit-box-orient: horizontal
-    -webkit-box-direction: normal
-    -webkit-flex-direction: row
-    -ms-flex-direction: row
     flex-direction: row
     @media (max-width: $media-medium-max)
       display: block
 
   .flex-row
     margin-right: 1rem
-    -webkit-box-flex: 1
-    -webkit-flex: 1
-    -ms-flex: 1
     flex: 1
 
   .stacked-column
-    display: -webkit-box
-    display: -webkit-flex
-    display: -ms-flexbox
     display: flex
     flex-flow: column
-    -webkit-box-flex: 1
-    -webkit-flex: 1
-    -ms-flex: 1
     flex: 1
 
   .stacked-module
-    -webkit-box-flex: 1
-    -webkit-flex: 1
-    -ms-flex: 1
     flex: 1 auto
   
   &.show-student
@@ -314,13 +281,7 @@ ul.badge-grid
     padding: 0.2rem 0.5rem
 
 .event-information
-  display: -webkit-box
-  display: -webkit-flex
-  display: -ms-flexbox
   display: flex
-  -ms-flex-align: center
-  -webkit-align-items: center
-  -webkit-box-align: center
   align-items: center
   @media (max-width: $media-small-max)
     display: block

--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -77,9 +77,6 @@
       font-size: 1.1rem
       
       &.right
-        -webkit-box-ordinal-group: 2
-        -webkit-order: 1
-        -ms-flex-order: 1
         order: 1
 
     h2
@@ -101,9 +98,6 @@
     .half
       padding: 0 2rem 0 3rem
       box-sizing: border-box
-      -webkit-box-flex: 1
-      -webkit-flex: 1
-      -ms-flex: 1
       flex: 1
 
     .whole

--- a/app/assets/stylesheets/_features.sass
+++ b/app/assets/stylesheets/_features.sass
@@ -51,13 +51,7 @@
 
   .feature-section
     padding: 2rem
-    display: -webkit-box
-    display: -webkit-flex
-    display: -ms-flexbox
     display: flex
-    -webkit-box-align: center
-    -webkit-align-items: center
-    -ms-flex-align: center
     align-items: center
     
     &.double-height-feature-section

--- a/app/assets/stylesheets/_forms.sass
+++ b/app/assets/stylesheets/_forms.sass
@@ -262,8 +262,6 @@ input#grade_pass_fail_status + label:before
   left: 0
   border-radius: 15px
   background: $color-green-2
-  -moz-transition: .25s ease-in-out
-  -webkit-transition: .25s ease-in-out
   transition: .25s ease-in-out
 
 input#grade_pass_fail_status + label:after
@@ -277,8 +275,6 @@ input#grade_pass_fail_status + label:after
   border-radius: 15px
   background: $color-white
   box-shadow: inset 0 0 0 1px $color-grey-5
-  -moz-transition: .25s ease-in-out
-  -webkit-transition: .25s ease-in-out
   transition: .25s ease-in-out
 
 input#grade_pass_fail_status:checked + label:before
@@ -313,7 +309,6 @@ ul.locked-display li
   right: 0
   bottom: 0
   background-color: $color-grey-6
-  -webkit-transition: .4s
   transition: .4s
 
 .rubric-switch-handle:before
@@ -324,7 +319,6 @@ ul.locked-display li
   left: 2px
   bottom: 2px
   background-color: $color-white
-  -webkit-transition: .4s
   transition: .4s
 
 
@@ -335,8 +329,6 @@ input:focus + .rubric-switch-handle
   box-shadow: 0 0 1px #2196F3
 
 input:checked + .rubric-switch-handle:before
-  -webkit-transform: translateX(16px)
-  -ms-transform: translateX(16px)
   transform: translateX(16px)
 
 .rubric-switch-handle.round

--- a/app/assets/stylesheets/_history_timeline.sass
+++ b/app/assets/stylesheets/_history_timeline.sass
@@ -142,25 +142,13 @@ $color-timeline-vertical-line: $color-blue-4
 @keyframes timeline-bounce-1
   0%
     opacity: 0
-    -webkit-transform: scale(0.5)
-    -moz-transform: scale(0.5)
-    -ms-transform: scale(0.5)
-    -o-transform: scale(0.5)
     transform: scale(0.5)
 
   60%
     opacity: 1
-    -webkit-transform: scale(1.2)
-    -moz-transform: scale(1.2)
-    -ms-transform: scale(1.2)
-    -o-transform: scale(1.2)
     transform: scale(1.2)
 
   100%
-    -webkit-transform: scale(1)
-    -moz-transform: scale(1)
-    -ms-transform: scale(1)
-    -o-transform: scale(1)
     transform: scale(1)
 
 
@@ -264,15 +252,11 @@ $color-timeline-vertical-line: $color-blue-4
 
     &.bounce-in
       visibility: visible
-      -webkit-animation: timeline-bounce-2 0.6s
-      -moz-animation: timeline-bounce-2 0.6s
       animation: timeline-bounce-2 0.6s
 
 @media only screen and (min-width: $media-medium-max)
   /* inverse bounce effect on even content blocks */
   .cssanimations .timeline-block:nth-child(even) .timeline-content.bounce-in
-    -webkit-animation: timeline-bounce-2-inverse 0.6s
-    -moz-animation: timeline-bounce-2-inverse 0.6s
     animation: timeline-bounce-2-inverse 0.6s
 
 @-webkit-keyframes timeline-bounce-2

--- a/app/assets/stylesheets/_history_timeline.sass
+++ b/app/assets/stylesheets/_history_timeline.sass
@@ -113,32 +113,6 @@ $color-timeline-vertical-line: $color-blue-4
       visibility: visible
       animation: timeline-bounce-1 0.6s
 
-@-webkit-keyframes timeline-bounce-1
-  0%
-    opacity: 0
-    -webkit-transform: scale(0.5)
-
-  60%
-    opacity: 1
-    -webkit-transform: scale(1.2)
-
-  100%
-    -webkit-transform: scale(1)
-
-
-@-moz-keyframes timeline-bounce-1
-  0%
-    opacity: 0
-    -moz-transform: scale(0.5)
-
-  60%
-    opacity: 1
-    -moz-transform: scale(1.2)
-
-  100%
-    -moz-transform: scale(1)
-
-
 @keyframes timeline-bounce-1
   0%
     opacity: 0
@@ -259,103 +233,28 @@ $color-timeline-vertical-line: $color-blue-4
   .cssanimations .timeline-block:nth-child(even) .timeline-content.bounce-in
     animation: timeline-bounce-2-inverse 0.6s
 
-@-webkit-keyframes timeline-bounce-2
-  0%
-    opacity: 0
-    -webkit-transform: translateX(-100px)
-
-  60%
-    opacity: 1
-    -webkit-transform: translateX(20px)
-
-  100%
-    -webkit-transform: translateX(0)
-
-
-@-moz-keyframes timeline-bounce-2
-  0%
-    opacity: 0
-    -moz-transform: translateX(-100px)
-
-  60%
-    opacity: 1
-    -moz-transform: translateX(20px)
-
-  100%
-    -moz-transform: translateX(0)
-
 
 @keyframes timeline-bounce-2
   0%
     opacity: 0
-    -webkit-transform: translateX(-100px)
-    -moz-transform: translateX(-100px)
-    -ms-transform: translateX(-100px)
-    -o-transform: translateX(-100px)
     transform: translateX(-100px)
 
   60%
     opacity: 1
-    -webkit-transform: translateX(20px)
-    -moz-transform: translateX(20px)
-    -ms-transform: translateX(20px)
-    -o-transform: translateX(20px)
     transform: translateX(20px)
 
   100%
-    -webkit-transform: translateX(0)
-    -moz-transform: translateX(0)
-    -ms-transform: translateX(0)
-    -o-transform: translateX(0)
     transform: translateX(0)
-
-
-@-webkit-keyframes timeline-bounce-2-inverse
-  0%
-    opacity: 0
-    -webkit-transform: translateX(100px)
-
-  60%
-    opacity: 1
-    -webkit-transform: translateX(-20px)
-
-  100%
-    -webkit-transform: translateX(0)
-
-
-@-moz-keyframes timeline-bounce-2-inverse
-  0%
-    opacity: 0
-    -moz-transform: translateX(100px)
-
-  60%
-    opacity: 1
-    -moz-transform: translateX(-20px)
-
-  100%
-    -moz-transform: translateX(0)
 
 
 @keyframes timeline-bounce-2-inverse
   0%
     opacity: 0
-    -webkit-transform: translateX(100px)
-    -moz-transform: translateX(100px)
-    -ms-transform: translateX(100px)
-    -o-transform: translateX(100px)
     transform: translateX(100px)
 
   60%
     opacity: 1
-    -webkit-transform: translateX(-20px)
-    -moz-transform: translateX(-20px)
-    -ms-transform: translateX(-20px)
-    -o-transform: translateX(-20px)
     transform: translateX(-20px)
 
   100%
-    -webkit-transform: translateX(0)
-    -moz-transform: translateX(0)
-    -ms-transform: translateX(0)
-    -o-transform: translateX(0)
     transform: translateX(0)

--- a/app/assets/stylesheets/_history_timeline.sass
+++ b/app/assets/stylesheets/_history_timeline.sass
@@ -21,12 +21,8 @@ $color-timeline-vertical-line: $color-blue-4
 
 #history-timeline
   *
-    -webkit-box-sizing: border-box
-    -moz-box-sizing: border-box
     box-sizing: border-box
     &:after, &:before
-      -webkit-box-sizing: border-box
-      -moz-box-sizing: border-box
       box-sizing: border-box
 
   position: relative
@@ -115,8 +111,6 @@ $color-timeline-vertical-line: $color-blue-4
 
     &.bounce-in
       visibility: visible
-      -webkit-animation: timeline-bounce-1 0.6s
-      -moz-animation: timeline-bounce-1 0.6s
       animation: timeline-bounce-1 0.6s
 
 @-webkit-keyframes timeline-bounce-1

--- a/app/assets/stylesheets/_icons.sass
+++ b/app/assets/stylesheets/_icons.sass
@@ -5,8 +5,6 @@ i
 
 /** Icon styling! **/
 i.fa-slack
-  -ms-transform: rotate(19deg)
-  -webkit-transform: rotate(19deg)
   transform: rotate(19deg)
 
 .orange

--- a/app/assets/stylesheets/_layout.sass
+++ b/app/assets/stylesheets/_layout.sass
@@ -5,14 +5,7 @@ body
   margin: 0 auto
   padding: 0
   position: relative
-  display: -webkit-box
-  display: -webkit-flex
-  display: -ms-flexbox
   display: flex
-  -webkit-box-orient: vertical
-  -webkit-box-direction: normal
-  -webkit-flex-direction: column
-  -ms-flex-direction: column
   flex-direction: column
   height: 100vh
 
@@ -20,9 +13,6 @@ body
   margin: 2.75rem auto 0 auto
   max-width: 1500px
   width: 100%
-  -webkit-box-flex: 1
-  -webkit-flex: 1 0 auto
-  -ms-flex: 1 0 auto
   flex: 1 0 auto
   background-color: $color-white
 

--- a/app/assets/stylesheets/_offscreen_sidebar.sass
+++ b/app/assets/stylesheets/_offscreen_sidebar.sass
@@ -71,10 +71,6 @@
         position: absolute
         top: 8px
         right: 8px
-        -webkit-transition: all 0.2s ease-in-out
-        -moz-transition: all 0.2s ease-in-out
-        -o-transition: all 0.2s ease-in-out
-        -ms-transition: all 0.2s ease-in-out
         transition: all 0.2s ease-in-out
 
     .course-site i
@@ -87,10 +83,6 @@
     ul.course-info
       max-height: 0px
       overflow: hidden
-      -webkit-transition: all 0.5s ease-in-out
-      -moz-transition: all 0.5s ease-in-out
-      -o-transition: all 0.5s ease-in-out
-      -ms-transition: all 0.5s ease-in-out
       transition: all 0.5s ease-in-out
 
     ul.course-info.open
@@ -115,15 +107,12 @@
 
   .offscreen-sidebar.animating
     transition: transform 0.25s ease-in-out
-    -webkit-transition: -webkit-transform 0.25s ease-in-out
 
   .offscreen-sidebar.animating.opening
     transform: translate3d(280px, 0, 0)
-    -webkit-transform: translate3d(280px, 0, 0)
 
   .offscreen-sidebar.animating.closing
     transform: translate3d(-280px, 0, 0)
-    -webkit-transform: translate3d(-280px, 0, 0)
 
   .offscreen-sidebar.menu-visible
     left: 0

--- a/app/assets/stylesheets/_pages.sass
+++ b/app/assets/stylesheets/_pages.sass
@@ -2,18 +2,8 @@
 @import layout
 
 .public
-  display: -webkit-box
-  display: -webkit-flex
-  display: -ms-flexbox
   display: flex
-  -webkit-box-orient: vertical
-  -webkit-box-direction: normal
-  -webkit-flex-direction: column
-  -ms-flex-direction: column
   flex-direction: column
-  -webkit-box-flex: 1
-  -webkit-flex: 1 0 auto
-  -ms-flex: 1 0 auto
   flex: 1 0 auto
 
 .public-with-background

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -552,10 +552,8 @@ $card-margin-1 : 3px
       font-size: $predictor-font-size-4
     #svg-predicted-key
       transform: translate(10px,120px)
-      -webkit-transform: translate(10px,120px)
     #svg-predicted-grade
       transform: translate(10px, 160px)
-      -webkit-transform: translate(10px, 160px)
   #predictor-post-graph-spacer
     height: 175px
 

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -72,7 +72,6 @@ $card-margin-1 : 3px
   #svg-graph-points-predicted
     fill: $color-blue-3
   #svg-earned-key
-    -webkit-transform: translate(10px,90px) /* Safari */
     transform: translate(10px,90px)
     .key
       fill: $color-green-3
@@ -80,7 +79,6 @@ $card-margin-1 : 3px
       height: 20
   #svg-predicted-key
     transform: translate(230px,90px)
-    -webkit-transform: translate(230px,90px)
     .key
       fill: $color-blue-3
       width: 20
@@ -88,7 +86,6 @@ $card-margin-1 : 3px
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold
-    -webkit-transform: translate(10px,130px) /* Safari */
 
 
 // ICONS AND TOOLTIPS
@@ -153,14 +150,13 @@ $card-margin-1 : 3px
   border-left: 5px solid transparent
   border-right: 5px solid transparent
   border-top: 8px solid $color-blue-4
-  -webkit-backface-visibility: hidden
+  backface-visibility: hidden
   &:hover
     cursor: pointer
 
 .collapsed
   .collapse-arrow
     transform: rotate(-90deg)
-    -webkit-transform: rotate(-90deg)
 
 .predictor-section-title
   font-size: $predictor-font-size-3
@@ -184,10 +180,7 @@ $card-margin-1 : 3px
   text-align: right
   position: relative
   // don't interfere with collapsable section heads onClick()
-  -moz-user-select: none
-  -khtml-user-select: none
-  -webkit-user-select: none
-  -o-user-select: none
+  user-select: none
 
 .predictor-unweighted-point-total, .predictor-weighted-point-total, .predictor-title-right-span, .weighted-earned-points
   float: left

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -86,6 +86,7 @@ $card-margin-1 : 3px
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold
+    transform: translate(10px, 130px)
 
 
 // ICONS AND TOOLTIPS

--- a/app/assets/stylesheets/_predictor.sass
+++ b/app/assets/stylesheets/_predictor.sass
@@ -184,10 +184,10 @@ $card-margin-1 : 3px
   text-align: right
   position: relative
   // don't interfere with collapsable section heads onClick()
-  -moz-user-select: none;
-  -khtml-user-select: none;
-  -webkit-user-select: none;
-  -o-user-select: none;
+  -moz-user-select: none
+  -khtml-user-select: none
+  -webkit-user-select: none
+  -o-user-select: none
 
 .predictor-unweighted-point-total, .predictor-weighted-point-total, .predictor-title-right-span, .weighted-earned-points
   float: left

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -364,9 +364,6 @@ button.meets-expectations-status.no-expectation
 
   ul.level-tabs
     padding-left: 0
-    display: -webkit-box
-    display: -webkit-flex
-    display: -ms-flexbox
     display: flex
     margin: 0
 

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -311,8 +311,6 @@ button.meets-expectations-status.no-expectation
   top: 50%
   left: 50%
   transform: translate(-50%, -50%)
-  -webkit-transform: translate(-50%, -50%)
-  -moz-transform: translate(-50%, -50%)
 
   background-color: $color-blue-4
   box-shadow: 4px 4px 80px #000
@@ -370,9 +368,6 @@ button.meets-expectations-status.no-expectation
   .level-tab
     list-style-type: none
     display: inline-block
-    -webkit-box-flex: 1
-    -webkit-flex: 1
-    -ms-flex: 1
     flex: 1
     text-align: center
     padding: 0.25rem

--- a/app/assets/stylesheets/_signup.sass
+++ b/app/assets/stylesheets/_signup.sass
@@ -3,17 +3,8 @@
 
 .center-items
   padding-top: 50px
-  -webkit-box-align: center
-  -webkit-align-items: center
-  -ms-flex-align: center
   align-items: center
-  -webkit-box-pack: justify
-  -webkit-justify-content: center
-  -ms-flex-pack: justify
   justify-content: center
-  display: -webkit-box
-  display: -ms-flexbox
-  display: -webkit-flex
   display: flex
 
 section.pilot
@@ -43,4 +34,3 @@ section.pilot
 
   .center-items
     display: block
-

--- a/app/assets/stylesheets/_student_sidebar.sass
+++ b/app/assets/stylesheets/_student_sidebar.sass
@@ -141,8 +141,8 @@
   .student-panel
     display: none
 
-@-webkit-keyframes pulsate
-    0% {-webkit-transform: scale(1, 1); opacity: 0.0;}
+@keyframes pulsate
+    0% {transform: scale(1, 1); opacity: 0.0;}
     25% {opacity: 0.8}
-    50% {-webkit-transform: scale(2, 2); opacity: 0.0;}
+    50% {transform: scale(2, 2); opacity: 0.0;}
     100% {opacity: 0.0}

--- a/app/assets/stylesheets/_student_sidebar.sass
+++ b/app/assets/stylesheets/_student_sidebar.sass
@@ -53,14 +53,14 @@
 
   .info-hint-pulse
       border: 3px solid $color-blue-4
-      -webkit-border-radius: 30px
+      border-radius: 30px
       height: 12px
       width: 12px
       position: absolute
       right: 5px
       top: 0px
-      -webkit-animation: pulsate 2s linear
-      -webkit-animation-iteration-count: infinite
+      animation: pulsate 2s linear
+      animation-iteration-count: infinite
       opacity: 0.0
   .hide-hint-link
     text-align: right

--- a/app/assets/stylesheets/animation.sass
+++ b/app/assets/stylesheets/animation.sass
@@ -1,23 +1,11 @@
 @mixin transition-property($properties)
-  -webkit-transition-property: $properties
-  -moz-transition-property: $properties
-  -o-transition-property: $properties
   transition-property: $properties
 
 @mixin transition-duration($properties)
-  -webkit-transition-duration: $properties
-  -moz-transition-duration: $properties
-  -o-transition-duration: $properties
   transition-duration: $properties
 
 @mixin transition-timing-function($timing_function)
-  -webkit-transition-timing-function: $timing_function
-  -moz-transition-timing-function: $timing_function
-  -o-transition-timing-function: $timing_function
   transition-timing-function: $timing_function
 
 @mixin transition($property, $duration, $easing)
-  -webkit-transition: $property $duration $easing
-  -ms-transition: $property $duration $easing
-  -o-transition: $property $duration $easing
   transition: $property $duration $easing

--- a/app/assets/stylesheets/color.sass
+++ b/app/assets/stylesheets/color.sass
@@ -77,20 +77,10 @@ $alert-color: $color-orange-1
 
 @mixin four-color-horizontal-gradient($color1, $color2, $color3, $color4)
   background-color: $color1 //* Fallback Color */
-  background-image: -webkit-gradient(linear, left, right, from($color1), to($color4)) /* Saf4+, Chrome */
-  background-image: -webkit-linear-gradient(to right, $color1, $color2, $color3, $color4) // Chrome 10+, Saf5.1+, iOS 5+ */
-  background-image:    -moz-linear-gradient(to right, $color1, $color2, $color3, $color4) /* FF3.6 */
-  background-image:     -ms-linear-gradient(to right, $color1, $color2, $color3, $color4) /* IE10 */
-  background-image:      -o-linear-gradient(to right, $color1, $color2, $color3, $color4) /* Opera 11.10+ */
   background-image:         linear-gradient(to right, $color1, $color2, $color3, $color4)s
   filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,StartColorStr='#{$color1}', EndColorStr='#{$color4}')
 
 @mixin linear-gradient($fromColor, $toColor)
   background-color: $toColor //* Fallback Color */
-  background-image: -webkit-gradient(linear, left top, left bottom, from($fromColor), to($toColor)) /* Saf4+, Chrome */
-  background-image: -webkit-linear-gradient(top, $fromColor, $toColor)s // Chrome 10+, Saf5.1+, iOS 5+ */
-  background-image:    -moz-linear-gradient(top, $fromColor, $toColor) /* FF3.6 */
-  background-image:     -ms-linear-gradient(top, $fromColor, $toColor) /* IE10 */
-  background-image:      -o-linear-gradient(top, $fromColor, $toColor) /* Opera 11.10+ */
   background-image:         linear-gradient(top, $fromColor, $toColor)
   filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0,StartColorStr='#{$fromColor}', EndColorStr='#{$toColor}')

--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -11,9 +11,7 @@ $media-large-max:   90rem // 1440px
 $media-xlarge-max:  120rems
 
 @mixin rounded-corners($radius)
-  -webkit-border-radius: $radius /* Safari 3-4, iOS 1-3.2, Android 1.6- */
-  -moz-border-radius: $radius /* Firefox 1-3.6 */
-  border-radius: $radius /* Opera 10.5, IE 9, Safari 5, Chrome, Firefox 4, iOS 4, Android 2.1+ */
+  border-radius: $radius
 
 @mixin opacity($opacity)
   $ms_opacity: $opacity * 100


### PR DESCRIPTION
This PR adds [Autoprefixer Rails](https://github.com/ai/autoprefixer-rails) to add vendor prefixes to CSS in post-production. This allows us to remove vendor prefixes from the Sass files and be assured that we are up to date with most recent standards.
