### PR TITLE
2619 - Fix papertrail warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,7 @@ class ApplicationController < ActionController::Base
   before_action :require_login, except: [:not_authenticated]
   before_action :increment_page_views
   before_action :course_scores
+  before_action :set_paper_trail_whodunnit
 
   include ApplicationHelper
 


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes a warning with [Papertrail](https://github.com/airblade/paper_trail) 5. It no longer explicitly sets the `Papertrail.whodunnit` field in the controller actions and a warning get's thrown when it is is not set explicitly.

The warning is documented here: https://github.com/airblade/paper_trail/blob/master/doc/warning_about_not_setting_whodunnit.md

### Migrations
NO

### Steps to Test or Reproduce
Visit any area of the application and ensure that the logs do not contain a Papertrail warning.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* All controller routes.

Closes #2619 

