### PR TITLE
update badges on grades when grade is updated

### DIFF
--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -20,6 +20,7 @@ class Assignments::GradesController < ApplicationController
 
     grade_ids = grades.collect do |grade|
       grade.update(status: status)
+      EarnedBadge.where(grade_id: grade.id).each(&:save)
       grade.id
     end
 

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -35,6 +35,7 @@ class GradesController < ApplicationController
 
     if grade.update_attributes grade_params.merge(graded_at: DateTime.now, instructor_modified: true)
       if GradeProctor.new(grade).viewable?
+        EarnedBadge.where(grade_id: grade.id).each(&:save)
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end
       if params[:redirect_to_next_grade].present?

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -33,6 +33,12 @@ describe Assignments::GradesController do
         put :update_status, { assignment_id: assignment.id, grade_ids: [grade.id], grade: { status: "Graded" }}
         expect(response).to redirect_to(login_path)
       end
+
+      it "updates badges earned on the grade" do
+        earned_badge = create :earned_badge, grade: grade, student_visible: false
+        put :update_status, { assignment_id: assignment.id, grade_ids: [grade.id], grade: { status: "Graded" }}
+        expect(earned_badge.reload.student_visible).to be_truthy
+      end
     end
 
     describe "GET export" do

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -103,6 +103,12 @@ describe GradesController do
         expect(grade.reload.score).to eq(nil)
       end
 
+      it "updates badges earned on the grade" do
+        earned_badge = create :earned_badge, grade: grade, student_visible: false
+        put :update, { id: grade.id, grade: { status: "Graded" }}
+        expect(earned_badge.reload.student_visible).to be_truthy
+      end
+
       context "when grading a series of students" do
         let!(:next_student) do
           create(:student_course_membership, course: course,


### PR DESCRIPTION
### Status
**READY**

### Description
Adds earned badge for grade re-saving through grade routes that can affect a grades status, and the visibility of the earned badge by association.

### Related PRs

#2588 (merged)
closes #2587
#2583 (partially addressed -- status changes)

###Steps to Test or Reproduce

Submit a grade through the standard Grade form, verify that an associated earned badge is visible to the student.

Same should be true through the grade status change.