### PR TITLE
2445 instructor rubric

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -20,10 +20,19 @@
     $scope.services()
 
   $scope.services = () ->
+    # because getting Criteria requires badges from $scope
+    # we need to wait until the badges are created before
+    # making this call.
+    queCriteriaAfterBadges = ()->
+      if (RubricService.badgesAvailable() == false)
+        window.setTimeout(queCriteriaAfterBadges, 100)
+      else
+        RubricService.getCriteria($scope.assignment.id, $scope)
+
     promises = [
-      RubricService.getCriterionGrades($scope.assignment),
-      RubricService.getCriteria($scope.assignment.id, $scope),
       RubricService.getBadges(),
+      RubricService.getCriterionGrades($scope.assignment),
+      queCriteriaAfterBadges(),
       RubricService.getGrade($scope.assignment)]
     $q.all(promises)
 

--- a/app/assets/javascripts/angular/factories/Level.js.coffee
+++ b/app/assets/javascripts/angular/factories/Level.js.coffee
@@ -112,7 +112,7 @@
     removeFromCriterion: (index)->
       @criterion.levels.splice(index,1)
 
-    ##rubric ctrl
+    ##rubric-design ctrl
     loadLevelBadge: (levelBadge)->
       courseBadge = @availableBadges[levelBadge.badge_id]
       loadedBadge = new LevelBadge(@, angular.copy(courseBadge))
@@ -126,7 +126,7 @@
         if (@availableBadges[levelBadge.badge_id])
           @loadLevelBadge(levelBadge)
       )
-    #rubric ctrl
+    #rubric-design ctrl
     # Badges
     addBadge: (attrs={})->
       newBadge = new LevelBadge(@, attrs)

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -115,22 +115,22 @@ td.level-td
     margin-right: 10px
     height: 240px
     position: relative
-    float: left
     width: 190px
+    display: inline-block
+    white-space: initial
+    vertical-align: middle
 
 .level-container
   height: 280px !important
-  width: 10000px
-
-  .level
-    float: left
-    display: inline
 
 .criterion
   background: $color-grey-6
 
   &.saved
     background: $color-blue-3
+
+  input
+    margin-right: 0.2rem
 
   input.points
     z-index: 500
@@ -274,9 +274,7 @@ button.meets-expectations-status.no-expectation
   border: none
 
 .add-level
-  position: absolute
-  margin-top: -20px
-  right: 70px
+  vertical-align: bottom
 
 #rubric .rubric-container
   margin: 1rem 0
@@ -284,8 +282,9 @@ button.meets-expectations-status.no-expectation
   border: 1px solid $color-grey-6
   padding: 10px
   cursor: move
-  overflow-y: auto
+  overflow-x: auto
   height: 400px !important
+  white-space: nowrap
 
   .order-label
     display: inline-block

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -21,6 +21,10 @@ $no-expectation-color: $color-grey-5
     height: 65px
     resize: none
     color: $color-black
+    &.criterion-description
+      width: 50em
+      height: 2rem
+      vertical-align: middle
 
   input
     height: 2rem
@@ -88,13 +92,6 @@ h4.notice
     color: $color-green-2
 
 #rubric-column-heading
-  margin-top: 1rem
-  .criterion-heading
-    background: $color-grey-7
-    margin: 0 .5rem .5rem
-    padding: .5rem
-    float: left
-    width: 195px
 
   .level-heading
     background: $color-grey-7
@@ -106,9 +103,14 @@ td.level-td
   border: 1px solid $color-grey-7
 
 #criterion-box
-  width: 94%
+  .criterion
+    position: relative
+    padding: 0.5rem 0.5rem 0 0.5rem
+    margin-bottom: 0.5rem
+    display: inline-block
+    width: 95%
 
-  .criterion, .level
+  .level
     padding: 2rem .5rem .5rem
     margin-right: 10px
     height: 240px
@@ -279,23 +281,19 @@ button.meets-expectations-status.no-expectation
 #rubric .rubric-container
   margin: 1rem 0
   clear: both
-  border: 1px dashed $color-grey-7
+  border: 1px solid $color-grey-6
   padding: 10px
   cursor: move
-  border-left: 2px solid $color-grey-5
-  width: 100%
-  overflow-y: scroll
-  height: 280px !important
+  overflow-y: auto
+  height: 400px !important
 
   .order-label
-    display: block
-    float: left
-    right: 0
+    display: inline-block
     background: $color-blue-2
-    padding: .5rem
+    padding: 0.77rem 
     color: $color-white
-    margin-top: 0
-    margin-right: 0px
+    margin-right: -4px
+    vertical-align: middle
 
 .badge-row.clickable
   cursor: hand

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -502,20 +502,6 @@ button.meets-expectations-status.no-expectation
       padding-right: 0
 
 #rubric-table
-  td
-    vertical-align: top
-    text-align: left
-
-  td.criterion.heading
-    background-color: $color-blue-3
-    color: $color-white
-
-  td.level.heading
-    background-color: $color-blue-3
-
-  .criterion
-    background-color: $color-blue-3
-
   .criterion-name, .level-name
     font-weight: bold
 
@@ -526,12 +512,25 @@ button.meets-expectations-status.no-expectation
     font-size: 80%
     text-transform: uppercase
 
-  .criterion-description, .level-description
-    font-style: italic
+  .level-tab
+    padding: 0
 
-  td.level-level
-    border: 1px solid $color-white
-    background-color: $color-grey-7
+  .level-heading
+    border-bottom: 1px solid $color-white
+    padding: 0.2rem 0
+
+  .level-details
+    display: inline-block
+    vertical-align: top
+
+  .badge-row
+    display: inline-block
+    vertical-align: bottom
+
+  .level-description
+    text-align: left
+    padding: 0.2rem 0.5rem
+    font-size: 0.7rem
 
   .level.meets-expectations
     background-color: $meets-expectations-color
@@ -543,8 +542,10 @@ button.meets-expectations-status.no-expectation
   .level.selected.meets-expectations
     background-color: $meets-expectations-selected-color
 
-  .level-badge-image img
-    height: 35px
+  .level-badge-image
+    list-style: none
+    img
+      height: 25px
 
   .badge-row:hover
     background-color: transparent
@@ -561,7 +562,7 @@ button.meets-expectations-status.no-expectation
   .graded-students
     background-color: $color-blue-3
 
-  td.comments-box
+  .comments-box
     background-color: $color-grey-7
     border: none
     padding: .25rem

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -8,12 +8,13 @@
     background-color: $color-white
 
 $below-expectations-color: $color-grey-6
-$below-expectations-selected-color: $color-grey-4
-$meets-expectations-color: $color-green-2
-$meets-expectations-selected-color: $color-green-1
+$below-expectations-selected-color: lighten($color-grey-6, 10%)
+$meets-expectations-color: $color-green-1
+$meets-expectations-selected-color: lighten($color-green-1, 10%)
 $no-expectation-color: $color-grey-5
 
-#rubric
+// styles for rubric design view
+#rubric-design
   textarea
     @include rubric-level-input
     width: 11.75rem
@@ -21,6 +22,7 @@ $no-expectation-color: $color-grey-5
     height: 65px
     resize: none
     color: $color-black
+    padding: .5rem
     &.criterion-description
       width: 50em
       height: 2rem
@@ -33,74 +35,43 @@ $no-expectation-color: $color-grey-5
     border: 0
     padding: .5rem
 
-  textarea
-    padding: .5rem
+  .rubric-container
+    margin: 1.5rem 0
+    border: 1px solid $color-grey-6
+    padding: 10px
+    cursor: move
+    overflow-x: auto
+    white-space: nowrap
 
-.splash, #rubric-grader-splash
-  display: none
+  .badge-row.clickable
+    cursor: hand
 
-[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak
-  display: none !important
+  .badge-modal-window
+    /* A centered div above the overlay with a box shadow. */
+    z-index: 1000
+    position: absolute
+    width: 200px
+    padding: 1rem !important
+    top: 50%
+    left: 50%
+    transform: translate(-50%, -50%)
+    background-color: $color-blue-4
+    box-shadow: 4px 4px 80px #000
+    .level-badge
+      margin: 0.5rem
+      padding: 0.2rem
+      background: $color-blue-3
+      img
+        vertical-align: middle
+    select
+      width: 200px
 
-  &.splash
-    display: block !important
-    font-size: 26px
-
-  &#rubric-grader-splash
-    display: block !important
-    font-size: 26px
-
-/* Points tally in the upper right hand corner*/
-#points-overview-floating
-  float: right
-  text-align: right
-  border-top: none
-  position: fixed
-  top: 2.8rem
-  right: 28px
-  z-index: 800
-  padding: .5rem 1rem .5rem
-  border-bottom-left-radius: $global-radius
-  border-bottom-right-radius: $global-radius
-  background: $color-blue-2
-
-  h4#points-legend, h4.points-legend
-    font-size: 24px
-    font-style: italic
-    color: $color-blue-4
-
-    .points-assigned
-      margin-right: -4px
-      font-weight: bold
-      color: $color-yellow-1
-    .points-missing
-      color: $color-yellow-1
-    .points-satisfied
-      color: $color-green-2
-    .points-overage
-      color: $color-red-1
-
-h4.notice
-  font-size: 14px
-  font-style: italic
-  font-weight: normal
-  color: $color-yellow-1
-  text-transform: none
-  &.adjustment
-    color: $color-orange-1
-  &.adjustment.positive-adjustment
-    color: $color-green-2
-
-#rubric-column-heading
-
-  .level-heading
-    background: $color-grey-7
-    padding: .5rem
-    float: left
-    width: calc(100% - 250px)
-
-td.level-td
-  border: 1px solid $color-grey-7
+  .update-badges
+    width: 100%
+    margin: .75rem auto 0
+    text-align: center
+    padding: 0
+    border-radius: $global-radius
 
 #criterion-box
   .criterion
@@ -109,6 +80,37 @@ td.level-td
     margin-bottom: 0.5rem
     display: inline-block
     width: 95%
+    background-color: $color-grey-6
+    &.saved
+      background-color: $color-blue-2
+    input
+      margin-right: 0.2rem
+      &.points
+        z-index: 500
+
+    input.ng-invalid, input.ng-pristine.ng-invalid
+      border: 1px solid $color-red-1
+      background: $color-red-1
+
+    input.ng-valid-required
+      background: $color-blue-4
+
+    select
+      color: $color-grey-4
+      font-size: 13px
+      padding: -4px 2px
+
+      &[disabled]
+        color: $color-grey-7
+
+      option.default, option.selected.default
+        color: $color-grey-5
+
+  .order-label
+    display: inline-block
+    padding: 0 0.5rem 0 0.25rem
+    color: $color-white
+    vertical-align: middle
 
   .level
     padding: 2rem .5rem .5rem
@@ -122,40 +124,6 @@ td.level-td
 
 .level-container
   height: 280px !important
-
-.criterion
-  background: $color-grey-6
-
-  &.saved
-    background: $color-blue-3
-
-  input
-    margin-right: 0.2rem
-
-  input.points
-    z-index: 500
-
-  input.ng-pristine.ng-invalid
-    border: 1px solid $color-red-1
-    background: $color-red-1
-
-  input.ng-valid-required
-    background: $color-blue-4
-
-  input.ng-invalid
-    border: 1px solid $color-red-1
-    background: $color-red-1
-
-  select
-    color: $color-grey-4
-    font-size: 13px
-    padding: -4px 2px
-
-    &[disabled]
-      color: $color-grey-7
-
-    option.default, option.selected.default
-      color: $color-grey-5
 
 .messages
   position: absolute
@@ -262,12 +230,6 @@ button.meets-expectations-status.no-expectation
   margin-bottom: 2px
   position: relative
 
-.modal-window
-  .level-badge
-    margin: .5rem
-    background: $color-blue-3
-    clear: both
-
 .level-badge-image
   float: left
   background: none
@@ -276,56 +238,64 @@ button.meets-expectations-status.no-expectation
 .add-level
   vertical-align: bottom
 
-#rubric .rubric-container
-  margin: 1rem 0
-  clear: both
-  border: 1px solid $color-grey-6
-  padding: 10px
-  cursor: move
-  overflow-x: auto
-  height: 400px !important
-  white-space: nowrap
+// loading screens for rubric grading view and rubric design view
+.splash, #rubric-grader-splash
+  display: none
 
-  .order-label
-    display: inline-block
-    background: $color-blue-2
-    padding: 0.77rem 
-    color: $color-white
-    margin-right: -4px
-    vertical-align: middle
+[ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak
+  display: none !important
 
-.badge-row.clickable
-  cursor: hand
+  &.splash
+    display: block !important
+    font-size: 26px
 
-.modal-window
-  /* A centered div above the overlay with a box shadow. */
-  z-index: 1000
-  position: absolute
-  width: 200px
-  padding: 1rem !important
+  &#rubric-grader-splash
+    display: block !important
+    font-size: 26px
 
-  /* Center the dialog */
-  top: 50%
-  left: 50%
-  transform: translate(-50%, -50%)
+// Points tally in the upper right hand corner of rubric grader
+#points-overview-floating
+  text-align: right
+  position: fixed
+  top: 2.8rem
+  right: 28px
+  z-index: 800
+  padding: .5rem 1rem .5rem
+  border-bottom-left-radius: $global-radius
+  border-bottom-right-radius: $global-radius
+  background: $color-blue-2
 
-  background-color: $color-blue-4
-  box-shadow: 4px 4px 80px #000
+  h4#points-legend, h4.points-legend
+    font-size: 24px
+    font-style: italic
+    color: $color-blue-4
 
-  select
-    width: 200px
+    .points-assigned
+      margin-right: -4px
+      font-weight: bold
+      color: $color-yellow-1
+    .points-missing
+      color: $color-yellow-1
+    .points-satisfied
+      color: $color-green-2
+    .points-overage
+      color: $color-red-1
 
-.update-badges
-  width: 100%
-  margin: .75rem auto 0
-  text-align: center
-  padding: 0
-  border-radius: $global-radius
+//notices used on rubric design and rubric grading views
+h4.notice
+  font-size: 14px
+  font-style: italic
+  font-weight: normal
+  color: $color-yellow-1
+  text-transform: none
+  &.adjustment
+    color: $color-orange-1
+  &.adjustment.positive-adjustment
+    color: $color-green-2
 
-.download-link
-  margin: 0.5rem 0
 
-#rubric-graded, #rubric-ungraded, #rubric-table
+// base styles for graded rubric, ungraded rubric and rubric edit views
+#rubric-graded, #rubric-ungraded, #rubric-grade-edit
   *
     font-weight: 300
   h4
@@ -448,6 +418,7 @@ button.meets-expectations-status.no-expectation
       @media (max-width: $media-small-max)
         background-color: inherit
 
+  // styles for slider on mobile graded rubric view
   .slick-slide
     padding: 0
     display: block
@@ -478,6 +449,7 @@ button.meets-expectations-status.no-expectation
   display: inline
   vertical-align: top
 
+// styles for ungraded rubric view
 #rubric-ungraded
   .tab-panel
     border-bottom: 1px solid $color-grey-6
@@ -490,8 +462,6 @@ button.meets-expectations-status.no-expectation
 
   .meets-expectations-tag
     font-size: 0.8rem
-
-  .meets-expectations-tag
     position: absolute
     bottom: 0
     right: 0
@@ -501,7 +471,8 @@ button.meets-expectations-status.no-expectation
       width: inherit
       padding-right: 0
 
-#rubric-table
+// Edit rubric grade view
+#rubric-grade-edit
   .criterion-name, .level-name
     font-weight: bold
 
@@ -514,6 +485,12 @@ button.meets-expectations-status.no-expectation
 
   .level-tab
     padding: 0
+    &.selected
+      .check-mark
+        display: inline-block
+
+  .check-mark
+    display: none
 
   .level-heading
     border-bottom: 1px solid $color-white
@@ -532,15 +509,14 @@ button.meets-expectations-status.no-expectation
     padding: 0.2rem 0.5rem
     font-size: 0.7rem
 
-  .level.meets-expectations
-    background-color: $meets-expectations-color
-    border: 1px solid $color-white
+  .level-meets-expectations
+    background-color: $color-green-1
+    padding: 0.2rem
 
-  .level.selected
-    background-color: $below-expectations-selected-color
 
-  .level.selected.meets-expectations
+  .level-tab.selected
     background-color: $meets-expectations-selected-color
+
 
   .level-badge-image
     list-style: none
@@ -550,31 +526,12 @@ button.meets-expectations-status.no-expectation
   .badge-row:hover
     background-color: transparent
 
-  .badges, .earned_level, .graded-students
-    display: block
-    padding: .25rem
-
-  .earned_level
-    background-color: $color-green-2
-    color: $color-white
-    font-style: italic
-
-  .graded-students
-    background-color: $color-blue-3
-
   .comments-box
     background-color: $color-grey-7
     border: none
     padding: .25rem
     font-size: .8rem
     min-width: 300px
-
-    textarea
-      margin: 0
-      width: 100%
-      height: 105%
-      resize: none
-      background: $color-white
 
   h4.notice
     color: $color-green-2
@@ -585,6 +542,5 @@ button.meets-expectations-status.no-expectation
 .total-points
   margin-bottom: 1rem
 
-#grade-rubric-table.edit
-  .level:hover
-    background-color: $color-green-2
+.download-link
+  margin: 0.5rem 0

--- a/app/assets/stylesheets/_rubrics.sass
+++ b/app/assets/stylesheets/_rubrics.sass
@@ -325,7 +325,7 @@ button.meets-expectations-status.no-expectation
 .download-link
   margin: 0.5rem 0
 
-#rubric-graded, #rubric-ungraded
+#rubric-graded, #rubric-ungraded, #rubric-table
   *
     font-weight: 300
   h4

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -35,15 +35,17 @@
         %ul.level-tabs
           %li.level-tab(ng-repeat="level in criterion.levels" ng-click="criterion.gradeWithLevel(level)" ng-class="{selected: criterion.isUsingLevel(level), 'meets-expectations': level.pointsMeetExpectations()}")
             .level-heading
-              .level-name {{level.name.replace(" ","&nbsp;")}}
-              .level-meets-expectations(ng-show="level.meetsExpectations") Meets Expectations
-              .level-points
-                {{level.points | number:0}}&nbsp;Points
+              .level-details
+                .level-name {{level.name.replace(" ","&nbsp;")}}
+                .level-points
+                  {{level.points | number:0}}&nbsp;Points
+              %ul.badge-row.design-view
+                %li.level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
+                  %img(ng-src="{{levelBadge.badge.icon}}")
+
             .level-description
+              .level-meets-expectations(ng-show="level.meetsExpectations") Meets Expectations
               {{level.description}}
-            %ul.badge-row.design-view
-              %li.level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
-                %img(ng-src="{{levelBadge.badge.icon}}" height="50px")
 
         .comments-box
           %textarea(ng-model="criterion.comments" ng-model-options="{debounce: 1000}" ng-change="updateCriterion(criterion, 'comments')" froala="froalaOptions")

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -43,7 +43,7 @@
                   %img(ng-src="{{levelBadge.badge.icon}}")
 
             .level-description
-              .level-meets-expectations(ng-show="level.meetsExpectations") Meets Expectations
+              .level-meets-expectations(ng-show="level.pointsMeetExpectations()") Meets Expectations
               {{level.description}}
 
         .comments-box

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -2,8 +2,7 @@
   #rubric-grader(ng-app="gradecraft" ng-controller="GradeRubricCtrl" ng-init="init(#{rubric.assignment_id}, '#{scope_type}', #{scoped_id})")
     .row
       #rubric-heading.columns
-        %h3.text-right
-          Grade Assignment by Rubric
+        %h3.text-right Grade Assignment by Rubric
         %h4.text-right (click to select the level earned for each criterion)
         %br
 
@@ -17,7 +16,6 @@
         %h4.notice(ng-show="isBelowThreshold()") {{ pointsBelowThreshold() | number:0 }} points below the threshold
         %h4.notice.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}" ng-show="pointsAdjusted()") You have adjusted the total by {{adjustmentPoints()}} points
 
-      .clear
 
     #grade-status(ng-cloak)
 
@@ -26,7 +24,7 @@
       %br
       %br
 
-    #rubric-table.edit(ng-cloak)
+    #rubric-grade-edit.edit(ng-cloak)
       .criterion(ng-repeat="criterion in criteria")
         .criterion-heading
           %h4.criterion-name {{criterion.name.replace(" ","&nbsp;")}} {{(criterion.max_points || 0) | number:0}}&nbsp;Points
@@ -36,6 +34,7 @@
           %li.level-tab(ng-repeat="level in criterion.levels" ng-click="criterion.gradeWithLevel(level)" ng-class="{selected: criterion.isUsingLevel(level), 'meets-expectations': level.pointsMeetExpectations()}")
             .level-heading
               .level-details
+                %span.check-mark= glyph("check")
                 .level-name {{level.name.replace(" ","&nbsp;")}}
                 .level-points
                   {{level.points | number:0}}&nbsp;Points

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -26,46 +26,27 @@
       %br
       %br
 
-    %table#rubric-table.edit(ng-cloak)
-      %thead
-        %tr
-          %td.criterion.heading
-            %label.larger
-              <strong>Criterion</strong>:&nbsp;Max&nbsp;points
+    #rubric-table.edit(ng-cloak)
+      .criterion(ng-repeat="criterion in criteria")
+        .criterion-heading
+          %h4.criterion-name {{criterion.name.replace(" ","&nbsp;")}} {{(criterion.max_points || 0) | number:0}}&nbsp;Points
+          %p.criterion-description {{criterion.description}}
 
-          %td.level.heading(colspan="#{rubric.max_level_count}")
-            %label.larger
-              %strong Level:
-              Points Awarded
-          %td.comments.heading(ng-show="selectedLevels().length > 0")
-            %label.larger
-              Comments
-
-      %tbody
-        %tr(ng-repeat="criterion in criteria")
-          %td.criterion
-            .criterion-heading
-              .criterion-name {{criterion.name.replace(" ","&nbsp;")}}
-              .criterion-points
-                {{(criterion.max_points || 0) | number:0}}&nbsp;Points
-            .criterion-description {{criterion.description}}
-
-          %td.level.level-level(ng-repeat="level in criterion.levels" ng-click="criterion.gradeWithLevel(level)" ng-class="{selected: criterion.isUsingLevel(level), 'meets-expectations': level.pointsMeetExpectations()}")
+        %ul.level-tabs
+          %li.level-tab(ng-repeat="level in criterion.levels" ng-click="criterion.gradeWithLevel(level)" ng-class="{selected: criterion.isUsingLevel(level), 'meets-expectations': level.pointsMeetExpectations()}")
             .level-heading
               .level-name {{level.name.replace(" ","&nbsp;")}}
               .level-meets-expectations(ng-show="level.meetsExpectations") Meets Expectations
               .level-points
                 {{level.points | number:0}}&nbsp;Points
-            .clear
             .level-description
               {{level.description}}
-            .row.badge-row.design-view
-              .level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
+            %ul.badge-row.design-view
+              %li.level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
                 %img(ng-src="{{levelBadge.badge.icon}}" height="50px")
-              .clear
-          %td.filler(ng-show="criterion.levels.length < #{rubric.max_level_count}" colspan="{{#{rubric.max_level_count} - criterion.levels.length}}")
-          %td.comments-box
-            %textarea(ng-model="criterion.comments" ng-model-options="{debounce: 1000}" ng-change="updateCriterion(criterion, 'comments')" froala="froalaOptions")
+
+        .comments-box
+          %textarea(ng-model="criterion.comments" ng-model-options="{debounce: 1000}" ng-change="updateCriterion(criterion, 'comments')" froala="froalaOptions")
 
     %br
     .right

--- a/app/views/rubrics/_new_criterion.html.haml
+++ b/app/views/rubrics/_new_criterion.html.haml
@@ -1,7 +1,7 @@
 %input(type="text" ng-model="criterion.name" name="name" placeholder="Criterion Name" value="{{criterion.name}}" required ng-blur="criterion.modify(criterionForm)" ng-Maxlength=30 ng-change="criterion.change()" maxlength=30)
 %input.points(type="number" ng-model="criterion.max_points" name="maxPoints" placeholder="Max Points" required integer min=0 ng-blur="criterion.modify(criterionForm)" ng-change="criterion.change()")
 
-%textarea(ng-model="criterion.description" placeholder="Description" value="{{criterion.description}}" ng-change="criterion.change()" ng-blur="criterion.update()")
+%textarea.criterion-description(ng-model="criterion.description" placeholder="Description" value="{{criterion.description}}" ng-change="criterion.change()" ng-blur="criterion.update()")
   -#
     %option(ng-repeat="(availableBadgeId, availableBadge) in criterion.availableBadges" value="{{availableBadge.id}}") {{availableBadge.name}}
 
@@ -9,4 +9,3 @@
 
 %input(type="hidden" value="{{$index}}")
 %button.delete(type="button" ng-click="criterion.delete($index)") X
-.messages Criterion

--- a/app/views/rubrics/_new_level.html.haml
+++ b/app/views/rubrics/_new_level.html.haml
@@ -26,4 +26,3 @@
 %button.meets-expectations-status(type="button" ng-class="{'no-expectation': !level.meetExpectationSet(),'show': level.meetsExpectations || level.showExpectationStatus()}") {{level.label()[0]}}
 %button.meets-expectations-toggle(type="button" ng-class="{'remove': level.meetsExpectations}" ng-click="level.toggleMeetsExpectations()") {{level.label()[1]}}
 %button.delete(type="button" ng-click="level.delete($index)" ng-hide="level.required") X
-

--- a/app/views/rubrics/_new_level.html.haml
+++ b/app/views/rubrics/_new_level.html.haml
@@ -9,7 +9,7 @@
     .level-badge-image(ng-repeat="(levelBadgeId, levelBadge) in level.badges")
       %img(ng-src="{{levelBadge.badge.icon}}" width="35px" height="35px")
 
-.modal-window(ng-show="level.editingBadges")
+.badge-modal-window(ng-show="level.editingBadges")
   %select(ng-disabled="! level.isSaved()" ng-change="level.selectBadge()" ng-model="level.selectedBadge" ng-options="availableBadge as availableBadge.name for (availableBadgeId, availableBadge) in level.availableBadges")
     %option.default(value="" selected disabled ng-show="level.availableBadges.length > 0") select a badge to add...
     %option.default(value="" selected disabled ng-show="level.availableBadges.length == 0") all available badges selected

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -34,7 +34,7 @@
           .level-wrapper
             .level(name="levelForm" ng-repeat="level in criterion.levels" ng-form ng-submit="level.create()" ng-class="{saved: level.isSaved(), nocredit: level.noCredit, 'level-meets-expectations': level.pointsMeetExpectations()}")
               = render partial: "rubrics/new_level"
-        %button.add-level(name="newLevel" ng-click="criterion.insertLevel()" ng-show="criterion.isSaved()")
-          + Level
+            %button.add-level(name="newLevel" ng-click="criterion.insertLevel()" ng-show="criterion.isSaved()")
+              + Level
 
     %button#new-rubric-criterion(type="button" ng-click="newCriterion()" ng-hide) + Criterion

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -1,7 +1,7 @@
 .pageContent
   = render "layouts/alerts"
 
-  #rubric(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@rubric.id}, #{@assignment.id}, #{@assignment.full_points})")
+  #rubric-design(ng-app="gradecraft" ng-controller="RubricCtrl" ng-init="init(#{@rubric.id}, #{@assignment.id}, #{@assignment.full_points})")
 
     #points-overview-floating(ng-cloak ng-hide="angular.element('#points-overview').isOnscreen()")
       %h4#points-legend
@@ -27,8 +27,8 @@
     #criterion-box(ng-cloak)
 
       .rubric-container.divider(ng-repeat="criterion in criteria")
-        .order-label {{$index + 1}}
         .criterion(name="criterionForm" ng-form ng-submit="criterion.create()" ng-class="{saved: criterion.isSaved()}" ng-animate="{enter: 'animate-enter', leave: 'animate-leave'}")
+          .order-label {{$index + 1}}
           = render partial: "rubrics/new_criterion"
         .level-container
           .level-wrapper

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -24,12 +24,6 @@
 
     .splash(ng-cloak) Loading rubric...
 
-    #rubric-column-heading
-      .criterion-heading
-        %h4.italic.not_bold Criteria
-      .level-heading
-        %h4.italic.not_bold Score Levels
-
     #criterion-box(ng-cloak)
 
       .rubric-container.divider(ng-repeat="criterion in criteria")


### PR DESCRIPTION
# Not Ready for Merging
This PR refines the style of the instructor rubric design and rubric grade edit views to match the updated student design.

## Considerations
We are using color to represent many different states of Criteria and Levels in rubrics. 
### Level States
- Saved : light grey -> counterintuitive since *unsaved* criterion is this color
- Unsaved: dark grey
- Meets Expectations: green -> proposing we shift this to an indicator other than background color
- Selected Meets Expectations Level: green
- Selected below or no meets expectations level: green
- Earned: green

### Criterion States
- Saved: dark blue -> this makes sense since in all other rubric views, criteria is dark blue
- Unsaved: light grey -> this is fine if we want to show unsaved state, but I wonder if users are realizing that this is what this color change means.

## Proposed changes
- Alter the way 'Meets Expectations' threshold is represented on both rubric design and grade edit view. Rather than using a green background-color to show these levels, let's add a marker to each of the levels that meets expectations so that all selected and earned levels can be green without confusion.
- get rid of the saved vs unsaved states in the rubric design view since users may not actually realize what is happening...?