### PR TITLE
add grade next for rubric graded assignments

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -22,6 +22,9 @@ class GradesController < ApplicationController
     @badges = @grade.student.earnable_course_badges_for_grade(@grade)
     @submission = @grade.student.submission_for_assignment(@grade.assignment)
     @team = Team.find(params[:team_id]) if params[:team_id]
+    if @grade.assignment.grade_with_rubric?
+      @grade_next_path = path_for_next_grade @grade, @team
+    end
   end
 
   # To avoid duplicate grades, we don't supply a create method. Update will

--- a/app/views/grades/_rubric_edit.html.haml
+++ b/app/views/grades/_rubric_edit.html.haml
@@ -97,6 +97,7 @@
 
     .right
       %button#submit-grade(ng-click="submitGrade('#{return_path}')" ng-class='{"disabled" : !grade.status}') Submit Grade
+      %button#submit-grade(ng-click="submitGrade('#{grade_next_path}')" ng-class='{"disabled" : !grade.status}') Submit and Grade Next
 
     - if scope_type == "student" && current_course.badges.present?
       %h3= "Award #{ @grade.student.name } #{term_for :badges} for #{ @grade.assignment.name }:"

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -5,7 +5,7 @@
 
   - if @grade.assignment.accepts_submissions? && @submission.present?
     %hr.dotted
-    
+
     %section
 
       %h4.uppercase= "#{@grade.student.first_name}'s Submission"
@@ -15,6 +15,6 @@
     %hr.dotted
 
   - if @grade.assignment.grade_with_rubric?
-    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, scope_type: "student", scoped_id: @grade.student.id, grade: @grade, return_path: URI(request.referer || "").path }
+    = render partial: "rubric_edit", locals: { rubric: @grade.assignment.rubric, scope_type: "student", scoped_id: @grade.student.id, grade: @grade, return_path: URI(request.referer || "").path,  grade_next_path: @grade_next_path }
   - else
     = render partial: "standard_edit", locals: { grade: @grade, badges: @badges, submission: @submission }


### PR DESCRIPTION
This PR adds a "Submit and Grade Next" button to the rubric grading form. Unlike standard grades, this form uses Angular to redirect after submitting a grade, so the next grade url is inserted into the haml on load rather than determined on grade submission. If this turns out to be problematic (multiple graders working at the same time, for instance), a next grade route could be returned in the json, but this would require a more circuitous logic path.

closes #2400 