### PR TITLE
1778 integrate badge award into announcements

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -162,7 +162,7 @@ class EarnedBadgesController < ApplicationController
 
   def send_earned_badge_notifications
     @valid_earned_badges.each do |earned_badge|
-      NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now
+      NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
       logger.info "Sent an earned badge notification for EarnedBadge ##{earned_badge[:id]}"
     end
   end

--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -162,6 +162,7 @@ class EarnedBadgesController < ApplicationController
 
   def send_earned_badge_notifications
     @valid_earned_badges.each do |earned_badge|
+      EarnedBadgeAnnouncement.create earned_badge
       NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
       logger.info "Sent an earned badge notification for EarnedBadge ##{earned_badge[:id]}"
     end

--- a/app/mailer_previews/earned_badge_awarded_preview.rb
+++ b/app/mailer_previews/earned_badge_awarded_preview.rb
@@ -1,6 +1,6 @@
 class EarnedBadgeAwardedPreview
   def earned_badge_awarded
     earned_badge = EarnedBadge.last
-    NotificationMailer.earned_badge_awarded earned_badge.id
+    NotificationMailer.earned_badge_awarded earned_badge
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -41,8 +41,8 @@ class NotificationMailer < ApplicationMailer
     send_student_email "#{@course.course_number} - #{@assignment.name} Graded"
   end
 
-  def earned_badge_awarded(earned_badge_id)
-    @earned_badge = EarnedBadge.find earned_badge_id
+  def earned_badge_awarded(earned_badge)
+    @earned_badge = earned_badge
     @student = @earned_badge.student
     @course = @earned_badge.course
     send_student_email "#{@course.course_number} - You've earned a new #{@course.badge_term}!"

--- a/app/models/earned_badge_announcement.rb
+++ b/app/models/earned_badge_announcement.rb
@@ -1,0 +1,42 @@
+class EarnedBadgeAnnouncement
+  def self.create(earned_badge)
+    new(earned_badge).create_announcement
+  end
+
+  def create_announcement
+    Announcement.create params
+  end
+
+  protected
+
+  attr_reader :earned_badge
+
+  def initialize(earned_badge)
+    @earned_badge = earned_badge
+  end
+
+  def body
+    url = Rails.application.routes.url_helpers.course_badge_earned_badge_url(
+      earned_badge.course,
+      earned_badge.badge,
+      earned_badge,
+      Rails.application.config.action_mailer.default_url_options)
+
+    "<p>Congratulations #{earned_badge.student.first_name}!</p>" \
+      "<p>You've earned the #{earned_badge.badge.name} #{earned_badge.course.badge_term}.</p>" \
+      "<p>Check out your new <a href='#{url}'>#{earned_badge.course.badge_term.downcase}</a>.</p>"
+  end
+
+  def params
+    { course_id: earned_badge.course_id,
+      author_id: earned_badge.awarded_by_id,
+      body:      body,
+      title:     title
+    }
+  end
+
+  def title
+    "#{earned_badge.course.course_number} - "\
+      "You've earned a new #{earned_badge.course.badge_term}!"
+  end
+end

--- a/app/models/earned_badge_announcement.rb
+++ b/app/models/earned_badge_announcement.rb
@@ -16,10 +16,7 @@ class EarnedBadgeAnnouncement
   end
 
   def body
-    url = Rails.application.routes.url_helpers.course_badge_earned_badge_url(
-      earned_badge.course,
-      earned_badge.badge,
-      earned_badge,
+    url = Rails.application.routes.url_helpers.badges_url(
       Rails.application.config.action_mailer.default_url_options)
 
     "<p>Congratulations #{earned_badge.student.first_name}!</p>" \

--- a/app/models/grade_announcement.rb
+++ b/app/models/grade_announcement.rb
@@ -1,0 +1,39 @@
+class GradeAnnouncement
+  def self.create(grade)
+    new(grade).create_announcement
+  end
+
+  def create_announcement
+    Announcement.create params
+  end
+
+  protected
+
+  attr_reader :grade
+
+  def initialize(grade)
+    @grade = grade
+  end
+
+  def body
+    url = Rails.application.routes.url_helpers.assignment_url(
+      grade.assignment,
+      Rails.application.config.action_mailer.default_url_options)
+
+    "<p>You can now view the grade for your #{grade.course.assignment_term.downcase} " \
+      "#{grade.assignment.name} in #{grade.course.name}.</p>" \
+      "<p>Visit <a href=#{url}>#{grade.assignment.name}</a> to view your results.</p>"
+  end
+
+  def params
+    { course_id: grade.course_id,
+      author_id: grade.graded_by_id,
+      body:      body,
+      title:     title
+    }
+  end
+
+  def title
+    "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+  end
+end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -42,18 +42,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def notify_grade_released
-    Announcement.create course_id: @grade.course_id, author_id: @grade.graded_by_id,
-      body: announcement_body,
-      title: "#{@grade.course.course_number} - #{@grade.assignment.name} Graded"
+    GradeAnnouncement.create @grade
     NotificationMailer.grade_released(@grade.id).deliver_now
-  end
-
-  def announcement_body
-    url = Rails.application.routes.url_helpers.assignment_url(
-      @grade.assignment,
-      Rails.application.config.action_mailer.default_url_options)
-    "<p>You can now view the grade for your #{@grade.course.assignment_term.downcase} " \
-      "#{@grade.assignment.name} in #{@grade.course.name}.</p>" \
-      "<p>Visit <a href=#{url}>#{@grade.assignment.name}</a> to view your results.</p>"
   end
 end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -9,7 +9,7 @@ module Services
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
           EarnedBadgeAnnouncement.create earned_badge
-          NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now
+          NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
         end
       end
     end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -8,28 +8,9 @@ module Services
       executed do |context|
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
-          Announcement.create course_id: earned_badge.course_id,
-            author_id: earned_badge.awarded_by_id,
-            body: announcement_body(earned_badge),
-            title: "#{earned_badge.course.course_number} - "\
-                   "You've earned a new #{earned_badge.course.badge_term}!"
-
+          EarnedBadgeAnnouncement.create earned_badge
           NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now
         end
-      end
-
-      protected
-
-      def self.announcement_body(earned_badge)
-        url = Rails.application.routes.url_helpers.course_badge_earned_badge_url(
-          earned_badge.course,
-          earned_badge.badge,
-          earned_badge,
-          Rails.application.config.action_mailer.default_url_options)
-
-        "<p>Congratulations #{earned_badge.student.first_name}!</p>" \
-          "<p>You've earned the #{earned_badge.badge.name} #{earned_badge.course.badge_term}.</p>" \
-          "<p>Check out your new <a href='#{url}'>#{earned_badge.course.badge_term.downcase}</a>.</p>"
       end
     end
   end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -6,10 +6,30 @@ module Services
       expects :earned_badge
 
       executed do |context|
-        if context.earned_badge.student_visible?
-          NotificationMailer.earned_badge_awarded(context.earned_badge.id)
-            .deliver_now
+        earned_badge = context.earned_badge
+        if earned_badge.student_visible?
+          Announcement.create course_id: earned_badge.course_id,
+            author_id: earned_badge.awarded_by_id,
+            body: announcement_body(earned_badge),
+            title: "#{earned_badge.course.course_number} - "\
+                   "You've earned a new #{earned_badge.course.badge_term}!"
+
+          NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now
         end
+      end
+
+      protected
+
+      def self.announcement_body(earned_badge)
+        url = Rails.application.routes.url_helpers.course_badge_earned_badge_url(
+          earned_badge.course,
+          earned_badge.badge,
+          earned_badge,
+          Rails.application.config.action_mailer.default_url_options)
+
+        "<p>Congratulations #{earned_badge.student.first_name}!</p>" \
+          "<p>You've earned the #{earned_badge.badge.name} #{earned_badge.course.badge_term}.</p>" \
+          "<p>Check out your new <a href='#{url}'>#{earned_badge.course.badge_term.downcase}</a>.</p>"
       end
     end
   end

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -123,7 +123,7 @@ describe EarnedBadgesController do
           allow(mail_responder).to receive(:deliver_now)
           allow(NotificationMailer).to receive(:earned_badge_awarded) { mail_responder }
           @earned_badges.each do |earned_badge|
-            expect(NotificationMailer).to receive(:earned_badge_awarded).with(earned_badge[:id])
+            expect(NotificationMailer).to receive(:earned_badge_awarded).with(earned_badge)
           end
           controller.instance_eval { send_earned_badge_notifications }
         end

--- a/spec/mailers/notification_mailer/earned_badge_awarded_spec.rb
+++ b/spec/mailers/notification_mailer/earned_badge_awarded_spec.rb
@@ -36,7 +36,7 @@ describe NotificationMailer do
   let(:earned_badge) { create(:earned_badge, earned_badge_attrs.merge(feedback: "You did a really great job.")) }
   let(:earned_badge_attrs) {{ student: student, course: course, badge: badge }}
 
-  let(:deliver_email) { NotificationMailer.earned_badge_awarded(earned_badge.id).deliver_now }
+  let(:deliver_email) { NotificationMailer.earned_badge_awarded(earned_badge).deliver_now }
 
   describe "#earned_badge_awarded" do
     before(:each) { deliver_email }

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -7,7 +7,7 @@ describe EarnedBadgeAnnouncement do
   let(:user) { create :user }
 
   describe ".create" do
-    it "creates an announcement in the database" do
+    it "creates an announcement for the earned badge" do
       expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
       expect(announcement.course).to eq earned_badge.course
       expect(announcement.author).to eq user

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -19,8 +19,7 @@ describe EarnedBadgeAnnouncement do
         "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
       expect(announcement.body).to include \
         "<p>Check out your new "\
-        "<a href='http://localhost:5000/courses/#{course.id}/badges/#{earned_badge.badge.id}/"\
-        "earned_badges/#{earned_badge.id}'>badge</a>.</p>"
+        "<a href='http://localhost:5000/badges'>badge</a>.</p>"
     end
   end
 end

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -1,0 +1,26 @@
+require "rails_spec_helper"
+
+describe EarnedBadgeAnnouncement do
+  let(:announcement) { Announcement.unscoped.last }
+  let(:course) { earned_badge.course }
+  let(:earned_badge) { create :earned_badge, awarded_by: user }
+  let(:user) { create :user }
+
+  describe ".create" do
+    it "creates an announcement in the database" do
+      expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq earned_badge.course
+      expect(announcement.author).to eq user
+      expect(announcement.title).to \
+        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
+      expect(announcement.body).to include \
+        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
+      expect(announcement.body).to include \
+        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
+      expect(announcement.body).to include \
+        "<p>Check out your new "\
+        "<a href='http://localhost:5000/courses/#{course.id}/badges/#{earned_badge.badge.id}/"\
+        "earned_badges/#{earned_badge.id}'>badge</a>.</p>"
+    end
+  end
+end

--- a/spec/models/grade_announcement_spec.rb
+++ b/spec/models/grade_announcement_spec.rb
@@ -1,0 +1,23 @@
+require "rails_spec_helper"
+
+describe GradeAnnouncement do
+  let(:announcement) { Announcement.unscoped.last }
+  let(:grade) { create :grade, graded_by: user }
+  let(:user) { create :user }
+
+  describe ".create" do
+    it "creates an announcement for the grade" do
+      expect { described_class.create grade }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq grade.course
+      expect(announcement.author).to eq grade.graded_by
+      expect(announcement.title).to eq \
+        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+      expect(announcement.body).to include \
+        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
+        "#{grade.assignment.name} in #{grade.course.name}."
+      expect(announcement.body).to include \
+        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
+        "#{grade.assignment.name}</a> to view your results."
+    end
+  end
+end

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -190,19 +190,6 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
 
     it "creates a new announcement for the student" do
       expect { notify }.to change { Announcement.count }.by(1)
-
-      announcement = Announcement.last
-
-      expect(announcement.course).to eq grade.course
-      expect(announcement.author).to eq grade.graded_by
-      expect(announcement.title).to eq \
-        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
-      expect(announcement.body).to include \
-        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
-        "#{grade.assignment.name} in #{grade.course.name}."
-      expect(announcement.body).to include \
-        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
-        "#{grade.assignment.name}</a> to view your results."
     end
   end
 

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -26,21 +26,6 @@ describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
 
       expect { described_class.execute earned_badge: earned_badge }.to \
         change { Announcement.count }.by 1
-
-      announcement = Announcement.unscoped.last
-
-      expect(announcement.course).to eq earned_badge.course
-      expect(announcement.author).to eq user
-      expect(announcement.title).to \
-        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
-      expect(announcement.body).to include \
-        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
-      expect(announcement.body).to include \
-        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
-      expect(announcement.body).to include \
-        "<p>Check out your new "\
-        "<a href='http://localhost:5000/courses/#{course.id}/badges/#{earned_badge.badge.id}/"\
-        "earned_badges/#{earned_badge.id}'>badge</a>.</p>"
     end
   end
 

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -1,28 +1,61 @@
-require "action_mailer"
-require "light-service"
-require "active_record_spec_helper"
+require "rails_spec_helper"
 require "./app/services/creates_earned_badge/notifies_of_earned_badge"
-require "./app/mailers/application_mailer"
-require "./app/mailers/notification_mailer"
 
-describe Services::Actions::NotifiesOfEarnedBadge do
-  let(:delivery) { double(:email) }
-  let(:earned_badge) { create :earned_badge }
+describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
+  let(:course) { earned_badge.course }
+  let(:delivery) { double(:email, deliver_now: nil) }
+  let(:earned_badge) { create :earned_badge, awarded_by: user }
+  let(:user) { create :user }
 
   it "expects an earned badge to send the notification about" do
     expect { described_class.execute }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
-  it "sends a notification to the student of the newly awarded badge if the badge is student visible" do
-    expect(delivery).to receive(:deliver_now)
-    expect(NotificationMailer).to receive(:earned_badge_awarded).with(earned_badge.id).and_return delivery
-    described_class.execute earned_badge: earned_badge
+  context "with a badge that is student visible" do
+
+    it "sends a notification to the student of the newly awarded badge" do
+      expect(delivery).to receive(:deliver_now)
+      expect(NotificationMailer).to \
+        receive(:earned_badge_awarded).with(earned_badge.id).and_return delivery
+      described_class.execute earned_badge: earned_badge
+    end
+
+    it "creates an announcement for the student" do
+      allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
+
+      expect { described_class.execute earned_badge: earned_badge }.to \
+        change { Announcement.count }.by 1
+
+      announcement = Announcement.unscoped.last
+
+      expect(announcement.course).to eq earned_badge.course
+      expect(announcement.author).to eq user
+      expect(announcement.title).to \
+        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
+      expect(announcement.body).to include \
+        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
+      expect(announcement.body).to include \
+        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
+      expect(announcement.body).to include \
+        "<p>Check out your new "\
+        "<a href='http://localhost:5000/courses/#{course.id}/badges/#{earned_badge.badge.id}/"\
+        "earned_badges/#{earned_badge.id}'>badge</a>.</p>"
+    end
   end
 
-  it "does not send the notification if the badge is not student visible" do
-    earned_badge.update_attributes(grade: create(:unreleased_grade))
-    expect(NotificationMailer).to_not receive(:earned_badge_awarded)
-    described_class.execute earned_badge: earned_badge
+  context "with a badge that is not student visible" do
+    before { earned_badge.update_attributes(grade: (create :unreleased_grade)) }
+
+    it "does not send the notification" do
+      expect(NotificationMailer).to_not receive(:earned_badge_awarded)
+      described_class.execute earned_badge: earned_badge
+    end
+
+    it "does not create an announcement for the student" do
+      expect { described_class.execute earned_badge: earned_badge }.to_not \
+        change { Announcement.count }
+    end
   end
 end
+

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -17,7 +17,7 @@ describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
     it "sends a notification to the student of the newly awarded badge" do
       expect(delivery).to receive(:deliver_now)
       expect(NotificationMailer).to \
-        receive(:earned_badge_awarded).with(earned_badge.id).and_return delivery
+        receive(:earned_badge_awarded).with(earned_badge).and_return delivery
       described_class.execute earned_badge: earned_badge
     end
 


### PR DESCRIPTION
### Status
**READY**

### Description
Creates an `Announcement` for the student when a badge is awarded to that student. The announcement shows up within the student's announcement list.

<img width="1526" alt="screen shot 2016-11-01 at 4 08 56 pm" src="https://cloud.githubusercontent.com/assets/35017/19906756/76702104-a052-11e6-84a4-fd141aaec214.png">

The announcement looks similar to the email that is sent out:

<img width="1532" alt="screen shot 2016-11-01 at 4 09 07 pm" src="https://cloud.githubusercontent.com/assets/35017/19906779/878a3a06-a052-11e6-89ec-1a1264528c57.png">

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Integrate grade feedback into announcements | [2607](https://github.com/UM-USElab/gradecraft-development/pull/2607)

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Login as an instructor
1. Award any badge to a student
1. Login as the student
1. View new announcement

1. Login as an instructor
1. Award multiple badges to various students
1. Login as each student
1. View new announcement

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Awarding badges
* Mass awarding badges

Closes #1778 
