### PR TITLE
2611 assignment order

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/article.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/article.html.haml
@@ -18,7 +18,6 @@
     %predictor-article-assignment-content{'ng-if' => 'article.type=="assignments"', 'article'=>'article'}
     %predictor-article-assignment-content{'ng-if' => 'article.type=="challenges"', 'article'=>'article'}
 
-  .predictor-position {{article.position}}
   .predictor-article-main-icons
     .icon.is_required{'ng-if' => 'article.is_required'}
       %i.fa.fa-fw.fa-asterisk

--- a/app/assets/javascripts/angular/templates/predictor/article.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/article.html.haml
@@ -18,6 +18,7 @@
     %predictor-article-assignment-content{'ng-if' => 'article.type=="assignments"', 'article'=>'article'}
     %predictor-article-assignment-content{'ng-if' => 'article.type=="challenges"', 'article'=>'article'}
 
+  .predictor-position {{article.position}}
   .predictor-article-main-icons
     .icon.is_required{'ng-if' => 'article.is_required'}
       %i.fa.fa-fw.fa-asterisk

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -3,7 +3,7 @@ class API::AssignmentsController < ApplicationController
 
   # GET api/assignments
   def index
-    @assignments = current_course.assignments
+    @assignments = current_course.assignments.ordered
 
     if  current_user_is_student?
       @student = current_student

--- a/db/migrate/20161031184138_change_positions_to_default.rb
+++ b/db/migrate/20161031184138_change_positions_to_default.rb
@@ -1,0 +1,6 @@
+class ChangePositionsToDefault < ActiveRecord::Migration[5.0]
+  def change
+    change_column :assignments, :position, :integer, null: false
+    change_column :badges, :position, :integer, null: false
+  end
+end

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1432,9 +1432,9 @@ me and I never know what to say.' ― Seymour Papert",
   },
   assignment_type: :sorting,
   attributes: {
-    name: "Class 1",
+    name: "Class 1 Position 1",
     description: "Tests that Assignments are Sorted Correctly by Alphanumeric
-      Name"
+      Name as well as by Position (most views use should use Position)"
   }
 }
 
@@ -1450,9 +1450,9 @@ capacities. - Seymour Papert",
   },
   assignment_type: :sorting,
   attributes: {
-    name: "Class 2",
+    name: "Class 2 Position 2",
     description: "Tests that Assignments are Sorted Correctly by Alphanumeric
-      Name"
+      Name as well as by Position (most views use should use Position)"
   }
 }
 
@@ -1463,9 +1463,9 @@ believe that you need the society as it is. ― Ivan Illich",
   },
   assignment_type: :sorting,
   attributes: {
-    name: "Class 12",
+    name: "Class 12 Position 3",
     description: "Tests that Assignments are Sorted Correctly by Alphanumeric
-      Name"
+      Name as well as by Position (most views use should use Position)"
   }
 }
 
@@ -1479,9 +1479,9 @@ Illich",
   },
   assignment_type: :sorting,
   attributes: {
-    name: "Class 10",
+    name: "Class 10 Position 4",
     description: "Tests that Assignments are Sorted Correctly by Alphanumeric
-      Name"
+      Name as well as by Position (most views use should use Position)"
   }
 }
 
@@ -1494,9 +1494,9 @@ the speed, and the route.― Jay Cross",
   },
   assignment_type: :sorting,
   attributes: {
-    name: "Class 20",
+    name: "Class 20 Position 5",
     description: "Tests that Assignments are Sorted Correctly by Alphanumeric
-      Name"
+      Name as well as by Position (most views use should use Position)"
   }
 }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003210720) do
+ActiveRecord::Schema.define(version: 20161031184138) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,7 +112,7 @@ ActiveRecord::Schema.define(version: 20161003210720) do
     t.string   "mass_grade_type"
     t.boolean  "include_in_timeline",          default: false,        null: false
     t.boolean  "include_in_predictor",         default: true,         null: false
-    t.integer  "position"
+    t.integer  "position",                                            null: false
     t.boolean  "include_in_to_do",             default: true,         null: false
     t.boolean  "use_rubric",                   default: true,         null: false
     t.boolean  "accepts_attachments",          default: true,         null: false
@@ -153,7 +153,7 @@ ActiveRecord::Schema.define(version: 20161003210720) do
     t.datetime "updated_at",                                   null: false
     t.boolean  "visible",                      default: true,  null: false
     t.boolean  "can_earn_multiple_times",      default: true,  null: false
-    t.integer  "position"
+    t.integer  "position",                                     null: false
     t.boolean  "visible_when_locked",          default: true,  null: false
     t.boolean  "show_name_when_locked",        default: true,  null: false
     t.boolean  "show_points_when_locked",      default: true
@@ -234,7 +234,6 @@ ActiveRecord::Schema.define(version: 20161003210720) do
     t.string   "role",                           default: "student", null: false
     t.boolean  "instructor_of_record",           default: false
     t.integer  "earned_grade_scheme_element_id"
-    t.index ["course_id", "user_id"], name: "index_course_memberships_on_course_id_and_user_id", unique: true, using: :btree
     t.index ["course_id", "user_id"], name: "index_courses_users_on_course_id_and_user_id", using: :btree
     t.index ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -217,6 +217,20 @@ describe Assignment do
     end
   end
 
+  describe "position" do
+
+    it "sets the position by assignment type on save (using acts_as_list gem)" do
+      expect(subject.position).to be_nil
+      subject.save
+      expect(subject.position).to be(1)
+      a2 = create :assignment
+      expect(a2.position).to be(1)
+      a3 = create :assignment, assignment_type: a2.assignment_type
+      expect(a3.position).to be(2)
+      badge
+    end
+  end
+
   describe "#min_group_size" do
     it "sets the default min group size at 2" do
       expect(subject.min_group_size).to eq(1)

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -227,7 +227,6 @@ describe Assignment do
       expect(a2.position).to be(1)
       a3 = create :assignment, assignment_type: a2.assignment_type
       expect(a3.position).to be(2)
-      badge
     end
   end
 


### PR DESCRIPTION
### Description
Adds ordered to assignments in predictor, so that they are ordered by position to address #2611. 

Also adds a couple refinements to use of `position`: 
  * makes this field `null: false` for `Assignments` and `Badges` to align with the field in `AssignmentTypes`
  * Also adds a spec in Assignments as rudimentary documentation as to how the position works via the acts as list gem
  * Adds position to the samples for `Sorting` so that they can be more effectively used for testing. I'm not sure if we sort by Alfanumeric anywhere still, so I left this part of the samples intact.

closes #2611 

### Migrations
YES

### Steps to Test or Reproduce

run samples and confirm that they are in the correct order (by position) in the Predictor `Sorting Settings` section. Reorder Assignments as a Professor, and confirm that the order updates on refresh of the predictor.

### Impacted Areas in Application

Assignment ordering