### PR TITLE
fixed predictor styling to show graph on mobile and remove gap due to…

### DIFF
--- a/app/assets/stylesheets/layout/_student_sidebar.sass
+++ b/app/assets/stylesheets/layout/_student_sidebar.sass
@@ -8,15 +8,20 @@
   overflow: hidden
   min-height: 100%
   border-right: 1px solid $color-grey-6
-  
+
+.staff .student-panel
+  margin-top: -2.75rem
+
 .student-panel
   width: 400px
-  top: -1rem
+  margin-top: -1rem
   float: right
   height: 100%
   position: relative
   font-weight: 300
   z-index: 18
+  @media (max-width: $media-medium-max)
+    display: none
   .align-box
     width: 100px
     height: 100px
@@ -52,16 +57,16 @@
     overflow: hidden
 
   .info-hint-pulse
-      border: 3px solid $color-blue-4
-      border-radius: 30px
-      height: 12px
-      width: 12px
-      position: absolute
-      right: 5px
-      top: 0px
-      animation: pulsate 2s linear
-      animation-iteration-count: infinite
-      opacity: 0.0
+    border: 3px solid $color-blue-4
+    border-radius: 30px
+    height: 12px
+    width: 12px
+    position: absolute
+    right: 5px
+    top: 0px
+    animation: pulsate 2s linear
+    animation-iteration-count: infinite
+    opacity: 0.0
   .hide-hint-link
     text-align: right
     color: $color-blue-3
@@ -131,17 +136,12 @@
    background-color: $color-grey-4
 
 .badge-panel
+  margin-top: -4rem
   .student-panel-article-header.status-completed
     background-color: $color-blue-3
     &.status-no-points
       background-color: $color-blue-3
 
-.badge-panel
-  margin-top: -3rem
-
-@media (max-width: $media-medium-max)
-  .student-panel
-    display: none
 
 @keyframes pulsate
     0% {transform: scale(1, 1); opacity: 0.0;}

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -42,7 +42,7 @@ $card-margin-1 : 3px
   height: 140px
 
 .predictor-graph
-  width: calc(100% - 401px)
+  width: 100%
   max-width: 1099px
   position: fixed
   top: 80px
@@ -229,7 +229,7 @@ $card-margin-1 : 3px
     height: 18px
     border-radius: 50%
   .coin
-      margin: 2px 0 0 -16px
+    margin: 2px 0 0 -16px
   .coin-non-interactive, .coin-slot
     margin: 2px 0 0 2px
   .coin, .coin-non-interactive
@@ -518,22 +518,16 @@ $card-margin-1 : 3px
       margin: 8px 3px
 
 
-// small
-@media (max-width: $media-small-max)
-  @include mobile-headers-mixin
-  @include mobile-graph-mixin
+// large
+@media (min-width: $media-medium-max + 5rem) and (max-width: $media-large-max)
   .predictor-article-card
-    width: $card-width-1
-    margin: $card-margin-1
-    .info-icon
-      display: none
-  .collapse-arrow.doubled
-    margin: 35px 0 0 0
-
-  .student .predictor-graph
-    margin-top: 0rem
-    top: 45px
-
+    width: $card-width-3
+    margin: $card-margin-3
+  #predictor-main-header, .predictor-section
+  .mainContainer.staff
+    .predictor-article-card
+      width: $card-width-1
+      margin: $card-margin-1
 
 // medium
 @media (min-width: $media-small-max) and (max-width: $media-medium-max + 5rem)
@@ -549,14 +543,18 @@ $card-margin-1 : 3px
     .student-panel
       display: none
 
-
-// large
-@media (min-width: $media-medium-max + 5rem) and (max-width: $media-large-max)
+// small
+@media (max-width: $media-small-max)
+  @include mobile-headers-mixin
+  @include mobile-graph-mixin
   .predictor-article-card
-    width: $card-width-3
-    margin: $card-margin-3
-  #predictor-main-header, .predictor-section
-  .mainContainer.staff
-    .predictor-article-card
-      width: $card-width-1
-      margin: $card-margin-1
+    width: $card-width-1
+    margin: $card-margin-1
+    .info-icon
+      display: none
+  .collapse-arrow.doubled
+    margin: 35px 0 0 0
+
+  .student .predictor-graph
+    margin-top: 0rem
+    top: 45px

--- a/app/assets/stylesheets/utilities/_mixins.sass
+++ b/app/assets/stylesheets/utilities/_mixins.sass
@@ -99,8 +99,9 @@
     cursor: pointer
 
 @mixin mobile-graph-mixin
-  #predictor-graph-svg
+  .staff #predictor-graph-svg
     height: 175px
+  #predictor-graph-svg
     .grade-point-axis text
       font-size: $predictor-font-size-6
     #svg-keys
@@ -109,8 +110,6 @@
       transform: translate(10px,120px)
     #svg-predicted-grade
       transform: translate(10px, 160px)
-  #predictor-post-graph-spacer
-    height: 175px
 
 // mixin for all rubric level form fields
 @mixin rubric-level-input


### PR DESCRIPTION
### Status
READY

### Description
This PR allows the predictor graph to show on mobile and removes gap caused by padding on pageheader (div containing breadcrumbs and pagetitle)


### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grade predictor on student side and predictor preview on instructor side as well as badge page for students.

We need to consider creating a no pagetitle/no breadcrumb layout to accommodate these side panel style pages. Right now, we are writing a lot of extra styling to make up for this.

Closes #2575 