### PR TITLE
2507 corrupted s3 object path

### DIFF
--- a/lib/s3_manager/carrierwave.rb
+++ b/lib/s3_manager/carrierwave.rb
@@ -40,7 +40,7 @@ module S3Manager
     end
 
     def s3_object_file_key
-      if self.store_dir && mounted_filename
+      if read_attribute(:store_dir) && mounted_filename
         cached_file_path # build a full file path from cached #store_dir and #filename attributes on the FooFile record
       elsif filepath_includes_filename?
         CGI::unescape(filepath)
@@ -59,7 +59,7 @@ module S3Manager
 
     def cached_file_path
       @cached_file_path ||=
-        [self.store_dir, mounted_filename].join("/")
+        [read_attribute(:store_dir), mounted_filename].join("/")
     end
 
     def mounted_filename

--- a/lib/s3_manager/carrierwave.rb
+++ b/lib/s3_manager/carrierwave.rb
@@ -40,7 +40,7 @@ module S3Manager
     end
 
     def s3_object_file_key
-      if read_attribute(:store_dir) && mounted_filename
+      if self.store_dir && mounted_filename
         cached_file_path # build a full file path from cached #store_dir and #filename attributes on the FooFile record
       elsif filepath_includes_filename?
         CGI::unescape(filepath)
@@ -59,7 +59,7 @@ module S3Manager
 
     def cached_file_path
       @cached_file_path ||=
-        [read_attribute(:store_dir), mounted_filename].join("/")
+        [self.store_dir, mounted_filename].join("/")
     end
 
     def mounted_filename

--- a/lib/s3_manager/carrierwave.rb
+++ b/lib/s3_manager/carrierwave.rb
@@ -59,7 +59,7 @@ module S3Manager
 
     def cached_file_path
       @cached_file_path ||=
-        [read_attribute(:store_dir), mounted_filename].join("/")
+        [read_attribute(:store_dir), mounted_filename].join "/"
     end
 
     def mounted_filename

--- a/lib/s3_manager/carrierwave.rb
+++ b/lib/s3_manager/carrierwave.rb
@@ -40,7 +40,7 @@ module S3Manager
     end
 
     def s3_object_file_key
-      if store_dir && mounted_filename
+      if read_attribute(:store_dir) && mounted_filename
         cached_file_path # build a full file path from cached #store_dir and #filename attributes on the FooFile record
       elsif filepath_includes_filename?
         CGI::unescape(filepath)
@@ -58,7 +58,8 @@ module S3Manager
     end
 
     def cached_file_path
-      @cached_file_path ||= [store_dir, mounted_filename].join("/")
+      @cached_file_path ||=
+        [read_attribute(:store_dir), mounted_filename].join("/")
     end
 
     def mounted_filename

--- a/spec/lib/s3_manager/carrierwave_spec.rb
+++ b/spec/lib/s3_manager/carrierwave_spec.rb
@@ -1,5 +1,4 @@
-require "active_record_spec_helper"
-require_relative "../../../lib/s3_manager"
+require "rails_spec_helper"
 
 RSpec.describe S3Manager::Carrierwave do
   subject { submission_file }
@@ -72,8 +71,9 @@ RSpec.describe S3Manager::Carrierwave do
 
     context "cached_file_path is present" do
       before do
+        submission_file.update_attributes store_dir: "great_dir"
+
         allow(submission_file).to receive_messages(
-          store_dir: "great_dir",
           mounted_filename: "stuff.txt",
           cached_file_path: "/some/great/path.png"
         )
@@ -169,11 +169,10 @@ RSpec.describe S3Manager::Carrierwave do
 
   describe "#cached_file_path" do
     subject { submission_file.cached_file_path }
-    before do
-      allow(submission_file).to receive_messages(
-        store_dir: "great_dir",
-        mounted_filename: "stuff.txt"
-      )
+
+    before(:each) do
+      submission_file.update_attributes store_dir: "great_dir"
+      allow(submission_file).to receive(:mounted_filename) { "stuff.txt" }
     end
 
     context "both store_dir and filename exist" do

--- a/spec/lib/s3_manager/carrierwave_spec.rb
+++ b/spec/lib/s3_manager/carrierwave_spec.rb
@@ -171,7 +171,8 @@ RSpec.describe S3Manager::Carrierwave do
     subject { submission_file.cached_file_path }
 
     before(:each) do
-      submission_file.update_attributes store_dir: "great_dir"
+      submission_file[:store_dir] = "great_dir"
+
       allow(submission_file).to receive(:mounted_filename) { "stuff.txt" }
     end
 


### PR DESCRIPTION
This patch fixes a minor issue in the s3-carrierwave adapater where the store_dir attribute wasn't being read properly on the included class.