### PR TITLE
save current user as grading agent on rubric grades

### DIFF
--- a/app/controllers/api/criterion_grades_controller.rb
+++ b/app/controllers/api/criterion_grades_controller.rb
@@ -31,9 +31,9 @@ class API::CriterionGradesController < ApplicationController
     end
   end
 
-  # PUT api/assignments/:assignment_id/students/:student_id/criterion_grade
+  # PUT api/assignments/:assignment_id/students/:student_id/criterion_grades
   def update
-    result = Services::CreatesGradeUsingRubric.create params
+    result = Services::CreatesGradeUsingRubric.create params, current_user
     if result.success?
       render json: {
         message: "Grade successfully saved", success: true },
@@ -61,9 +61,9 @@ class API::CriterionGradesController < ApplicationController
     end
   end
 
-  # PUT api/assignments/:assignment_id/groups/:group_id/criterion_grade
+  # PUT api/assignments/:assignment_id/groups/:group_id/criterion_grades
   def group_update
-    result = Services::CreatesGroupGradesUsingRubric.create params
+    result = Services::CreatesGroupGradesUsingRubric.create params, current_user
     if result.success?
       render json: {
         message: "Grade successfully saved", success: true

--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -17,6 +17,7 @@ class API::GradesController < ApplicationController
     grade = Grade.find(params[:id])
     grade.assign_attributes(grade_params)
     grade.instructor_modified = true
+    grade.graded_by_id = current_user.id
     if grade.raw_points_changed?
       grade.graded_at = DateTime.now
     end

--- a/app/services/creates_grade/builds_grade.rb
+++ b/app/services/creates_grade/builds_grade.rb
@@ -6,6 +6,7 @@ module Services
       expects :attributes
       expects :student
       expects :assignment
+      expects :grading_agent
 
       promises :grade
 
@@ -18,6 +19,7 @@ module Services
         grade.adjustment_points = context[:attributes]["grade"]["adjustment_points"]
         grade.adjustment_points_feedback = context[:attributes]["grade"]["adjustment_points_feedback"]
         grade.group_id = context[:attributes]["group_id"] if context[:attributes]["group_id"]
+        grade.graded_by_id = context[:grading_agent].id
         context[:grade] = grade
       end
     end

--- a/app/services/creates_grade_using_rubric.rb
+++ b/app/services/creates_grade_using_rubric.rb
@@ -16,8 +16,8 @@ module Services
 
     aliases raw_params: :attributes
 
-    def self.create(raw_params)
-      with(raw_params: raw_params)
+    def self.create(raw_params, grading_agent)
+      with(raw_params: raw_params, grading_agent: grading_agent)
         .reduce(
           Actions::VerifiesAssignmentStudent,
           Actions::BuildsCriterionGrades,

--- a/app/services/creates_group_grades_using_rubric.rb
+++ b/app/services/creates_group_grades_using_rubric.rb
@@ -5,8 +5,8 @@ module Services
   class CreatesGroupGradesUsingRubric
     extend LightService::Organizer
 
-    def self.create(raw_params)
-      with(raw_params: raw_params)
+    def self.create(raw_params, grading_agent)
+      with(raw_params: raw_params, grading_agent: grading_agent)
         .reduce(
           Actions::IteratesCreatesGradeUsingRubric
         )

--- a/app/services/group_services/iterates_creates_grade_using_rubric.rb
+++ b/app/services/group_services/iterates_creates_grade_using_rubric.rb
@@ -6,6 +6,7 @@ module Services
       extend LightService::Action
 
       expects :raw_params
+      expects :grading_agent
 
       executed do |context|
         begin
@@ -19,7 +20,7 @@ module Services
           params = context[:raw_params].deep_dup
           params["student_id"] = student.id
           params["group_id"] = group.id
-          context.add_to_context Services::CreatesGradeUsingRubric.create(params)
+          context.add_to_context Services::CreatesGradeUsingRubric.create(params, context[:grading_agent])
         end
       end
     end

--- a/spec/controllers/rubrics_controller_spec.rb
+++ b/spec/controllers/rubrics_controller_spec.rb
@@ -18,7 +18,6 @@ describe RubricsController do
     describe "GET design" do
       it "shows the design form" do
         get :design, { assignment_id: assignment.id, rubric: rubric}
-        expect(assigns(:title)).to eq("Design Rubric for #{assignment.name}")
         expect(response).to render_template(:design)
       end
     end

--- a/spec/services/creates_grade/builds_grade_spec.rb
+++ b/spec/services/creates_grade/builds_grade_spec.rb
@@ -4,12 +4,13 @@ require "./app/services/creates_grade/builds_grade"
 
 describe Services::Actions::BuildsGrade do
 
-  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge) }
+  let(:world) { World.create.with(:course, :professor, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge) }
   let(:attributes) { RubricGradePUT.new(world).params }
   let(:context) {{
       attributes: attributes,
       student: world.student,
-      assignment: world.assignment
+      assignment: world.assignment,
+      grading_agent: world.professor
     }}
 
   it "expects attributes to assign to grade" do
@@ -45,6 +46,7 @@ describe Services::Actions::BuildsGrade do
     expect(result[:grade].feedback).to eq "good jorb!"
     expect(result[:grade].adjustment_points).to eq -10
     expect(result[:grade].adjustment_points_feedback).to eq "reduced by 10 points"
+    expect(result[:grade].graded_by_id).to eq(world.professor.id)
   end
 
   it "adds the group id if supplied" do

--- a/spec/services/creates_grade_using_rubric_spec.rb
+++ b/spec/services/creates_grade_using_rubric_spec.rb
@@ -3,57 +3,58 @@ require "active_record_spec_helper"
 require "./app/services/creates_grade_using_rubric"
 
 describe Services::CreatesGradeUsingRubric do
+  let(:agent) { create :user }
   let(:params) { RubricGradePUT.new.params }
 
   describe ".create" do
     it "confirms the student and assignment" do
       expect(Services::Actions::VerifiesAssignmentStudent).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "initializes new criterion grades" do
       expect(Services::Actions::BuildsCriterionGrades).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "saves criterion grades" do
       expect(Services::Actions::SavesCriterionGrades).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "initializes new grade from params" do
       expect(Services::Actions::BuildsGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "adds the submission id to the grade" do
       expect(Services::Actions::AssociatesSubmissionWithGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "marks grade as graded" do
       expect(Services::Actions::MarksAsGraded).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "saves the grade" do
       expect(Services::Actions::SavesGrade).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "creates level badges" do
       expect(Services::Actions::BuildsEarnedLevelBadges).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "saves level badges" do
       expect(Services::Actions::SavesEarnedLevelBadges).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
 
     it "runs the grade updater job" do
       expect(Services::Actions::RunsGradeUpdaterJob).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, agent
     end
   end
 end

--- a/spec/services/creates_group_grades_using_rubric_spec.rb
+++ b/spec/services/creates_group_grades_using_rubric_spec.rb
@@ -3,14 +3,14 @@ require "active_record_spec_helper"
 require "./app/services/creates_group_grades_using_rubric"
 
 describe Services::CreatesGroupGradesUsingRubric do
-  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
+  let(:world) { World.create.with(:course, :professor, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
   let(:group_params) {{ "group_id" => world.group.id }}
   let(:params) { RubricGradePUT.new(world).params.merge group_params }
 
   describe ".create" do
     it "interates through the students in a group" do
       expect(Services::Actions::IteratesCreatesGradeUsingRubric).to receive(:execute).and_call_original
-      described_class.create params
+      described_class.create params, world.professor
     end
   end
 end

--- a/spec/services/group_services/iterates_creates_grade_using_rubric_spec.rb
+++ b/spec/services/group_services/iterates_creates_grade_using_rubric_spec.rb
@@ -3,23 +3,23 @@ require "active_record_spec_helper"
 require "./app/services/group_services/iterates_creates_grade_using_rubric"
 
 describe Services::Actions::IteratesCreatesGradeUsingRubric do
-  let(:world) { World.create.with(:course, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
+  let(:world) { World.create.with(:course, :professor, :student, :assignment, :rubric, :criterion, :criterion_grade, :badge, :group) }
   let(:group_params) {{ "group_id" => world.group.id }}
   let(:raw_params) { RubricGradePUT.new(world).params.merge group_params }
 
   it "fails if the group is not found" do
     raw_params["group_id"] = 1000
-    result = described_class.execute raw_params: raw_params
+    result = described_class.execute raw_params: raw_params, grading_agent: world.professor
     expect(result.message).to eq("Unable to find group")
   end
 
   it "iterates over the students in group" do
     expect(Services::CreatesGradeUsingRubric).to receive(:create).exactly(world.group.students.count).times.and_call_original
-    described_class.execute raw_params: raw_params
+    described_class.execute raw_params: raw_params, grading_agent: world.professor
   end
 
   it "adds the group id to the context" do
-    result = described_class.execute raw_params: raw_params
+    result = described_class.execute raw_params: raw_params, grading_agent: world.professor
     expect(result[:attributes]["group_id"]).to eq(world.group.id)
   end
 end


### PR DESCRIPTION
This PR insures that the `graded_by_id` for grades is set when a grade is updated through the following paths:

  * `api/grades/:grade_id`
  * `api/assignments/:assignment_id/students/:student_id/criterion_grades`
  * `api/assignments/:assignment_id/groups/:group_id/criterion_grades`

closes #2486