### PR TITLE
2516 additional ribbon menu refinements

### DIFF
--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,4 +1,2 @@
-= render partial: "groups/buttons"
-
 .pageContent
   = render partial: "groups/form"

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -1,5 +1,3 @@
-= render "buttons"
-
 .pageContent
   = render "layouts/alerts"
 

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -1,5 +1,3 @@
-= render "buttons"
-
 .pageContent
   = render "layouts/alerts"
 

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,5 +1,3 @@
-= render "buttons"
-
 .pageContent
   = render partial: "layouts/alerts", locals: { model: @user, term: "user" }
 

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -18,7 +18,7 @@ en:
       title: "Editing My #{ term_for :weight } Choices"
   assignment_types:
     index:
-      title: "#{ term_for :assignment_types }"
+      title: "#{ term_for :assignment_type } Analytics"
     new:
       title: "Create a New #{ term_for :assignment_type }"
     edit:
@@ -76,6 +76,8 @@ en:
       title: "Course Details"
     custom_terms:
       title: "Custom Terms"
+    multiplier_settings:
+      title: "Multiplier Settings"
     player_settings:
       title: "#{ term_for :student } Settings"
     student_onboarding_setup:


### PR DESCRIPTION
This PR removes the ribbon menu from several nested pages to maintain the pattern of using this menu to represent actions only rather than as secondary navigation. Also included is a replacement of a missing "Multiplier Settings" page title. 

We are also missing page titles on assignments/importers page.

``` 
assignments:
     importers:
         assignments_import:
             title: "Import #{ term_for :assignments }"
```
Should in theory be:

```
assignments:
     importers:
           title: "Import #{ term_for :assignments }"

```

But I didn't have any luck with this change...

Closes issue #2516 