### PR TITLE
2618 - Name error lull

### DIFF
--- a/app/controllers/analytics_events_controller.rb
+++ b/app/controllers/analytics_events_controller.rb
@@ -1,3 +1,5 @@
+require "lull"
+
 class AnalyticsEventsController < ApplicationController
   skip_before_action :increment_page_views
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
-require 'application_responder'
+require "application_responder"
+require "lull"
 
 class ApplicationController < ActionController::Base
   self.responder = ApplicationResponder


### PR DESCRIPTION
### Status
**READY**

### Description

PR fixes a `NameError` for a library named `Lull` which is an internal library to find the next downtime. 

It is used in the `ApplicationController` when recording events. A simple `require` should fix this error on production.

### Migrations
NO

### Steps to Test or Reproduce
1. Sign in on production so it records the login event.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Controllers

Fixes #2618 

