### PR TITLE
2613 - Mark imported grades as graded

### DIFF
--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -24,6 +24,7 @@ class CanvasGradeImporter
 
         grade.raw_points = canvas_grade["score"]
         grade.feedback = canvas_grade["submission_comments"]
+        grade.status = "Graded" if grade.status.nil?
         grade.instructor_modified = true
 
         if grade.save

--- a/app/services/imports_lms_grades.rb
+++ b/app/services/imports_lms_grades.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "imports_lms_grades/enqueues_grade_updater_jobs"
 require_relative "imports_lms_grades/imports_lms_grades"
 require_relative "imports_lms_grades/imports_lms_users"
 require_relative "imports_lms_grades/retrieves_lms_grades"
@@ -16,7 +17,8 @@ module Services
              Actions::RetrievesLMSGrades,
              Actions::RetrievesLMSUsers,
              Actions::ImportsLMSUsers,
-             Actions::ImportsLMSGrades)
+             Actions::ImportsLMSGrades,
+             Actions::EnqueuesGradeUpdaterJobs)
     end
   end
 end

--- a/app/services/imports_lms_grades/enqueues_grade_updater_jobs.rb
+++ b/app/services/imports_lms_grades/enqueues_grade_updater_jobs.rb
@@ -1,0 +1,10 @@
+module Services
+  module Actions
+    class EnqueuesGradeUpdaterJobs
+      extend LightService::Action
+
+      executed do |context|
+      end
+    end
+  end
+end

--- a/app/services/imports_lms_grades/enqueues_grade_updater_jobs.rb
+++ b/app/services/imports_lms_grades/enqueues_grade_updater_jobs.rb
@@ -1,9 +1,20 @@
+require_relative "../../background_jobs/grade_updater_job"
+
 module Services
   module Actions
     class EnqueuesGradeUpdaterJobs
       extend LightService::Action
 
+      expects :grades_import_result
+
       executed do |context|
+        result = context.grades_import_result
+
+        result.successful.each do |grade|
+          if grade.graded_or_released? && GradeProctor.new(grade).viewable?
+            GradeUpdaterJob.new(grade_id: grade.id).enqueue
+          end
+        end unless result.nil?
       end
     end
   end

--- a/spec/importers/grade_importers/canvas_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/canvas_grade_importer_spec.rb
@@ -38,6 +38,7 @@ describe CanvasGradeImporter do
         expect(grade.student).to eq user
         expect(grade.raw_points).to eq 98
         expect(grade.feedback).to eq "This is great!"
+        expect(grade.status).to eq "Graded"
         expect(grade).to be_instructor_modified
       end
 

--- a/spec/services/imports_lms_grades/enqueues_grade_updater_jobs_spec.rb
+++ b/spec/services/imports_lms_grades/enqueues_grade_updater_jobs_spec.rb
@@ -1,0 +1,39 @@
+require "rails_spec_helper"
+require "./app/services/imports_lms_grades/enqueues_grade_updater_jobs"
+
+describe Services::Actions::EnqueuesGradeUpdaterJobs do
+  let(:first_grade) { create :grade, status: "Graded" }
+  let(:second_grade) { create :grade, status: "Graded" }
+  let(:grades_import_result) { double(:result, successful: [first_grade, second_grade ]) }
+
+  before { allow_any_instance_of(GradeUpdaterJob).to receive(:enqueue) }
+
+  it "expects grade import results" do
+    expect { described_class.execute }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "enqueues the grade updater job for all sucessful imported grades" do
+    expect(GradeUpdaterJob).to receive(:new).with(grade_id: first_grade.id).and_call_original
+    expect(GradeUpdaterJob).to receive(:new).with(grade_id: second_grade.id).and_call_original
+
+    described_class.execute grades_import_result: grades_import_result
+  end
+
+  it "does not enqueue in progress grades" do
+    unreleased_grade = create :grade, status: "In Progress"
+    allow(grades_import_result).to receive(:successful).and_return [unreleased_grade]
+
+    expect(GradeUpdaterJob).to_not receive(:new).with(grade_id: second_grade.id)
+
+    described_class.execute grades_import_result: grades_import_result
+  end
+
+  it "does not enqueue grades that are not visible to the student" do
+    allow_any_instance_of(GradeProctor).to receive(:viewable?).and_return false
+
+    expect(GradeUpdaterJob).to_not receive(:new)
+
+    described_class.execute grades_import_result: grades_import_result
+  end
+end

--- a/spec/services/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades_spec.rb
@@ -47,5 +47,13 @@ describe Services::ImportsLMSGrades do
       described_class.import provider, access_token, course_id, assignment_ids,
         grade_ids, assignment, user
     end
+
+    it "enqueues the grade updater jobs" do
+      expect(Services::Actions::EnqueuesGradeUpdaterJobs).to \
+        receive(:execute).and_call_original
+
+      described_class.import provider, access_token, course_id, assignment_ids,
+        grade_ids, assignment, user
+    end
   end
 end

--- a/spec/services/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades_spec.rb
@@ -1,4 +1,4 @@
-require "active_record_spec_helper"
+require "rails_spec_helper"
 require "./app/services/imports_lms_grades"
 
 describe Services::ImportsLMSGrades do


### PR DESCRIPTION
### Status
**READY**

### Description
Sets the status for all `Grade`s that were imported via Canvas to "Graded" just as the `CSVGradeImporter` does.

In addition, it adds a step for enqueue all of the successfully imported `Grade`s to run through the `GradeUpdaterJob` background job.

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Login as an instructor
1. Link a course with Canvas
1. Import grades for an assignment
1. Ensure that all the grades were marked as "Graded"

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grade import

Closes #2613