### PR TITLE
2633 canvas api error response

### DIFF
--- a/app/controllers/api/grades/importers_controller.rb
+++ b/app/controllers/api/grades/importers_controller.rb
@@ -15,8 +15,14 @@ class API::Grades::ImportersController < ApplicationController
   def show
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
-    @grades = syllabus.grades(params[:id], [params[:assignment_ids]].flatten, nil, false, importer_params.to_h)
-    @provider_assignment = syllabus.assignment(params[:id], params[:assignment_ids])
+    @grades = syllabus.grades(params[:id], [params[:assignment_ids]].flatten, nil, false, importer_params.to_h) do
+      render json: { message: "There was an issue trying to retrieve the grades from #{@provider_name.capitalize}.",
+        success: false }, status: 500 and return
+    end
+    @provider_assignment = syllabus.assignment(params[:id], params[:assignment_ids]) do
+      render json: { message: "There was an issue trying to retrieve the assignment from #{@provider_name.capitalize}.",
+        success: false }, status: 500 and return
+    end
     render template: "api/grades/importers/show"
   end
 

--- a/app/controllers/api/grades/importers_controller.rb
+++ b/app/controllers/api/grades/importers_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable AndOr
 class API::Grades::ImportersController < ApplicationController
   include OAuthProvider
 

--- a/app/controllers/api/users/importers_controller.rb
+++ b/app/controllers/api/users/importers_controller.rb
@@ -13,7 +13,10 @@ class API::Users::ImportersController < ApplicationController
   # GET /api/users/importers/:importer_provider_id/course/:id/users
   def index
     @provider_name = params[:importer_provider_id]
-    @users = syllabus.users(params[:id], false, importer_params.to_h)
+    @users = syllabus.users(params[:id], false, importer_params.to_h) do
+      render json: { message: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}.",
+        success: false }, status: 500 and return
+    end
     render template: "api/users/importers/index"
   end
 

--- a/app/controllers/api/users/importers_controller.rb
+++ b/app/controllers/api/users/importers_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable AndOr
 class API::Users::ImportersController < ApplicationController
   include OAuthProvider
 

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -36,7 +36,10 @@ class Assignments::ImportersController < ApplicationController
     if @result.success?
       render :assignments_import_results
     else
-      @assignments = syllabus.assignments(@course_id)
+      @assignments = syllabus.assignments(@course_id) do
+        redirect_to assignment_importers_path,
+          alert: "There was an issue trying to retrieve the assignments from #{@provider_name.capitalize}." and return
+      end
       @assignment_types = @course.assignment_types.ordered
 
       render :assignments, alert: @result.message

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -1,5 +1,6 @@
 require_relative "../../services/imports_lms_assignments"
 
+# rubocop:disable AndOr
 class Assignments::ImportersController < ApplicationController
   include OAuthProvider
 

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -19,8 +19,14 @@ class Assignments::ImportersController < ApplicationController
   # GET /assignments/importers/:importer_provider_id/courses/:id/assignments
   def assignments
     @provider_name = params[:importer_provider_id]
-    @lms_course = syllabus.course(params[:id])
-    @assignments = syllabus.assignments(params[:id])
+    @lms_course = syllabus.course(params[:id]) do
+      redirect_to assignments_importers_path,
+        alert: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}." and return
+    end
+    @assignments = syllabus.assignments(params[:id]) do
+      redirect_to assignments_importers_path,
+        alert: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}." and return
+    end
     @assignment_types = current_course.assignment_types.ordered
   end
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -1,6 +1,7 @@
 require "active_lms"
 require_relative "../../services/imports_lms_grades"
 
+# rubocop:disable AndOr
 class Grades::ImportersController < ApplicationController
   include OAuthProvider
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -17,8 +17,14 @@ class Grades::ImportersController < ApplicationController
   def assignments
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
-    @lms_course = syllabus.course(params[:id])
-    @assignments = syllabus.assignments(params[:id])
+    @lms_course = syllabus.course(params[:id]) do
+      redirect_to assignment_grades_importer_grades_path(@assignment, @provider_name, params[:id]),
+        alert: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}." and return
+    end
+    @assignments = syllabus.assignments(params[:id]) do
+      redirect_to assignment_grades_importer_grades_path(@assignment, @provider_name, params[:id]),
+        alert: "There was an issue trying to retrieve the assignments from #{@provider_name.capitalize}." and return
+    end
   end
 
   # GET /assignments/:assignment_id/grades/download

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -54,10 +54,10 @@ class Grades::ImportersController < ApplicationController
     if @result.success?
       render :grades_import_results
     else
-      @grades = syllabus.grades(params[:id], params[:assignment_ids])[:data] do
+      @grades = syllabus.grades(params[:id], params[:assignment_ids]) do
         redirect_to assignment_grades_importers_path(@assignment),
           alert: "There was an issue trying to retrieve the grades from #{@provider_name.capitalize}." and return
-      end
+      end[:data]
 
       render :grades, alert: @result.message
     end

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -34,7 +34,7 @@ class Grades::ImportersController < ApplicationController
     end
   end
 
-  # POST /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades
+  # GET /assignments/:assignment_id/grades/importers/:importer_provider_id/courses/:id/grades
   def grades
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -54,7 +54,10 @@ class Grades::ImportersController < ApplicationController
     if @result.success?
       render :grades_import_results
     else
-      @grades = syllabus.grades(params[:id], params[:assignment_ids])[:data]
+      @grades = syllabus.grades(params[:id], params[:assignment_ids])[:data] do
+        redirect_to assignment_grades_importers_path(@assignment),
+          alert: "There was an issue trying to retrieve the grades from #{@provider_name.capitalize}." and return
+      end
 
       render :grades, alert: @result.message
     end

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -14,7 +14,10 @@ class Integrations::CoursesController < ApplicationController
     authorize! :read, @course
 
     @provider_name = params[:integration_id]
-    @courses = syllabus(@provider_name).courses
+    @courses = syllabus(@provider_name).courses do
+      redirect_to integrations_path,
+        alert: "There was an issue trying to retrieve the courses from #{@provider_name.capitalize}." and return
+    end
   end
 
   def create

--- a/app/controllers/integrations/courses_controller.rb
+++ b/app/controllers/integrations/courses_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable AndOr
 class Integrations::CoursesController < ApplicationController
   include OAuthProvider
 

--- a/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
+++ b/app/services/imports_lms_assignments/retrieves_lms_assignment.rb
@@ -17,11 +17,12 @@ module Services
         context.lms_assignment = nil
 
         syllabus = ActiveLMS::Syllabus.new provider, access_token
-        begin
-          context.lms_assignment = syllabus.assignment course_id, assignment_id
-        rescue StandardError => e
-          context.fail! e.message
+        context.lms_assignment = syllabus.assignment(course_id, assignment_id) do
+          context.fail!("An error occurred while attempting to retrieve the #{provider} assignment", error_code: 500)
+          next context
         end
+
+        next context if context.failure?
       end
     end
   end

--- a/app/services/imports_lms_assignments/retrieves_lms_assignments.rb
+++ b/app/services/imports_lms_assignments/retrieves_lms_assignments.rb
@@ -15,7 +15,12 @@ module Services
         course_id = context.course_id
 
         syllabus = ActiveLMS::Syllabus.new provider, access_token
-        context.assignments = syllabus.assignments course_id, assignment_ids
+        context.assignments = syllabus.assignments(course_id, assignment_ids) do
+          context.fail!("An error occurred while attempting to retrieve #{provider} assignments", error_code: 500)
+          next context
+        end
+
+        next context if context.failure?
       end
     end
   end

--- a/app/services/imports_lms_grades/retrieves_lms_grades.rb
+++ b/app/services/imports_lms_grades/retrieves_lms_grades.rb
@@ -16,7 +16,12 @@ module Services
         grade_ids = context.grade_ids
 
         syllabus = ActiveLMS::Syllabus.new provider, access_token
-        context.grades = syllabus.grades(course_id, assignment_ids, grade_ids)[:data]
+        context.grades = syllabus.grades(course_id, assignment_ids, grade_ids) do
+          context.fail!("An error occurred while attempting to retrieve #{provider} grades", error_code: 500)
+          next context
+        end[:data]
+
+        next context if context.failure?
         context.user_ids = context.grades.map { |h| h["user_id"] }.compact.uniq
       end
     end

--- a/app/services/imports_lms_users/retrieves_lms_users.rb
+++ b/app/services/imports_lms_users/retrieves_lms_users.rb
@@ -17,8 +17,13 @@ module Services
 
         syllabus = ActiveLMS::Syllabus.new provider, access_token
         user_ids.each do |user_id|
-          context.users << syllabus.user(user_id)
+          context.users << syllabus.user(user_id) do
+            context.fail!("An error occurred while attempting to retrieve #{provider} users", error_code: 500)
+            next context
+          end
         end
+
+        next context if context.failure?
       end
     end
   end

--- a/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
+++ b/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
@@ -19,6 +19,8 @@ module Services
           context.fail!("An error occurred while attempting to retrieve #{provider} users", error_code: 500)
           next context
         end[:data]
+
+        next context if context.failure?
       end
     end
   end

--- a/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
+++ b/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
@@ -15,7 +15,10 @@ module Services
         user_ids = context.user_ids
 
         syllabus = ActiveLMS::Syllabus.new provider, access_token
-        context.users = syllabus.users(course_id, true, user_ids: user_ids)[:data]
+        context.users = syllabus.users(course_id, true, user_ids: user_ids) do
+          context.fail!("An error occurred while attempting to retrieve #{provider} users", error_code: 500)
+          next context
+        end[:data]
       end
     end
   end

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -22,8 +22,8 @@ module ActiveLMS
       provider.courses
     end
 
-    def assignment(course_id, assignment_id)
-      provider.assignment(course_id, assignment_id)
+    def assignment(course_id, assignment_id, &exception_handler)
+      provider.assignment(course_id, assignment_id, &exception_handler)
     end
 
     def assignments(course_id, assignment_ids=nil)

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -14,8 +14,8 @@ module ActiveLMS
       raise InvalidProviderError.new(provider)
     end
 
-    def course(id)
-      provider.course(id)
+    def course(id, &exception_handler)
+      provider.course(id, &exception_handler)
     end
 
     def courses

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -18,8 +18,8 @@ module ActiveLMS
       provider.course(id, &exception_handler)
     end
 
-    def courses
-      provider.courses
+    def courses(&exception_handler)
+      provider.courses(&exception_handler)
     end
 
     def assignment(course_id, assignment_id, &exception_handler)

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -38,8 +38,8 @@ module ActiveLMS
       provider.update_assignment(course_id, assignment_id, params, &exception_handler)
     end
 
-    def user(id)
-      provider.user(id)
+    def user(id, &exception_handler)
+      provider.user(id, &exception_handler)
     end
 
     def users(course_id, fetch_next=true, options={})

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -34,8 +34,8 @@ module ActiveLMS
       provider.grades(course_id, assignment_ids, grade_ids, fetch_next, options, &exception_handler)
     end
 
-    def update_assignment(course_id, assignment_id, params)
-      provider.update_assignment(course_id, assignment_id, params)
+    def update_assignment(course_id, assignment_id, params, &exception_handler)
+      provider.update_assignment(course_id, assignment_id, params, &exception_handler)
     end
 
     def user(id)

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -26,8 +26,8 @@ module ActiveLMS
       provider.assignment(course_id, assignment_id, &exception_handler)
     end
 
-    def assignments(course_id, assignment_ids=nil)
-      provider.assignments(course_id, assignment_ids)
+    def assignments(course_id, assignment_ids=nil, &exception_handler)
+      provider.assignments(course_id, assignment_ids, &exception_handler)
     end
 
     def grades(course_id, assignment_ids, grade_ids=nil, fetch_next=true, options={}, &exception_handler)

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -30,8 +30,8 @@ module ActiveLMS
       provider.assignments(course_id, assignment_ids)
     end
 
-    def grades(course_id, assignment_ids, grade_ids=nil, fetch_next=true, options={})
-      provider.grades(course_id, assignment_ids, grade_ids, fetch_next, options)
+    def grades(course_id, assignment_ids, grade_ids=nil, fetch_next=true, options={}, &exception_handler)
+      provider.grades(course_id, assignment_ids, grade_ids, fetch_next, options, &exception_handler)
     end
 
     def update_assignment(course_id, assignment_id, params)

--- a/lib/active_lms/syllabus.rb
+++ b/lib/active_lms/syllabus.rb
@@ -42,8 +42,8 @@ module ActiveLMS
       provider.user(id, &exception_handler)
     end
 
-    def users(course_id, fetch_next=true, options={})
-      provider.users(course_id, fetch_next, options)
+    def users(course_id, fetch_next=true, options={}, &exception_handler)
+      provider.users(course_id, fetch_next, options, &exception_handler)
     end
   end
 end

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -18,6 +18,9 @@ module ActiveLMS
     # Internal: Retrieves a single course from the Canvas API.
     #
     # id - A String representing the course id from the Canvas API.
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
     #
     # Examples
     #
@@ -66,10 +69,12 @@ module ActiveLMS
     #   "access_restricted_by_date": false,
     #   "time_zone": "America/Denver"
     # }
-    def course(id)
-      course = nil
-      client.get_data("/courses/#{id}") { |data| course = data }
-      course
+    def course(id, &exception_handler)
+      handle_exceptions(exception_handler) do
+        course = nil
+        client.get_data("/courses/#{id}") { |data| course = data }
+        course
+      end
     end
 
     # Internal: Retrieves all the courses assigned to as a teacher from

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -226,6 +226,9 @@ module ActiveLMS
     #
     # course_id - A String representing the course id from the Canvas API.
     # assignment_id - A String representing the assignment id from the Canvas API.
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
     #
     # Examples
     #
@@ -291,12 +294,14 @@ module ActiveLMS
     #  "overrides": null,
     #  "omit_from_final_grade": true
     # }
-    def assignment(course_id, assignment_id)
-      assignment = nil
-      client.get_data("/courses/#{course_id}/assignments/#{assignment_id}") do |data|
-        assignment = data
+    def assignment(course_id, assignment_id, &exception_handler)
+      handle_exceptions(exception_handler) do
+        assignment = nil
+        client.get_data("/courses/#{course_id}/assignments/#{assignment_id}") do |data|
+          assignment = data
+        end
+        assignment
       end
-      assignment
     end
 
     # Internal: Retrieves all the grades for a specific course and assignments from

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -80,6 +80,10 @@ module ActiveLMS
     # Internal: Retrieves all the courses assigned to as a teacher from
     # the Canvas API.
     #
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
+    #
     # Examples
     #
     # GET: http://instructure.com/api/v1/courses?enrollment_type=teacher
@@ -127,11 +131,13 @@ module ActiveLMS
     #   "access_restricted_by_date": false,
     #   "time_zone": "America/Denver"
     # }]
-    def courses
+    def courses(&exception_handler)
       @courses || begin
         @courses = []
-        client.get_data("/courses", enrollment_type: "teacher") do |data|
-          @courses += data
+        handle_exceptions(exception_handler) do
+          client.get_data("/courses", enrollment_type: "teacher") do |data|
+            @courses += data
+          end
         end
       end
       @courses

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -138,6 +138,9 @@ module ActiveLMS
     # id - A String representing the course id from the Canvas API.
     # assignment_ids - An Array of ids that can filter out the assignments
     # there were retrieved.
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
     #
     # Examples
     #
@@ -203,13 +206,15 @@ module ActiveLMS
     #  "overrides": null,
     #  "omit_from_final_grade": true
     # }]
-    def assignments(course_id, assignment_ids=nil)
+    def assignments(course_id, assignment_ids=nil, &exception_handler)
       assignments = []
 
       if assignment_ids.nil?
-        client.get_data("/courses/#{course_id}/assignments") do |data|
-          data.select { |assignment| assignment["published"] }.each do |assignment|
-            assignments << assignment
+        handle_exceptions(exception_handler) do
+          client.get_data("/courses/#{course_id}/assignments") do |data|
+            data.select { |assignment| assignment["published"] }.each do |assignment|
+              assignments << assignment
+            end
           end
         end
       else

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -472,6 +472,9 @@ module ActiveLMS
     # Internal: Retrieves single user from the Canvas API.
     #
     # id - A String representing the user id from the Canvas API.
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
     #
     # Examples
     #
@@ -496,10 +499,12 @@ module ActiveLMS
     #  "time_zone": "America/Denver",
     #  "bio": "I like the Muppets."
     # }
-    def user(id)
-      user = nil
-      client.get_data("/users/#{id}/profile") { |data| user = data }
-      user
+    def user(id, &exception_handler)
+      handle_exceptions(exception_handler) do
+        user = nil
+        client.get_data("/users/#{id}/profile") { |data| user = data }
+        user
+      end
     end
 
     # Internal: Returns the list of users in this course. And optionally the user's enrollments in the course.

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -339,7 +339,7 @@ module ActiveLMS
     #   "assignment_visible": true,
     #   "excused": true
     # }]
-    def grades(course_id, assignment_ids, grade_ids=nil, fetch_next=false, options={})
+    def grades(course_id, assignment_ids, grade_ids=nil, fetch_next=false, options={}, &exception_handler)
       grades = []
       params = { assignment_ids: assignment_ids,
                  student_ids: "all",
@@ -357,6 +357,10 @@ module ActiveLMS
         end
       end
       { data: grades, has_next_page: result[:has_next_page] }
+    rescue JSON::ParserError => e
+      if block_given?
+        exception_handler.call(e)
+      end
     end
 
     def update_assignment(course_id, assignment_id, params)

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -544,15 +544,17 @@ module ActiveLMS
     #   },
     #   has_next_page: true
     # }
-    def users(course_id, fetch_next=false, options={})
-      users = []
-      params = {
-        include: ["enrollments", "email"]
-      }.merge(options)
-      result = client.get_data("/courses/#{course_id}/users", params, fetch_next) do |data|
-        users += data
+    def users(course_id, fetch_next=false, options={}, &exception_handler)
+      handle_exceptions(exception_handler) do
+        users = []
+        params = {
+          include: ["enrollments", "email"]
+        }.merge(options)
+        result = client.get_data("/courses/#{course_id}/users", params, fetch_next) do |data|
+          users += data
+        end
+        { data: users, has_next_page: result[:has_next_page] }
       end
-      { data: users, has_next_page: result[:has_next_page] }
     end
 
     private

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -250,7 +250,7 @@ module ActiveLMS
     #
     # GET: http://instructure.com/api/v1/courses/:course_id/assignments/:id
     #
-    # Returns a Hashes representing an assignments.
+    # Returns a Hash representing a single assignment.
     #
     # {
     #   "id": 4,
@@ -384,11 +384,87 @@ module ActiveLMS
       end
     end
 
-    def update_assignment(course_id, assignment_id, params)
+    # Internal: Updates an assignment on Canvas with the specified params on
+    # the Canvas API.
+    #
+    # course_id - A String representing the course id from the Canvas API.
+    # assignment_id - A String representing the assignment id from the Canvas API.
+    # params - A hash representing the changes for the assignment on the Canvas API.
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
+    #
+    # Examples
+    #
+    # PUT: http://instructure.com/api/v1/courses/:id/students/submission
+    #
+    # Returns a Hash representing an updated assignment.
+    #
+    # {
+    #   "id": 4,
+    #   "name": "some assignment",
+    #   "description": "<p>Do the following:</p>...",
+    #   "created_at": "2012-07-01T23:59:00-06:00",
+    #   "updated_at": "2012-07-01T23:59:00-06:00",
+    #   "due_at": "2012-07-01T23:59:00-06:00",
+    #   "lock_at": "2012-07-01T23:59:00-06:00",
+    #   "unlock_at": "2012-07-01T23:59:00-06:00",
+    #   "has_overrides": true,
+    #   "all_dates": null,
+    #   "course_id": 123,
+    #   "html_url": "https://...",
+    #   "submissions_download_url": ".../courses/:course_id/assignments/:id/submissions",
+    #  "assignment_group_id": 2,
+    #  "allowed_extensions": ["docx", "ppt"],
+    #  "turnitin_enabled": true,
+    #  "turnitin_settings": null,
+    #  "grade_group_students_individually": false,
+    #  "external_tool_tag_attributes": null,
+    #  "peer_reviews": false,
+    #  "automatic_peer_reviews": false,
+    #  "peer_review_count": 0,
+    #  "peer_reviews_assign_at": "2012-07-01T23:59:00-06:00",
+    #  "group_category_id": 1,
+    #  "needs_grading_count": 17,
+    #  "needs_grading_count_by_section": [{
+    #     "section_id":"123456",
+    #     "needs_grading_count":5 }],
+    #  "position": 1,
+    #  "post_to_sis": true,
+    #  "integration_id": "12341234",
+    #  "integration_data": "12341234",
+    #  "muted": null,
+    #  "points_possible": 12,
+    #  "submission_types": ["online_text_entry"],
+    #  "grading_type": "points",
+    #  "grading_standard_id": null,
+    #  "published": true,
+    #  "unpublishable": false,
+    #  "only_visible_to_overrides": false,
+    #  "locked_for_user": false,
+    #  "lock_info": null,
+    #  "lock_explanation": "This assignment is locked until September 1 at 12:00am",
+    #  "quiz_id": 620,
+    #  "anonymous_submissions": false,
+    #  "discussion_topic": null,
+    #  "freeze_on_copy": false,
+    #  "frozen": false,
+    #  "frozen_attributes": ["title"],
+    #  "submission": null,
+    #  "use_rubric_for_grading": true,
+    #  "rubric_settings": "{"points_possible"=>12}",
+    #  "rubric": null,
+    #  "assignment_visibility": [137, 381, 572],
+    #  "overrides": null,
+    #  "omit_from_final_grade": true
+    # }
+    def update_assignment(course_id, assignment_id, params, &exception_handler)
       assignment = nil
-      client.set_data(
-        "/courses/#{course_id}/assignments/#{assignment_id}", :put, params) do |data|
-          assignment = data
+      handle_exceptions(exception_handler) do
+        client.set_data(
+          "/courses/#{course_id}/assignments/#{assignment_id}", :put, params) do |data|
+            assignment = data
+        end
       end
       assignment
     end
@@ -401,7 +477,7 @@ module ActiveLMS
     #
     # GET: http://instructure.com/api/v1/users/:id/profile
     #
-    # Returns an Array of Hashes representing multiple grades.
+    # Returns a Hashe representing a single user.
     #
     # {
     #   "id": 2,

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -357,9 +357,11 @@ module ActiveLMS
         end
       end
       { data: grades, has_next_page: result[:has_next_page] }
-    rescue JSON::ParserError => e
+    rescue Canvas::ResponseError, HTTParty::Error, JSON::ParserError => e
       if block_given?
         exception_handler.call(e)
+      else
+        raise e
       end
     end
 
@@ -369,7 +371,7 @@ module ActiveLMS
         "/courses/#{course_id}/assignments/#{assignment_id}", :put, params) do |data|
           assignment = data
       end
-        assignment
+      assignment
     end
 
     # Internal: Retrieves single user from the Canvas API.

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -310,7 +310,9 @@ module ActiveLMS
     # automatically
     # options - A hash representing any additional parameters that should be included
     # in the query
-    #
+    # exception_handler - A block that is called (if provided) when an error occurs
+    # so the calling client can handle an exception gracefully. Currently rescues
+    # `HTTParty::Error`, `Canvas::ResponseError`, and `JSON::ParserError`.
     # Examples
     #
     # GET: http://instructure.com/api/v1/courses/:id/students/submission

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -1,14 +1,43 @@
 describe Grades::ImportersController do
   let(:course) { build :course }
-  let!(:student)  { create(:course_membership, :student, course: course).user }
-  let(:professor) { create(:course_membership, :professor, course: course).user }
   let(:assignment) { create :assignment, course: course }
-  let(:grade) { create(:grade, student: student, assignment: assignment, course: course) }
+  let(:grade) { build_stubbed :grade, student: student, assignment: assignment, course: course }
+  let(:student) { build :user, courses: [course], role: :student }
 
   before { allow(controller).to receive(:current_course).and_return course }
 
   context "as a professor" do
+    let(:professor) { build :user, courses: [course], role: :professor }
+
     before { login_user professor }
+
+    describe "GET assignments" do
+      let(:provider) { :canvas }
+      let(:course_id) { "COURSE_ID" }
+      let(:access_token) { "BLAH" }
+      let!(:user_authorization) do
+        create :user_authorization, :canvas, user: professor, access_token: access_token,
+          expires_at: 2.days.from_now
+      end
+
+      it "redirects to the grade import page if the course cannot be retrieved" do
+        allow_any_instance_of(ActiveLMS::Syllabus).to receive(:course) { |&b| b.call }
+        get :assignments, params: { assignment_id: assignment.id, importer_provider_id: provider,
+          id: course_id }
+
+        expect(response).to redirect_to assignment_grades_importer_grades_path assignment,
+          provider, course_id
+      end
+
+      it "redirects to the grade import page if the assignments cannot be retrieved" do
+        allow_any_instance_of(ActiveLMS::Syllabus).to receive(:assignments) { |&b| b.call }
+        get :assignments, params: { assignment_id: assignment.id, importer_provider_id: provider,
+          id: course_id }
+
+        expect(response).to redirect_to assignment_grades_importer_grades_path assignment,
+          provider, course_id
+      end
+    end
 
     describe "GET download" do
       it "returns sample csv data" do
@@ -78,7 +107,7 @@ describe Grades::ImportersController do
       let(:assignment_ids) { ["ASSIGNMENT_1"] }
       let(:course_id) { "COURSE_ID" }
       let(:grade_ids) { ["GRADE1", "GRADE2"] }
-      let(:result) { double(:result, success?: true, message: "") }
+      let(:result) { double :result, success?: true, message: "" }
       let!(:user_authorization) do
         create :user_authorization, :canvas, user: professor, access_token: access_token,
           expires_at: 2.days.from_now

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -15,13 +15,19 @@ describe Grades::ImportersController do
       let(:provider) { :canvas }
       let(:course_id) { "COURSE_ID" }
       let(:access_token) { "BLAH" }
+      let(:syllabus) { double :syllabus, course: {}, assignments: [] }
       let!(:user_authorization) do
         create :user_authorization, :canvas, user: professor, access_token: access_token,
           expires_at: 2.days.from_now
       end
 
+      before(:each) do
+        allow(ActiveLMS::Syllabus).to receive(:new).with("canvas", access_token).and_return \
+          syllabus
+      end
+
       it "redirects to the grade import page if the course cannot be retrieved" do
-        allow_any_instance_of(ActiveLMS::Syllabus).to receive(:course) { |&b| b.call }
+        allow(syllabus).to receive(:course) { |&b| b.call }
         get :assignments, params: { assignment_id: assignment.id, importer_provider_id: provider,
           id: course_id }
 
@@ -30,7 +36,7 @@ describe Grades::ImportersController do
       end
 
       it "redirects to the grade import page if the assignments cannot be retrieved" do
-        allow_any_instance_of(ActiveLMS::Syllabus).to receive(:assignments) { |&b| b.call }
+        allow(syllabus).to receive(:assignments) { |&b| b.call }
         get :assignments, params: { assignment_id: assignment.id, importer_provider_id: provider,
           id: course_id }
 

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -73,35 +73,6 @@ describe Grades::ImportersController do
       end
     end
 
-    describe "GET grades" do
-      let(:access_token) { "BLAH" }
-
-      before do
-        UserAuthorization.create user: professor,
-          provider: :canvas, access_token: access_token, refresh_token: "BLAH",
-          expires_at: 2.days.from_now
-        WebMock.disable_net_connect!(allow_localhost: true)
-      end
-      after { WebMock.allow_net_connect! }
-
-      context "unable to connect to Canvas" do
-        it "redirects back to the importers selection" do
-          stub_request(:get,
-                       "https://umich-dev.instructure.com/api/v1/courses/123/assignments/")
-            .with(query: { "access_token" => access_token })
-            .to_raise(JSON::ParserError)
-
-          get :grades, params: { assignment_id: world.assignment.id,
-                                 importer_provider_id: :canvas,
-                                 id: "123" }
-
-          expect(flash[:alert]).to eq \
-            "There was an issue trying to retrieve the assignment from Canvas."
-          expect(response).to redirect_to assignment_grades_importers_path(world.assignment)
-        end
-      end
-    end
-
     describe "POST grades_import" do
       let(:access_token) { "BLAH" }
       let(:assignment_ids) { ["ASSIGNMENT_1"] }

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -73,6 +73,35 @@ describe Grades::ImportersController do
       end
     end
 
+    describe "GET grades" do
+      let(:access_token) { "BLAH" }
+
+      before do
+        UserAuthorization.create user: professor,
+          provider: :canvas, access_token: access_token, refresh_token: "BLAH",
+          expires_at: 2.days.from_now
+        WebMock.disable_net_connect!(allow_localhost: true)
+      end
+      after { WebMock.allow_net_connect! }
+
+      context "unable to connect to Canvas" do
+        it "redirects back to the importers selection" do
+          stub_request(:get,
+                       "https://umich-dev.instructure.com/api/v1/courses/123/assignments/")
+            .with(query: { "access_token" => access_token })
+            .to_raise(JSON::ParserError)
+
+          get :grades, params: { assignment_id: world.assignment.id,
+                                 importer_provider_id: :canvas,
+                                 id: "123" }
+
+          expect(flash[:alert]).to eq \
+            "There was an issue trying to retrieve the assignment from Canvas."
+          expect(response).to redirect_to assignment_grades_importers_path(world.assignment)
+        end
+      end
+    end
+
     describe "POST grades_import" do
       let(:access_token) { "BLAH" }
       let(:assignment_ids) { ["ASSIGNMENT_1"] }

--- a/spec/controllers/users/importers_controller_spec.rb
+++ b/spec/controllers/users/importers_controller_spec.rb
@@ -18,29 +18,35 @@ describe Users::ImportersController do
     describe "#users_import" do
       let(:id) { 1 }
       let(:user_ids) { [12, 23] }
-      let(:result) { double(:result, success?: true, message: "") }
 
       before(:each) do
         allow(Services::ImportsLMSUsers).to receive(:import).and_return result
       end
 
-      it "imports the lms users" do
-        expect(Services::ImportsLMSUsers).to receive(:import).and_return result
-        post :users_import, params: { id: id, importer_provider_id: provider,
-          user_ids: user_ids }
+      context "when successful" do
+        let(:result) { double(:result, success?: true, message: "") }
+
+        it "imports the lms users" do
+          expect(Services::ImportsLMSUsers).to receive(:import).and_return result
+          post :users_import, params: { id: id, importer_provider_id: provider,
+            user_ids: user_ids }
+        end
+
+        it "renders the results if successful" do
+          post :users_import, params: { id: id, importer_provider_id: provider,
+            user_ids: user_ids }
+          expect(response).to render_template :user_import_results
+        end
       end
 
-      it "renders the results if successful" do
-        post :users_import, params: { id: id, importer_provider_id: provider,
-          user_ids: user_ids }
-        expect(response).to render_template :user_import_results
-      end
+      context "when unsuccessful" do
+        let(:result) { double(:result, success?: false) }
 
-      it "redirects to the user import page if unsuccessful" do
-        allow(result).to receive(:success?).and_return false
-        post :users_import, params: { id: id, importer_provider_id: provider,
-          user_ids: user_ids }
-        expect(response).to redirect_to users_importer_users_path(provider, id)
+        it "redirects to the user import page" do
+          post :users_import, params: { id: id, importer_provider_id: provider,
+            user_ids: user_ids }
+          expect(response).to redirect_to users_importer_users_path(provider, id)
+        end
       end
     end
   end

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -305,18 +305,34 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
   end
 
   describe "#user" do
-    subject { described_class.new access_token }
-
-    it "retrieves the user for the id from the api" do
+    let(:stub) do
       stub_request(:get, "https://canvas.instructure.com/api/v1/users/123/profile")
         .with(query: { "access_token" => access_token })
-        .to_return(status: 200, body: { name: "Jimmy Page" }.to_json,
-                   headers: {})
+    end
+    subject { described_class.new access_token }
 
-      user = subject.user(123)
+    context "with a successful API call" do
+      it "retrieves the user for the id from the api" do
+        stub.to_return(status: 200, body: { name: "Jimmy Page" }.to_json, headers: {})
 
-      expect(user).to_not be_nil
-      expect(user["name"]).to eq "Jimmy Page"
+        user = subject.user(123)
+
+        expect(user).to_not be_nil
+        expect(user["name"]).to eq "Jimmy Page"
+      end
+    end
+
+    context "with an API error" do
+      let!(:json_error) { stub.to_raise(JSON::ParserError) }
+
+      it "calls the exception handler if one is provided" do
+        expect { |b| subject.user(123, &b) }.to \
+          yield_with_args(instance_of(JSON::ParserError))
+      end
+
+      it "raises the error if an exception handler is not provided" do
+        expect { subject.user(123) }.to raise_error JSON::ParserError
+      end
     end
   end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -17,19 +17,35 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
   end
 
   describe "#assignment" do
-    subject { described_class.new access_token }
-
-    it "retrieves the assignment for the id from the api" do
-      body = { name: "This is a published assignment" }
+    let(:stub) do
       stub_request(:get,
                    "https://canvas.instructure.com/api/v1/courses/123/assignments/456")
         .with(query: { "access_token" => access_token })
-        .to_return(status: 200, body: body.to_json,
-                   headers: {})
+    end
+    subject { described_class.new access_token }
 
-      assignment = subject.assignment(123, 456)
+    context "with a successful API call" do
+      it "retrieves the assignment for the id from the api" do
+        body = { name: "This is a published assignment" }
+        stub.to_return(status: 200, body: body.to_json, headers: {})
 
-      expect(assignment["name"]).to eq "This is a published assignment"
+        assignment = subject.assignment(123, 456)
+
+        expect(assignment["name"]).to eq "This is a published assignment"
+      end
+    end
+
+    context "with an API error" do
+      let!(:json_error) { stub.to_raise(JSON::ParserError) }
+
+      it "calls the exception handler if one is provided" do
+        expect { |b| subject.assignment(123, 456, &b) }.to \
+          yield_with_args(instance_of(JSON::ParserError))
+      end
+
+      it "raises the error if an exception handler is not provided" do
+        expect { subject.assignment(123, 456) }.to raise_error JSON::ParserError
+      end
     end
   end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -199,7 +199,9 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
           yield_with_args(instance_of(JSON::ParserError))
       end
 
-      xit "raises the error if an exception handler is not provided"
+      it "raises the error if an exception handler is not provided" do
+        expect { subject.grades(123, assignment_ids, "456") }.to raise_error JSON::ParserError
+      end
     end
   end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -134,56 +134,72 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
         { id: 777, score: nil, submission_comments: "good jorb!" }
       ]
     end
-    let!(:stub) do
+    let(:stub) do
       stub_request(:get,
           "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
         .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
                        "include" => ["assignment", "course", "user", "submission_comments"],
                        "per_page" => 25,
                        "access_token" => access_token })
-        .to_return(status: 200, body: grades.to_json, headers: {})
     end
     subject { described_class.new access_token }
 
-    it "returns a hash containing only grades with scores or feedback" do
-      result = subject.grades(123, assignment_ids)
-
-      expect(result[:data].count).to eq 2
-      expect(result[:data]).to include({ "id" => 456, "score" => 87 },
-        { "id" => 777, "score" => nil, "submission_comments" => "good jorb!" })
-      expect(result[:has_next_page]).to eq false
-    end
-
-    it "merges options if provided" do
-      stub_request(:get,
-          "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
-        .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
-                       "include" => ["assignment", "course", "user", "submission_comments"],
-                       "per_page" => 5, "test" => true,
-                       "access_token" => access_token })
-        .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
-      result = subject.grades(123, assignment_ids, nil, nil, { per_page: 5, test: true })
-      expect(result[:data].count).to eq 1
-    end
-
-    context "for specific ids" do
-      it "filters out a single id" do
-        result = subject.grades(123, assignment_ids, "456")
-
-        expect(result[:data].first["id"]).to eq 456
+    context "with a successful API call" do
+      let!(:successful_stub) do
+        stub.to_return(status: 200, body: grades.to_json, headers: {})
       end
 
-      it "does not duplicate the grades for double grade ids" do
-        result = subject.grades(123, assignment_ids, [456, 456])
+      it "returns a hash containing only grades with scores or feedback" do
+        result = subject.grades(123, assignment_ids)
 
+        expect(result[:data].count).to eq 2
+        expect(result[:data]).to include({ "id" => 456, "score" => 87 },
+          { "id" => 777, "score" => nil, "submission_comments" => "good jorb!" })
+        expect(result[:has_next_page]).to eq false
+      end
+
+      it "merges options if provided" do
+        stub_request(:get,
+            "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
+          .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
+                         "include" => ["assignment", "course", "user", "submission_comments"],
+                         "per_page" => 5, "test" => true,
+                         "access_token" => access_token })
+          .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
+        result = subject.grades(123, assignment_ids, nil, nil, { per_page: 5, test: true })
         expect(result[:data].count).to eq 1
       end
 
-      it "filters out the grade ids" do
-        result = subject.grades(123, assignment_ids, [123])
+      context "for specific ids" do
+        it "filters out a single id" do
+          result = subject.grades(123, assignment_ids, "456")
 
-        expect(result[:data]).to be_empty
+          expect(result[:data].first["id"]).to eq 456
+        end
+
+        it "does not duplicate the grades for double grade ids" do
+          result = subject.grades(123, assignment_ids, [456, 456])
+
+          expect(result[:data].count).to eq 1
+        end
+
+        it "filters out the grade ids" do
+          result = subject.grades(123, assignment_ids, [123])
+
+          expect(result[:data]).to be_empty
+        end
       end
+    end
+
+    context "with an API error" do
+      let!(:json_error) { stub.to_raise(JSON::ParserError) }
+
+      it "calls the exception handler if one is provided" do
+        expect { |b| subject.grades(123, assignment_ids, "456",  &b) }.to \
+          yield_with_args(instance_of(JSON::ParserError))
+      end
+
+      xit "raises the error if an exception handler is not provided"
     end
   end
 

--- a/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
+++ b/spec/services/imports_lms_assignments/retrieves_lms_assignment_spec.rb
@@ -36,15 +36,12 @@ describe Services::Actions::RetrievesLMSAssignment do
   end
 
   it "fails the context if the assignment cannot be found" do
-    allow_any_instance_of(ActiveLMS::Syllabus).to \
-      receive(:assignment).with(imported_assignment.provider_data["course_id"],
-                                imported_assignment.provider_resource_id)
-      .and_raise("Resource not found")
+    allow_any_instance_of(ActiveLMS::Syllabus).to receive(:assignment) { |&b| b.call }
 
     result = described_class.execute access_token: access_token,
       imported_assignment: imported_assignment, provider: provider
 
     expect(result).to_not be_success
-    expect(result.message).to eq "Resource not found"
+    expect(result.message).to eq "An error occurred while attempting to retrieve the #{provider} assignment"
   end
 end

--- a/spec/services/imports_lms_assignments/retrieves_lms_assignments_spec.rb
+++ b/spec/services/imports_lms_assignments/retrieves_lms_assignments_spec.rb
@@ -38,4 +38,14 @@ describe Services::Actions::RetrievesLMSAssignments do
     result = described_class.execute provider: provider, access_token: access_token,
       assignment_ids: assignment_ids, course_id: course_id
   end
+
+  it "fails the context if there was an error" do
+    allow_any_instance_of(ActiveLMS::Syllabus).to receive(:assignments) { |&b| b.call }
+
+    result = described_class.execute provider: provider, access_token: access_token,
+      assignment_ids: assignment_ids, course_id: course_id
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "An error occurred while attempting to retrieve #{provider} assignments"
+  end
 end

--- a/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
@@ -55,4 +55,14 @@ describe Services::Actions::RetrievesLMSGrades do
 
     expect(result).to have_key :user_ids
   end
+
+  it "fails the context if an error occurs" do
+    allow_any_instance_of(ActiveLMS::Syllabus).to receive(:grades) { |&b| b.call }
+
+    result = described_class.execute provider: provider, access_token: access_token,
+      course_id: course_id, assignment_ids: assignment_ids, grade_ids: grade_ids
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "An error occurred while attempting to retrieve #{provider} grades"
+  end
 end

--- a/spec/services/imports_lms_users/retrieves_lms_users_spec.rb
+++ b/spec/services/imports_lms_users/retrieves_lms_users_spec.rb
@@ -44,4 +44,14 @@ describe Services::Actions::RetrievesLMSUsers do
     described_class.execute provider: provider, access_token: access_token,
       user_ids: user_ids
   end
+
+  it "fails the context if there was an error" do
+    allow_any_instance_of(ActiveLMS::Syllabus).to receive(:user) { |&b| b.call }
+
+    result = described_class.execute provider: provider, access_token: access_token,
+      user_ids: user_ids
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "An error occurred while attempting to retrieve #{provider} users"
+  end
 end

--- a/spec/services/imports_lms_users/retrieves_lms_users_with_roles_spec.rb
+++ b/spec/services/imports_lms_users/retrieves_lms_users_with_roles_spec.rb
@@ -39,8 +39,7 @@ describe Services::Actions::RetrievesLMSUsersWithRoles, type: :disable_external_
   end
 
   it "fails the context if an error occurs" do
-    allow_any_instance_of(Canvas::API).to \
-      receive(:get_data).and_raise(JSON::ParserError)
+    allow_any_instance_of(ActiveLMS::Syllabus).to receive(:users) { |&b| b.call }
 
     result = described_class.execute provider: provider, access_token: access_token,
       course_id: course_id, user_ids: user_ids

--- a/spec/services/imports_lms_users/retrieves_lms_users_with_roles_spec.rb
+++ b/spec/services/imports_lms_users/retrieves_lms_users_with_roles_spec.rb
@@ -1,6 +1,6 @@
 require "./app/services/imports_lms_users/retrieves_lms_users_with_roles"
 
-describe Services::Actions::RetrievesLMSUsersWithRoles do
+describe Services::Actions::RetrievesLMSUsersWithRoles, type: :disable_external_api do
   let(:access_token) { "TOKEN" }
   let(:provider) { "canvas" }
   let(:course_id) { "123" }
@@ -36,5 +36,16 @@ describe Services::Actions::RetrievesLMSUsersWithRoles do
 
     described_class.execute provider: provider, access_token: access_token,
       course_id: course_id, user_ids: user_ids
+  end
+
+  it "fails the context if an error occurs" do
+    allow_any_instance_of(Canvas::API).to \
+      receive(:get_data).and_raise(JSON::ParserError)
+
+    result = described_class.execute provider: provider, access_token: access_token,
+      course_id: course_id, user_ids: user_ids
+
+    expect(result).to_not be_success
+    expect(result.message).to eq "An error occurred while attempting to retrieve #{provider} users"
   end
 end


### PR DESCRIPTION
### Status
**HOLD**

### Description
Gracefully handle any Canvas communication issues in the controller. This adds an exception handler block for any canvas call so the controller can redirect to a non-canvas controller method and display an alert to the user saying that the communication with Canvas did not work.

**WAITING ON WHAT TO DO ABOUT GETTING THE ACTUAL ERROR FROM CANVAS**

### Migrations
NO

### Steps to Test or Reproduce

1.  Login as an instructor
1. Link the Canvas course 97697 with any GC course
1. Import grades from assignment 103424
1. Should see error message and the error should be gracefully handled

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Linking Canvas courses
* Canvas importing of assignments
* Canvas importing of grades

Closes #2633