### PR TITLE
2617 - Fix no method for nil on reflection call

### DIFF
--- a/app/models/course_router.rb
+++ b/app/models/course_router.rb
@@ -8,7 +8,7 @@ class CourseRouter
 
     def current_course_for(user, current_course_id=nil)
       return nil if user.nil?
-      course = user.courses.find_by(id: current_course_id) unless current_course_id.nil?
+      course = user.courses.where(id: current_course_id).first
       course ||= user.current_course
       course ||= user.courses.first
       course

--- a/spec/models/course_router_spec.rb
+++ b/spec/models/course_router_spec.rb
@@ -29,18 +29,18 @@ describe CourseRouter do
 
     context "with a current course id" do
       it "returns the course that the user has access to" do
-        allow(courses).to receive(:find_by).and_return course
+        allow(courses).to receive(:where).and_return [course]
         expect(described_class.current_course_for(user, course.id)).to eq course
       end
 
       it "returns the default course if one is not specified" do
-        allow(courses).to receive(:find_by).and_return nil
+        allow(courses).to receive(:where).and_return [nil]
         allow(user).to receive(:current_course).and_return course
         expect(described_class.current_course_for(user, course.id)).to eq course
       end
 
       it "returns the first course if there is not one set as the default" do
-        allow(courses).to receive(:find_by).and_return nil
+        allow(courses).to receive(:where).and_return [nil]
         allow(user).to receive(:current_course).and_return nil
         allow(courses).to receive(:first).and_return course
         expect(described_class.current_course_for(user, course.id)).to eq course


### PR DESCRIPTION
### Status
**READY**

### Description
This PR attempts to fix an issue when using `find_by` on a relationship in Rails 5 by replacing it with a `where#first` call.

This error occurred when a user is signed in and it attempts to find the current course they have visited last.

I am unsure if this fixes the issue because I was unable to replicate it locally. I traced down the issue and I believe to be from using the `find_by` method with associations.

### Migrations
NO

### Steps to Test or Reproduce

1.  Visit the home page while being signed on

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Course switcher

Fixes #2617

