### PR TITLE
2444-meets-expectations-hints

### DIFF
--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -66,6 +66,14 @@ $no-expectation-color: $color-grey-5
     padding: 0
     border-radius: $global-radius
 
+  .meets-expectations-hint
+    margin-top: 0.5rem
+    padding-left: 1rem
+    cursor: pointer
+    font-size: 0.8rem
+    p
+      margin: 0
+
 #criterion-box
   .criterion
     position: relative
@@ -369,6 +377,9 @@ h4.notice
 
   .meets-expectations-label
     font-size: 0.8rem
+    a
+      text-decoration: none
+      cursor: pointer
 
   .tab-panel-body
     padding: 0.5rem

--- a/app/views/rubrics/components/_level_heading.haml
+++ b/app/views/rubrics/components/_level_heading.haml
@@ -2,5 +2,8 @@
   %h5.level-name You earned 
 %h5.level-name= "#{level.name}: #{points level.points} Points"
 - if level.meets_expectations || level.above_expectations?
-  %p.italic.meets-expectations-label Meets Expectations
+  .meets-expectations-label
+    %a.italic Meets Expectations
+    .display_on_hover.hover-style
+      %p This level is above the threshold for meeting expectations on this criterion.
 .level-description= level.description

--- a/app/views/rubrics/components/_level_heading.haml
+++ b/app/views/rubrics/components/_level_heading.haml
@@ -5,5 +5,5 @@
   .meets-expectations-label
     %a.italic Meets Expectations
     .display_on_hover.hover-style
-      %p This level is above the threshold for meeting expectations on this criterion.
+      %p Earning this level means that you met or surpassed the minimum expectations for this criterion, and will earn the associated points. 
 .level-description= level.description

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -16,6 +16,11 @@
       –
       %span Rubric is saved automatically.
 
+      .meets-expectations-hint
+        %a.italic What does "Set as 'meets expectations' mean?"
+        .display_on_hover.hover-style
+          %p Adding this marker to a level sets a threshold so that all levels below this do not earn any points.
+
       - if ! @assignment.grade_with_rubric?
         .clear
         %a.button{href: index_for_copy_assignment_rubrics_path(@assignment) }

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -19,7 +19,7 @@
       .meets-expectations-hint
         %a.italic What does "Set as 'meets expectations' mean?"
         .display_on_hover.hover-style
-          %p Adding this marker to a level sets a threshold so that all levels below this do not earn any points.
+          %p Adding this marker to a level sets a threshold so that all levels below it do not award any points.
 
       - if ! @assignment.grade_with_rubric?
         .clear


### PR DESCRIPTION
This PR adds hoverable descriptions of the 'meets-expectations' markers found in the graded, ungraded and rubric design interfaces.

<img width="380" alt="screen shot 2016-10-06 at 3 29 28 pm" src="https://cloud.githubusercontent.com/assets/12573921/19167457/cb68d35a-8bd9-11e6-87e6-d7adf8bc3053.png">

<img width="380" alt="screen shot 2016-10-06 at 3 29 38 pm" src="https://cloud.githubusercontent.com/assets/12573921/19167458/cd26143c-8bd9-11e6-88eb-0fb112db086d.png">

<img width="380" alt="screen shot 2016-10-06 at 3 29 53 pm" src="https://cloud.githubusercontent.com/assets/12573921/19167465/d005f730-8bd9-11e6-91d9-90340af95c4b.png">
