### PR TITLE
Bugfix the recording of student's last course login event

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,7 @@ class ApplicationController < ActionController::Base
     return unless request.format.html? || request.format.xml?
     event_attrs = event_session.merge event_options
     return unless [:course, :user].all? { |attr| event_attrs[attr].present? }
+    current_user.course_memberships.where(course: current_course).first.last_login_at = Time.now
     LoginEventLogger.new(event_attrs).enqueue_with_fallback
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where Sorcery handled recording a User's last login, but we needed this data per-course. 

### Deploy Notes
Check to make sure the non-predictor analytics displays start to reflect this new data.

