### PR TITLE
2616 - Cookie Overflow bug

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :cookie_store, key: '_grade_craft_session'


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes an issue that occurs when a user signs in using SAML. This action results in an `ActionDispatch::Cookies::CookieOverflow` error.

This occurs because the response from SAML get's put into session. The `session_store` for production used to be an [ActiveRecord SessionStore](https://github.com/rails/activerecord-session_store) but it was changed with the Rails 5 upgrade by accident.

When upgrading Rails 5 through the Rake task, an initializer that sets the `session_store` to `cookie_store` was created and checked in. This overwrote [the config for production](https://github.com/UM-USElab/gradecraft-development/blob/master/config/environments/production.rb#L31) which set the `session_store` to `:active_record_store`.

The `ActiveRecordSessionStore` allows for text size data instead of the `CookieStore` size of 65K and it is therefore needed for SAML responses.

### Migrations
NO

### Steps to Test or Reproduce

1.  Sign in on production using SAML.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* SAML authentication

Fixes #2616