### PR TITLE
Downcasing the email on import

### DIFF
--- a/app/importers/student_importer.rb
+++ b/app/importers/student_importer.rb
@@ -46,7 +46,7 @@ class StudentImporter
   end
 
   def find_or_create_user(row, course)
-    user = User.find_by_insensitive_email row.email if row.email
+    user = User.find_by_insensitive_email row.email.downcase if row.email
     user ||= User.find_by_insensitive_username row.username if row.username
     user ||= Services::CreatesNewUser
       .create(row.to_h.merge(internal: internal_students), send_welcome)[:user]

--- a/app/services/creates_new_user/builds_user.rb
+++ b/app/services/creates_new_user/builds_user.rb
@@ -9,6 +9,8 @@ module Services
       executed do |context|
         attributes = context[:attributes]
         context[:user] = User.new attributes
+        user = context[:user]
+        user.email = user.email.downcase
       end
     end
   end

--- a/app/services/creates_new_user/builds_user.rb
+++ b/app/services/creates_new_user/builds_user.rb
@@ -10,7 +10,7 @@ module Services
         attributes = context[:attributes]
         context[:user] = User.new attributes
         user = context[:user]
-        user.email = user.email.downcase
+        user.email = user.email.to_s.downcase
       end
     end
   end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -10,7 +10,8 @@ module Services
 
       executed do |context|
         attributes = context[:attributes]
-        email = attributes[:email]
+        entered_email = attributes[:email]
+        email = entered_email.downcase
 
         if email.blank?
           context.fail! "Email can't be blank", 422

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -10,8 +10,7 @@ module Services
 
       executed do |context|
         attributes = context[:attributes]
-        entered_email = attributes[:email]
-        email = entered_email.downcase
+        email = attributes[:email].to_s.downcase
 
         if email.blank?
           context.fail! "Email can't be blank", 422


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This PR downcases emails on import and user creation so that matching them across contexts is simplified. 

## Related PRs
n/a

## Todos
- [ ] Tests
- [ ] Documentation

## Deploy Notes
None

## Steps to Test or Reproduce
1. Create a new user with the email address "TEST@gradecraft.com"
2. Confirm that the stored email address is "test@gradecraft.com"
--
1. Import a CSV of user with the email addresses "TESTING@gradecraft.com" 
2. Confirm that the stored email address is "testing@gradecraft.com"

## Impacted Areas in Application

* Import workflow
* User creation
