### PR TITLE
1743 predictions close

### DIFF
--- a/app/assets/javascripts/angular/directives/student_panel/article_icon.coffee
+++ b/app/assets/javascripts/angular/directives/student_panel/article_icon.coffee
@@ -4,7 +4,10 @@
 # "is_required", "is_late", "has_info", "is_locked", "has_been_unlocked", "is_a_condition", "group"
 # example:
 #   .predictor-article-icon{'ng-repeat'=>'icon in icons', 'icon-name'=>'icon', 'article'=>'assignment', 'article_type'=>'assignment'}
-# Does not handle locked/unlocked icons, which include lists of lock conditions
+#
+# This Does not handle locked/unlocked icons, which include lists conditions
+# and is managed by /templates/student_panel/panel_article/condition_icons.html.haml
+
 @gradecraft.directive 'studentPanelArticleIcon', [ 'StudentPanelService', (StudentPanelService)->
 
   return {

--- a/app/assets/javascripts/angular/services/AssignmentService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.js.coffee
@@ -37,8 +37,18 @@
         # add null prediction and grades when JSON contains none
         assignment.prediction = { predicted_points: 0 } if !assignment.prediction
         assignment.grade = { score: null, final_points: null, is_excluded: false } if !assignment.grade
-      )
 
+        # Iterate through all Assignments that are conditions,
+        # If they are closed_without_submission,
+        # flag this assignment to be closed as well
+        if assignment.conditional_assignment_ids
+          assignment.is_closed_by_condition = false
+          _.each(assignment.conditional_assignment_ids, (id)->
+            a = _.find(assignments, {id: id})
+            if a.is_closed_without_submission == true
+              assignment.is_closed_by_condition = true
+          )
+      )
       GradeCraftAPI.setTermFor("assignment", response.meta.term_for_assignment)
       GradeCraftAPI.setTermFor("pass", response.meta.term_for_pass)
       GradeCraftAPI.setTermFor("fail", response.meta.term_for_fail)

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -122,6 +122,8 @@
   articleCompleted = (article)->
     if article.type == "badges"
       return ! article.can_earn_multiple_times && article.earned_badge_count > 0
+    if article.is_closed_without_submission == true
+      return true
     if article.grade.score == null
       return false
     else

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -136,7 +136,9 @@
     # Always treats badges as if they "count"
     return false if article.type == "badges"
     return true if article.grade.pass_fail_status == "Fail"
-    return true if article.grade.score == 0
+    return true if article.grade.score == 0 ||
+      article.is_closed_without_submission == true ||
+      article.is_closed_by_condition == true
     return true if article.grade.is_excluded
     return false
 

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -124,6 +124,8 @@
       return ! article.can_earn_multiple_times && article.earned_badge_count > 0
     if article.is_closed_without_submission == true
       return true
+    if article.is_closed_by_condition == true
+      return true
     if article.grade.score == null
       return false
     else

--- a/app/assets/javascripts/angular/templates/predictor/article_assignment_content.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/article_assignment_content.html.haml
@@ -1,7 +1,10 @@
 .article-completed{'ng-if' => 'articleCompleted()', 'ng-class'=>'{"excluded" : article.grade.is_excluded}'}
 
   .grade{'ng-if' => '!article.pass_fail'}
-    {{article.grade.final_points | number}} / {{article.full_points | number}}
+    %span{'ng-if' => 'article.grade.final_points != null'} {{article.grade.final_points | number}}
+    %span{'ng-if' => 'article.grade.final_points == null'} 0
+
+    %span / {{article.full_points | number}}
 
   .grade{'ng-if' => 'article.pass_fail'}
     .no-status{{'ng-if'=>'!article.grade.pass_fail_status'}}

--- a/app/assets/javascripts/angular/templates/student_panel/panel_article/condition_icons.html.haml
+++ b/app/assets/javascripts/angular/templates/student_panel/panel_article/condition_icons.html.haml
@@ -8,7 +8,7 @@
 
 .multi-part-icon{'ng-if' => 'article.has_been_unlocked'}
   .icon.is_unlocked
-    %i.fa.fa-fw.fa-unlock-alt
+    %i.fa.fa-fw.fa-unlock
   %span this {{articleTerm()}} has been unlocked
   %ul.icon-list
     %li{'ng-repeat' => 'condition in article.unlocked_conditions'}

--- a/app/views/api/assignments/index.json.jbuilder
+++ b/app/views/api/assignments/index.json.jbuilder
@@ -77,6 +77,7 @@ json.data @assignments do |assignment|
     # conditions and keys
 
     if assignment.unlock_conditions.present?
+
       unlock_conditions = assignment.unlock_conditions.map do |condition|
         condition.requirements_description_sentence
       end
@@ -86,6 +87,9 @@ json.data @assignments do |assignment|
         condition.requirements_completed_sentence
       end
       json.unlocked_conditions unlocked_conditions
+
+      # used in predictor front end to determine if any conditions are closed
+      json.conditional_assignment_ids assignment.unlock_conditions.where(condition_type: "Assignment").pluck(:condition_id)
     end
 
     if assignment.unlock_keys.present?

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1390,6 +1390,41 @@ test that teaches you a lesson. – Tom Bodett",
   }
 }
 
+@assignments[:passed_unlock_submission_condition] = {
+  quotes: {
+  },
+  assignment_type: :unlocks,
+  attributes: {
+    name: "Past-Submission-Key",
+    description:
+      "It's too late, but I was the thing you need to submit to unlock 'Unlocked-By-Past-Submission'",
+    due_at: 4.weeks.ago,
+    full_points: 180000,
+    accepts_submissions: true,
+    accepts_attachments: true,
+    accepts_links: true,
+    accepts_text: true,
+  }
+}
+
+@assignments[:past_submission_is_an_unlock] = {
+  quotes: {
+  },
+  assignment_type: :unlocks,
+  attributes: {
+    name: "Unlocked-By-Past-Submission",
+    description: "Submitting 'Submission-Key' would have unlocked this assignment, now I am closed in the predictor",
+    full_points: 180000,
+  },
+  unlock_condition: true,
+  unlock_attributes: {
+    condition: :passed_unlock_submission_condition,
+    condition_type: "Assignment",
+    condition_state: "Submitted"
+  }
+}
+
+
 #------------------------------------------------------------------------------#
 
 #                        Sorting Assignment Type

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -603,7 +603,7 @@ on hover",
   assignment_type: :predictor,
   attributes: {
     name: "Past Assignment no Grade but Prediction",
-    description: "Fixed at 0 points, displays 'Closed' and 'Late' icons.",
+    description: "Has prediction but closed at 0 points in the Predictor. displays 'Closed' and 'Late' icons.",
     due_at: 1.week.ago,
     accepts_submissions: true,
     accepts_submissions_until: 1.week.ago,
@@ -688,7 +688,7 @@ accepts predictions.",
   assignment_type: :predictor,
   attributes: {
     name: "Not Submitted, Closed",
-    description: "Fixed at 0 points, displays 'Closed' and 'Late' icons.",
+    description: "Fixed at 0 points, displays 'Closed' and 'Late' icons. Closed in Predictor",
     due_at: 1.week.ago,
     accepts_submissions_until: 1.week.ago,
     full_points: 15000,
@@ -697,12 +697,6 @@ accepts predictions.",
     accepts_attachments: true,
     accepts_text: true,
     accepts_links: true,
-  },
-  grades: true,
-  grade_attributes: {
-    instructor_modified: false,
-    raw_points: -> { nil },
-    status: nil,
   },
   prediction: true,
   prediction_attributes: {
@@ -1397,13 +1391,11 @@ test that teaches you a lesson. – Tom Bodett",
   attributes: {
     name: "Past-Submission-Key",
     description:
-      "It's too late, but I was the thing you needed to submit to unlock 'Unlocked-By-Past-Submission'",
+      "It's too late, but I was the thing you needed to submit to unlock 'Unlocked-By-Past-Submission' Should be closed in Predictor",
     due_at: 4.weeks.ago,
     full_points: 180000,
     accepts_submissions: true,
-    accepts_attachments: true,
-    accepts_links: true,
-    accepts_text: true,
+    accepts_submissions_until: 1.week.ago,
   }
 }
 

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1397,7 +1397,7 @@ test that teaches you a lesson. – Tom Bodett",
   attributes: {
     name: "Past-Submission-Key",
     description:
-      "It's too late, but I was the thing you need to submit to unlock 'Unlocked-By-Past-Submission'",
+      "It's too late, but I was the thing you needed to submit to unlock 'Unlocked-By-Past-Submission'",
     due_at: 4.weeks.ago,
     full_points: 180000,
     accepts_submissions: true,


### PR DESCRIPTION
### Status
**READY**

### Description

This PR improves the display of predictions for Assignments that are now closed to this student.  The conditions that cause this are: the `assignment.submissions_have_closed` and the student has not submitted anything for this assignment.

It also manages closing Assignments when conditional assignments are also closed.  This is rather ugly because conditions can be badges or assignments, and each one has to be checked for this condition in the context of this student. The best solution I could come up with was to pass the ids of all condition `Assignments` through the json, and then check each of them in Angular for `submissions_have_closed`, which sets a `is_closed_by_condition` boolean on the original assignment.

### Steps to Test or Reproduce

Load the predictor and verify that the following sample Assignments are displayed as earning zero points and without a slider:

  * Under Predictor Settings
    * "Past Assignment no Grade but Prediction"
    * "Not Submitted, Closed"

  * Under Unlock Settings
    * "Past-Submission-Key"
    * "Unlocked-By-Past-Submission"

### Impacted Areas in Application

* Predictor display of assignments who's submission acceptance is closed 

### Related

closes #1743
