### PR TITLE
2429 overwrite grades on import

### DIFF
--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -33,7 +33,8 @@ class Grade < ActiveRecord::Base
   accepts_nested_attributes_for :grade_files
 
   validates_presence_of :assignment, :assignment_type, :course, :student
-  validates :assignment_id, uniqueness: { scope: :student_id }
+  validates :student_id, uniqueness: { scope: :assignment_id,
+    message: "has already been graded on this assignment" }
 
   delegate :name, :description, :due_at, :assignment_type, :course, to: :assignment
 

--- a/app/services/imports_lms_grades/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades/imports_lms_grades.rb
@@ -22,7 +22,8 @@ module Services
           klass = constantize("#{camelize(provider)}GradeImporter")
           syllabus = ActiveLMS::Syllabus.new provider,
             authorization.access_token
-          context.grades_import_result = klass.new(grades).import assignment.id, syllabus
+          context.grades_import_result = klass.new(grades).import \
+            assignment.id, syllabus, true
         end
       end
     end

--- a/app/views/grades/importers/_grade_row.html.haml
+++ b/app/views/grades/importers/_grade_row.html.haml
@@ -15,3 +15,7 @@
           Import grade to create GradeCraft account for this user
   %td.center
     = check_box_tag "grade_ids[]", lms_grade["id"], false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-grades-command']" }
+    = link_to glyph("info-circle"), "#", title: "Override existing GradeCraft grade?", data: { behavior: "toggle-card", "target-selector" => "#grade-override-#{lms_grade["id"]}-info" }, style: "visibility: #{grade.raw_points.nil? ? "hidden" : "visible"}"
+    .grade-info-card-wrapper{ id: "grade-override-#{lms_grade["id"]}-info" }
+      .grade-info-card
+        Importing this grade would override the existing grade in GradeCraft with the grade from #{@provider_name.capitalize}

--- a/spec/importers/grade_importers/canvas_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/canvas_grade_importer_spec.rb
@@ -66,6 +66,34 @@ describe CanvasGradeImporter do
         expect(result.unsuccessful.count).to eq 1
         expect(result.unsuccessful.first[:errors]).to eq "Something is wrong"
       end
+
+      context "with an existing grade for the assignment and student" do
+        let!(:existing_grade) { create :grade,
+                                assignment_id: assignment.id, student_id: user.id,
+                                raw_points: 76, feedback: "You rock!" }
+
+        context "with override" do
+          it "replaces the grade score and comments" do
+            result = subject.import(assignment.id, syllabus, true)
+
+            expect(result.successful.count).to eq 1
+            expect(result.unsuccessful.count).to eq 0
+            expect(grade.assignment).to eq assignment
+            expect(grade.student).to eq user
+            expect(grade.raw_points).to eq 98
+            expect(grade.feedback).to eq "This is great!"
+          end
+        end
+
+        context "without an override" do
+          it "contains an unsuccessful row" do
+            result = subject.import(assignment.id, syllabus)
+
+            expect(result.successful.count).to eq 0
+            expect(result.unsuccessful.count).to eq 1
+          end
+        end
+      end
     end
   end
 end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -57,7 +57,7 @@ describe Grade do
       subject.save!
       another_grade = build(:grade, course: subject.course, assignment: subject.assignment, student: subject.student)
       expect(another_grade).to_not be_valid
-      expect(another_grade.errors[:assignment_id]).to include "has already been taken"
+      expect(another_grade.errors[:student_id]).to include "has already been graded on this assignment"
     end
   end
 

--- a/spec/services/imports_lms_grades/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades/imports_lms_grades_spec.rb
@@ -35,7 +35,7 @@ describe Services::Actions::ImportsLMSGrades do
     let!(:user_authorization) { create :user_authorization, user: user,
                                 provider: provider, access_token: "BLAH" }
 
-    it "creates the grades" do
+    it "imports the grades" do
       allow_any_instance_of(ActiveLMS::Syllabus).to \
         receive(:user).and_return({ "primary_email" => user.email })
       result = described_class.execute assignment: assignment,


### PR DESCRIPTION
If a grade already exists for a user and an assignment, this PR displays an information circle next to the checkbox for importing the grade to let the professor know the grade will be overridden.

The importer has the option to overwrite the grade in which the import just updates the score and the feedback.

Closes #2429