### PR TITLE
passing team id through submit and grade next

### DIFF
--- a/app/controllers/assignments/students_controller.rb
+++ b/app/controllers/assignments/students_controller.rb
@@ -4,6 +4,6 @@ class Assignments::StudentsController < ApplicationController
   # POST /assignments/:assignment_id/students/:student_id/grade
   def grade
     grade = Grade.find_or_create params[:assignment_id], params[:student_id]
-    redirect_to edit_grade_path grade
+    redirect_to edit_grade_path grade, team_id: params[:team_id]
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -65,22 +65,27 @@ module Gradable
     predicted_earned_grades.predicted_to_be_done.count
   end
 
-  def ungraded_students(ids_to_include=[])
-    course.students.order_by_name -
-      (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
-  end
-
-  def ungraded_students_with_submissions(ids_to_include=[])
-    ungraded_students(ids_to_include) & User.find(submissions.pluck(:student_id))
-  end
-
-  def next_ungraded_student(student)
-    if accepts_submissions?
-      ungraded_students = ungraded_students_with_submissions([student.id])
+  def ungraded_students(ids_to_include=[], team=nil)
+    if team
+      course.students_by_team(team).order_by_name -
+        (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
     else
-      ungraded_students = ungraded_students([student.id])
+      course.students.order_by_name -
+        (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
     end
-    i = ungraded_students.map(&:id).index(student.id)
-    i && i < ungraded_students.length - 1 ? ungraded_students[i + 1] : nil
+  end
+
+  def ungraded_students_with_submissions(ids_to_include=[], team=nil)
+    ungraded_students(ids_to_include, team) & User.find(submissions.pluck(:student_id))
+  end
+
+  def next_ungraded_student(student, team=nil)
+    if accepts_submissions?
+      ungraded = ungraded_students_with_submissions([student.id], team)
+    else
+      ungraded = ungraded_students([student.id], team)
+    end
+    i = ungraded.map(&:id).index(student.id)
+    i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -67,12 +67,11 @@ module Gradable
 
   def ungraded_students(ids_to_include=[], team=nil)
     if team
-      course.students_by_team(team).order_by_name -
-        (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
+      students = course.students_by_team(team).order_by_name
     else
-      course.students.order_by_name -
-        (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
+      students = course.students.order_by_name
     end
+    students - (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
   end
 
   def ungraded_students_with_submissions(ids_to_include=[], team=nil)

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -71,7 +71,8 @@
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               %li= link_to glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - has_submission = presenter.assignment.accepts_submissions? && !submissions_for_assignment.empty?
-            %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student), method: :post, class: "button #{has_submission ? "danger" : ""}"
+            - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
+            %li= link_to glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{has_submission ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -56,7 +56,8 @@
             %ul
               %li= submit_tag "#{grade.persisted? && grade.is_graded? ? 'Update' : 'Submit'} Grade", class: "button"
               - unless grade.is_graded?
-                %li= submit_tag "Submit and Grade Next", name: "redirect_to_next_grade", class: "button"
+                - redirect_name = @team.present? ? "redirect_to_next_team_grade" : "redirect_to_next_grade"
+                %li= submit_tag "Submit and Grade Next", name: redirect_name, class: "button"
               %li= link_to glyph("times-circle") + "Cancel", assignment_path(grade.assignment), class: "button"
 
         %section

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_spec_helper"
 require "grade_proctor"
 
-describe GradesController , focus: true do
+describe GradesController do
   include PredictorEventJobsToolkit
 
   let(:course) { create :course }
@@ -18,10 +18,6 @@ describe GradesController , focus: true do
 
     before do
       login_user(professor)
-    end
-
-    after(:each) do
-      grade.delete
     end
 
     describe "GET show" do
@@ -254,8 +250,6 @@ describe GradesController , focus: true do
       login_user(student)
       allow(controller).to receive(:current_student).and_return(student)
     end
-
-    after(:each) { grade.delete }
 
     describe "GET show" do
       it "redirects to the assignment show page" do

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -1,47 +1,41 @@
 require "rails_spec_helper"
 require "grade_proctor"
 
-describe GradesController do
+describe GradesController , focus: true do
   include PredictorEventJobsToolkit
 
-  before(:all) do
-    @course = create(:course)
-    @assignment = create(:assignment, course: @course)
-    @student = create(:user)
-    @student.courses << @course
-  end
+  let(:course) { create :course }
+  let(:student) { create(:student_course_membership, course: course).user }
+  let(:assignment) { create :assignment, course: course }
+  let(:grade) { create(:grade, student: student, assignment: assignment, course: course) }
 
-  before(:each) do
+  before do
     allow(Resque).to receive(:enqueue).and_return(true)
   end
 
   context "as professor" do
-    before(:all) do
-      @professor = create(:user)
-      CourseMembership.create user: @professor, course: @course, role: "professor"
-    end
+    let(:professor) { create(:professor_course_membership, course: course).user }
 
-    before (:each) do
-      @grade = create(:grade, student: @student, assignment: @assignment, course: @course)
-      login_user(@professor)
+    before do
+      login_user(professor)
     end
 
     after(:each) do
-      @grade.delete
+      grade.delete
     end
 
     describe "GET show" do
       context "for a group grade" do
+        let(:group) { create :group, course: course }
+        let(:assignment) { create :group_assignment, course: course }
         let(:grade) { create :grade, group: group, assignment: assignment,
-                        course: @course, student_id: @student.id }
-        let(:group) { create :group, course: @course }
-        let(:assignment) { create :group_assignment, course: @course }
+                        course: course, student_id: student.id }
 
         before do
           group.assignments << assignment
-          group.students << @student
+          group.students << student
         end
-        
+
         it "renders the template" do
           get :show, id: grade.id
           expect(response).to render_template(:show)
@@ -51,17 +45,17 @@ describe GradesController do
 
     describe "GET edit" do
       it "assigns grade parameters and renders edit" do
-        get :edit, { id: @grade.id }
-        expect(assigns(:grade)).to eq(@grade)
+        get :edit, { id: grade.id }
+        expect(assigns(:grade)).to eq(grade)
         expect(response).to render_template(:edit)
       end
 
       context "with additional grade items" do
         it "assigns existing submissions, badges and score levels" do
-          submission = create(:submission, student: @student, assignment: @assignment)
-          badge = create(:badge, course: @course)
+          submission = create(:submission, student: student, assignment: assignment)
+          badge = create(:badge, course: course)
 
-          get :edit, { id: @grade.id }
+          get :edit, { id: grade.id }
           expect(assigns(:submission)).to eq(submission)
           expect(assigns(:badges)).to eq([badge])
         end
@@ -70,21 +64,21 @@ describe GradesController do
 
     describe "PUT update" do
       it "updates the grade" do
-        put :update, { id: @grade.id, grade: { raw_points: 12345 }}
-        expect(@grade.reload.score).to eq(12345)
-        expect(response).to redirect_to(assignment_path(@grade.assignment))
+        put :update, { id: grade.id, grade: { raw_points: 12345 }}
+        expect(grade.reload.score).to eq(12345)
+        expect(response).to redirect_to(assignment_path(grade.assignment))
       end
 
       it "timestamps the grade" do
         current_time = DateTime.now
-        put :update, { id: @grade.id, grade: { raw_points: 12345 }}
-        expect(@grade.reload.graded_at).to be > current_time
+        put :update, { id: grade.id, grade: { raw_points: 12345 }}
+        expect(grade.reload.graded_at).to be > current_time
       end
 
       it "attaches the student submission" do
-        submission = create :submission, assignment: @assignment, student: @student
+        submission = create :submission, assignment: assignment, student: student
         grade_params = { raw_points: 12345, submission_id: submission.id }
-        put :update, { id: @grade.id, grade: grade_params }
+        put :update, { id: grade.id, grade: grade_params }
         grade = Grade.last
         expect(grade.submission).to eq submission
       end
@@ -93,59 +87,70 @@ describe GradesController do
         grade_params = { raw_points: 12345, "grade_files_attributes" => {"0" => {
           "file" => [fixture_file("test_file.txt", "txt")] }}}
 
-        put :update, { id: @grade.id, grade: grade_params}
+        put :update, { id: grade.id, grade: grade_params}
         expect expect(GradeFile.count).to eq(1)
         expect expect(GradeFile.last.filename).to eq("test_file.txt")
       end
 
       it "handles commas in raw score params" do
-        put :update, { id: @grade.id, grade: { raw_points: "12,345" }}
-        expect(@grade.reload.score).to eq(12345)
+        put :update, { id: grade.id, grade: { raw_points: "12,345" }}
+        expect(grade.reload.score).to eq(12345)
       end
 
       it "handles reverting nil raw score" do
-        put :update, { id: @grade.id, grade: { raw_points: nil }}
-        expect(@grade.reload.score).to eq(nil)
+        put :update, { id: grade.id, grade: { raw_points: nil }}
+        expect(grade.reload.score).to eq(nil)
       end
 
       it "reverts empty raw score to nil, not zero" do
-        put :update, { id: @grade.id, grade: { raw_points: "" }}
-        expect(@grade.reload.score).to eq(nil)
+        put :update, { id: grade.id, grade: { raw_points: "" }}
+        expect(grade.reload.score).to eq(nil)
       end
 
       context "when grading a series of students" do
-        before do
-          @next_student = create(
-            :student_course_membership, course: @assignment.course,
+        let!(:next_student) do
+          create(:student_course_membership, course: course,
             user: create(:user, last_name: "Zzz")).user
         end
 
         it "creates and redirects to grade the next ungraded student when not accepting submissions" do
-          @assignment.update(accepts_submissions: false)
-          put :update, { id: @grade.id, grade: { raw_points: 12345, status: "Graded"}, redirect_to_next_grade: true}
+          assignment.update(accepts_submissions: false)
+          put :update, { id: grade.id, grade: { raw_points: 12345, status: "Graded"}, redirect_to_next_grade: true}
           expect(response).to redirect_to(edit_grade_path(
             Grade.where(
-              student: @next_student,
-              assignment: @assignment).first)
+              student: next_student,
+              assignment: assignment).first)
           )
         end
 
         it "creates and redirects to grade the next student with submission" do
-          create :submission, assignment: @assignment, student: @student
-          create :submission, assignment: @assignment, student: @next_student
-          put :update, { id: @grade.id, grade: { raw_points: 12345 }, redirect_to_next_grade: true}
+          create :submission, assignment: assignment, student: student
+          create :submission, assignment: assignment, student: next_student
+          put :update, { id: grade.id, grade: { raw_points: 12345 }, redirect_to_next_grade: true}
           expect(response).to redirect_to(edit_grade_path(
             Grade.where(
-              student: @next_student,
-              assignment: @assignment).first)
+              student: next_student,
+              assignment: assignment).first)
+          )
+        end
+
+        it "redirects by team when team in params" do
+          assignment.update(accepts_submissions: false)
+          team = create :team, course: course
+          create :team_membership, team: team, student: student
+          create :team_membership, team: team, student: next_student
+          put :update, { id: grade.id, grade: { raw_points: 12345, status: "Graded"}, redirect_to_next_team_grade: true}
+          expect(response).to redirect_to(
+            edit_grade_path(
+              Grade.where(student: next_student, assignment: assignment).first, team_id: team.id )
           )
         end
       end
 
       it "redirects on failure" do
         allow_any_instance_of(Grade).to receive(:update_attributes).and_return false
-        put :update, { id: @grade.id, grade: { full_points: 100 }}
-        expect(response).to redirect_to(edit_grade_path(@grade))
+        put :update, { id: grade.id, grade: { full_points: 100 }}
+        expect(response).to redirect_to(edit_grade_path(grade))
       end
     end
 
@@ -156,7 +161,7 @@ describe GradesController do
       end
 
       it "marks the Grade as excluded, but preserves the data" do
-        @grade.update(
+        grade.update(
           raw_points: 500,
           feedback: "should be nil",
           feedback_read: true,
@@ -167,26 +172,26 @@ describe GradesController do
           graded_at: DateTime.now,
           status: "Graded"
         )
-        post :exclude, { id: @grade }
+        post :exclude, { id: grade }
 
-        @grade.reload
-        expect(@grade.excluded_from_course_score).to eq(true)
-        expect(@grade.raw_points).to eq(500)
-        expect(@grade.score).to eq(500)
+        grade.reload
+        expect(grade.excluded_from_course_score).to eq(true)
+        expect(grade.raw_points).to eq(500)
+        expect(grade.score).to eq(500)
       end
 
       it "adds exclusion metadata" do
         current_time = DateTime.now
-        post :exclude, { id: @grade }
+        post :exclude, { id: grade }
 
-        @grade.reload
-        expect(@grade.excluded_at).to be > current_time
-        expect(@grade.excluded_by_id).to eq(@professor.id)
+        grade.reload
+        expect(grade.excluded_at).to be > current_time
+        expect(grade.excluded_by_id).to eq(professor.id)
       end
 
       it "returns an error message on failure" do
         allow_any_instance_of(Grade).to receive(:save).and_return false
-        post :exclude, { id: @grade }
+        post :exclude, { id: grade }
         expect(flash[:alert]).to include("grade was not successfully excluded")
       end
     end
@@ -198,86 +203,84 @@ describe GradesController do
       end
 
       it "marks the Grade as included, and clears the excluded details" do
-        @grade.update(
+        grade.update(
           raw_points: 500,
           status: "Graded",
           excluded_from_course_score: true,
           excluded_by_id: 2,
           excluded_at: Time.now
         )
-        post :include, { id: @grade }
+        post :include, { id: grade }
 
-        @grade.reload
-        expect(@grade.excluded_from_course_score).to eq(false)
-        expect(@grade.raw_points).to eq(500)
-        expect(@grade.score).to eq(500)
-        expect(@grade.excluded_by_id).to be nil
-        expect(@grade.excluded_at).to be nil
+        grade.reload
+        expect(grade.excluded_from_course_score).to eq(false)
+        expect(grade.raw_points).to eq(500)
+        expect(grade.score).to eq(500)
+        expect(grade.excluded_by_id).to be nil
+        expect(grade.excluded_at).to be nil
       end
 
       it "returns an error message on failure" do
         allow_any_instance_of(Grade).to receive(:save).and_return false
-        post :include, { id: @grade }
+        post :include, { id: grade }
         expect(flash[:alert]).to include("grade was not successfully re-added")
       end
     end
 
     describe "DELETE destroy" do
       it "removes the grade entirely" do
-        expect{ delete :destroy, { id: @grade.id }}.to \
+        grade
+        expect{ delete :destroy, { id: grade.id }}.to \
           change{Grade.count}.by(-1)
       end
 
       it "redirects to the assignments if the professor does not have access" do
         allow_any_instance_of(GradeProctor).to \
           receive(:destroyable?).and_return false
-        expect(delete :destroy, { id: @grade.id }).to \
-          redirect_to(assignment_path(@grade.assignment))
+        expect(delete :destroy, { id: grade.id }).to \
+          redirect_to(assignment_path(grade.assignment))
       end
     end
 
     describe "POST feedback_read" do
       it "should be protected and redirect to root" do
-        expect(post :feedback_read, id: @grade.id).to redirect_to(:root)
+        expect(post :feedback_read, id: grade.id).to redirect_to(:root)
       end
     end
   end
 
   context "as student" do
     before do
-      @grade = create :grade, student: @student, assignment: @assignment,
-        course: @course
-      login_user(@student)
-      allow(controller).to receive(:current_student).and_return(@student)
+      login_user(student)
+      allow(controller).to receive(:current_student).and_return(student)
     end
-    after(:each) { @grade.delete }
+
+    after(:each) { grade.delete }
 
     describe "GET show" do
       it "redirects to the assignment show page" do
-        get :show, id: @grade.id
-        expect(response).to redirect_to(assignment_path(@assignment))
+        get :show, id: grade.id
+        expect(response).to redirect_to(assignment_path(assignment))
       end
     end
 
     describe "POST feedback_read" do
       it "marks the grade as read by the student" do
-        post :feedback_read, id: @grade.id
-        expect(@grade.reload.feedback_read).to be_truthy
-        expect(@grade.feedback_read_at).to be_within(1.second).of(Time.now)
-        expect(response).to redirect_to assignment_path(@assignment)
+        post :feedback_read, id: grade.id
+        expect(grade.reload.feedback_read).to be_truthy
+        expect(grade.feedback_read_at).to be_within(1.second).of(Time.now)
+        expect(response).to redirect_to assignment_path(assignment)
       end
     end
 
     describe "protected routes" do
-      before(:all) do
-        @group = create(:group)
-        @assignment.groups << @group
-      end
+      let(:group) { create :group}
 
       it "all redirect to root" do
-        [ Proc.new { get :edit, {id: @grade.id }},
-          Proc.new { get :update, { id: @grade.id }},
-          Proc.new { delete :destroy, { id: @grade.id }},
+        assignment.groups << group
+        [ Proc.new { get :edit, {id: grade.id }},
+          Proc.new { get :update, { id: grade.id }},
+          Proc.new { delete :destroy, { id: grade.id }},
         ].each do |protected_route|
           expect(protected_route.call).to redirect_to(:root)
         end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -865,6 +865,15 @@ describe Assignment do
       it "returns nil for student without a submission" do
         expect(subject.next_ungraded_student(middleton)).to be_nil
       end
+
+      it "filters to team members if team present" do
+        create :submission, assignment: subject, student: middleton
+        team = create :team, course: subject.course
+        create :team_membership, team: team, student: apex
+        create :team_membership, team: team, student: zenith
+
+        expect(subject.next_ungraded_student(apex, team).last_name).to eq("Zenith")
+      end
     end
 
     context "when not accepting submissions" do
@@ -880,6 +889,14 @@ describe Assignment do
 
       it "returns nil for student not in the list" do
         expect(subject.next_ungraded_student(create(:user))).to be_nil
+      end
+
+      it "filters to team members if team present" do
+        team = create :team, course: subject.course
+        create :team_membership, team: team, student: apex
+        create :team_membership, team: team, student: zenith
+
+        expect(subject.next_ungraded_student(apex, team).last_name).to eq("Zenith")
       end
     end
 


### PR DESCRIPTION
This PR adds an additional layer to the "Grade for next Student" workflow, to enhance the GSI experience.  If a student is chosen for grading from the assignment show page with the page filtered down to a single team, the "submit and grade next" should bring up the next student *in that team*.  This requires passing team id in the params through the process.