### PR TITLE
clear LTI UID when copying a course

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -102,11 +102,11 @@ class Course < ActiveRecord::Base
 
   def copy(copy_type, attributes={})
     if copy_type != "with_students"
-      copy_with_associations(attributes, [])
+      copy_with_associations(attributes={lti_uid: nil}, [])
     else
       begin
         Course.skip_callback(:create, :after, :create_admin_memberships)
-        copy_with_associations(attributes, [:course_memberships])
+        copy_with_associations(attributes={lti_uid: nil}, [:course_memberships])
       ensure
         Course.set_callback(:create, :after, :create_admin_memberships)
       end
@@ -274,6 +274,6 @@ class Course < ActiveRecord::Base
                                  :challenges,
                                  :grade_scheme_elements
                                ] + associations,
-                               options: { prepend: { name: "Copy of " }})
+                               options: { prepend: { name: "Copy of "} })
   end
 end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR clears the LTI UID if one is set on a course when it's copied. This prevents a whole host of issues that occur when Canvas attempts to connect to a GC site via the LTI ID, and there are two courses present. 

### Steps to Test or Reproduce
1) Set an LTI UID value on a course.
2) Copy that course
3) Confirm that the LTI UID of the copied course has been cleraed