### PR TITLE
Remove high level on the grade scheme element

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
@@ -7,13 +7,20 @@
 
     $scope.validateElements = (index)->
       for element, i in $scope.grade_scheme_elements
-        $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', true)
+        $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('directConflict', true)
+        $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('nearConflict', true)
         for otherElement, j in $scope.grade_scheme_elements
           continue if i == j
 
-          pointRange = [(element.lowest_points - 1)..(element.lowest_points + 1)]
-          if otherElement.lowest_points in pointRange
-            $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', false)
-            $scope.gradeSchemeForm["lowest_points_#{j}"].$setValidity('conflict', false)
+          if element.lowest_points == otherElement.lowest_points
+            # Invalid because it is in direct conflict with another level
+            $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('directConflict', false)
+            $scope.gradeSchemeForm["lowest_points_#{j}"].$setValidity('directConflict', false)
+
+          if (element.lowest_points - 1 == otherElement.lowest_points ||
+              element.lowest_points + 1 == otherElement.lowest_points)
+            # Invalid because it is within one point of another level
+            $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('nearConflict', false)
+            $scope.gradeSchemeForm["lowest_points_#{j}"].$setValidity('nearConflict', false)
     return
 ]

--- a/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
@@ -13,6 +13,17 @@
     # directives, but this works for now and probably isn't worth the additional
     # time to implement the directives properly.
     #
+    $scope.validateElements = (index)->
+      for element, i in $scope.grade_scheme_elements
+        $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', true)
+        for otherElement, j in $scope.grade_scheme_elements
+          continue if i == j
+
+          pointRange = [(element.lowest_points - 1)..(element.lowest_points + 1)]
+          if otherElement.lowest_points in pointRange
+            $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', false)
+            $scope.gradeSchemeForm["lowest_points_#{j}"].$setValidity('conflict', false)
+
     $scope.updatePreviousElement = (index)->
       currentElement = $scope.grade_scheme_elements[index]
       previousElement = $scope.grade_scheme_elements[index - 1]

--- a/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeSchemeElementsCtrl.js.coffee
@@ -5,14 +5,6 @@
     $scope.gradeService = GradeSchemeElementsService
     $scope.grade_scheme_elements = $scope.gradeService.elements
 
-    # these can't be performed in the service without injecting the scope into
-    # the service and then applying the scope from within the service, which
-    # kind of violates the purpose of the scope.
-    #
-    # additionally these could be performed in the high-points and low-points
-    # directives, but this works for now and probably isn't worth the additional
-    # time to implement the directives properly.
-    #
     $scope.validateElements = (index)->
       for element, i in $scope.grade_scheme_elements
         $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', true)
@@ -23,56 +15,5 @@
           if otherElement.lowest_points in pointRange
             $scope.gradeSchemeForm["lowest_points_#{i}"].$setValidity('conflict', false)
             $scope.gradeSchemeForm["lowest_points_#{j}"].$setValidity('conflict', false)
-
-    $scope.updatePreviousElement = (index)->
-      currentElement = $scope.grade_scheme_elements[index]
-      previousElement = $scope.grade_scheme_elements[index - 1]
-
-      if previousElement
-        if currentElement.highest_points
-          previousElement.lowest_points = currentElement.highest_points + 1
-        else
-          previousElement.lowest_points = null
-
-    $scope.updateNextElement = (index)->
-      currentElement = $scope.grade_scheme_elements[index]
-      nextElement = $scope.grade_scheme_elements[index + 1]
-
-      if nextElement
-        if currentElement.lowest_points > 0
-          nextElement.highest_points = currentElement.lowest_points - 1
-        else
-          nextElement.highest_points = null
-
-    $scope.highPointsMin = (index) ->
-      element = $scope.grade_scheme_elements[index]
-
-      if element && element.lowest_points >= 0
-        element.lowest_points + 1
-      else
-        null
-
-    $scope.highPointsMax = (index) ->
-      prevElement = $scope.grade_scheme_elements[index - 1]
-      if prevElement
-        prevElement.lowest_points - 1
-      else
-        null
-
-    $scope.lowPointsMin = (index) ->
-      nextElement = $scope.grade_scheme_elements[index + 1]
-      if nextElement
-        nextElement.highest_points + 1
-      else
-        null
-
-    $scope.lowPointsMax = (index) ->
-      element = $scope.grade_scheme_elements[index]
-
-      if element && element.highest_points > 0
-        element.highest_points - 1
-      else
-        null
-
     return
 ]

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -37,8 +37,7 @@
       {
         letter: ''
         level: ''
-        highest_points: highestPoints(index)
-        lowest_points: lowestPoints(index)
+        lowest_points: null
       }
 
     highestPoints = (index) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -72,6 +72,7 @@
           window.location.href = '/grade_scheme_elements/'
       ).error(
         (error) ->
+          alert('An error occurred that prevented saving.')
           console.log(error)
       )
 

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.js.coffee
@@ -66,15 +66,20 @@
         deleted_ids: deletedIds
       }
 
-      $http.put('/grade_scheme_elements/mass_update', data).success(
-        (data) ->
-          angular.copy(data.grade_scheme_elements, elements)
-          window.location.href = '/grade_scheme_elements/'
-      ).error(
-        (error) ->
-          alert('An error occurred that prevented saving.')
-          console.log(error)
-      )
+      # Make sure we have a zero-level
+      thresholds = (element.lowest_points for element in elements)
+      if 0 in thresholds
+        $http.put('/grade_scheme_elements/mass_update', data).success(
+          (data) ->
+            angular.copy(data.grade_scheme_elements, elements)
+            window.location.href = '/grade_scheme_elements/'
+        ).error(
+          (error) ->
+            alert('An error occurred that prevented saving.')
+            console.log(error)
+        )
+      else
+        alert('A level with a Point Threshold of 0 (zero) is required.')
 
     return {
         getGradeSchemeElements: getGradeSchemeElements

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -16,7 +16,7 @@
   .right
     %span
       %button.add-element.button(type='button' ng-click='gradeService.addNew($index)')
-        %i.fa.fa-plus Add A Level
+        %i.fa.fa-plus Add a level below
       %button.remove-element.button.alert(type='button' ng-click='gradeService.remove($index)')
         Remove
         %i.fa.fa-times

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -6,23 +6,12 @@
   %span.form_label Level name
   %input.level(name='level' ng-model='element.level')
 
-  %span.form_label Low Point Threshold
+  %span.form_label Point Threshold
   %input.low-range(type='number'
                    ng-model='element.lowest_points'
                    ng-model-options='{allowInvalid: true}'
-                   ng-change='updateNextElement($index)'
                    required
-                   name='lowest_points'
-                   max='{{lowPointsMax($index)}}')
-
-  %span.form_label High Point Threshold
-  %input.high-range(type='number'
-                    ng-model='element.highest_points'
-                    ng-model-options='{allowInvalid: true}'
-                    ng-change='updatePreviousElement($index)'
-                    required
-                    name='highest_points'
-                    min='{{highPointsMin($index)}}')
+                   name='lowest_points')
 
   .right
     %span

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -25,9 +25,9 @@
                     min='{{highPointsMin($index)}}')
 
   .right
-    %button.remove-element.button.alert(type='button' ng-click='gradeService.remove($index)')
-      Remove
-      %i.fa.fa-times
-
-  %button.add-element.button(type='button' ng-click='gradeService.addNew($index)')
-    %i.fa.fa-plus Add A Level
+    %span
+      %button.add-element.button(type='button' ng-click='gradeService.addNew($index)')
+        %i.fa.fa-plus Add A Level
+      %button.remove-element.button.alert(type='button' ng-click='gradeService.remove($index)')
+        Remove
+        %i.fa.fa-times

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -15,13 +15,17 @@
                    min=0
                    name='lowest_points_{{$index}}')
 
-  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.directConflict'
-                         title='Has the same point threshold as another level.')
-    %i.fa.fa-exclamation-triangle
+  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.directConflict')
+    %a
+      %i.fa.fa-exclamation-triangle
+    .display-on-hover.hover-style.gse-bar
+      This level has the same point threshold as another level.
 
-  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.nearConflict'
-                         title='Is within one point of another level.')
-    %i.fa.fa-exclamation-triangle
+  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.nearConflict')
+    %a
+      %i.fa.fa-exclamation-triangle
+    .display-on-hover.hover-style.gse-bar
+      This level is within one point of another level.
 
   .right
     %span

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -10,8 +10,9 @@
   %input.low-range(type='number'
                    ng-model='element.lowest_points'
                    ng-model-options='{allowInvalid: true}'
+                   ng-change='validateElements($index)'
                    required
-                   name='lowest_points')
+                   name='lowest_points_{{$index}}')
 
   .right
     %span

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -12,7 +12,16 @@
                    ng-model-options='{allowInvalid: true}'
                    ng-change='validateElements($index)'
                    required
+                   min=0
                    name='lowest_points_{{$index}}')
+
+  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.directConflict'
+                         title='Has the same point threshold as another level.')
+    %i.fa.fa-exclamation-triangle
+
+  %span.validation-error(ng-show='gradeSchemeForm["lowest_points_{{$index}}"].$error.nearConflict'
+                         title='Is within one point of another level.')
+    %i.fa.fa-exclamation-triangle
 
   .right
     %span

--- a/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
+++ b/app/assets/javascripts/angular/templates/ng_gradeScheme.html.haml
@@ -26,7 +26,8 @@
   .right
     %span
       %button.add-element.button(type='button' ng-click='gradeService.addNew($index)')
-        %i.fa.fa-plus Add a level below
+        %i.fa.fa-plus 
+        Add a level below
       %button.remove-element.button.alert(type='button' ng-click='gradeService.remove($index)')
         Remove
         %i.fa.fa-times

--- a/app/assets/javascripts/angular/templates/predictor/assignment_types.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/assignment_types.html.haml
@@ -20,7 +20,7 @@
           .assignment-type-tooltip.icon
             %a
               %i.fa.fa-fw.fa-exclamation-circle
-            .display_on_hover.hover-style
+            .display-on-hover.hover-style
               You've predicted {{assignmentTypePointExcess(assignmentType) | number}} more points than you are allowed to earn for this {{termFor("assignmentType")}}!
 
   .collapsable.predictor-articles

--- a/app/assets/javascripts/angular/templates/weights/main.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/main.html.haml
@@ -27,5 +27,5 @@
           .assignment-type-tooltip.icon
             %a
               %i.fa.fa-fw.fa-exclamation-circle
-            .display_on_hover.hover-style
+            .display-on-hover.hover-style
               You've predicted {{assignmentTypePointExcess(assignmentType) | number}} more points than you are allowed to earn for this {{termFor("assignmentType")}}!

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -61,7 +61,7 @@ hr.light-grey
   border-color: $color-grey-6
   border: 1px
 
-a:hover + .display_on_hover
+a:hover + .display-on-hover
   display: block
 
 .hover-style

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -71,10 +71,10 @@ p.predictor-description
     width: 150px !important
 
   .add-element
-    display: none
+    visibility: hidden
 
   .grade-scheme-row:hover .add-element
-    display: block
+    visibility: visible
 
   .required-notice
     display: none

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -86,6 +86,9 @@ p.predictor-description
   button[type=submit][disabled]
     color: $color-grey-6
     opacity: 0.7
+    
+  .hover-style.gse-bar
+    margin-left: 575px
 
 .ng-invalid
   .required-notice

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -65,7 +65,6 @@ p.predictor-description
   .low-range, .high-range
     &.ng-invalid-conflict
       background: red
-      border: 1px solid red
 
   input.low-range, .high-range
     width: 150px !important

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -63,7 +63,7 @@ p.predictor-description
 /* for the grade scheme elements mass edit form */
 .grade-scheme-elements
   .low-range, .high-range
-    &.ng-invalid-max, &.ng-invalid-min
+    &.ng-invalid-conflict
       background: red
       border: 1px solid red
 

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -64,7 +64,7 @@ p.predictor-description
 .grade-scheme-elements
   .low-range, .high-range
     &.ng-invalid-conflict
-      background: red
+      background: #ff7777
 
   input.low-range, .high-range
     width: 150px !important

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -63,11 +63,14 @@ p.predictor-description
 /* for the grade scheme elements mass edit form */
 .grade-scheme-elements
   .low-range, .high-range
-    &.ng-invalid-conflict
-      background: #ff7777
+    &.ng-invalid
+      background: #ffcfcf
 
   input.low-range, .high-range
     width: 150px !important
+
+  .validation-error
+    color: #dd5555
 
   .add-element
     visibility: hidden

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -120,7 +120,7 @@ $card-margin-1 : 3px
     color: $color-blue-4
     i
       padding-top: 4px
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     right: 0
     background-color: $color-red-1
 

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -99,13 +99,13 @@ class GradeSchemeElementsController < ApplicationController
       next_gse = gse_attributes[i+1]
       if next_gse.nil?
         # TODO: Make sure last element's highest_points is course's max points
-        if gse["lowest_points"] < @course.total_points
-          gse["highest_points"] = @course.total_points
+        if gse["lowest_points"] < @course.total_points.to_i
+          gse["highest_points"] = @course.total_points.to_i
         else
-          gse["highest_points"] = gse["highest_points"] + 1
+          gse["highest_points"] = gse["highest_points"].to_i + 1
         end
       else
-        gse["highest_points"] = next_gse["lowest_points"] - 1
+        gse["highest_points"] = next_gse["lowest_points"].to_i - 1
       end
     end
   end

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -83,6 +83,9 @@ class GradeSchemeElementsController < ApplicationController
       :highest_points, :level, :description, :course_id]
   end
 
+  # Clean up the grade_scheme_elements_attributes param and modify
+  # highest_points for each Element to be one point lower than the next level's
+  # lowest_points.
   def fix_grade_scheme_elements_attributes_params
     gse_attributes = params["grade_scheme_elements_attributes"]
 

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -101,7 +101,7 @@ class GradeSchemeElementsController < ApplicationController
     gse_attributes.each_with_index do |gse, i|
       next_gse = gse_attributes[i+1]
       if next_gse.nil?
-        # TODO: Make sure last element's highest_points is course's max points
+        # Make sure last element's highest_points is course's max points
         if gse["lowest_points"] < @course.total_points.to_i
           gse["highest_points"] = @course.total_points.to_i
         else

--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -3,7 +3,7 @@ module BadgesHelper
     content_tag(:a) do
       concat image_tag(badge.icon, alt: "You have earned the #{badge.name} badge", class: "earned")
     end.concat(
-      content_tag(:div, nil, class: "display_on_hover hover-style right") do
+      content_tag(:div, nil, class: "display-on-hover hover-style right") do
         hover_content = "#{badge.name}#{", #{points badge.full_points} points" if badge.full_points.present? && badge.full_points > 0}"
         if badge.is_unlockable?
           lock_icon_class = badge.is_unlocked_for_student?(student) ? "fa-unlock-alt" : "fa-lock"

--- a/app/helpers/history_helper.rb
+++ b/app/helpers/history_helper.rb
@@ -53,7 +53,7 @@ module HistoryHelper
     unless from_attribute.nil?
       if from_attribute.length > 50
         replacement = omission_link_to from_attribute, "#", title: ""
-        replacement += content_tag(:div, from_attribute.html_safe, class: "display_on_hover hover-style")
+        replacement += content_tag(:div, from_attribute.html_safe, class: "display-on-hover hover-style")
         timeline_change = timeline_change.gsub "#{from_attribute}", replacement
       end
     end
@@ -63,7 +63,7 @@ module HistoryHelper
     unless to_attribute.nil?
       if to_attribute.length > 50
         replacement = omission_link_to to_attribute, "#", title: ""
-        replacement += content_tag(:div, to_attribute.html_safe, class: "display_on_hover hover-style")
+        replacement += content_tag(:div, to_attribute.html_safe, class: "display-on-hover hover-style")
         timeline_change = timeline_change.gsub "#{to_attribute}", replacement
       end
     end

--- a/app/views/assignments/_index_icons.haml
+++ b/app/views/assignments/_index_icons.haml
@@ -1,7 +1,7 @@
 - if assignment.is_unlockable?
   %a
     %i.fa.fa-lock
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     %h3 This #{term_for :assignment} is Locked
     .small.italic In order to unlock it you must:
     %ol
@@ -10,7 +10,7 @@
 - if assignment.is_a_condition?
   %a
     %i.fa.fa-key
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     %h3 This #{term_for :assignment} is a Key
     %ol
       - assignment.unlock_keys.each do |key|
@@ -18,5 +18,5 @@
 - if assignment.has_groups?
   %a
     %i.fa.fa-group.fa-fw
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     This #{term_for :assignment} is completed by #{term_for :students} in #{term_for :groups}

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -33,12 +33,12 @@
       - if grade.feedback_read?
         %a
           %i.fa.fa-check
-        .display_on_hover.hover-style
+        .display-on-hover.hover-style
           This feedback has been <strong>viewed</strong> by the #{term_for :student}.
       - elsif grade.feedback_reviewed?
         %a
           %i.fa.fa-eye
-        .display_on_hover.hover-style
+        .display-on-hover.hover-style
           This feedback has been <strong>marked as read</strong> by the #{term_for :student}.
 
     %td= grade.status

--- a/app/views/assignments/settings.html.haml
+++ b/app/views/assignments/settings.html.haml
@@ -20,46 +20,46 @@
               %span
                 %a
                   %i.fa.fa-eye.fa-fw
-                .display_on_hover.hover-style
+                .display-on-hover.hover-style
                   Visible to Students
             %th{scope: "col"}
               %a
                 !
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Required
             %th{scope: "col"}
               %a
                 %i.fa.fa-paperclip.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Accepts Submissions
             %th{scope: "col"}
               %a
                 %i.fa.fa-calendar.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Shown in Timeline
 
             %th{scope: "col"}
               %a
                 %i.fa.fa-sliders.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Shown in Predictor
 
             %th{scope: "col"}
               %a
                 %i.fa.fa-list.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Shown in Due This Week
 
             %th{scope: "col"}
               %a
                 %i.fa.fa-pencil.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Logged By Students
 
             %th{scope: "col"}
               %a
                 %i.fa.fa-unlock-alt.fa-fw
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 Release Required
 
             %th{scope: "col"} Grade Form Preview
@@ -77,55 +77,55 @@
                 - if assignment.visible?
                   %a
                     %i.fa.fa-eye
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Visible to Students
 
               %td
                 - if assignment.required?
                   %a
                     Required
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     !
               %td
                 - if assignment.accepts_submissions?
                   %a
                     %i.fa.fa-paperclip
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Accepts Submissions
 
               %td
                 - if assignment.include_in_timeline?
                   %a
                     %i.fa.fa-calendar
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Shown in Timeline
 
               %td
                 - if assignment.include_in_predictor?
                   %a
                     %i.fa.fa-sliders
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Shown in Predictor
 
               %td
                 - if assignment.include_in_to_do?
                   %a
                     %i.fa.fa-list.fa-fw
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Shown in Due This Week
 
               %td
                 - if assignment.student_logged?
                   %a
                     %i.fa.fa-pencil.fa-fw
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Logged By Students
 
               %td
                 - if assignment.release_necessary?
                   %a
                     %i.fa.fa-unlock-alt.fa-fw
-                  .display_on_hover.hover-style
+                  .display-on-hover.hover-style
                     Release Required
 
               %td

--- a/app/views/assignments/student_index/components/_assignment_icons.haml
+++ b/app/views/assignments/student_index/components/_assignment_icons.haml
@@ -2,13 +2,13 @@
   - if assignment.has_groups?
     %a
       %i.fa.fa-group.fa-fw
-    .display_on_hover.hover-style
+    .display-on-hover.hover-style
       This #{term_for :assignment} is completed by #{term_for :students} in #{term_for :groups}
   - if assignment.is_unlockable?
     - if ! assignment.is_unlocked_for_student?(presenter.student)
       %a
         %i.fa.fa-lock
-      .display_on_hover.hover-style
+      .display-on-hover.hover-style
         %h3 This #{term_for :assignment} is Locked
         .small.italic In order to unlock it you must:
         %ol
@@ -17,7 +17,7 @@
     - else
       %a
         %i.fa.fa-unlock
-      .display_on_hover.hover-style
+      .display-on-hover.hover-style
         %h3 You have unlocked this #{term_for :assignment}
         .small.italic To achieve this you:
         %ol
@@ -26,7 +26,7 @@
   - if assignment.is_a_condition?
     %a
       %i.fa.fa-key
-    .display_on_hover.hover-style
+    .display-on-hover.hover-style
       %h3 This #{term_for :assignment} is a Key
       %ol
         - assignment.unlock_keys.each do |key|

--- a/app/views/badges/components/_hover_icons.haml
+++ b/app/views/badges/components/_hover_icons.haml
@@ -1,7 +1,7 @@
 - if badge.is_unlockable?
   %a
     = glyph(:lock)
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     %h3 Unlock Requirements
     %ul
       - badge.unlock_conditions.each do |condition|
@@ -9,7 +9,7 @@
 - if badge.is_a_condition?
   %a
     = glyph(:key)
-  .display_on_hover.hover-style
+  .display-on-hover.hover-style
     %h3 Unlock Key
     %ul
       - badge.unlock_keys.each do |key|

--- a/app/views/grade_scheme_elements/_instructor_index.haml
+++ b/app/views/grade_scheme_elements/_instructor_index.haml
@@ -12,8 +12,7 @@
       %tr
         %th{scope: "col"} Grade
         %th{scope: "col"} Level
-        %th{scope: "col"} Low Points
-        %th{scope: "col"} High Points
+        %th{scope: "col"} Point Threshold
         %th{scope: "col"} Locked?
         %th{scope: "col"}
     %tbody
@@ -22,7 +21,6 @@
           %td= element.letter
           %td= element.level
           %td{data: { :"sort-value" => "#{element.lowest_points }" }}= points element.lowest_points
-          %td{data: { :"sort-value" => "#{element.highest_points }" }}= points element.highest_points
           %td
             - if element.unlock_conditions.present?
               - element.unlock_conditions.each do |uc|

--- a/app/views/grade_scheme_elements/mass_edit.html.haml
+++ b/app/views/grade_scheme_elements/mass_edit.html.haml
@@ -11,7 +11,8 @@
 
     .grade-scheme-elements
       .grade-scheme-element(ng-repeat='element in grade_scheme_elements'
-                            ng-include="'ng_gradeScheme.html'")
+                            ng-include="'ng_gradeScheme.html'"
+                            name="element_{{$index}}")
 
       %button.button.right(ng-click='gradeService.addFirst()'
                            ng-hide='gradeService.elements.length > 0') Add Your Highest Grade

--- a/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
+++ b/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
@@ -9,7 +9,7 @@
       - if presenter.starred?(assignment)
         %a.starred
           %i.fa.fa-flag.fa-fw.orange
-        .display_on_hover.hover-style
+        .display-on-hover.hover-style
           You have included this #{(term_for :assignment).downcase} in your grade prediction
       - if presenter.submitted?(assignment)
         %span.strikethrough.assignment-name= link_to "#{assignment.try(:name)}", assignment

--- a/app/views/info/earned_badges.html.haml
+++ b/app/views/info/earned_badges.html.haml
@@ -27,7 +27,7 @@
                   %img{:src => badge.try(:icon), :alt => badge.try(:name), :width => "20", :title => badge.name}
                   %i
                     x#{student.earned_badges_for_badge_count(badge.id)}
-                .display_on_hover.hover-style
+                .display-on-hover.hover-style
                   = badge.name
           - if current_course.valuable_badges?
             %td= points student.earned_badge_score_for_course(current_course)

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -20,13 +20,13 @@
               Ave
               %a
                 %i.fa.fa-info-circle
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 The average of all grades, including those who earned zero
             %th{"scope" => "col"}
               Avg Earned
               %a
                 %i.fa.fa-info-circle
-              .display_on_hover.hover-style
+              .display-on-hover.hover-style
                 The average of all scores above zero
             %th{"scope" => "col"} Predicted
             %th Submissions

--- a/app/views/rubrics/components/_level_heading.haml
+++ b/app/views/rubrics/components/_level_heading.haml
@@ -4,6 +4,6 @@
 - if level.meets_expectations || level.above_expectations?
   .meets-expectations-label
     %a.italic Meets Expectations
-    .display_on_hover.hover-style
+    .display-on-hover.hover-style
       %p Earning this level means that you met or surpassed the minimum expectations for this criterion, and will earn the associated points. 
 .level-description= level.description

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -18,7 +18,7 @@
 
       .meets-expectations-hint
         %a.italic What does "Set as 'meets expectations' mean?"
-        .display_on_hover.hover-style
+        .display-on-hover.hover-style
           %p Adding this marker to a level sets a threshold so that all levels below it do not award any points.
 
       - if ! @assignment.grade_with_rubric?

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -37,7 +37,7 @@
               - student.earned_badges_for_course(current_course).each do |badge|
                 %a
                   %img{:src => badge.try(:icon), :alt => badge.try(:name), :width => "20", :title => badge.name }
-                .display_on_hover.hover-style
+                .display-on-hover.hover-style
                   = badge.try(:name)
 
             %th{:style => "display: none"}= student.earned_badges_for_course(current_course).count

--- a/spec/helpers/badges_helper_spec.rb
+++ b/spec/helpers/badges_helper_spec.rb
@@ -34,7 +34,7 @@ describe BadgesHelper do
 
     it "renders the badge name in a hover state" do
       html = helper.sidebar_earned_badge(badge, student)
-      expect(html).to have_tag "div", with: { class: "display_on_hover" } do
+      expect(html).to have_tag "div", with: { class: "display-on-hover" } do
         with_text "badgy"
       end
     end
@@ -42,7 +42,7 @@ describe BadgesHelper do
     it "renders the points earned if it has points" do
       allow(badge).to receive(:full_points).and_return 10_000
       html = helper.sidebar_earned_badge(badge, student)
-      expect(html).to have_tag "div", with: { class: "display_on_hover" } do
+      expect(html).to have_tag "div", with: { class: "display-on-hover" } do
         with_text "badgy, 10,000 points"
       end
     end


### PR DESCRIPTION
This PR begins work on #2241.

It removes the highest_points parts of the GSE interface, and adds a method to calculate highest_points before saving changes to the grading scheme.

So these changes are compatible with the existing GradeSchemeElement model. Next step will be to begin to update the parts of the application that rely on highest_points, and then eliminate highest_points from the model.