### PR TITLE
2527 limit delete all grades

### DIFF
--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -2,14 +2,13 @@ class Assignments::GradesController < ApplicationController
   before_filter :ensure_staff?, except: :self_log
   before_filter :ensure_student?, only: :self_log
   before_filter :save_referer, only: :edit_status
-  before_action :find_assignment, only: [:mass_edit, :delete_all]
+  before_action :find_assignment, only: [:edit_status, :mass_edit, :mass_update, :self_log, :delete_all]
   before_action :find_grades_for_assignment, only: [:mass_edit, :delete_all]
 
   # GET /assignments/:assignment_id/grades/edit_status
   # For changing the status of a group of grades passed in grade_ids
   # ("In Progress" => "Graded", or "Graded" => "Released")
   def edit_status
-    @assignment = current_course.assignments.find(params[:assignment_id])
     @grades = @assignment.grades.find(params[:grade_ids])
   end
 
@@ -85,7 +84,6 @@ class Assignments::GradesController < ApplicationController
     params[:assignment][:grades_attributes].each do |index, grade_params|
       grade_params.merge!(graded_at: DateTime.now)
     end if params[:assignment][:grades_attributes].present?
-    @assignment = current_course.assignments.find(params[:assignment_id])
     if @assignment.update_attributes(assignment_params)
       # @mz TODO: add specs
       enqueue_multiple_grade_update_jobs(mass_update_grade_ids)
@@ -119,7 +117,6 @@ class Assignments::GradesController < ApplicationController
   # either sets raw points to params[:grade][:raw_points]
   # or defaults to point total for assignment
   def self_log
-    @assignment = current_course.assignments.find(params[:assignment_id])
     if @assignment.open? && @assignment.student_logged?
       @grade = Grade.find_or_create(@assignment.id, current_student.id)
 

--- a/app/views/assignments/individual/_individual_show.haml
+++ b/app/views/assignments/individual/_individual_show.haml
@@ -3,6 +3,7 @@
 - if presenter.assignment.grades.any?
   .clear.right
     = simple_form_for presenter.assignment, :url => delete_all_assignment_grades_path(assignment_id: presenter.assignment.id), method: :delete do |f|
+      = hidden_field_tag :team_id, presenter.team.id unless presenter.team.nil?
       .submit-buttons
         %button{ :type => "submit", class: "button button-slim", data: { confirm: "Are you sure you want to delete all grades for this assignment?" } }
           %i.fa.fa-trash

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -1,52 +1,45 @@
 require "rails_spec_helper"
 
 describe Assignments::GradesController do
-  before(:all) do
-    @course = create(:course)
-    @assignment = create(:assignment, course: @course)
-    @student = create(:user)
-    @student.courses << @course
-  end
-  before(:each) do
-    @grade = create :grade, student: @student, assignment: @assignment,
-      course: @course
-  end
-  after(:each) { @grade.delete }
+  let(:course) { create(:course) }
+  let(:assignment) { create(:assignment, course: course) }
+  let(:student) { create(:user) }
+  let!(:student_course_membership) { create(:student_course_membership, course: course, user: student) }
+  let!(:grade) { create(:grade, student: student, assignment: assignment, course: course) }
 
   context "as professor" do
-    before(:all) do
-      @professor = create(:user)
-      CourseMembership.create user: @professor, course: @course, role: "professor"
-    end
-    before (:each) { login_user(@professor) }
+    let(:professor) { create(:user) }
+    let!(:professor_course_membership) { create(:professor_course_membership, course: course, user: professor) }
+
+    before(:each) { login_user(professor) }
 
     describe "GET edit_status" do
       it "assigns params" do
-        get :edit_status, { assignment_id: @assignment.id, grade_ids: [@grade.id] }
-        expect(assigns(:assignment)).to eq(@assignment)
-        expect(assigns(:grades)).to eq([@grade])
+        get :edit_status, { assignment_id: assignment.id, grade_ids: [grade.id] }
+        expect(assigns(:assignment)).to eq(assignment)
+        expect(assigns(:grades)).to eq([grade])
         expect(response).to render_template(:edit_status)
       end
     end
 
     describe "PUT update_status" do
       it "updates the grade status for grades" do
-        put :update_status, { assignment_id: @assignment.id, grade_ids: [@grade.id], grade: { status: "Graded" }}
-        expect(@grade.reload.status).to eq("Graded")
+        put :update_status, { assignment_id: assignment.id, grade_ids: [grade.id], grade: { status: "Graded" }}
+        expect(grade.reload.status).to eq("Graded")
       end
 
       it "redirects to session if present"  do
         session[:return_to] = login_path
-        put :update_status, { assignment_id: @assignment.id, grade_ids: [@grade.id], grade: { status: "Graded" }}
+        put :update_status, { assignment_id: assignment.id, grade_ids: [grade.id], grade: { status: "Graded" }}
         expect(response).to redirect_to(login_path)
       end
     end
 
     describe "GET export" do
       it "returns sample csv data" do
-        submission = create(:submission, grade: @grade, student: @student,
-                            assignment: @assignment)
-        get :export, assignment_id: @assignment, format: :csv
+        submission = create(:submission, grade: grade, student: student,
+                            assignment: assignment)
+        get :export, assignment_id: assignment, format: :csv
         expect(response.body).to \
           include("First Name,Last Name,Email,Score,Feedback,Raw Score,Statement")
       end
@@ -54,12 +47,12 @@ describe Assignments::GradesController do
 
     describe "GET export_earned_levels" do
       it "returns example earned levels data" do
-        rubric = create(:rubric_with_criteria, assignment: @assignment)
+        rubric = create(:rubric_with_criteria, assignment: assignment)
         rubric.criteria.each do |criterion|
           level = Level.create(criterion_id: criterion.id, name: "Sushi Success", points: 2000)
-          CriterionGrade.create(criterion: criterion, level_id: level.id, student: @student, points: 2000, assignment: @assignment)
+          CriterionGrade.create(criterion: criterion, level_id: level.id, student: student, points: 2000, assignment: assignment)
         end
-        get :export_earned_levels, assignment_id: @assignment, format: :csv
+        get :export_earned_levels, assignment_id: assignment, format: :csv
 
         expect(response.body).to \
           include("First Name,Last Name,Email,Username,Team")
@@ -68,39 +61,39 @@ describe Assignments::GradesController do
 
     describe "GET index" do
       it "redirects to the assignments show view if the assigment is not a rubric" do
-        allow(@assignment).to receive(:grade_with_rubric?).and_return false
-        get :index, assignment_id: @assignment.id
-        expect(response).to redirect_to assignment_path(@assignment)
+        allow(assignment).to receive(:grade_with_rubric?).and_return false
+        get :index, assignment_id: assignment.id
+        expect(response).to redirect_to assignment_path(assignment)
       end
     end
 
     describe "GET mass_edit" do
       it "assigns params" do
-        get :mass_edit, assignment_id: @assignment.id
-        expect(assigns(:assignment)).to eq(@assignment)
-        expect(assigns(:assignment_type)).to eq(@assignment.assignment_type)
-        expect(assigns(:assignment_score_levels)).to eq(@assignment.assignment_score_levels)
-        expect(assigns(:grades)).to eq([@grade])
-        expect(assigns(:students)).to eq([@student])
+        get :mass_edit, assignment_id: assignment.id
+        expect(assigns(:assignment)).to eq(assignment)
+        expect(assigns(:assignment_type)).to eq(assignment.assignment_type)
+        expect(assigns(:assignment_score_levels)).to eq(assignment.assignment_score_levels)
+        expect(assigns(:grades)).to eq([grade])
+        expect(assigns(:students)).to eq([student])
         expect(response).to render_template(:mass_edit)
       end
 
       it "creates missing grades and orders grades by student name" do
         student_2 = create(:user, last_name: "zzimmer", first_name: "aaron")
         student_3 = create(:user, last_name: "zzimmer", first_name: "zoron")
-        [student_2,student_3].each {|s| s.courses << @course }
-        expect{ get :mass_edit, assignment_id: @assignment.id }.to \
-          change{Grade.count}.by(2)
+        [student_2,student_3].each {|s| s.courses << course }
+        expect { get :mass_edit, assignment_id: assignment.id }.to \
+          change { Grade.count }.by(2)
         expect(assigns(:grades)[1].student).to eq(student_2)
         expect(assigns(:grades)[2].student).to eq(student_3)
       end
 
       context "with teams" do
         it "assigns params" do
-          team = create(:team, course: @course)
-          team.students << @student
-          get :mass_edit, assignment_id: @assignment.id, team_id: team.id
-          expect(assigns(:students)).to eq([@student])
+          team = create(:team, course: course)
+          team.students << student
+          get :mass_edit, assignment_id: assignment.id, team_id: team.id
+          expect(assigns(:students)).to eq([student])
           expect(assigns(:team)).to eq(team)
         end
       end
@@ -108,57 +101,57 @@ describe Assignments::GradesController do
 
     describe "PUT mass_update" do
       let(:grades_attributes) do
-        { "#{@assignment.reload.grades.index(@grade)}" =>
-          { graded_by_id: @professor.id, instructor_modified: true,
-            student_id: @grade.student_id, raw_points: 1000, status: "Graded",
-            id: @grade.id
+        { "#{assignment.reload.grades.index(grade)}" =>
+          { graded_by_id: professor.id, instructor_modified: true,
+            student_id: grade.student_id, raw_points: 1000, status: "Graded",
+            id: grade.id
           }
         }
       end
 
       it "updates the grades for the specific assignment" do
-        put :mass_update, assignment_id: @assignment.id,
+        put :mass_update, assignment_id: assignment.id,
           assignment: { grades_attributes: grades_attributes }
-        expect(@grade.reload.raw_points).to eq 1000
+        expect(grade.reload.raw_points).to eq 1000
       end
 
       it "timestamps the grades" do
         current_time = DateTime.now
-        put :mass_update, assignment_id: @assignment.id,
+        put :mass_update, assignment_id: assignment.id,
           assignment: { grades_attributes: grades_attributes }
-        expect(@grade.reload.graded_at).to be > current_time
+        expect(grade.reload.graded_at).to be > current_time
       end
 
       it "only sends notifications to the students if the grade changed" do
-        @grade.update_attributes({ raw_points: 1000 })
+        grade.update_attributes({ raw_points: 1000 })
         run_background_jobs_immediately do
-          expect { put :mass_update, assignment_id: @assignment.id,
+          expect { put :mass_update, assignment_id: assignment.id,
                    assignment: { grades_attributes: grades_attributes } }.to_not \
             change { ActionMailer::Base.deliveries.count }
         end
       end
 
       it "redirects to assignment path with a team" do
-        team = create(:team, course: @course)
-        put :mass_update, assignment_id: @assignment.id, team_id: team.id,
+        team = create(:team, course: course)
+        put :mass_update, assignment_id: assignment.id, team_id: team.id,
           assignment: { grades_attributes: grades_attributes }
         expect(response).to \
-          redirect_to(assignment_path(@assignment, team_id: team.id))
+          redirect_to(assignment_path(assignment, team_id: team.id))
       end
 
       it "redirects on failure" do
         allow_any_instance_of(Assignment).to \
           receive(:update_attributes).and_return false
-        put :mass_update, assignment_id: @assignment.id,
+        put :mass_update, assignment_id: assignment.id,
           assignment: { grades_attributes: grades_attributes }
         expect(response).to \
-          redirect_to(mass_edit_assignment_grades_path(@assignment))
+          redirect_to(mass_edit_assignment_grades_path(assignment))
       end
     end
 
     describe "POST self_log" do
       it "redirects back to the root" do
-        expect(post :self_log, assignment_id: @assignment.id ).to \
+        expect(post :self_log, assignment_id: assignment.id ).to \
           redirect_to(:root)
       end
     end
@@ -166,71 +159,68 @@ describe Assignments::GradesController do
     describe "DELETE delete_all" do
       context "when there is no team id" do
         it "deletes all the grades for the assignment" do
-          delete :delete_all, assignment_id: @assignment.id
-          expect(@assignment.reload.grades).to be_empty
+          delete :delete_all, assignment_id: assignment.id
+          expect(assignment.reload.grades).to be_empty
         end
       end
 
       context "when there is a team id" do
-        let(:team) { create(:team, course: @course) }
-        let(:student) { create(:user) }
+        let(:team) { create(:team, course: course) }
         let!(:team_membership) { create(:team_membership, team: team, student: student) }
-        let!(:course_membership) { create(:student_course_membership, user: student, course: @course) }
-        let!(:grade) { create(:grade, student: student, assignment: @assignment, course: @course) }
 
         it "deletes only the grades for the team on the assignment" do
-          expect{ delete :delete_all, assignment_id: @assignment.id, team_id: team.id }.to \
-            change { @assignment.reload.grades.count }.by(-1)
+          expect { delete :delete_all, assignment_id: assignment.id, team_id: team.id }.to \
+            change { assignment.reload.grades.count }.by(-1)
         end
       end
 
       it "redirects to assignments page on success" do
-        delete :delete_all, assignment_id: @assignment.id
-        expect(response).to redirect_to(assignment_path(@assignment))
+        delete :delete_all, assignment_id: assignment.id
+        expect(response).to redirect_to(assignment_path(assignment))
       end
     end
   end
 
   context "as student" do
     before do
-      login_user(@student)
-      allow(controller).to receive(:current_student).and_return(@student)
+      login_user(student)
+      allow(controller).to receive(:current_student).and_return(student)
     end
 
     describe "POST self_log" do
       context "with a student loggable grade" do
-        before(:all) { @assignment.update(student_logged: true) }
+        before(:each) { assignment.update(student_logged: true) }
 
         it "creates a maximum score by the student if present" do
-          post :self_log, assignment_id: @assignment.id
-          grade = @student.grade_for_assignment(@assignment)
-          expect(grade.raw_points).to eq @assignment.full_points
+          post :self_log, assignment_id: assignment.id
+          grade = student.grade_for_assignment(assignment)
+          expect(grade.raw_points).to eq assignment.full_points
         end
 
         it "reports errors on failure to save" do
           allow_any_instance_of(Grade).to receive(:save).and_return false
-          post :self_log, assignment_id: @assignment.id
-          grade = @student.grade_for_assignment(@assignment)
+          post :self_log, assignment_id: assignment.id
+          grade = student.grade_for_assignment(assignment)
           expect(flash[:notice]).to \
             eq("We're sorry, there was an error saving your grade.")
         end
 
         context "with assignment levels" do
           it "creates a score for the student at the specified level" do
-            post :self_log, assignment_id: @assignment.id,
+            post :self_log, assignment_id: assignment.id,
               grade: { raw_points: "10000" }
-            grade = @student.grade_for_assignment(@assignment)
+            grade = student.grade_for_assignment(assignment)
             expect(grade.raw_points).to eq 10000
           end
         end
       end
 
       context "with an assignment not student loggable" do
-        before(:all) { @assignment.update(student_logged: false) }
+        before(:each) { assignment.update(student_logged: false) }
 
         it "creates should not change the student score" do
-          post :self_log, assignment_id: @assignment.id
-          grade = @student.grade_for_assignment(@assignment)
+          post :self_log, assignment_id: assignment.id
+          grade = student.grade_for_assignment(assignment)
           expect(grade.raw_points).to eq nil
         end
       end
@@ -238,42 +228,42 @@ describe Assignments::GradesController do
 
     describe "GET edit_status" do
       it "redirects back to the root" do
-        expect(get :edit_status, assignment_id: @assignment).to \
+        expect(get :edit_status, assignment_id: assignment).to \
           redirect_to(:root)
       end
     end
 
     describe "GET update_status" do
       it "redirects back to the root" do
-        expect(put :update_status, assignment_id: @assignment).to \
+        expect(put :update_status, assignment_id: assignment).to \
           redirect_to(:root)
       end
     end
 
     describe "GET export" do
       it "redirects back to the root" do
-        expect(get :export, assignment_id: @assignment, format: :csv).to \
+        expect(get :export, assignment_id: assignment, format: :csv).to \
           redirect_to(:root)
       end
     end
 
     describe "GET index" do
       it "redirects back to the root" do
-        expect(get :index, { assignment_id: @assignment }).to \
+        expect(get :index, { assignment_id: assignment }).to \
           redirect_to(:root)
       end
     end
 
     describe "GET mass_edit" do
       it "redirects back to the root" do
-        expect(get :mass_edit, { assignment_id: @assignment.id  }).to \
+        expect(get :mass_edit, { assignment_id: assignment.id }).to \
           redirect_to(:root)
       end
     end
 
     describe "PUT mass_update" do
       it "redirects back to the root" do
-        expect(get :mass_update, { assignment_id: @assignment.id  }).to \
+        expect(get :mass_update, { assignment_id: assignment.id }).to \
           redirect_to(:root)
       end
     end

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -165,6 +165,8 @@ describe Assignments::GradesController do
       end
 
       context "when there is a team id" do
+        let!(:other_student) { create(:student_course_membership, course: course).user }
+        let!(:other_grade) { create(:grade, assignment: assignment, course: course, student: other_student) }
         let(:team) { create(:team, course: course) }
         let!(:team_membership) { create(:team_membership, team: team, student: student) }
 


### PR DESCRIPTION
### Status
Ready

### Description
When viewing grades for an assignment, there is a button that allows the user to "Delete All Grades". The delete action was previously deleting all grades for the assignment, regardless of whether the user filtered down students by team or not.

This change allows for the deletion of all grades on the assignment if no team is selected, as well as the deletion of grades for a subset of students belonging to a team.

### Deploy Notes
N/A

### Migrations
NO

### Steps to Test or Reproduce
Ensure grade deletions for an assignment work as intended.

Closes #2527