### PR TITLE
2568 challenge grade

### DIFF
--- a/app/controllers/challenge_grades_controller.rb
+++ b/app/controllers/challenge_grades_controller.rb
@@ -19,7 +19,8 @@ class ChallengeGradesController < ApplicationController
     @team = @challenge_grade.team
     if @challenge_grade.update_attributes(challenge_grade_params)
 
-      if ChallengeGradeProctor.new(@challenge_grade).viewable?
+      # if challenge grades are released, they're visible to _all_ students
+      if ChallengeGradeProctor.new(@challenge_grade).viewable? user: current_course.students.first
         ChallengeGradeUpdaterJob.new(challenge_grade_id: @challenge_grade.id).enqueue
       end
 

--- a/app/controllers/challenge_grades_controller.rb
+++ b/app/controllers/challenge_grades_controller.rb
@@ -20,7 +20,7 @@ class ChallengeGradesController < ApplicationController
     if @challenge_grade.update_attributes(challenge_grade_params)
 
       # if challenge grades are released, they're visible to _all_ students
-      if ChallengeGradeProctor.new(@challenge_grade).viewable? user: current_course.students.first
+      if ChallengeGradeProctor.new(@challenge_grade).viewable?
         ChallengeGradeUpdaterJob.new(challenge_grade_id: @challenge_grade.id).enqueue
       end
 

--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -15,7 +15,7 @@ class Challenges::ChallengeGradesController < ApplicationController
     @team = @challenge_grade.team
     if @challenge_grade.save
 
-      if ChallengeGradeProctor.new(@challenge_grade).viewable? user: current_user
+      if ChallengeGradeProctor.new(@challenge_grade).viewable?
         ChallengeGradeUpdaterJob.new(challenge_grade_id: @challenge_grade.id).enqueue
       end
 

--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -15,7 +15,7 @@ class Challenges::ChallengeGradesController < ApplicationController
     @team = @challenge_grade.team
     if @challenge_grade.save
 
-      if ChallengeGradeProctor.new(@challenge_grade).viewable?
+      if ChallengeGradeProctor.new(@challenge_grade).viewable? user: current_user
         ChallengeGradeUpdaterJob.new(challenge_grade_id: @challenge_grade.id).enqueue
       end
 

--- a/app/proctors/challenge_grade_proctor.rb
+++ b/app/proctors/challenge_grade_proctor.rb
@@ -2,8 +2,7 @@ require_relative "challenge_grade_proctor/base"
 require_relative "challenge_grade_proctor/viewable"
 require_relative "challenge_grade_proctor/updatable"
 
-# determines what sort of CRUD operations can be performed
-# on a `Grade` resource
+# determines what sort of CRUD operations can be performed on a `ChallengeGrade`
 class ChallengeGradeProctor
   include Viewable
 

--- a/app/proctors/challenge_grade_proctor.rb
+++ b/app/proctors/challenge_grade_proctor.rb
@@ -1,5 +1,6 @@
 require_relative "challenge_grade_proctor/base"
 require_relative "challenge_grade_proctor/viewable"
+require_relative "challenge_grade_proctor/updatable"
 
 # determines what sort of CRUD operations can be performed
 # on a `Grade` resource

--- a/app/proctors/challenge_grade_proctor/base.rb
+++ b/app/proctors/challenge_grade_proctor/base.rb
@@ -1,4 +1,4 @@
-# common methods for CRUD operations on a `Grade`
+# common methods for CRUD operations on a `ChallengeGrade`
 class ChallengeGradeProctor
   module Base
 

--- a/app/proctors/challenge_grade_proctor/updatable.rb
+++ b/app/proctors/challenge_grade_proctor/updatable.rb
@@ -1,8 +1,7 @@
-# Determines if a `ChallengeGrade` resource can be updated by a user. If no user is
-# supplied in the options, it will default to the Grade's student.
+# Determines if a `ChallengeGrade` resource can be updated by a user.
 #
 # Options include:
-#   course:  Will verify the grade is for the course
+#   course:  Will verify the challenge grade is for the course
 #   user:    Determines permissions for supplied user
 #
 class ChallengeGradeProctor

--- a/app/proctors/challenge_grade_proctor/viewable.rb
+++ b/app/proctors/challenge_grade_proctor/viewable.rb
@@ -15,7 +15,7 @@ class ChallengeGradeProctor
       course = options[:course] || challenge_grade.team.course
 
       challenge_grade_for_course?(course) && 
-        (user.is_staff?(course) || challenge_grade_visible_by_students?)
+        ((user.present? && user.is_staff?(course)) || challenge_grade_visible_by_students?)
     end
 
     private

--- a/app/proctors/challenge_grade_proctor/viewable.rb
+++ b/app/proctors/challenge_grade_proctor/viewable.rb
@@ -1,10 +1,8 @@
-# Determines if a `ChallengeGrade` resource can be viewed by a user. If no user
-# is supplied in the options, it will default to the Grade's student.
+# Determines if a `ChallengeGrade` resource can be viewed by a user.
 #
 # Options include:
 #   course:  Will verify the challenge grade is for the course
-#   user:    Determines permissions for supplied user rather than the
-#            challenge grade's student
+#   user:    Determines permissions for supplied user
 #
 class ChallengeGradeProctor
   module Viewable

--- a/app/proctors/challenge_grade_proctor/viewable.rb
+++ b/app/proctors/challenge_grade_proctor/viewable.rb
@@ -16,8 +16,8 @@ class ChallengeGradeProctor
       user = options[:user]
       course = options[:course] || challenge_grade.team.course
 
-      challenge_grade_for_course?(course) &&
-        challenge_grade_visible_by_students?
+      challenge_grade_for_course?(course) && 
+        (user.is_staff?(course) || challenge_grade_visible_by_students?)
     end
 
     private

--- a/app/proctors/grade_proctor/viewable.rb
+++ b/app/proctors/grade_proctor/viewable.rb
@@ -17,8 +17,7 @@ class GradeProctor
       course = options[:course] || grade.course
 
       grade_for_course?(course) &&
-        (user.is_staff?(course) ||
-          (grade_for_user?(user) && grade_visible_by_student?))
+        (user.is_staff?(course) || (grade_for_user?(user) && grade_visible_by_student?))
     end
 
     private

--- a/app/views/api/challenges/index.json.jbuilder
+++ b/app/views/api/challenges/index.json.jbuilder
@@ -31,7 +31,7 @@ json.data @challenges do |challenge|
 
     if @grades.present? && @grades.where(challenge_id: challenge.id).present?
       grade =  @grades.where(challenge_id: challenge.id).first
-      if ChallengeGradeProctor.new(grade).viewable? user: @student
+      if ChallengeGradeProctor.new(grade).viewable?
         json.grade data: { type: "challenge_grades", id: grade.id.to_s }
       end
     end
@@ -52,7 +52,7 @@ json.included do
 
   if @grades.present?
     json.array! @grades do |grade|
-      next unless ChallengeGradeProctor.new(grade).viewable? user: @student
+      next unless ChallengeGradeProctor.new(grade).viewable?
       json.type "challenge_grades"
       json.id grade.id.to_s
       json.attributes do

--- a/app/views/api/challenges/index.json.jbuilder
+++ b/app/views/api/challenges/index.json.jbuilder
@@ -31,7 +31,7 @@ json.data @challenges do |challenge|
 
     if @grades.present? && @grades.where(challenge_id: challenge.id).present?
       grade =  @grades.where(challenge_id: challenge.id).first
-      if ChallengeGradeProctor.new(grade).viewable?(@student)
+      if ChallengeGradeProctor.new(grade).viewable? user: @student
         json.grade data: { type: "challenge_grades", id: grade.id.to_s }
       end
     end
@@ -52,7 +52,7 @@ json.included do
 
   if @grades.present?
     json.array! @grades do |grade|
-      next unless ChallengeGradeProctor.new(grade).viewable?(@student)
+      next unless ChallengeGradeProctor.new(grade).viewable? user: @student
       json.type "challenge_grades"
       json.id grade.id.to_s
       json.attributes do

--- a/app/views/challenges/_index_student.haml
+++ b/app/views/challenges/_index_student.haml
@@ -7,12 +7,13 @@
       %th Due
 
   %tbody
-    - current_course.challenges.visible.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
-      %tr
-        %td= link_to challenge.name, challenge
-        %td
-          - if @team.present? && challenge.challenge_grade_for_team(@team).present?
-            = "#{ points challenge.challenge_grade_for_team(@team).try(:score) } / #{ points challenge.full_points }"
-          - else
-            %span.italic= " #{ points challenge.full_points } points possible"
-        %td= challenge.due_at
+    - current_course.challenges.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
+      - if challenge.visible_for_student?(current_student) || ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable?
+        %tr
+          %td= link_to challenge.name, challenge
+          %td
+            - if @team.present? && challenge.challenge_grade_for_team(@team).present?
+              = "#{ points challenge.challenge_grade_for_team(@team).try(:score) } / #{ points challenge.full_points }"
+            - else
+              %span.italic= " #{ points challenge.full_points } points possible"
+          %td= challenge.due_at

--- a/app/views/challenges/_index_student.haml
+++ b/app/views/challenges/_index_student.haml
@@ -8,11 +8,11 @@
 
   %tbody
     - current_course.challenges.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
-      - if challenge.visible_for_student?(current_student) || ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable?
+      - if challenge.visible? || (ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable? user: current_student)
         %tr
           %td= link_to challenge.name, challenge
           %td
-            - if @team.present? && challenge.challenge_grade_for_team(@team).present?
+            - if @team.present? && (ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable? user: current_student)
               = "#{ points challenge.challenge_grade_for_team(@team).try(:score) } / #{ points challenge.full_points }"
             - else
               %span.italic= " #{ points challenge.full_points } points possible"

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -21,7 +21,7 @@
         - challenge_grade = @challenge.challenge_grades.find_by team: team
         %tr
           %td= team.name
-          %td= points challenge_grade.score if challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?
+          %td= points challenge_grade.score if (challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?(user: current_user))
           - if @challenge.has_levels?
             %td
               = @challenge.grade_level(grade) if challenge_grade

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -21,7 +21,7 @@
         - challenge_grade = @challenge.challenge_grades.find_by team: team
         %tr
           %td= team.name
-          %td= points challenge_grade.score if (challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?(user: current_user))
+          %td= points challenge_grade.score if (challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?)
           - if @challenge.has_levels?
             %td
               = @challenge.grade_level(grade) if challenge_grade

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -21,7 +21,7 @@
         - challenge_grade = @challenge.challenge_grades.find_by team: team
         %tr
           %td= team.name
-          %td= points challenge_grade.score if challenge_grade
+          %td= points challenge_grade.score if challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?
           - if @challenge.has_levels?
             %td
               = @challenge.grade_level(grade) if challenge_grade

--- a/spec/features/editing_a_team_challenge_grade_spec.rb
+++ b/spec/features/editing_a_team_challenge_grade_spec.rb
@@ -3,8 +3,10 @@ require "rails_spec_helper"
 feature "editing a team challenge grade" do
   context "as a professor" do
     let(:course) { create :course, has_team_challenges: true }
-    let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
+    let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
+    let(:student) { create :user }
+    let!(:course_membership_2) { create :student_course_membership, user: student, course: course }
     let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
     let!(:team) { create :team, name: "Team Name", course: course }
     let!(:challenge_grade) { create :challenge_grade, team: team, challenge: challenge, score: 100 }
@@ -37,6 +39,8 @@ feature "editing a team challenge grade" do
         fill_in("challenge_grade_score", with: 101)
         click_button "Update Grade"
       end
+      
+      expect(current_path).to eq challenge_path(challenge.id)
       expect(page).to have_notification_message("notice", "Team Name's Grade for Team Challenge Name Team Challenge successfully updated")
     end
   end

--- a/spec/features/editing_a_team_challenge_grade_spec.rb
+++ b/spec/features/editing_a_team_challenge_grade_spec.rb
@@ -5,8 +5,6 @@ feature "editing a team challenge grade" do
     let(:course) { create :course, has_team_challenges: true }
     let(:professor) { create :user }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
-    let(:student) { create :user }
-    let!(:course_membership_2) { create :student_course_membership, user: student, course: course }
     let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
     let!(:team) { create :team, name: "Team Name", course: course }
     let!(:challenge_grade) { create :challenge_grade, team: team, challenge: challenge, score: 100 }


### PR DESCRIPTION
### Status

**READY**
### Description

This PR fixes two bugs: 
1) Released grades for invisible challenges were never showing to students
2) On a single challenge show page, unreleased grades were showing to students
### Steps to Test or Reproduce

1) Go to the team index page on the student side. Confirm that the awarded grade for the invisible challenge in sample data displays the points awarded.
2) On the instructor side, set one challenge grade to "In Progress." Go to that challenge show page on the student side, and confirm that the challenge grade set to In Progress does not display.  
### Impacted Areas in Application

Teams display page, challenge show page
