### PR TITLE
Handle nil scores in points this week calculation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -315,7 +315,7 @@ class User < ActiveRecord::Base
 
   # Returning the total number of points for all grades released this week
   def points_earned_for_course_this_week(course)
-    grades_released_for_course_this_week(course).sum(&:final_points)
+    grades_released_for_course_this_week(course).map(&:final_points).compact.sum
   end
 
   # Grabbing the grade for an assignment


### PR DESCRIPTION
### Status
**READY**

### Description
Bugfix to address situations where students have released grades, that have no points attached to them. I believe in this situation it's an error, but we still need to properly display the total.
