### PR TITLE
1778 integrate grade feedback into annoucements

### DIFF
--- a/app/assets/stylesheets/layout/_student_subnav.sass
+++ b/app/assets/stylesheets/layout/_student_subnav.sass
@@ -43,8 +43,9 @@ dl
 
   li.announcement-nav
     position: relative
+    padding-right: 1.9rem !important
     a
-      padding-right: 1.8rem
+      padding-right: 0
 
   li .announcement-notification-badge
     position: absolute

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -39,10 +39,18 @@ class GradeUpdatePerformer < ResqueJob::Performer
 
   def fetch_grade_with_assignment
     Grade.where(id: @attrs[:grade_id]).includes(:assignment).load.first
-    # Grade.find(@attrs[:grade_id])
   end
 
   def notify_grade_released
+    Announcement.create course_id: @grade.course_id, author_id: @grade.graded_by_id,
+      body: announcement_body,
+      title: "#{@grade.course.course_number} - #{@grade.assignment.name} Graded"
     NotificationMailer.grade_released(@grade.id).deliver_now
+  end
+
+  def announcement_body
+    "<p>You can now view the grade for your #{@grade.course.assignment_term.downcase} " \
+      "#{@grade.assignment.name} in #{@grade.course.name}.</p>" \
+      "<p>Visit #{Rails.application.routes.url_helpers.assignment_url(@grade.assignment, Rails.application.config.action_mailer.default_url_options)} to view your results.</p>"
   end
 end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -51,6 +51,6 @@ class GradeUpdatePerformer < ResqueJob::Performer
   def announcement_body
     "<p>You can now view the grade for your #{@grade.course.assignment_term.downcase} " \
       "#{@grade.assignment.name} in #{@grade.course.name}.</p>" \
-      "<p>Visit #{Rails.application.routes.url_helpers.assignment_url(@grade.assignment, Rails.application.config.action_mailer.default_url_options)} to view your results.</p>"
+      "<p>Visit <a href=#{Rails.application.routes.url_helpers.assignment_url(@grade.assignment, Rails.application.config.action_mailer.default_url_options)}>#{@grade.assignment.name}</a> to view your results.</p>"
   end
 end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -49,8 +49,11 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def announcement_body
+    url = Rails.application.routes.url_helpers.assignment_url(
+      @grade.assignment,
+      Rails.application.config.action_mailer.default_url_options)
     "<p>You can now view the grade for your #{@grade.course.assignment_term.downcase} " \
       "#{@grade.assignment.name} in #{@grade.course.name}.</p>" \
-      "<p>Visit <a href=#{Rails.application.routes.url_helpers.assignment_url(@grade.assignment, Rails.application.config.action_mailer.default_url_options)}>#{@grade.assignment.name}</a> to view your results.</p>"
+      "<p>Visit <a href=#{url}>#{@grade.assignment.name}</a> to view your results.</p>"
   end
 end

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -16,7 +16,7 @@
     %li{class: ("active" if current_page?(teams_path)) }
       = link_to_unless_current "#{term_for :teams}", teams_path
   - if current_course.announcements.present?
-    %li{class: (current_page?(announcements_path)? "active" : "announcement-nav") }
+    %li{class: "announcement-nav #{"active" if current_page?(announcements_path)}"}
       - unread_count = unread_count_for current_student, current_course
       = link_to_unless_current "Announcements", announcements_path
       - if unread_count > 0

--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -7,7 +7,7 @@
 %p
 %h4{:align => "center"}
   Click
-  =link_to "here", assignment_path(@assignment)
+  =link_to "here", assignment_url(@assignment)
   to view your results.
 %hr/
 %p{:align => "center"}

--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -13,5 +13,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    %a{:href => "https://www.gradecraft.com/predictor"} grade predictor
+    = link_to "grade predictor", predictor_url
 %hr/

--- a/app/views/notification_mailer/grade_released.text.haml
+++ b/app/views/notification_mailer/grade_released.text.haml
@@ -2,7 +2,7 @@ Dear #{ @student.first_name },
 
 You can now view the grade for your #{ @course.assignment_term.downcase } "#{ @assignment.name }" in course #{ @course.name }.
 
-Visit https://www.gradecraft.com/assignments/#{ @assignment.id } to view your results.
+Visit #{ assignment_url(@assignment) } to view your results.
 
 Don't forget to update your plan for the semester by checking your grade predictor here: https://www.gradecraft.com/predictor
 

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -201,7 +201,8 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
         "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
         "#{grade.assignment.name} in #{grade.course.name}."
       expect(announcement.body).to include \
-        "Visit http://localhost:5000/assignments/#{(grade.assignment.id)} to view your results."
+        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
+        "#{grade.assignment.name}</a> to view your results."
     end
   end
 

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -2,7 +2,8 @@ require "rails_spec_helper"
 
 RSpec.describe GradeUpdatePerformer, type: :background_job do
   let(:assignment) { create(:assignment) }
-  let(:grade) { create(:grade, assignment_id: assignment.id) }
+  let(:instructor) { create :user }
+  let(:grade) { create(:grade, assignment_id: assignment.id, graded_by_id: instructor.id) }
   let(:attrs) {{ grade_id: grade[:id] }}
   let(:performer) { GradeUpdatePerformer.new(attrs) }
   subject { performer }
@@ -171,18 +172,36 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
   end
 
   describe "notify_grade_released" do
-    subject { performer.instance_eval { notify_grade_released } }
     let(:mailer_double) { double(:mailer).as_null_object }
+    let(:notify) { performer.instance_eval { notify_grade_released } }
+
     before(:each) { allow(NotificationMailer).to receive(:grade_released).and_return(mailer_double) }
-    after(:each) { subject }
 
     it "should create a new grade released notifier with the grade id" do
       expect(NotificationMailer).to receive(:grade_released).with(grade.id)
+      notify
     end
 
     it "should deliver the mailer" do
       allow(performer).to receive_messages(grade_released:  mailer_double)
       expect(mailer_double).to receive(:deliver_now)
+      notify
+    end
+
+    it "creates a new announcement for the student" do
+      expect { notify }.to change { Announcement.count }.by(1)
+
+      announcement = Announcement.last
+
+      expect(announcement.course).to eq grade.course
+      expect(announcement.author).to eq grade.graded_by
+      expect(announcement.title).to eq \
+        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+      expect(announcement.body).to include \
+        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
+        "#{grade.assignment.name} in #{grade.course.name}."
+      expect(announcement.body).to include \
+        "Visit http://localhost:5000/assignments/#{(grade.assignment.id)} to view your results."
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
Creates an `Announcement` for a specific `Student` and `Assignment` when a `Grade` is released. This is done at the same time that the notification email is sent out.

The announcement title matches the email's subject and the announcement body matches the middle of the email's body.

The announcement is displayed for the student in their announcement list as such:

<img width="1525" alt="screen shot 2016-10-25 at 1 20 05 pm" src="https://cloud.githubusercontent.com/assets/35017/19702899/9d3113c6-9acf-11e6-8726-969a9450f3a8.png">

The announcement body is similar to the following:

<img width="1522" alt="screen shot 2016-10-25 at 1 20 15 pm" src="https://cloud.githubusercontent.com/assets/35017/19702903/a4de049e-9acf-11e6-924e-0e9e15a5eece.png">

### Related PRs

This is working towards completing #1778 but badges will be in a separate PR off of this branch.

### Todos

### Deploy Notes

### Migrations
NO

### Steps to Test or Reproduce

1. As a instructor or admin, grade a student for an assignment and release that grade
1. As the student who was graded above, log in and view the announcements
1. You should see the announcement for the grade that was released

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Announcements
* Releasing grades
