### PR TITLE
2474-predictor-text-on-svg-internet-explorer

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -5,17 +5,15 @@
     %rect#svg-graph-points-earned{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgEarnedBarWidth()}}", "height"=>"20"}
   %g{"id" => "svg-grade-level-text"}
   %g{"id" => "svg-keys"}
-    %g{"id" => "svg-earned-key"}
+    %g{"id" => "svg-earned-key", "transform" => "translate(10,90)"}
       %rect.key{"width"=>"20", "height"=>"20"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Total Earned: {{allPointsEarned() | number}}
-    %g{"id" => "svg-predicted-key"}
+    %g{"id" => "svg-predicted-key", "transform" => "translate(230,90)"}
       %rect.key{"width"=>"20", "height"=>"20"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Total Predicted: {{allPointsPredicted() | number}} (left to earn: {{allPointsPredicted() - allPointsEarned() | number}})
-    %g{"id" => "svg-predicted-grade"}
+    %g{"id" => "svg-predicted-grade", "transform" => "translate(10,130)"}
       %text.description
         Predicted Final Grade:
         {{predictedGradeLevel()}}
-
-


### PR DESCRIPTION
Issue:
![screen shot 2016-09-26 at 10 55 13 am](https://cloud.githubusercontent.com/assets/12573921/18846462/0662c382-83f4-11e6-88bd-6ec148f65ed9.png)

IE doesn't support transforms on SVG in CSS - so have to add these as attributes instead of properties.

After:
![screen shot 2016-09-26 at 2 18 42 pm](https://cloud.githubusercontent.com/assets/12573921/18846505/2ca30ee4-83f4-11e6-9979-3087ed3ea54f.png)
