### PR TITLE
make criterion bars full width

### DIFF
--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -285,7 +285,7 @@ h4.notice
 
 
 // base styles for graded rubric, ungraded rubric and rubric edit views
-#rubric-graded, #rubric-ungraded, #rubric-grade-edit
+.rubric
   *
     font-weight: 300
   h4

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -73,8 +73,9 @@ $no-expectation-color: $color-grey-5
     padding: 0.5rem 0.5rem 0 0.5rem
     margin-bottom: 0.5rem
     display: inline-block
-    width: 95%
+    width: 100%
     background-color: $color-grey-6
+    box-sizing: border-box
     &.saved
       background-color: $color-blue-2
     input

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -2,9 +2,8 @@
 @import "../utilities/mixins"
 
 $below-expectations-color: $color-grey-6
-$below-expectations-selected-color: lighten($color-grey-6, 10%)
 $meets-expectations-color: $color-green-1
-$meets-expectations-selected-color: lighten($color-green-1, 10%)
+$level-selected-color: lighten($color-green-1, 10%)
 $no-expectation-color: $color-grey-5
 
 // styles for rubric design view
@@ -74,10 +73,9 @@ $no-expectation-color: $color-grey-5
     margin-bottom: 0.5rem
     display: inline-block
     width: 100%
-    background-color: $color-grey-6
+    background-color: $color-blue-2
     box-sizing: border-box
-    &.saved
-      background-color: $color-blue-2
+
     input
       margin-right: 0.2rem
       &.points
@@ -167,15 +165,12 @@ button.meets-expectations-status.no-expectation
   background-color: $no-expectation-color
 
 .level
-  background: $color-grey-5
+  background-color: $below-expectations-color
+  &.level-meets-expectations
+    background-color: $meets-expectations-color
 
   &.nocredit
     width: 180px
-
-  &.saved
-    background-color: $below-expectations-color
-    &.level-meets-expectations
-      background-color: $meets-expectations-color
 
   .badge-messages
     text-align: center
@@ -510,7 +505,7 @@ h4.notice
 
 
   .level-tab.selected
-    background-color: $meets-expectations-selected-color
+    background-color: $level-selected-color
 
 
   .level-badge-image

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -24,7 +24,7 @@
       %br
       %br
 
-    #rubric-grade-edit.edit(ng-cloak)
+    #rubric-grade-edit.rubric.edit(ng-cloak)
       .criterion(ng-repeat="criterion in criteria")
         .criterion-heading
           %h4.criterion-name {{criterion.name.replace(" ","&nbsp;")}} {{(criterion.max_points || 0) | number:0}}&nbsp;Points

--- a/app/views/rubrics/components/_criteria.haml
+++ b/app/views/rubrics/components/_criteria.haml
@@ -8,4 +8,4 @@
       .tab-panel.selected{:class => ("meets-expectations-cutoff" if level.meets_expectations)}
         - if level.meets_expectations
           %p.meets-expectations-tag Meets expectations #{glyph('long-arrow-up')}
-        = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: include_grade_info }
+        = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: false }

--- a/app/views/rubrics/components/_level.haml
+++ b/app/views/rubrics/components/_level.haml
@@ -3,7 +3,7 @@
     = render partial: "rubrics/components/level_grade_analysis", locals: { level: level, student: student }
 
 %section.level{class: ("meets-expectations" if level.meets_expectations || level.above_expectations?)}
-  = render partial: "rubrics/components/level_heading", locals: { level: level, student: student }
+  = render partial: "rubrics/components/level_heading", locals: { level: level, student: student, include_grade_info: include_grade_info }
 
 - if !level.level_badges(current_user).empty? && !include_grade_info
   %section.badges-earned

--- a/app/views/rubrics/components/_level_heading.haml
+++ b/app/views/rubrics/components/_level_heading.haml
@@ -1,4 +1,4 @@
-- if current_student.present? && level.earned_for?(student.id)
+- if current_student.present? && include_grade_info && level.earned_for?(student.id)
   %h5.level-name You earned 
 %h5.level-name= "#{level.name}: #{points level.points} Points"
 - if level.meets_expectations || level.above_expectations?

--- a/app/views/rubrics/components/_rubric_table.haml
+++ b/app/views/rubrics/components/_rubric_table.haml
@@ -7,8 +7,8 @@
       %input#class-analytics-toggle{:type => "checkbox", :checked => true}
       .rubric-switch-handle.round
 
-  #rubric-graded
+  #rubric-graded.rubric
     = render partial: "rubrics/components/criteria_graded", locals: { rubric: rubric, student: student, include_grade_info: include_grade_info }
 - else
-  #rubric-ungraded
-    = render partial: "rubrics/components/criteria", locals: { rubric: rubric, student: student, include_grade_info: include_grade_info }
+  #rubric-ungraded.rubric
+    = render partial: "rubrics/components/criteria", locals: { rubric: rubric, student: student, include_grade_info: false }


### PR DESCRIPTION
This PR makes the criterion bars full width on the rubric design interface and updates the level heading file in order to only show levels earned when grade has been released.

Closes issue #2523 