### PR TITLE
Remove in_team_leaderboards_display for teams

### DIFF
--- a/app/views/teams/_in_team_rankings.html.haml
+++ b/app/views/teams/_in_team_rankings.html.haml
@@ -1,6 +1,6 @@
-%h3.subtitle= "In-#{term_for :team} Rankings"
+%h3.subtitle= "In-#{ term_for :team } Rankings"
 - if team.present?
-  - if current_user_is_student? && ! current_student.display_name? && (current_course.has_in_team_leaderboards? || team.has_in_team_leaderboards?)
+  - if current_user_is_student? && ! current_student.display_name?
     %h6.small.right
       %span= "Want to participate in the #{term_for :team} leaderboard?"
       %span.bold= link_to "Set your screen name!", edit_profile_users_path

--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -24,7 +24,7 @@
 
       %hr.dotted
       - if @user.is_student?(current_course)
-        - if current_course.teams_visible? && (current_course.has_in_team_leaderboards? || (current_student.team_for_course(current_course).present? && current_student.team_for_course(current_course).has_in_team_leaderboards?)) || current_course.has_character_names?
+        - if current_course.teams_visible? && (current_course.has_in_team_leaderboards? || current_course.has_character_names?)
           .form-item
             = f.label :display_name, "Pseudonym"
             = f.text_field :display_name


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where the legacy per-team has_in_team_leaderboards method was being referenced. The setting is now solely at the course level. 

### Deploy Notes
Close related bugs on Rollbar after posting to production

### Impacted Areas in Application
Edit profile page, and leaderboard display