### PR TITLE
2453 canvas course linking

### DIFF
--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -31,6 +31,9 @@ $media-xlarge-max:  120rems
   /* Good browsers */
   opacity: $opacity
 
+.inline
+  display: inline
+
 @media (max-width: $media-xsmall-max)
   .hide-for-xsmall
     display: none

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -7,7 +7,8 @@ class Assignments::ImportersController < ApplicationController
 
   before_filter :ensure_staff?
   before_filter except: :index do |controller|
-    controller.unauthorized_path assignments_importers_path
+    controller.redirect_path assignments_importer_courses_path \
+      params[:importer_provider_id]
   end
   before_filter :require_authorization, except: :index
 

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -3,6 +3,8 @@ require_relative "../../services/imports_lms_assignments"
 class Assignments::ImportersController < ApplicationController
   include OAuthProvider
 
+  oauth_provider_param :importer_provider_id
+
   before_filter :ensure_staff?
   before_filter except: :index do |controller|
     controller.unauthorized_path assignments_importers_path

--- a/app/controllers/concerns/external_authorization.rb
+++ b/app/controllers/concerns/external_authorization.rb
@@ -1,0 +1,22 @@
+module ExternalAuthorization
+  extend ActiveSupport::Concern
+
+  protected
+
+  def validate_authorization(provider)
+    auth = authorization(provider)
+
+    if auth.nil?
+      redirect_to "/auth/#{provider}"
+    elsif auth.expired?
+      config = ActiveLMS.configuration.providers[provider.to_sym]
+      auth.refresh_with_config! config
+    end
+
+    auth
+  end
+
+  def authorization(provider)
+    UserAuthorization.for(current_user, provider)
+  end
+end

--- a/app/controllers/concerns/oauth_provider.rb
+++ b/app/controllers/concerns/oauth_provider.rb
@@ -1,5 +1,6 @@
 module OAuthProvider
   extend ActiveSupport::Concern
+  include ExternalAuthorization
 
   class_methods do
     def oauth_provider_param(param)
@@ -19,17 +20,6 @@ module OAuthProvider
   end
 
   def require_authorization_with(provider)
-    auth = authorization(provider)
-
-    if auth.nil?
-      redirect_to "/auth/#{provider}"
-    elsif auth.expired?
-      config = ActiveLMS.configuration.providers[provider.to_sym]
-      auth.refresh_with_config! config
-    end
-  end
-
-  def authorization(provider)
-    UserAuthorization.for(current_user, provider)
+    validate_authorization(provider)
   end
 end

--- a/app/controllers/concerns/oauth_provider.rb
+++ b/app/controllers/concerns/oauth_provider.rb
@@ -9,7 +9,7 @@ module OAuthProvider
 
   protected
 
-  def unauthorized_path(path)
+  def redirect_path(path)
     session[:return_to] = path
   end
 
@@ -22,8 +22,7 @@ module OAuthProvider
     auth = authorization(provider)
 
     if auth.nil?
-      redirect_to "/auth/#{provider}",
-        notice: "You could not be authorized with #{provider.capitalize}."
+      redirect_to "/auth/#{provider}"
     elsif auth.expired?
       config = ActiveLMS.configuration.providers[provider.to_sym]
       auth.refresh_with_config! config

--- a/app/controllers/concerns/oauth_provider.rb
+++ b/app/controllers/concerns/oauth_provider.rb
@@ -2,9 +2,15 @@ module OAuthProvider
   extend ActiveSupport::Concern
   include ExternalAuthorization
 
+  included do
+    self.provider_param = nil
+  end
+
   class_methods do
+    attr_accessor :provider_param
+
     def oauth_provider_param(param)
-      @@oauth_provider_param = param
+      @provider_param = param
     end
   end
 
@@ -15,7 +21,7 @@ module OAuthProvider
   end
 
   def require_authorization
-    provider = params.fetch @@oauth_provider_param
+    provider = params.fetch self.class.provider_param
     require_authorization_with provider
   end
 

--- a/app/controllers/concerns/oauth_provider.rb
+++ b/app/controllers/concerns/oauth_provider.rb
@@ -1,6 +1,12 @@
 module OAuthProvider
   extend ActiveSupport::Concern
 
+  class_methods do
+    def oauth_provider_param(param)
+      @@oauth_provider_param = param
+    end
+  end
+
   protected
 
   def unauthorized_path(path)
@@ -8,7 +14,7 @@ module OAuthProvider
   end
 
   def require_authorization
-    provider = params[:importer_provider_id]
+    provider = params.fetch @@oauth_provider_param
     require_authorization_with provider
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -5,10 +5,17 @@ class CoursesController < ApplicationController
   skip_before_filter :require_login, only: [:badges]
   before_filter :ensure_staff?, except: [:index, :badges, :change]
   before_filter :ensure_not_impersonating?, only: [:index]
-  before_action :find_course, only: [:show, :edit, :copy, :update,
-    :destroy, :badges]
-  before_action :use_current_course, only: [:course_details, :custom_terms,
-    :multiplier_settings, :player_settings, :student_onboarding_setup ]
+  before_action :find_course, only: [:show,
+                                     :edit,
+                                     :copy,
+                                     :update,
+                                     :destroy,
+                                     :badges]
+  before_action :use_current_course, only: [:course_details,
+                                            :custom_terms,
+                                            :multiplier_settings,
+                                            :player_settings,
+                                            :student_onboarding_setup]
   skip_before_filter :verify_authenticity_token, only: [:change]
   before_filter :ensure_not_impersonating?, only: [:change]
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -8,7 +8,9 @@ class Grades::ImportersController < ApplicationController
 
   before_filter :ensure_staff?
   before_filter except: [:download, :index, :show, :upload] do |controller|
-    controller.unauthorized_path assignment_grades_importers_path(params[:assignment_id])
+    controller.redirect_path \
+      assignment_grades_importer_courses_path(params[:assignment_id],
+                                              params[:importer_provider_id])
   end
   before_filter :require_authorization, except: [:download, :index, :show, :upload]
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -4,6 +4,8 @@ require_relative "../../services/imports_lms_grades"
 class Grades::ImportersController < ApplicationController
   include OAuthProvider
 
+  oauth_provider_param :importer_provider_id
+
   before_filter :ensure_staff?
   before_filter except: [:download, :index, :show, :upload] do |controller|
     controller.unauthorized_path assignment_grades_importers_path(params[:assignment_id])

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -22,8 +22,11 @@ class Integrations::CoursesController < ApplicationController
     authorize! :read, course
 
     provider_name = params[:integration_id]
-    LinkedCourse.create course_id: course.id, provider_resource_id: params[:id],
-      provider: provider_name, last_linked_at: DateTime.now
+    linked_course = LinkedCourse.find_or_initialize_by course_id: course.id,
+      provider: provider_name
+    linked_course.provider_resource_id = params[:id]
+    linked_course.last_linked_at = DateTime.now
+    linked_course.save
 
     redirect_to integrations_path(provider_name)
   end

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -1,0 +1,27 @@
+class Integrations::CoursesController < ApplicationController
+  include OAuthProvider
+
+  oauth_provider_param :integration_id
+
+  before_filter :ensure_staff?
+  before_filter do |controller|
+    controller.redirect_path(integration_courses_path(params[:integration_id]))
+  end
+  before_filter :require_authorization
+
+  def index
+    @course = current_course
+    authorize! :read, @course
+
+    @provider_name = params[:integration_id]
+    @courses = syllabus(@provider_name).courses
+  end
+
+  private
+
+  def syllabus(provider)
+    @syllabus ||= ActiveLMS::Syllabus.new \
+      provider,
+      authorization(provider).access_token
+  end
+end

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -28,7 +28,7 @@ class Integrations::CoursesController < ApplicationController
     linked_course.last_linked_at = DateTime.now
     linked_course.save
 
-    redirect_to integrations_path(provider_name)
+    redirect_to integrations_path(provider_name), notice: "The #{provider_name.capitalize} course has been linked to #{course.name}"
   end
 
   def destroy
@@ -41,7 +41,7 @@ class Integrations::CoursesController < ApplicationController
                        course_id: course.id,
                        provider_resource_id: params[:id]).destroy_all
 
-    redirect_to integrations_path(provider_name)
+    redirect_to integrations_path(provider_name), notice: "The #{provider_name.capitalize} course has been unlinked from #{course.name}"
   end
 
   private

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -19,7 +19,7 @@ class Integrations::CoursesController < ApplicationController
 
   def create
     course = current_course
-    authorize! :read, course
+    authorize! :update, course
 
     provider_name = params[:integration_id]
     linked_course = LinkedCourse.find_or_initialize_by course_id: course.id,
@@ -27,6 +27,19 @@ class Integrations::CoursesController < ApplicationController
     linked_course.provider_resource_id = params[:id]
     linked_course.last_linked_at = DateTime.now
     linked_course.save
+
+    redirect_to integrations_path(provider_name)
+  end
+
+  def destroy
+    course = current_course
+    authorize! :update, course
+
+    provider_name = params[:integration_id]
+
+    LinkedCourse.where(provider: provider_name,
+                       course_id: course.id,
+                       provider_resource_id: params[:id]).destroy_all
 
     redirect_to integrations_path(provider_name)
   end

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -28,7 +28,7 @@ class Integrations::CoursesController < ApplicationController
     linked_course.last_linked_at = DateTime.now
     linked_course.save
 
-    redirect_to integrations_path(provider_name), notice: "The #{provider_name.capitalize} course has been linked to #{course.name}"
+    redirect_to integrations_path, notice: "The #{provider_name.capitalize} course has been linked to #{course.name}"
   end
 
   def destroy
@@ -41,7 +41,7 @@ class Integrations::CoursesController < ApplicationController
                        course_id: course.id,
                        provider_resource_id: params[:id]).destroy_all
 
-    redirect_to integrations_path(provider_name), notice: "The #{provider_name.capitalize} course has been unlinked from #{course.name}"
+    redirect_to integrations_path, notice: "The #{provider_name.capitalize} course has been unlinked from #{course.name}"
   end
 
   private

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -17,6 +17,17 @@ class Integrations::CoursesController < ApplicationController
     @courses = syllabus(@provider_name).courses
   end
 
+  def create
+    course = current_course
+    authorize! :read, course
+
+    provider_name = params[:integration_id]
+    LinkedCourse.create course_id: course.id, provider_resource_id: params[:id],
+      provider: provider_name, last_linked_at: DateTime.now
+
+    redirect_to integrations_path(provider_name)
+  end
+
   private
 
   def syllabus(provider)

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,0 +1,8 @@
+class IntegrationsController < ApplicationController
+  before_filter :ensure_staff?
+
+  def index
+    @course = current_course
+    authorize! :read, @course
+  end
+end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,6 +1,8 @@
 class IntegrationsController < ApplicationController
   include OAuthProvider
 
+  oauth_provider_param :integration_id
+
   before_filter :ensure_staff?, :require_authorization
 
   def index
@@ -9,6 +11,6 @@ class IntegrationsController < ApplicationController
   end
 
   def create
-    redirect_to integration_courses_path(params[:importer_provider_id])
+    redirect_to integration_courses_path(params[:integration_id])
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,8 +1,14 @@
 class IntegrationsController < ApplicationController
-  before_filter :ensure_staff?
+  include OAuthProvider
+
+  before_filter :ensure_staff?, :require_authorization
 
   def index
     @course = current_course
     authorize! :read, @course
+  end
+
+  def create
+    redirect_to integration_courses_path(params[:importer_provider_id])
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -5,7 +5,7 @@ class IntegrationsController < ApplicationController
 
   before_filter :ensure_staff?
   before_filter except: :index do |controller|
-    controller.redirect_path(courses_integration_path(params[:integration_id]))
+    controller.redirect_path(integration_courses_path(params[:integration_id]))
   end
   before_filter :require_authorization, except: :index
 
@@ -15,7 +15,7 @@ class IntegrationsController < ApplicationController
   end
 
   def create
-    redirect_to courses_integration_path(params[:integration_id])
+    redirect_to integration_courses_path(params[:integration_id])
   end
 
   def courses

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -4,6 +4,9 @@ class IntegrationsController < ApplicationController
   oauth_provider_param :integration_id
 
   before_filter :ensure_staff?
+  before_filter except: :index do |controller|
+    controller.redirect_path(courses_integration_path(params[:integration_id]))
+  end
   before_filter :require_authorization, except: :index
 
   def index
@@ -12,6 +15,22 @@ class IntegrationsController < ApplicationController
   end
 
   def create
-    redirect_to integration_courses_path(params[:integration_id])
+    redirect_to courses_integration_path(params[:integration_id])
+  end
+
+  def courses
+    @course = current_course
+    authorize! :read, @course
+
+    @provider_name = params[:integration_id]
+    @courses = syllabus(@provider_name).courses
+  end
+
+  private
+
+  def syllabus(provider)
+    @syllabus ||= ActiveLMS::Syllabus.new \
+      provider,
+      authorization(provider).access_token
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -17,20 +17,4 @@ class IntegrationsController < ApplicationController
   def create
     redirect_to integration_courses_path(params[:integration_id])
   end
-
-  def courses
-    @course = current_course
-    authorize! :read, @course
-
-    @provider_name = params[:integration_id]
-    @courses = syllabus(@provider_name).courses
-  end
-
-  private
-
-  def syllabus(provider)
-    @syllabus ||= ActiveLMS::Syllabus.new \
-      provider,
-      authorization(provider).access_token
-  end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -3,7 +3,8 @@ class IntegrationsController < ApplicationController
 
   oauth_provider_param :integration_id
 
-  before_filter :ensure_staff?, :require_authorization
+  before_filter :ensure_staff?
+  before_filter :require_authorization, except: :index
 
   def index
     @course = current_course

--- a/app/helpers/integrations_helper.rb
+++ b/app/helpers/integrations_helper.rb
@@ -1,0 +1,27 @@
+module IntegrationsHelper
+  def integration_card_for(provider, course)
+    if course.linked?(provider)
+      linked_integration_card_for(course.linked_for(provider))
+    else
+      unlinked_integration_card_for provider
+    end
+  end
+
+  def linked_integration_card_for(linked_course)
+    render partial: "integrations/courses/linked_card",
+      locals: { linked_course: syllabus_course(linked_course),
+                provider: linked_course.provider }
+  end
+
+  def unlinked_integration_card_for(provider)
+    render partial: "integrations/courses/unlinked_#{provider}_card"
+  end
+
+  private
+
+  def syllabus_course(linked_course)
+    authorization = UserAuthorization.for(current_user, linked_course.provider)
+    syllabus = ActiveLMS::Syllabus.new linked_course.provider, authorization.access_token
+    syllabus.course(linked_course.provider_resource_id)
+  end
+end

--- a/app/helpers/integrations_helper.rb
+++ b/app/helpers/integrations_helper.rb
@@ -1,4 +1,6 @@
 module IntegrationsHelper
+  include ExternalAuthorization
+
   def integration_card_for(provider, course)
     if course.linked?(provider)
       linked_integration_card_for(course.linked_for(provider))
@@ -20,7 +22,7 @@ module IntegrationsHelper
   private
 
   def syllabus_course(linked_course)
-    authorization = UserAuthorization.for(current_user, linked_course.provider)
+    authorization = validate_authorization(linked_course.provider)
     syllabus = ActiveLMS::Syllabus.new linked_course.provider, authorization.access_token
     syllabus.course(linked_course.provider_resource_id)
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,11 +1,11 @@
 require "cancan"
-require_relative "abilities/course_ability"
-require_relative "abilities/announcement_ability"
-require_relative "abilities/assignment_type_weight_ability"
-require_relative "abilities/challenge_grade_ability"
-require_relative "abilities/grade_ability"
-require_relative "abilities/submission_ability"
-require_relative "abilities/submission_file_ability"
+require_dependency "abilities/announcement_ability"
+require_dependency "abilities/assignment_type_weight_ability"
+require_dependency "abilities/challenge_grade_ability"
+require_dependency "abilities/course_ability"
+require_dependency "abilities/grade_ability"
+require_dependency "abilities/submission_ability"
+require_dependency "abilities/submission_file_ability"
 
 class Ability
   include CanCan::Ability

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -297,6 +297,13 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Integrations')
   end
 
+  def integrations_courses_index
+    breadcrumb('Dashboard', dashboard_path)
+    breadcrumb(objects[:course].name, course_path(objects[:course]))
+    breadcrumb('Integrations', integrations_path)
+    breadcrumb("#{objects[:provider_name].capitalize} Integration")
+  end
+
   def downloads_index
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('Course Data Exports', downloads_path)

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -84,11 +84,11 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('#{ term_for :assignment } Types', assignment_types_path)
     breadcrumb('Editing ' + objects[:assignment_type].name)
   end
-  
+
   def assignments_groups_grade
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :assignments }', assignments_path)
-    
+
   end
 
   def badges_index
@@ -265,7 +265,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('Awarded #{ term_for :badges }')
   end
-  
+
   def info_multiplier_choices
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :weight } Choices')
@@ -289,6 +289,12 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
   def info_top_10
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('Top 10/Bottom 10', top_10_path)
+  end
+
+  def integrations_index
+    breadcrumb('Dashboard', dashboard_path)
+    breadcrumb(objects[:course].name, course_path(objects[:course]))
+    breadcrumb('Integrations')
   end
 
   def downloads_index
@@ -411,12 +417,12 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :students }', students_path)
   end
-  
+
   def submissions_show
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb(objects[:submission].assignment.name, assignment_path(objects[:submission].assignment))
   end
-  
+
   def teams_index
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :teams }', teams_path)
@@ -451,7 +457,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Users', users_path)
     breadcrumb('Import Users')
   end
-  
+
   def users_import_results
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('Users', users_path)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -60,6 +60,7 @@ class Course < ActiveRecord::Base
     c.has_many :grades
     c.has_many :groups
     c.has_many :group_memberships
+    c.has_many :linked_courses, dependent: :destroy
     c.has_many :submissions
     c.has_many :teams
     c.has_many :course_memberships
@@ -113,7 +114,7 @@ class Course < ActiveRecord::Base
   end
 
   def linked?(provider)
-    LinkedCourse.where(provider: provider, course_id: self.id).exists?
+    self.linked_courses.where(provider: provider).exists?
   end
 
   def valuable_badges?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -112,6 +112,10 @@ class Course < ActiveRecord::Base
     end
   end
 
+  def linked?(provider)
+    LinkedCourse.where(provider: provider, course_id: self.id).exists?
+  end
+
   def valuable_badges?
     badges.any? { |badge| badge.full_points.present? && badge.full_points > 0 }
   end
@@ -237,14 +241,14 @@ class Course < ActiveRecord::Base
       elements: elements
     }
   end
-  
+
   # creating a list of students who do not have any predictions
   def nonpredictors
     nonpredictors = []
     self.students.each do |student|
       if student.predictions_for_course?(self) == false
         nonpredictors << student
-      end 
+      end
     end
     return nonpredictors
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -117,6 +117,10 @@ class Course < ActiveRecord::Base
     self.linked_courses.where(provider: provider).exists?
   end
 
+  def linked_for(provider)
+    self.linked_courses.where(provider: provider).first
+  end
+
   def valuable_badges?
     badges.any? { |badge| badge.full_points.present? && badge.full_points > 0 }
   end

--- a/app/models/linked_course.rb
+++ b/app/models/linked_course.rb
@@ -1,0 +1,3 @@
+class LinkedCourse < ActiveRecord::Base
+  belongs_to :course
+end

--- a/app/views/integrations/courses/_linked_card.html.haml
+++ b/app/views/integrations/courses/_linked_card.html.haml
@@ -1,5 +1,5 @@
 %h4.card-title Canvas Course Linked
 %p.card-text= linked_course["name"]
 %p.card-text= (linked_course["syllabus_body"] || "").html_safe
-%form{ method: :post, action: integrations_path(provider), class: "inline" }
+= form_tag(integration_course_path(provider, linked_course["id"]), method: :delete, class: "inline") do
   %button{ type: :submit, class: "card-link button" } Unlink Canvas Course

--- a/app/views/integrations/courses/_linked_card.html.haml
+++ b/app/views/integrations/courses/_linked_card.html.haml
@@ -1,0 +1,5 @@
+%h4.card-title Canvas Course Linked
+%p.card-text= linked_course["name"]
+%p.card-text= (linked_course["syllabus_body"] || "").html_safe
+%form{ method: :post, action: integrations_path(provider), class: "inline" }
+  %button{ type: :submit, class: "card-link button" } Unlink Canvas Course

--- a/app/views/integrations/courses/_unlinked_canvas_card.html.haml
+++ b/app/views/integrations/courses/_unlinked_canvas_card.html.haml
@@ -1,0 +1,9 @@
+%h4.card-title Canvas LMS
+%p.card-text An open-source LMS from Instructure.
+%p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
+
+%form{ method: :post, action: integrations_path, class: "inline" }
+  = hidden_field_tag :authenticity_token, form_authenticity_token
+  = hidden_field_tag :integration_id, :canvas
+  %button{ type: :submit, class: "card-link button" } Link a Canvas Course
+  = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"

--- a/app/views/integrations/courses/index.html.haml
+++ b/app/views/integrations/courses/index.html.haml
@@ -19,4 +19,7 @@
           %td
             .right
               %ul.button-bar
-                %li= link_to glyph("link") + "Link Course", "#", class: "button"
+                %li
+                  = form_tag integrations_path, method: :post do
+                    = hidden_field_tag :id, course["id"]
+                    = button_tag glyph("link") + "Link Course", class: "button"

--- a/app/views/integrations/courses/index.html.haml
+++ b/app/views/integrations/courses/index.html.haml
@@ -1,7 +1,3 @@
-= content_nav_for @course, "#{@provider_name.capitalize} Integration"
-
-%h2.pagetitle Link #{@provider_name.capitalize} Course with #{@course.name}
-
 .pageContent
   = render partial: "layouts/alerts"
 

--- a/app/views/integrations/courses/index.html.haml
+++ b/app/views/integrations/courses/index.html.haml
@@ -20,6 +20,6 @@
             .right
               %ul.button-bar
                 %li
-                  = form_tag integrations_path, method: :post do
+                  = form_tag integration_courses_path(@provider_name), method: :post do
                     = hidden_field_tag :id, course["id"]
                     = button_tag glyph("link") + "Link Course", class: "button"

--- a/app/views/integrations/courses/index.html.haml
+++ b/app/views/integrations/courses/index.html.haml
@@ -1,0 +1,22 @@
+= content_nav_for @course, "#{@provider_name.capitalize} Integration"
+
+%h2.pagetitle Link #{@provider_name.capitalize} Course with #{@course.name}
+
+.pageContent
+  = render partial: "layouts/alerts"
+
+  %table.dynatable.no-table-header
+    %thead
+      %tr
+        %th{scope: "col"} Name
+        %th{scope: "col"} Description
+        %th.button-column{"data-dynatable-no-sort" => "true"}
+    %tbody
+      - @courses.each do |course|
+        %tr
+          %td= course["name"]
+          %td= course["syllabus_body"]
+          %td
+            .right
+              %ul.button-bar
+                %li= link_to glyph("link") + "Link Course", "#", class: "button"

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -8,13 +8,4 @@
   .card{style: "height: 350px;"}
     .card-cap
       %img{src: "/images/canvas-logo.png"}
-    .card-block
-      %h4.card-title Canvas LMS
-      %p.card-text An open-source LMS from Instructure.
-      %p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
-
-      %form{ method: :post, action: integrations_path, class: "inline" }
-        = hidden_field_tag :authenticity_token, form_authenticity_token
-        = hidden_field_tag :integration_id, :canvas
-        %button{ type: :submit, class: "card-link button" } Link a Canvas Course
-        = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"
+    .card-block= integration_card_for(:canvas, @course)

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -14,6 +14,7 @@
       %p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
 
       %form{ method: :post, action: integrations_path, class: "inline" }
-        %input{ type: :hidden, name: :integration_id, value: :canvas }
+        = hidden_field_tag :authenticity_token, form_authenticity_token
+        = hidden_field_tag :integration_id, :canvas
         %button{ type: :submit, class: "card-link button" } Link a Canvas Course
         = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -14,6 +14,6 @@
       %p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
 
       %form{ method: :post, action: integrations_path, class: "inline" }
-        %input{ type: :hidden, value: :canvas }
+        %input{ type: :hidden, name: :importer_provider_id, value: :canvas }
         %button{ type: :submit, class: "card-link button" } Link a Canvas Course
         = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -14,6 +14,6 @@
       %p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
 
       %form{ method: :post, action: integrations_path, class: "inline" }
-        %input{ type: :hidden, name: :importer_provider_id, value: :canvas }
+        %input{ type: :hidden, name: :integration_id, value: :canvas }
         %button{ type: :submit, class: "card-link button" } Link a Canvas Course
         = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -1,7 +1,3 @@
-= content_nav_for @course, "Integrations"
-
-%h2.pagetitle Use your favorite tools with GradeCraft
-
 .pageContent
   = render partial: "layouts/alerts"
 

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -1,0 +1,19 @@
+= content_nav_for @course, "Integrations"
+
+%h2.pagetitle Use your favorite tools with GradeCraft
+
+.pageContent
+  = render partial: "layouts/alerts"
+
+  .card{style: "height: 350px;"}
+    .card-cap
+      %img{src: "/images/canvas-logo.png"}
+    .card-block
+      %h4.card-title Canvas LMS
+      %p.card-text An open-source LMS from Instructure.
+      %p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
+
+      %form{ method: :post, action: integrations_path, class: "inline" }
+        %input{ type: :hidden, value: :canvas }
+        %button{ type: :submit, class: "card-link button" } Link a Canvas Course
+        = link_to "More Info", "http://canvaslms.com", target: "_blank", class: "card-link"

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -51,6 +51,7 @@
 %h5 Course Setup
 %li= link_to_unless_current glyph(:cog) + "Basic Settings", edit_course_path(current_course)
 %li= link_to_unless_current glyph("map-signs") + "Course Details", course_details_path
+%li= link_to_unless_current glyph(:mixcloud) + "Course Integrations", integrations_path
 %li= link_to_unless_current glyph(:language) + "Custom Terms", custom_terms_path
 %li= link_to_unless_current glyph(:database) + "Multiplier Settings", multiplier_settings_path
 %li= link_to_unless_current glyph(:child) + "Player Settings", player_settings_path

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -87,6 +87,9 @@ en:
     dashboard:
       title: "Dashboard"
   integrations:
+    courses:
+      index:
+        title: "Link #{@provider_name.capitalize} Course with #{@course.name}"
     index:
       title: "Use your favorite tools with GradeCraft"
   earned_badges:

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -1,10 +1,10 @@
 en:
   announcements:
-    show: 
+    show:
       title: "#{ @announcement.title }"
-    new: 
+    new:
       title: "Create a New Announcement"
-    edit: 
+    edit:
       title: "Edit { @announcement.title } Announcement"
   analytics:
     students:
@@ -86,6 +86,9 @@ en:
   info:
     dashboard:
       title: "Dashboard"
+  integrations:
+    index:
+      title: "Use your favorite tools with GradeCraft"
   earned_badges:
     show:
       title: "#{ @student.name }'s #{ @badge.name } #{ term_for :badge }"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,8 +174,8 @@ GradeCraft::Application.routes.draw do
 
   #8. Integrations
 
-  resources :integrations, only: [:index, :create] do
-    resources :courses, only: :index
+  resources :integrations, only: [:create, :index] do
+    resources :courses, only: [:create, :index], module: :integrations
   end
 
   #9. Courses

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ GradeCraft::Application.routes.draw do
   #5. Assignment Type Weights
   #6. Badges
   #7. Challenges
-  #8. Importers
+  #8. Integrations
   #9. Courses
   #10. Groups
   #11. Informational Pages
@@ -172,6 +172,10 @@ GradeCraft::Application.routes.draw do
 
   resources :challenge_grades, except: [:index, :new, :create]
 
+  #8. Integrations
+
+  resources :integrations, only: [:index, :create]
+
   #9. Courses
 
   resources :courses do
@@ -188,7 +192,6 @@ GradeCraft::Application.routes.draw do
   controller :courses do
     get :course_details
     get :custom_terms
-    get :integrations
     get :multiplier_settings
     get :player_settings
     get :student_onboarding_setup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ GradeCraft::Application.routes.draw do
   controller :courses do
     get :course_details
     get :custom_terms
+    get :integrations
     get :multiplier_settings
     get :player_settings
     get :student_onboarding_setup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,9 @@ GradeCraft::Application.routes.draw do
 
   #8. Integrations
 
-  resources :integrations, only: [:index, :create]
+  resources :integrations, only: [:index, :create] do
+    resources :courses, only: :index
+  end
 
   #9. Courses
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,7 @@ GradeCraft::Application.routes.draw do
   #8. Integrations
 
   resources :integrations, only: [:create, :index] do
-    resources :courses, only: [:create, :index], module: :integrations
+    resources :courses, only: [:create, :destroy, :index], module: :integrations
   end
 
   #9. Courses

--- a/db/migrate/20160922173457_create_linked_courses.rb
+++ b/db/migrate/20160922173457_create_linked_courses.rb
@@ -1,0 +1,12 @@
+class CreateLinkedCourses < ActiveRecord::Migration
+  def change
+    create_table :linked_courses do |t|
+      t.references :course, index: true, foreign_key: true
+      t.string :provider
+      t.string :provider_resource_id
+      t.datetime :last_linked_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160915164717) do
+ActiveRecord::Schema.define(version: 20160922173457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -496,6 +496,17 @@ ActiveRecord::Schema.define(version: 20160915164717) do
     t.boolean  "meets_expectations", default: false
   end
 
+  create_table "linked_courses", force: :cascade do |t|
+    t.integer  "course_id"
+    t.string   "provider"
+    t.string   "provider_resource_id"
+    t.datetime "last_linked_at"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "linked_courses", ["course_id"], name: "index_linked_courses_on_course_id", using: :btree
+
   create_table "lti_providers", force: :cascade do |t|
     t.string   "name"
     t.string   "uid"
@@ -768,6 +779,7 @@ ActiveRecord::Schema.define(version: 20160915164717) do
   add_foreign_key "flagged_users", "users", column: "flagger_id"
   add_foreign_key "imported_assignments", "assignments"
   add_foreign_key "imported_grades", "grades"
+  add_foreign_key "linked_courses", "courses"
   add_foreign_key "secure_tokens", "courses"
   add_foreign_key "secure_tokens", "users"
   add_foreign_key "user_authorizations", "users"

--- a/spec/controllers/integrations/courses_controller_spec.rb
+++ b/spec/controllers/integrations/courses_controller_spec.rb
@@ -40,7 +40,7 @@ describe Integrations::CoursesController do
         it "redirects back to the integrations page" do
           post :create, { integration_id: provider, id: course_id }
 
-          expect(response).to redirect_to integrations_path(provider)
+          expect(response).to redirect_to integrations_path
         end
 
         context "with an existing linked course" do
@@ -79,7 +79,7 @@ describe Integrations::CoursesController do
         it "redirects back to the integrations page" do
           delete :destroy, { integration_id: provider, id: course_id }
 
-          expect(response).to redirect_to integrations_path(provider)
+          expect(response).to redirect_to integrations_path
         end
       end
     end

--- a/spec/controllers/integrations/courses_controller_spec.rb
+++ b/spec/controllers/integrations/courses_controller_spec.rb
@@ -58,6 +58,31 @@ describe Integrations::CoursesController do
         end
       end
     end
+
+    describe "DELETE #destroy" do
+      context "with an existing authentication" do
+        let(:course_id) { "COURSE_1" }
+        let!(:linked_course) { LinkedCourse.create provider: provider,
+                               course_id: course.id,
+                               provider_resource_id: course_id }
+        let!(:user_authorization) do
+          create :user_authorization, :canvas, user: professor,
+            access_token: "BLAH", expires_at: 2.days.from_now
+        end
+
+        it "deletes the linked course" do
+          delete :destroy, { integration_id: provider, id: course_id }
+
+          expect(LinkedCourse.exists?(linked_course.id)).to be_falsey
+        end
+
+        it "redirects back to the integrations page" do
+          delete :destroy, { integration_id: provider, id: course_id }
+
+          expect(response).to redirect_to integrations_path(provider)
+        end
+      end
+    end
   end
 
   context "as a student" do

--- a/spec/controllers/integrations/courses_controller_spec.rb
+++ b/spec/controllers/integrations/courses_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_spec_helper"
+
+describe Integrations::CoursesController do
+  let(:provider) { :canvas }
+
+  context "as a professor" do
+    let(:professor) { professor_membership.user }
+    let(:professor_membership) { create :professor_course_membership }
+
+    before { login_user(professor) }
+
+    describe "POST #link" do
+      context "without an existing authentication" do
+        it "redirects to authorize the integration" do
+          post :create, { integration_id: provider }
+
+          expect(response).to redirect_to "/auth/canvas"
+        end
+      end
+
+      xit "creates the link between the course and the provider course"
+      xit "redirects back to the integrations page"
+    end
+  end
+
+  context "as a student" do
+    let(:student) { student_membership.user }
+    let(:student_membership) { create :student_course_membership }
+
+    before { login_user(student) }
+
+    xit "redirects to the root" do
+    end
+  end
+end

--- a/spec/controllers/integrations/courses_controller_spec.rb
+++ b/spec/controllers/integrations/courses_controller_spec.rb
@@ -44,7 +44,17 @@ describe Integrations::CoursesController do
         end
 
         context "with an existing linked course" do
-          xit "replaces the current linked course"
+          before do
+            LinkedCourse.create! provider: provider, course_id: course.id,
+              provider_resource_id: "BLAH"
+          end
+
+          it "replaces the current linked course" do
+            post :create, { integration_id: provider, id: course_id }
+
+            expect(LinkedCourse.count).to eq 1
+            expect(linked_course.course_id).to eq course.id
+          end
         end
       end
     end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -12,7 +12,7 @@ describe IntegrationsController do
     describe "POST create" do
       context "without an existing authentication" do
         it "redirects to authorize the integration" do
-          post :create, { importer_provider_id: provider }
+          post :create, { integration_id: provider }
 
           expect(response).to redirect_to "/auth/canvas"
         end
@@ -27,7 +27,7 @@ describe IntegrationsController do
         it "retrieves a refresh token" do
           expect_any_instance_of(UserAuthorization).to receive(:refresh!)
 
-          post :create, { importer_provider_id: provider }
+          post :create, { integration_id: provider }
         end
       end
 
@@ -38,7 +38,7 @@ describe IntegrationsController do
         end
 
         it "redirects to the redirect url" do
-          post :create, { importer_provider_id: provider }
+          post :create, { integration_id: provider }
 
           expect(response).to redirect_to integration_courses_path(:canvas)
         end
@@ -53,7 +53,7 @@ describe IntegrationsController do
     before { login_user(student) }
 
     it "redirects to the root" do
-      post :create, { importer_provider_id: provider }
+      post :create, { integration_id: provider }
 
       expect(response).to redirect_to root_path
     end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -40,7 +40,7 @@ describe IntegrationsController do
         it "redirects to the redirect url" do
           post :create, { integration_id: provider }
 
-          expect(response).to redirect_to courses_integration_path(:canvas)
+          expect(response).to redirect_to integration_courses_path(:canvas)
         end
       end
     end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -1,0 +1,61 @@
+require "rails_spec_helper"
+
+describe IntegrationsController do
+  let(:provider) { :canvas }
+
+  context "as a professor" do
+    let(:professor) { professor_membership.user }
+    let(:professor_membership) { create :professor_course_membership }
+
+    before { login_user(professor) }
+
+    describe "POST create" do
+      context "without an existing authentication" do
+        it "redirects to authorize the integration" do
+          post :create, { importer_provider_id: provider }
+
+          expect(response).to redirect_to "/auth/canvas"
+        end
+      end
+
+      context "with an expired authentication" do
+        let!(:user_authorization) do
+          create :user_authorization, :canvas, user: professor,
+            access_token: "BLAH", expires_at: 2.days.ago
+        end
+
+        it "retrieves a refresh token" do
+          expect_any_instance_of(UserAuthorization).to receive(:refresh!)
+
+          post :create, { importer_provider_id: provider }
+        end
+      end
+
+      context "with an existing authentication" do
+        let!(:user_authorization) do
+          create :user_authorization, :canvas, user: professor,
+            access_token: "BLAH", expires_at: 2.days.from_now
+        end
+
+        it "redirects to the redirect url" do
+          post :create, { importer_provider_id: provider }
+
+          expect(response).to redirect_to integration_courses_path(:canvas)
+        end
+      end
+    end
+  end
+
+  context "as a student" do
+    let(:student) { student_membership.user }
+    let(:student_membership) { create :student_course_membership }
+
+    before { login_user(student) }
+
+    it "redirects to the root" do
+      post :create, { importer_provider_id: provider }
+
+      expect(response).to redirect_to root_path
+    end
+  end
+end

--- a/spec/controllers/integrations_controller_spec.rb
+++ b/spec/controllers/integrations_controller_spec.rb
@@ -40,7 +40,7 @@ describe IntegrationsController do
         it "redirects to the redirect url" do
           post :create, { integration_id: provider }
 
-          expect(response).to redirect_to integration_courses_path(:canvas)
+          expect(response).to redirect_to courses_integration_path(:canvas)
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -144,6 +144,16 @@ describe Course do
     end
   end
 
+  describe "#linked_for" do
+    let!(:linked_course) { LinkedCourse.create provider: provider, course_id: subject.id }
+    let(:provider) { :canvas }
+    subject { create :course }
+
+    it "returns the linked course for the specified provider" do
+      expect(subject.linked_for(provider)).to eq linked_course
+    end
+  end
+
   describe "#staff" do
     it "returns an alphabetical list of the staff in the course" do
       course = create(:course)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,7 +2,8 @@ require "active_record_spec_helper"
 
 describe Course do
   subject { build(:course) }
-  let(:staff_membership) { create :staff_course_membership, course: subject, instructor_of_record: true }
+  let(:staff_membership) { create :staff_course_membership, course: subject,
+                                  instructor_of_record: true }
 
   describe "validations" do
     it "requires a name" do
@@ -83,9 +84,12 @@ describe Course do
   end
 
   describe "#grade_scheme_elements" do
-    let!(:high) { create(:grade_scheme_element, lowest_points: 2001, highest_points: 3000, course: subject) }
-    let!(:low) { create(:grade_scheme_element, lowest_points: 100, highest_points: 1000, course: subject) }
-    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001, highest_points: 2000, course: subject) }
+    let!(:high) { create(:grade_scheme_element, lowest_points: 2001,
+                         highest_points: 3000, course: subject) }
+    let!(:low) { create(:grade_scheme_element, lowest_points: 100,
+                        highest_points: 1000, course: subject) }
+    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001,
+                           highest_points: 2000, course: subject) }
 
     describe "#for_score" do
       it "returns the grade scheme element that falls within that points range" do
@@ -122,6 +126,21 @@ describe Course do
 
         expect(result.id).to be_nil
       end
+    end
+  end
+
+  describe "#linked?" do
+    let(:provider) { :canvas }
+    subject { create :course }
+
+    it "is linked if it has a linked course to the specified provider" do
+      LinkedCourse.create provider: provider, course_id: subject.id
+
+      expect(subject).to be_linked provider
+    end
+
+    it "is not linked if it does not have a linked course for the specified provider" do
+      expect(subject).to_not be_linked provider
     end
   end
 
@@ -668,8 +687,8 @@ describe Course do
       expect(subject.scores).to eq({:scores => [100, 200, 300]})
     end
   end
-  
-  describe "#earned_grade_scheme_elements_by_student_count" do 
+
+  describe "#earned_grade_scheme_elements_by_student_count" do
     it "returns the number of students who have earned each grade scheme element" do
       gse = create(:grade_scheme_element_high, course: subject)
       gse2 = create(:grade_scheme_element_low, course: subject)
@@ -678,9 +697,9 @@ describe Course do
       expect(subject.earned_grade_scheme_elements_by_student_count).to eq({:elements => [["#{gse2.name}", 1], ["#{gse.name}", 1]]})
     end
   end
-  
-  describe "#nonpredictors" do 
-    it "returns the students who have not yet predicted any assignments" do 
+
+  describe "#nonpredictors" do
+    it "returns the students who have not yet predicted any assignments" do
       student = create(:user)
       student_2 = create(:user)
       course = create(:course)


### PR DESCRIPTION
This PR adds a new section to the sidebar for "Course Integrations" which allows an instructor to add integrations to the existing course.

The only available course integration so far is Canvas integration. This integration allows the instructor to link a Canvas course to a current GC course. This link can then be used when importing grades and assignments (the adjustment to the flow will be made in a subsequent PR).

The linked course is stored in a new table `linked_courses` and displayed when the course integrations is displayed.

Here is the workflow:

The instructor visits `/integrations` which just lists the Canvas integration for now:

<img width="1516" alt="screen shot 2016-09-27 at 3 30 07 pm" src="https://cloud.githubusercontent.com/assets/35017/18888755/afcb5cbc-84c7-11e6-826b-32fa1d4afd2b.png">

The instructor can click on "Link Canvas Course", oauth with Canvas, and then the available Canvas courses are displayed:

<img width="1518" alt="screen shot 2016-09-27 at 3 30 37 pm" src="https://cloud.githubusercontent.com/assets/35017/18888768/b85bda0a-84c7-11e6-8a87-356a1409edea.png">

The instructor is redirected back to `/integrations` and they see that the course has been linked:

<img width="1515" alt="screen shot 2016-09-27 at 3 30 46 pm" src="https://cloud.githubusercontent.com/assets/35017/18888773/bee04afa-84c7-11e6-91ed-8b94c66fb2aa.png">

The instructor can unlink the course as well:

<img width="1512" alt="screen shot 2016-09-27 at 3 30 59 pm" src="https://cloud.githubusercontent.com/assets/35017/18888777/c5d6b40c-84c7-11e6-9a27-a792cae8d5a7.png">

Closes #2453 