### PR TITLE
summing of completed group members bugfix

### DIFF
--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -50,7 +50,7 @@ class UnlockCondition < ActiveRecord::Base
     unlocked_count = 0
     return 0 unless group.present?
     group.students.each do |student|
-      unlocked_count += group.students.count { |student| self.is_complete?(student) }
+      unlocked_count += 1 if self.is_complete?(student)
     end
     return unlocked_count
   end
@@ -110,18 +110,18 @@ class UnlockCondition < ActiveRecord::Base
       "Completed"
     end
   end
-  
+
   def check_assignment_type_condition(student)
     method = "check_#{ condition_state.parameterize('_') }_condition"
     self.send method, student
   end
-  
+
   def check_assignments_completed_condition(student)
     assignment_type = AssignmentType.find(condition_id)
     assignment_completed_count = assignment_type.count_grades_for(student)
     assignment_completed_count >= condition_value
   end
-  
+
   def check_min_points_condition(student)
     assignment_type = AssignmentType.find(condition_id)
     assignment_type_score = assignment_type.score_for_student(student)


### PR DESCRIPTION
### Description
Bugfix for group member sum for unlocked conditions. 

### Steps to Test or Reproduce

Create group for "Group-Assignment-Unlocked-By-Submission" and submit for one student.

#### before:

![screen shot 2016-10-20 at 2 30 04 pm](https://cloud.githubusercontent.com/assets/1138350/19572818/c7cd9f48-96d1-11e6-96b2-7c8e503e02fa.png)

#### after:

![screen shot 2016-10-20 at 2 29 41 pm](https://cloud.githubusercontent.com/assets/1138350/19572831/d5738482-96d1-11e6-9747-703dd4e90b09.png)

#### Related

Based on the description, it's possible that this shouldn't be unlocked for any student until all have submitted? Currently is unlocked for any student who submits, locked for others until they submit.


