### PR TITLE
add grade id to criterion grades

### DIFF
--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -15,6 +15,7 @@ class Grade < ActiveRecord::Base
 
   has_one :imported_grade, dependent: :destroy
   has_many :earned_badges, dependent: :destroy
+  has_many :criterion_grades, dependent: :destroy
 
   has_many :badges, through: :earned_badges
   accepts_nested_attributes_for :earned_badges,

--- a/app/services/creates_criterion_grade/adds_grade_id_to_criterion_grades.rb
+++ b/app/services/creates_criterion_grade/adds_grade_id_to_criterion_grades.rb
@@ -1,0 +1,16 @@
+module Services
+  module Actions
+    class AddsGradeIdToCriterionGrades
+      extend LightService::Action
+
+      expects :criterion_grades
+      expects :grade
+
+      executed do |context|
+        context[:criterion_grades].each do |cg|
+          cg.grade_id = context[:grade].id
+        end
+      end
+    end
+  end
+end

--- a/app/services/creates_grade_using_rubric.rb
+++ b/app/services/creates_grade_using_rubric.rb
@@ -1,4 +1,5 @@
 require "light-service"
+require_relative "creates_criterion_grade/adds_grade_id_to_criterion_grades"
 require_relative "creates_criterion_grade/builds_criterion_grades"
 require_relative "creates_criterion_grade/builds_earned_level_badges"
 require_relative "creates_criterion_grade/saves_criterion_grades"
@@ -21,11 +22,12 @@ module Services
         .reduce(
           Actions::VerifiesAssignmentStudent,
           Actions::BuildsCriterionGrades,
-          Actions::SavesCriterionGrades,
           Actions::BuildsGrade,
           Actions::AssociatesSubmissionWithGrade,
           Actions::MarksAsGraded,
           Actions::SavesGrade,
+          Actions::AddsGradeIdToCriterionGrades,
+          Actions::SavesCriterionGrades,
           Actions::BuildsEarnedLevelBadges,
           Actions::SavesEarnedLevelBadges,
           Actions::RunsGradeUpdaterJob

--- a/db/migrate/20161102180020_add_grade_id_to_criterion_grades.rb
+++ b/db/migrate/20161102180020_add_grade_id_to_criterion_grades.rb
@@ -1,0 +1,5 @@
+class AddGradeIdToCriterionGrades < ActiveRecord::Migration[5.0]
+  def change
+    add_column :criterion_grades, :grade_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161031184138) do
+ActiveRecord::Schema.define(version: 20161102180020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -256,7 +256,7 @@ ActiveRecord::Schema.define(version: 20161031184138) do
     t.string   "team_leader_term",                                        default: "TA",                         null: false
     t.string   "group_term",                                              default: "Group",                      null: false
     t.boolean  "accepts_submissions",                                     default: true,                         null: false
-    t.boolean  "teams_visible",                                           default: false,                         null: false
+    t.boolean  "teams_visible",                                           default: false,                        null: false
     t.string   "weight_term",                                             default: "Multiplier",                 null: false
     t.decimal  "default_weight",                  precision: 4, scale: 1, default: "1.0"
     t.string   "tagline"
@@ -317,6 +317,7 @@ ActiveRecord::Schema.define(version: 20161031184138) do
     t.integer  "assignment_id", null: false
     t.integer  "student_id",    null: false
     t.text     "comments"
+    t.integer  "grade_id"
     t.index ["criterion_id", "student_id"], name: "index_criterion_grades_on_criterion_id_and_student_id", unique: true, using: :btree
   end
 

--- a/spec/services/creates_criterion_grade/adds_grade_id_to_criterion_grades_spec.rb
+++ b/spec/services/creates_criterion_grade/adds_grade_id_to_criterion_grades_spec.rb
@@ -1,0 +1,23 @@
+require "light-service"
+require "active_record_spec_helper"
+require "./app/services/creates_criterion_grade/adds_grade_id_to_criterion_grades"
+
+describe Services::Actions::AddsGradeIdToCriterionGrades do
+  let(:crt_grade) { build :criterion_grade }
+  let(:grade) { double :grade, id: 777 }
+
+  it "expects criterion grades passed to service" do
+    expect { described_class.execute grade: grade }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "expects grade passed to service" do
+    expect { described_class.execute criterion_grades: [crt_grade] }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
+  end
+
+  it "adds the grade id to the criterion grades" do
+    result = described_class.execute criterion_grades: [crt_grade], grade: grade
+    expect(result[:criterion_grades].first.grade_id).to eq(777)
+  end
+end

--- a/spec/services/creates_grade_using_rubric_spec.rb
+++ b/spec/services/creates_grade_using_rubric_spec.rb
@@ -17,11 +17,6 @@ describe Services::CreatesGradeUsingRubric do
       described_class.create params, professor.id
     end
 
-    it "saves criterion grades" do
-      expect(Services::Actions::SavesCriterionGrades).to receive(:execute).and_call_original
-      described_class.create params, professor.id
-    end
-
     it "initializes new grade from params" do
       expect(Services::Actions::BuildsGrade).to receive(:execute).and_call_original
       described_class.create params, professor.id
@@ -39,6 +34,16 @@ describe Services::CreatesGradeUsingRubric do
 
     it "saves the grade" do
       expect(Services::Actions::SavesGrade).to receive(:execute).and_call_original
+      described_class.create params, professor.id
+    end
+
+    it "associates the grade and criterion grades" do
+      expect(Services::Actions::AddsGradeIdToCriterionGrades).to receive(:execute).and_call_original
+      described_class.create params, professor.id
+    end
+
+    it "saves criterion grades" do
+      expect(Services::Actions::SavesCriterionGrades).to receive(:execute).and_call_original
       described_class.create params, professor.id
     end
 


### PR DESCRIPTION
### Description

Criterion Grades did not have an associated to a Grade, so deleting a rubric graded `Grade` would not remove the Criteria and Level information from the grade form. This PR fixes that.

### Migrations
YES

### Steps to Test or Reproduce

Grade a student from the rubric form and verify new `CriterionGrades` have a `grade_id` that matches the `Grade.id`. Delete the grade from the assignment page, and verify that the `CriterionGrades` are destroyed as well, and that on reload the Grade form is blank.

closes #2604 