### PR TITLE
2585-hover-message-placement-assignment-index

### DIFF
--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -89,16 +89,6 @@ a:hover + .display-on-hover
       display: block
       clear: both
 
-.centered
-  position: absolute
-  left: 50%
-  top: 50%
-  transform: translate(-50%, -50%)
-
-.hover-style.right
-  position: absolute
-  margin-left: -240px
-
 .preview-bar
   padding: 1rem 1rem .75rem
 

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -123,6 +123,11 @@
     word-wrap: break-word
     white-space: nowrap
 
+.assignment-details-icon
+  position: relative
+  .hover-style
+    left: 0
+
 .assignment-info
   display: inline-block
   font-size: 0.8rem

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -100,6 +100,18 @@
   &.predicted
     border-left: 2px solid $color-orange-1
 
+  .assignment-name
+    display: inline-block
+    width: 50%
+    @media (max-width: $media-medium-max)
+      width: 90%
+      font-size: 0.9rem
+      height: 1.3rem
+      overflow: hidden
+      text-overflow: ellipsis
+      word-wrap: break-word
+      white-space: nowrap
+
 .assignment-indicator-icon
   width: 16px
   @media (max-width: $media-medium-max)
@@ -110,18 +122,6 @@
     color: $color-orange-1
   .asterisk
     color: $color-purple-2
-
-.assignment-name
-  display: inline-block
-  width: 50%
-  @media (max-width: $media-medium-max)
-    width: 90%
-    font-size: 0.9rem
-    height: 1.3rem
-    overflow: hidden
-    text-overflow: ellipsis
-    word-wrap: break-word
-    white-space: nowrap
 
 .assignment-details-icon
   position: relative

--- a/app/views/assignments/student_index/_assignment_table.haml
+++ b/app/views/assignments/student_index/_assignment_table.haml
@@ -6,15 +6,15 @@
           %span.checkmark= glyph(:check)
         - elsif assignment.is_predicted_by_student?(current_student)
           %span.flag= glyph(:flag)
-        - if assignment.required? && !assignment.is_predicted_by_student?(current_student)
+        - if assignment.required? && !assignment.is_predicted_by_student?(current_student) && !GradeProctor.new(presenter.grade_for(assignment)).viewable?
           %a.asterisk= glyph(:asterisk)
-          .display_on_hover.hover-style
-            This #{term_for :assignment} is required!
+          .display-on-hover.hover-style
+            %p This #{term_for :assignment} is required!
 
       .assignment-name
         - if presenter.name_visible?(assignment)
           = link_to assignment.name, assignment_path(assignment)
-          %span= render partial: "assignments/student_index/components/assignment_icons", locals: { presenter: presenter, assignment: assignment }
+          = render partial: "assignments/student_index/components/assignment_icons", locals: { presenter: presenter, assignment: assignment }
         - else
           %i= "The name for this #{term_for :assignment} has been hidden until you unlock it"
       .assignment-info.assignment-due-date

--- a/app/views/assignments/student_index/components/_assignment_icons.haml
+++ b/app/views/assignments/student_index/components/_assignment_icons.haml
@@ -1,13 +1,11 @@
-%span
+%span.assignment-details-icon
   - if assignment.has_groups?
-    %a
-      %i.fa.fa-group.fa-fw
+    %a= glyph(:group)
     .display-on-hover.hover-style
       This #{term_for :assignment} is completed by #{term_for :students} in #{term_for :groups}
   - if assignment.is_unlockable?
     - if ! assignment.is_unlocked_for_student?(presenter.student)
-      %a
-        %i.fa.fa-lock
+      %a= glyph(:lock)
       .display-on-hover.hover-style
         %h3 This #{term_for :assignment} is Locked
         .small.italic In order to unlock it you must:
@@ -15,8 +13,7 @@
           - assignment.unlock_conditions.each do |condition|
             %li= condition.requirements_description_sentence
     - else
-      %a
-        %i.fa.fa-unlock
+      %a= glyph(:unlock)
       .display-on-hover.hover-style
         %h3 You have unlocked this #{term_for :assignment}
         .small.italic To achieve this you:
@@ -24,8 +21,7 @@
           - assignment.unlock_conditions.each do |condition|
             %li= condition.requirements_completed_sentence
   - if assignment.is_a_condition?
-    %a
-      %i.fa.fa-key
+    %a= glyph(:key)
     .display-on-hover.hover-style
       %h3 This #{term_for :assignment} is a Key
       %ol


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updated hover states on assignment details icons and added logic to show required icon only if assignment is neither graded nor predicted.

### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Student assignment index page

Closes issue #2585 