### PR TITLE
2592 canvas grade import enhancements

### DIFF
--- a/app/importers/grade_importers.rb
+++ b/app/importers/grade_importers.rb
@@ -1,3 +1,2 @@
 require_relative "grade_importers/canvas_grade_importer"
 require_relative "grade_importers/csv_grade_importer"
-

--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -24,6 +24,7 @@ class CanvasGradeImporter
 
         grade.raw_points = canvas_grade["score"]
         grade.feedback = canvas_grade["submission_comments"]
+        grade.instructor_modified = true
 
         if grade.save
           link_imported canvas_grade["id"], grade

--- a/app/importers/student_importers/canvas_student_importer.rb
+++ b/app/importers/student_importers/canvas_student_importer.rb
@@ -18,7 +18,7 @@ class CanvasStudentImporter
 
         if user.valid?
           link_imported canvas_student["id"], user
-          successful << user
+          successful << user unless user.previous_changes.empty?
         else
           unsuccessful << { data: canvas_student,
                             errors: user.errors.full_messages.join(", ") }

--- a/spec/importers/grade_importers/canvas_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/canvas_grade_importer_spec.rb
@@ -38,6 +38,7 @@ describe CanvasGradeImporter do
         expect(grade.student).to eq user
         expect(grade.raw_points).to eq 98
         expect(grade.feedback).to eq "This is great!"
+        expect(grade).to be_instructor_modified
       end
 
       it "creates a link to the grade id in canvas" do

--- a/spec/importers/student_importers/canvas_student_importer_spec.rb
+++ b/spec/importers/student_importers/canvas_student_importer_spec.rb
@@ -64,11 +64,20 @@ describe CanvasStudentImporter do
         expect(imported_user.last_imported_at).to be_within(1.second).of(DateTime.now)
       end
 
-      it "contains a successful row if the user is valid" do
+      it "contains a successful row if the user is valid and changed" do
         result = subject.import course
 
         expect(result.successful.count).to eq 1
         expect(result.successful.last).to eq student
+      end
+
+      it "does not contain a successful row if the user was not changed" do
+        existing_student = create :user, email: "jimmy@example.com", first_name: "Jimmy",
+          last_name: "Page"
+
+        result = subject.import course
+
+        expect(result.successful).to be_empty
       end
 
       it "contains an unsuccessful row if the user is not valid" do


### PR DESCRIPTION
### Status
**READY**

### Description
This adds some improvements to the existing canvas grade importer.

1. It marks any Canvas imported `Grade` as `instructor_modified`.
2. When importing Canvas grades, the students are imported as well. It used to report all students as successful, even if they were not imported. This now adds a check to ensure that only changed students get counted in the successful bucket.

### Related PRs

### Deploy Notes

### Migrations
NO

### Steps to Test or Reproduce

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing grades from Canvas

Closes #2592
