### PR TITLE
Fix viewable bug in grade history

### DIFF
--- a/app/models/history_filter.rb
+++ b/app/models/history_filter.rb
@@ -9,6 +9,23 @@ class HistoryFilter
     @history = history
   end
 
+  def clear_initial_value(*attributes)
+    attrs = Array(attributes).flatten
+
+    attrs.each do |attribute|
+      @history = history.select do |history_item|
+        unless history_item.changeset[attribute].nil? ||
+               history_item.changeset[attribute][0].nil?
+          history_item.changeset[attribute][0] = ""
+        end
+        history_item
+      end
+    end
+
+    clear_empty_changesets
+    self
+  end
+
   def exclude(options={})
     exclusions = options.keys
 

--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -25,18 +25,43 @@ module Submissions::GradeHistory
           history_item.changeset["event"] = "upload"
         end
       end
+      .transform do |history_item|
+        # Check to see if this change is for a grade and it's an update
+        if history_item.changeset["object"] == "Grade" &&
+            history_item.version.event == "update" &&
+            only_student_visible_grades
+
+          version = history_item.version.reify
+
+          # Check to see if the current version is viewable. If it is, check the previous version based on the attributes
+          # we care about (feedback and raw score). If that version is not viewable
+          if GradeProctor.new(version).viewable?
+            ["feedback", "raw_points"].each do |attribute|
+              previous_changeset = history_item.version.changeset[attribute]
+              if previous_changeset.present?
+                previous_version = version.versions.select { |v| v.changeset[attribute].present? && v.changeset[attribute][1] == previous_changeset[0] }.last
+                if previous_version.present?
+                  history_item.changeset[attribute][0] = "" if !GradeProctor.new(previous_version.reify).viewable?
+                end
+              end
+            end
+          end
+        end
+      end
       .rename("SubmissionFile" => "Attachment")
       .include do |history_item, history|
         viewable = true
 
-        if history_item.changeset["object"] == "Grade" && only_student_visible_grades
+        if history_item.changeset["object"] == "Grade" &&
+            history_item.version.event == "update" &&
+            only_student_visible_grades
+
           version = history_item.version.reify
           viewable = GradeProctor.new(version).viewable?
 
-          # Make the change viewable if the grade was updated first but then it was
-          # released. This displays the changeset where the grade was updated
-
-          if !viewable && history_item.version.event == "update"
+          # Make the change viewable if the grade was updated first but then it
+          # was released. This displays the changeset where the grade was updated
+          if !viewable
             last_raw_points_change = last_change?(history, history_item, "Grade",
                                                   "raw_points")
 

--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -25,29 +25,7 @@ module Submissions::GradeHistory
           history_item.changeset["event"] = "upload"
         end
       end
-      .transform do |history_item|
-        # Check to see if this change is for a grade and it's an update
-        if history_item.changeset["object"] == "Grade" &&
-            history_item.version.event == "update" &&
-            only_student_visible_grades
-
-          version = history_item.version.reify
-
-          # Check to see if the current version is viewable. If it is, check the previous version based on the attributes
-          # we care about (feedback and raw score). If that version is not viewable
-          if GradeProctor.new(version).viewable?
-            ["feedback", "raw_points"].each do |attribute|
-              previous_changeset = history_item.version.changeset[attribute]
-              if previous_changeset.present?
-                previous_version = version.versions.select { |v| v.changeset[attribute].present? && v.changeset[attribute][1] == previous_changeset[0] }.last
-                if previous_version.present?
-                  history_item.changeset[attribute][0] = "" if !GradeProctor.new(previous_version.reify).viewable?
-                end
-              end
-            end
-          end
-        end
-      end
+      .clear_initial_value("raw_score", "feedback")
       .rename("SubmissionFile" => "Attachment")
       .include do |history_item, history|
         viewable = true

--- a/spec/models/history_filter_spec.rb
+++ b/spec/models/history_filter_spec.rb
@@ -7,6 +7,21 @@ describe HistoryFilter do
     expect(described_class.new(history).history).to eq history
   end
 
+  describe "#clear_initial_value" do
+    it "sets the from value for those attributes to empty" do
+      history = [OpenStruct.new(changeset: { "change1" => ["before1", "after1"] }),
+                 OpenStruct.new(changeset: { "change2" => ["before2", "after2"] }),
+                 OpenStruct.new(changeset: { "change3" => ["before3", "after3"] }),
+                 OpenStruct.new(changeset: {})]
+
+      result = described_class.new(history).clear_initial_value("change1", "change2").changesets
+
+      expect(result).to eq [{ "change1" => ["", "after1"] },
+                            { "change2" => ["", "after2"] },
+                            { "change3" => ["before3", "after3"] }]
+    end
+  end
+
   describe "#empty_changeset?" do
     it "is not empty if none of the values are arrays which represent changes" do
       history = [double(:history_item, changeset: [{ "change" => ["before", "after"] }])]


### PR DESCRIPTION
### Status

**READY**
### Description

A bug was found with the display of the grade history for a student. The bug happened when the `raw_score` or `feedback` was changed when the grade was not visible but then it was made visible the very next change.

The change checks to see if the changeset for the previous grade was not visible to the student. If it was not, the history was transformed to blank out the previous change so the student could not view the previous change.

Instead of a student seeing this: `The feedback was changed from "This needs work" to "You rock"`, to this: `The feedback was changed to "You rock"`.
### Related PRs

List related PRs against other branches:

| branch | PR |
| --- | --- |
| 1846-fix-released-grades-bug | [https://github.com/UM-USElab/gradecraft-development/pull/2374](https://github.com/UM-USElab/gradecraft-development/pull/2374) |
### Todos
- [x] Test production data to ensure the grade in question is handled
### Migrations

NO
### Steps to Test or Reproduce

To test on development:
1.  Mark an assignment as "release is necessary"
2. Grade a student under that assignment by specifying a raw score or give feedback
3. Release the grade for that student
4. Log in or preview as that student and view assignment
5. Latest grade and feedback should be visible but not the grade/feedback while the grade/feedback was not released.
### Impacted Areas in Application

List general components of the application that this PR will affect:
- Grade history as a student.
