### PR TITLE
1705 criterion grades review

### DIFF
--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -336,7 +336,7 @@ h4.notice
     @media (max-width: $media-small-max)
       display: none
 
-  .level-tab
+  .level-tab, .criterion-tab, .comments-tab
     list-style-type: none
     display: inline-block
     flex: 1
@@ -366,6 +366,10 @@ h4.notice
 
   .level-name
     display: inline
+
+  .earned
+    background-color: lighten($color-green-1, 20%)
+
 
   .level-description
     font-size: 0.85rem
@@ -446,6 +450,10 @@ h4.notice
   display: inline
   vertical-align: top
 
+// styles for the rubric grade review page
+#rubric-results-table
+
+
 // styles for ungraded rubric view
 #rubric-ungraded
   .tab-panel
@@ -469,7 +477,7 @@ h4.notice
       padding-right: 0
 
 // Edit rubric grade view
-#rubric-grade-edit
+#rubric-grade-edit, #rubric-results-table
   .criterion-name, .level-name
     font-weight: bold
 
@@ -480,7 +488,7 @@ h4.notice
     font-size: 80%
     text-transform: uppercase
 
-  .level-tab
+  .level-tab, .criterion-tab, .comments-tab
     padding: 0
     &.selected
       .check-mark
@@ -531,6 +539,10 @@ h4.notice
 
   h4.notice
     color: $color-green-2
+
+#rubric-results-table
+  .criterion
+    margin-bottom: 0
 
 .points-adjustment-feedback
   margin-right: 1rem

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -548,9 +548,9 @@ h4.notice
     border-bottom: 1px solid $color-white
   .criterion-tab
     background-color: $color-blue-2
-    &:hover 
+    &:hover
       background-color: $color-blue-2
-  .comments-tab 
+  .comments-tab
     background-color: $color-white
     .comments-heading
       padding: 0.25rem
@@ -562,7 +562,7 @@ h4.notice
   .level-heading
     border-bottom: 0
     .earned
-      background-color: $meets-expectations-selected-color
+      background-color: $meets-expectations-color
   .feedback-name
     background-color: $color-grey-6
     padding: .25rem
@@ -572,9 +572,9 @@ h4.notice
     &:hover, &.selected
       background-color: $color-grey-6
     &.earned
-      background-color: $meets-expectations-selected-color
+      background-color: $meets-expectations-color
       &:hover
-        background-color: $meets-expectations-selected-color
+        background-color: $meets-expectations-color
 
 .points-adjustment-feedback
   margin-right: 1rem

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -317,7 +317,7 @@ h4.notice
   .criterion
     background-color: $color-white
     margin-bottom: 2rem
-    border: 1px solid $color-grey-6
+    border-bottom: 1px solid $color-grey-6
   .criterion-heading
     background-color: $color-blue-2
     color: $color-white
@@ -344,7 +344,8 @@ h4.notice
     padding: 0.25rem
     background-color: $color-grey-6
     color: $color-grey-2
-    border: 1px solid $color-white
+    border-left: 1px solid $color-white
+    border-right: 1px solid $color-white
     font-size: 0.8rem
     cursor: pointer
     position: relative
@@ -518,7 +519,6 @@ h4.notice
     background-color: $color-green-1
     padding: 0.2rem
 
-
   .level-tab.selected
     background-color: $level-selected-color
 
@@ -541,8 +541,40 @@ h4.notice
     color: $color-green-2
 
 #rubric-results-table
+  padding: 1px
+  border: 1px solid $color-grey-6
   .criterion
     margin-bottom: 0
+    border-bottom: 1px solid $color-white
+  .criterion-tab
+    background-color: $color-blue-2
+    &:hover 
+      background-color: $color-blue-2
+  .comments-tab 
+    background-color: $color-white
+    .comments-heading
+      padding: 0.25rem
+      background-color: $color-grey-4
+      color: $color-white
+    .comments-text, .comments-text:hover
+      background-color: $color-white
+      padding: 0.25rem
+  .level-heading
+    border-bottom: 0
+    .earned
+      background-color: $meets-expectations-selected-color
+  .feedback-name
+    background-color: $color-grey-6
+    padding: .25rem
+  .level-comments
+    padding: .25rem
+  .level-tab, .criterion-tab, .comments-tab
+    &:hover, &.selected
+      background-color: $color-grey-6
+    &.earned
+      background-color: $meets-expectations-selected-color
+      &:hover
+        background-color: $meets-expectations-selected-color
 
 .points-adjustment-feedback
   margin-right: 1rem

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -514,7 +514,6 @@ h4.notice
   .level-tab.selected
     background-color: $level-selected-color
 
-
   .level-badge-image
     list-style: none
     img
@@ -541,3 +540,6 @@ h4.notice
 
 .download-link
   margin: 0.5rem 0
+
+.level-earned
+  background-color: lighten($color-green-1, 20%)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -121,6 +121,18 @@ class AssignmentsController < ApplicationController
     end
   end
 
+  def criterion_grades_review
+    assignment = current_course.assignments.find(params[:id])
+    @criteria = assignment.rubric.criteria.includes(levels: :level_badges)
+    @criterion_grades = assignment.criterion_grades
+    render :criterion_grades_review, Assignments::Presenter.build({
+      assignment: assignment,
+      course: current_course,
+      team_id: params[:team_id],
+      view_context: view_context
+      })
+  end
+
   private
 
   def sanitize_params

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -121,12 +121,14 @@ class AssignmentsController < ApplicationController
     end
   end
 
-  def criterion_grades_review
-    assignment = current_course.assignments.find(params[:id])
-    @criteria = assignment.rubric.criteria.includes(levels: :level_badges)
-    @criterion_grades = assignment.criterion_grades
-    render :criterion_grades_review, Assignments::Presenter.build({
-      assignment: assignment,
+  def grades_review
+    @assignment = current_course.assignments.find(params[:id])
+    if @assignment.grade_with_rubric?
+      @criteria = @assignment.rubric.criteria.includes(levels: :level_badges)
+      @criterion_grades = @assignment.criterion_grades
+    end
+    render :grades_review, Assignments::Presenter.build({
+      assignment: @assignment,
       course: current_course,
       team_id: params[:team_id],
       view_context: view_context

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -46,11 +46,18 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('#{ term_for :assignment } Import', assignments_importers_path)
     breadcrumb(objects[:provider_name].capitalize + ' #{ term_for :assignments }', assignments_importer_assignments_path(objects[:provider_name], objects[:course_id]))
   end
-  
+
   def assignments_grades_edit_status
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :assignments }', assignments_path)
     breadcrumb("Update Grade Statuses")
+  end
+
+  def assignments_grades_review
+    breadcrumb('Dashboard', dashboard_path)
+    breadcrumb('#{ term_for :assignments }', assignments_path)
+    breadcrumb(objects[:assignment].name, assignment_path(objects[:assignment]))
+    breadcrumb("Review Grades")
   end
 
   def assignments_settings

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -35,7 +35,7 @@ class Assignments::Presenter < Showtime::Presenter
   def prediction_for(assignment)
     grade_for(assignment).predicted_points
   end
-  
+
   def positive_prediction_for?(assignment)
     grade_for(assignment).predicted_points > 0
   end
@@ -199,5 +199,17 @@ class Assignments::Presenter < Showtime::Presenter
 
   def teams
     course.teams
+  end
+
+  # !
+  def viewable_criterion_grades(student_id=nil)
+    query = assignment.criterion_grades
+    query = query.where(student_id: student_id) if student_id.present?
+    query
+  end
+
+ # !
+  def viewable_rubric_level_earned?(student_id, level_id)
+    viewable_criterion_grades(student_id).any? { |criterion_grade| criterion_grade.level_id == level_id }
   end
 end

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -200,16 +200,4 @@ class Assignments::Presenter < Showtime::Presenter
   def teams
     course.teams
   end
-
-  # !
-  def viewable_criterion_grades(student_id=nil)
-    query = assignment.criterion_grades
-    query = query.where(student_id: student_id) if student_id.present?
-    query
-  end
-
- # !
-  def viewable_rubric_level_earned?(student_id, level_id)
-    viewable_criterion_grades(student_id).any? { |criterion_grade| criterion_grade.level_id == level_id }
-  end
 end

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -6,6 +6,8 @@
         %li
           %a.button.button-edit.button-options= glyph(:cog) + "Options" + glyph("caret-down")
         %ul.options-menu
+          - if presenter.assignment.grades.present?
+            %li= link_to glyph(:"check-square") + "Review Grades", grades_review_assignment_path(id: presenter.assignment)
           %li= link_to glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
           - if presenter.assignment.has_groups?
             %li= link_to glyph(:users) + "Create #{term_for :group}", new_group_path

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -1,0 +1,31 @@
+.rubric-container
+  %table#rubric-results-table
+    %thead
+      %tr
+        %td.criterion.heading
+          Criterion:&nbsp;Max&nbsp;points
+
+        %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
+          Level: Points Awarded
+        %td.comments.heading
+          Comments
+
+
+    %tbody
+      - @criteria.each do |criterion|
+        - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
+        %tr
+          %td.criterion
+            .criterion-heading
+              .criterion-name= criterion.name
+
+          - criterion.levels.order("points ASC").each do |level|
+            %td.level{class: ("level-earned" if criterion_grade.level_id == level.id)}
+              .level-heading
+                .level-name= level.name
+
+              - if criterion_grade.level_id == level.id
+                .earned_level #{student.first_name} earned this level
+
+          %td.level.level-comments.comments-box
+            = raw criterion_grade.comments

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -5,7 +5,8 @@
       %ul.level-tabs
         %li.criterion-tab
           .criterion-heading
-            %h4.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
+            %h4.criterion-name= "#{criterion.name}"
+            .level-points= "#{points criterion.max_points} Points"
 
         - criterion.levels.order("points ASC").each do |level|
           %li.level-tab{class: ("earned selected" if criterion_grade.level_id == level.id)}
@@ -21,9 +22,10 @@
                   %li.level-badge-image
                     %img{:src => level_badge.badge.try(:icon), class: "level_badge" }
 
-            .level-description
-              .level-meets-expectations Meets Expectations
+              - if level.meets_expectations? || level.above_expectations?
+                .level-description
+                  .level-meets-expectations Meets Expectations
 
         %li.comments-tab
-          .level-comments.comments-box
-            = raw criterion_grade.comments
+          .comments-heading Feedback
+          .comments-text= raw criterion_grade.comments

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -3,10 +3,10 @@
     %thead
       %tr
         %td.criterion.heading
-          Criterion:&nbsp;Max&nbsp;points
+          Criteria
 
         %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
-          Level: Points Awarded
+          Levels
         %td.comments.heading
           Comments
 
@@ -16,16 +16,19 @@
         - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
         %tr
           %td.criterion
-            .criterion-heading
-              .criterion-name= criterion.name
-
+            %h4.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
           - criterion.levels.order("points ASC").each do |level|
             %td.level{class: ("level-earned" if criterion_grade.level_id == level.id)}
-              .level-heading
-                .level-name= level.name
-
               - if criterion_grade.level_id == level.id
-                .earned_level #{student.first_name} earned this level
+                %span.earned_level= glyph(:check) 
+              %span.level-heading= level.name
+              .badges
+                - level.level_badges.each_with_index do |level_badge, index|
+                  - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
+                    .level-badge-image
+                      %img{:src => level_badge.badge.try(:icon), class: "level_badge", width: 20 }
+
+              
 
           %td.level.level-comments.comments-box
             = raw criterion_grade.comments

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -1,34 +1,29 @@
-.rubric-container
-  %table#rubric-results-table
-    %thead
-      %tr
-        %td.criterion.heading
-          Criteria
-
-        %td.heading(colspan="#{presenter.rubric.max_level_count}")
-          Levels
-        %td.comments.heading
-          Comments
-
-
-    %tbody
-      - @criteria.each do |criterion|
-        - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
-        %tr
-          %td.criterion
+#rubric-results-table
+  - @criteria.each do |criterion|
+    - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
+    .criterion
+      %ul.level-tabs
+        %li.criterion-tab
+          .criterion-heading
             %h4.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
-          - criterion.levels.order("points ASC").each do |level|
-            %td.level{class: ("level-earned" if criterion_grade.level_id == level.id)}
-              - if criterion_grade.level_id == level.id
-                %span.earned_level= glyph(:check) 
-              %span.level-heading= level.name
-              .badges
+
+        - criterion.levels.order("points ASC").each do |level|
+          %li.level-tab{class: ("earned selected" if criterion_grade.level_id == level.id)}
+            .level-heading
+              .level-details
+                - if criterion_grade.level_id == level.id
+                  %span.check-mark= glyph("check")
+                .level-name= level.name
+                .level-points
+                  = "#{ points level.points } Points"
+              %ul.badge-row.design-view
                 - level.level_badges.each_with_index do |level_badge, index|
-                  - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
-                    .level-badge-image
-                      %img{:src => level_badge.badge.try(:icon), class: "level_badge", width: 20 }
+                  %li.level-badge-image
+                    %img{:src => level_badge.badge.try(:icon), class: "level_badge" }
 
-              
+            .level-description
+              .level-meets-expectations Meets Expectations
 
-          %td.level-comments.comments-box
+        %li.comments-tab
+          .level-comments.comments-box
             = raw criterion_grade.comments

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -1,4 +1,4 @@
-#rubric-results-table
+#rubric-results-table.rubric
   - @criteria.each do |criterion|
     - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
     .criterion

--- a/app/views/assignments/_rubric_grade_review.haml
+++ b/app/views/assignments/_rubric_grade_review.haml
@@ -5,7 +5,7 @@
         %td.criterion.heading
           Criteria
 
-        %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
+        %td.heading(colspan="#{presenter.rubric.max_level_count}")
           Levels
         %td.comments.heading
           Comments
@@ -30,5 +30,5 @@
 
               
 
-          %td.level.level-comments.comments-box
+          %td.level-comments.comments-box
             = raw criterion_grade.comments

--- a/app/views/assignments/criterion_grades_review.haml
+++ b/app/views/assignments/criterion_grades_review.haml
@@ -1,0 +1,102 @@
+= content_nav_for presenter.assignment, "Review Rubric Grades"
+
+%h3.pagetitle= "#{presenter.assignment.name} Review Rubric Grades (#{ points presenter.assignment.full_points } points)"
+
+.pageContent
+  = render "layouts/alerts"
+
+  - if presenter.has_teams? && presenter.assignment.is_individual?
+    .team-filter
+      = form_tag criterion_grades_review_assignment_path(presenter.assignment), name: "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
+        %label.sr-only{:for => "team_id"}
+          Select #{term_for :team}
+        = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
+
+  - if presenter.grade_with_rubric?
+
+    .rubric-container
+      %table#rubric-results-table
+        %thead
+          %tr
+            %td.criterion.heading
+              Criterion:&nbsp;Max&nbsp;points
+
+            %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
+              Level: Points Awarded
+        %tbody
+          - presenter.assignment.rubric.criteria.ordered.includes(levels: :level_badges).each do |criterion|
+            %tr
+              %td.criterion
+                .criterion-heading
+                  .criterion-name= criterion.name
+                  .criterion-points= "#{points criterion.max_points} Points"
+                  .clear
+                .criterion-description= criterion.description
+
+              - criterion.levels.order("points ASC").each do |level|
+                %td.level.level-level
+                  .level-heading
+                    .level-name= level.name
+                    .clear
+                    .level-points= "#{points level.points} Points"
+                  .clear
+                  .level-description= level.description
+
+                  .row.badge-row
+                    - level.level_badges.each_with_index do |badge, index|
+                      - if index < 2
+                        %span.level-badge-image
+                          %img{:src => badge.badge.icon, width: "30px", height: "30px" }
+                    .clear
+
+                  - if !presenter.hide_analytics?
+                    - unless level.criterion_grades(current_user).empty?
+                      .students-padding
+                      .graded-students= "#{pluralize(level.criterion_grades(current_user).size, 'student')} earned this level"
+
+
+
+    - presenter.students_being_graded.each do |student|
+      - grade_for_assignment = student.grade_for_assignment(presenter.assignment)
+      - if grade_for_assignment.present? && grade_for_assignment.instructor_modified?
+        %h4.uppercase= student.name
+        .left
+          %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "
+        .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(grade_for_assignment), class: "button"
+        %br
+        %br
+        .rubric-container
+          %table#rubric-results-table
+            %thead
+              %tr
+                %td.criterion.heading
+                  Criterion:&nbsp;Max&nbsp;points
+
+                %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
+                  Level: Points Awarded
+                %td.comments.heading
+                  Comments
+
+
+            %tbody
+              - @criteria.each do |criterion|
+                - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
+                %tr
+                  %td.criterion
+                    .criterion-heading
+                      .criterion-name= criterion.name
+
+                  - criterion.levels.order("points ASC").each do |level|
+                    %td.level.level-level
+                      .level-heading
+                        .level-name= level.name
+
+                      - if criterion_grade.level_id == level.id
+                        .earned_level #{student.first_name} earned this level
+
+                  %td.level.level-comments.comments-box
+                    = raw criterion_grade.comments
+        %br
+        %b= "Feedback from #{ grade_for_assignment.graded_by.name }:" if grade_for_assignment.graded_by.present?
+        %p.summary-comments= raw grade_for_assignment.try(:feedback)
+        %hr

--- a/app/views/assignments/grades_review.haml
+++ b/app/views/assignments/grades_review.haml
@@ -10,91 +10,21 @@
           Select #{term_for :team}
         = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
-  - if presenter.grade_with_rubric?
+  - presenter.students_being_graded.each do |student|
+    - grade = student.grade_for_assignment(presenter.assignment)
+    - if grade.present? && grade.instructor_modified?
+      %h4.uppercase= student.name
+      .left
+        %h5.bold= "#{points grade.score} / #{points presenter.assignment.full_points} points "
+      .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(grade), class: "button"
+      %br
+      %br
 
-    .rubric-container
-      %table#rubric-results-table
-        %thead
-          %tr
-            %td.criterion.heading
-              Criterion:&nbsp;Max&nbsp;points
+    - if presenter.grade_with_rubric?
+      = render partial: "assignments/rubric_grade_review", locals: { presenter: presenter, student: student, grade: grade }
 
-            %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
-              Level: Points Awarded
-        %tbody
-          - presenter.assignment.rubric.criteria.ordered.includes(levels: :level_badges).each do |criterion|
-            %tr
-              %td.criterion
-                .criterion-heading
-                  .criterion-name= criterion.name
-                  .criterion-points= "#{points criterion.max_points} Points"
-                  .clear
-                .criterion-description= criterion.description
+    - if grade.graded_by.present? && grade.feedback.present?
+      %b= "Feedback from #{ grade.graded_by.name }:"
+      %p.summary-comments= raw grade.feedback
 
-              - criterion.levels.order("points ASC").each do |level|
-                %td.level.level-level
-                  .level-heading
-                    .level-name= level.name
-                    .clear
-                    .level-points= "#{points level.points} Points"
-                  .clear
-                  .level-description= level.description
-
-                  .row.badge-row
-                    - level.level_badges.each_with_index do |badge, index|
-                      - if index < 2
-                        %span.level-badge-image
-                          %img{:src => badge.badge.icon, width: "30px", height: "30px" }
-                    .clear
-
-                  - if !presenter.hide_analytics?
-                    - unless level.criterion_grades(current_user).empty?
-                      .students-padding
-                      .graded-students= "#{pluralize(level.criterion_grades(current_user).size, 'student')} earned this level"
-
-
-
-    - presenter.students_being_graded.each do |student|
-      - grade_for_assignment = student.grade_for_assignment(presenter.assignment)
-      - if grade_for_assignment.present? && grade_for_assignment.instructor_modified?
-        %h4.uppercase= student.name
-        .left
-          %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "
-        .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(grade_for_assignment), class: "button"
-        %br
-        %br
-        .rubric-container
-          %table#rubric-results-table
-            %thead
-              %tr
-                %td.criterion.heading
-                  Criterion:&nbsp;Max&nbsp;points
-
-                %td.level.heading(colspan="#{presenter.rubric.max_level_count}")
-                  Level: Points Awarded
-                %td.comments.heading
-                  Comments
-
-
-            %tbody
-              - @criteria.each do |criterion|
-                - criterion_grade = @criterion_grades.where(student_id: student.id, criterion_id: criterion.id).first
-                %tr
-                  %td.criterion
-                    .criterion-heading
-                      .criterion-name= criterion.name
-
-                  - criterion.levels.order("points ASC").each do |level|
-                    %td.level.level-level
-                      .level-heading
-                        .level-name= level.name
-
-                      - if criterion_grade.level_id == level.id
-                        .earned_level #{student.first_name} earned this level
-
-                  %td.level.level-comments.comments-box
-                    = raw criterion_grade.comments
-        %br
-        %b= "Feedback from #{ grade_for_assignment.graded_by.name }:" if grade_for_assignment.graded_by.present?
-        %p.summary-comments= raw grade_for_assignment.try(:feedback)
-        %hr
+    %hr

--- a/app/views/assignments/grades_review.haml
+++ b/app/views/assignments/grades_review.haml
@@ -1,5 +1,3 @@
-= content_nav_for presenter.assignment, "Review Rubric Grades"
-
 %h3.pagetitle= "#{presenter.assignment.name} Review Rubric Grades (#{ points presenter.assignment.full_points } points)"
 
 .pageContent
@@ -7,7 +5,7 @@
 
   - if presenter.has_teams? && presenter.assignment.is_individual?
     .team-filter
-      = form_tag criterion_grades_review_assignment_path(presenter.assignment), name: "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
+      = form_tag grades_review_assignment_path(presenter.assignment), name: "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
         %label.sr-only{:for => "team_id"}
           Select #{term_for :team}
         = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"

--- a/app/views/assignments/grades_review.haml
+++ b/app/views/assignments/grades_review.haml
@@ -1,30 +1,23 @@
-%h3.pagetitle= "#{presenter.assignment.name} Review Rubric Grades (#{ points presenter.assignment.full_points } points)"
-
 .pageContent
   = render "layouts/alerts"
 
-  - if presenter.has_teams? && presenter.assignment.is_individual?
-    .team-filter
-      = form_tag grades_review_assignment_path(presenter.assignment), name: "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
-        %label.sr-only{:for => "team_id"}
-          Select #{term_for :team}
-        = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
+  = team_filter(presenter.teams) if presenter.has_teams? && presenter.individual_assignment?
 
   - presenter.students_being_graded.each do |student|
     - grade = student.grade_for_assignment(presenter.assignment)
     - if grade.present? && grade.instructor_modified?
       %h4.uppercase= student.name
-      .left
-        %h5.bold= "#{points grade.score} / #{points presenter.assignment.full_points} points "
-      .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(grade), class: "button"
-      %br
-      %br
+      .left= render partial: "grades/components/score", locals: { student: student, grade: grade, assignment_type: grade.assignment_type, assignment: grade.assignment }
+      .right= render partial: "grades/components/edit_button", locals: { student: student, grade: grade }
 
     - if presenter.grade_with_rubric?
+      .clear
       = render partial: "assignments/rubric_grade_review", locals: { presenter: presenter, student: student, grade: grade }
 
     - if grade.graded_by.present? && grade.feedback.present?
-      %b= "Feedback from #{ grade.graded_by.name }:"
-      %p.summary-comments= raw grade.feedback
+      = render partial: "grades/components/feedback", locals: { student: student, grade: grade }
+    - if grade.grade_files.present?
+      = render partial: "grades/components/attachments", locals: { student: student, grade: grade }
 
-    %hr
+    .clear
+    %hr.dotted

--- a/app/views/grades/components/_badges.haml
+++ b/app/views/grades/components/_badges.haml
@@ -1,4 +1,4 @@
-.bold= "Earned #{ term_for :badges }:"
+%h4.uppercase= "Earned #{ term_for :badges }:"
 %ul.earned-badge-list
   - grade.earned_badges.each do |earned_badge|
     %li

--- a/app/views/grades/components/_feedback.haml
+++ b/app/views/grades/components/_feedback.haml
@@ -1,2 +1,2 @@
-%h4 Grader's Feedback:
+%h4.uppercase Grader's Feedback:
 %p= raw grade.feedback

--- a/app/views/grades/components/_score.haml
+++ b/app/views/grades/components/_score.haml
@@ -1,5 +1,5 @@
 -# Requires: grade, assignment, assignment_type
-- if GradeProctor.new(grade).viewable? && grade.final_points
+- if GradeProctor.new(grade).viewable? && grade.final_points || current_user_is_staff?
   - if assignment_type.student_weightable?
     %p= "#{points grade.final_points} / #{ points assignment.full_points } points (Raw)"
     %p= "#{ points grade.score } / #{points grade.full_points} points (Multiplied)"

--- a/app/views/grades/components/_status.haml
+++ b/app/views/grades/components/_status.haml
@@ -1,3 +1,3 @@
 %p
-  %span.small_uppercase Status:
+  %h4.uppercase Status:
   %span.bold= grade.status

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -36,6 +36,8 @@ en:
       title: "Create a New #{ term_for :assignment }"
     show:
       title: "#{ @assignment.name }"
+    grades_review:
+      title: "Review Grades for #{ @assignment.name }"
     grades:
       mass_edit:
         title: "Quick Grade #{ @assignment.name }"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ GradeCraft::Application.routes.draw do
     end
 
     member do
-      get "criterion_grades_review"
+      get "grades_review"
     end
 
     # routes for all grades that are associated with an assignment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,10 @@ GradeCraft::Application.routes.draw do
       get "export_structure"
     end
 
+    member do
+      get "criterion_grades_review"
+    end
+
     # routes for all grades that are associated with an assignment
     # single resources should go directly on the grades controller
     resources :grades, only: [:index], module: :assignments do

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -365,8 +365,7 @@ is for. Did you learn nothing from my chemistry class? - Walter H. White",
     status: "Graded",
     instructor_modified: true,
     raw_points: -> { 80000 },
-    feedback: 'As Aristotle said, <strong>"The whole is greater than the sum \
-of its parts."</strong>'
+    feedback: 'As Aristotle said, <strong>"The whole is greater than the sum of its parts."</strong>'
   },
   rubric: true,
   student_submissions: true


### PR DESCRIPTION
NOT READY FOR MERGE

This PR revives the lost "Criterion Grades Review" page, renames it "Grades Review", and modifies it to work with both standard and rubric graded assignments.  The page has no public linking, but it available for any assignment at `/assignments/:id/grades_review`.  This page still uses a legacy rubric view structure, which I have quickly stripped down to what I think is the important information.

I am passing it along for review so we can determine:
  * where the link button on the assignment page should be
  * what grade and rubric information do we want to display, and what should be left out for the sake of reviewing a list of ~300 grades.  
  * If some of the current class tags and partials dealing with rubric display can be modified to be used on this page as well.

I am happy to pass this work along to others or to take it back with some guidance regarding these quesitons.