### PR TITLE
add earned badge update service for saving a grade

### DIFF
--- a/app/services/creates_earned_badge/updates_earned_badges_for_grade.rb
+++ b/app/services/creates_earned_badge/updates_earned_badges_for_grade.rb
@@ -1,0 +1,15 @@
+require_relative "../../proctors/earned_badge_proctor"
+
+module Services
+  module Actions
+    class UpdatesEarnedBadgesForGrade
+      extend LightService::Action
+
+      expects :grade
+
+      executed do |context|
+        EarnedBadge.where(grade_id: context[:grade].id).each(&:save)
+      end
+    end
+  end
+end

--- a/app/services/creates_grade_using_rubric.rb
+++ b/app/services/creates_grade_using_rubric.rb
@@ -4,6 +4,7 @@ require_relative "creates_criterion_grade/builds_earned_level_badges"
 require_relative "creates_criterion_grade/saves_criterion_grades"
 require_relative "creates_criterion_grade/saves_earned_level_badges"
 require_relative "creates_criterion_grade/verifies_assignment_student"
+require_relative "creates_earned_badge/updates_earned_badges_for_grade"
 require_relative "creates_grade/associates_submission_with_grade"
 require_relative "creates_grade/builds_grade"
 require_relative "creates_grade/marks_as_graded"
@@ -26,6 +27,7 @@ module Services
           Actions::AssociatesSubmissionWithGrade,
           Actions::MarksAsGraded,
           Actions::SavesGrade,
+          Actions::UpdatesEarnedBadgesForGrade,
           Actions::BuildsEarnedLevelBadges,
           Actions::SavesEarnedLevelBadges,
           Actions::RunsGradeUpdaterJob

--- a/spec/services/creates_earned_badge/updates_badges_for_grade_spec.rb
+++ b/spec/services/creates_earned_badge/updates_badges_for_grade_spec.rb
@@ -1,0 +1,23 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_earned_badge/updates_earned_badges_for_grade"
+
+describe Services::Actions::UpdatesEarnedBadgesForGrade do
+  let(:course) { create :course }
+  let(:assignment) { create :assignment, course: course }
+  let(:student) { create(:student_course_membership, course: course).user }
+  let!(:grade) { create :released_grade, student: student, assignment: assignment }
+  let(:badge) { create :badge, course: course }
+  let!(:earned_badge) { create :earned_badge, badge: badge, grade: grade, student_visible: false }
+
+
+  it "expects attributes to have a grade" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "updates the earned badge with the correct awarded_by" do
+    described_class.execute grade: grade
+    expect(earned_badge.student_visible).to be_truthy
+  end
+end

--- a/spec/services/creates_grade_using_rubric_spec.rb
+++ b/spec/services/creates_grade_using_rubric_spec.rb
@@ -42,6 +42,11 @@ describe Services::CreatesGradeUsingRubric do
       described_class.create params, agent
     end
 
+    it "updates the badges for grade" do
+      expect(Services::Actions::UpdatesEarnedBadgesForGrade).to receive(:execute).and_call_original
+      described_class.create params, agent
+    end
+
     it "creates level badges" do
       expect(Services::Actions::BuildsEarnedLevelBadges).to receive(:execute).and_call_original
       described_class.create params, agent


### PR DESCRIPTION
### Status
**READY**

### Description

Adds a service action that resaves all EarnedBadges associated with a grade. This will ensure that the visibility status is updated to reflect that of the Grade.

### Related PRs

  * #2587 request to verify this behavior works for standard edit grades as well.
  * #2583 requests a more thorough refactoring of the Earned Badge Lifecycle. 

### Steps to Test or Reproduce
As a professor: In the grade rubric form, add a badge, and then save the grade as released. As a student: verify that the badge shows as earned.

### Impacted Areas in Application

EarnedBadges awarded on a grade from the rubric grade form.