### PR TITLE
Temp disable announcements

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -162,7 +162,7 @@ class EarnedBadgesController < ApplicationController
 
   def send_earned_badge_notifications
     @valid_earned_badges.each do |earned_badge|
-      EarnedBadgeAnnouncement.create earned_badge
+      # EarnedBadgeAnnouncement.create earned_badge
       NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
       logger.info "Sent an earned badge notification for EarnedBadge ##{earned_badge[:id]}"
     end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -42,7 +42,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def notify_grade_released
-    GradeAnnouncement.create @grade
+    # GradeAnnouncement.create @grade
     NotificationMailer.grade_released(@grade.id).deliver_now
   end
 end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -8,7 +8,7 @@ module Services
       executed do |context|
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
-          EarnedBadgeAnnouncement.create earned_badge
+          # EarnedBadgeAnnouncement.create earned_badge
           NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
         end
       end

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -131,8 +131,9 @@ describe EarnedBadgesController do
         end
 
         it "should create an announcement" do
-          expect { controller.instance_eval { send_earned_badge_notifications }}.to \
-            change { Announcement.count }.by 2
+          skip "pending bugfix to handle individuals"
+          # expect { controller.instance_eval { send_earned_badge_notifications }}.to \
+          #   change { Announcement.count }.by 2
         end
       end
 

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -1,25 +1,26 @@
 require "rails_spec_helper"
 
 describe EarnedBadgeAnnouncement do
-  let(:announcement) { Announcement.unscoped.last }
-  let(:course) { earned_badge.course }
-  let(:earned_badge) { create :earned_badge, awarded_by: user }
-  let(:user) { create :user }
-
-  describe ".create" do
-    it "creates an announcement for the earned badge" do
-      expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
-      expect(announcement.course).to eq earned_badge.course
-      expect(announcement.author).to eq user
-      expect(announcement.title).to \
-        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
-      expect(announcement.body).to include \
-        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
-      expect(announcement.body).to include \
-        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
-      expect(announcement.body).to include \
-        "<p>Check out your new "\
-        "<a href='http://localhost:5000/badges'>badge</a>.</p>"
-    end
-  end
+  skip "pending bugfix to handle individuals"
+  # let(:announcement) { Announcement.unscoped.last }
+  # let(:course) { earned_badge.course }
+  # let(:earned_badge) { create :earned_badge, awarded_by: user }
+  # let(:user) { create :user }
+  # 
+  # describe ".create" do
+  #   it "creates an announcement for the earned badge" do
+  #     expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
+  #     expect(announcement.course).to eq earned_badge.course
+  #     expect(announcement.author).to eq user
+  #     expect(announcement.title).to \
+  #       eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
+  #     expect(announcement.body).to include \
+  #       "<p>Congratulations #{earned_badge.student.first_name}!</p>"
+  #     expect(announcement.body).to include \
+  #       "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
+  #     expect(announcement.body).to include \
+  #       "<p>Check out your new "\
+  #       "<a href='http://localhost:5000/badges'>badge</a>.</p>"
+  #   end
+  # end
 end

--- a/spec/models/grade_announcement_spec.rb
+++ b/spec/models/grade_announcement_spec.rb
@@ -1,23 +1,24 @@
 require "rails_spec_helper"
 
 describe GradeAnnouncement do
-  let(:announcement) { Announcement.unscoped.last }
-  let(:grade) { create :grade, graded_by: user }
-  let(:user) { create :user }
-
-  describe ".create" do
-    it "creates an announcement for the grade" do
-      expect { described_class.create grade }.to change { Announcement.count }.by 1
-      expect(announcement.course).to eq grade.course
-      expect(announcement.author).to eq grade.graded_by
-      expect(announcement.title).to eq \
-        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
-      expect(announcement.body).to include \
-        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
-        "#{grade.assignment.name} in #{grade.course.name}."
-      expect(announcement.body).to include \
-        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
-        "#{grade.assignment.name}</a> to view your results."
-    end
-  end
+  skip "pending bugfix to handle individuals"
+  # let(:announcement) { Announcement.unscoped.last }
+  # let(:grade) { create :grade, graded_by: user }
+  # let(:user) { create :user }
+  # 
+  # describe ".create" do
+  #   it "creates an announcement for the grade" do
+  #     expect { described_class.create grade }.to change { Announcement.count }.by 1
+  #     expect(announcement.course).to eq grade.course
+  #     expect(announcement.author).to eq grade.graded_by
+  #     expect(announcement.title).to eq \
+  #       "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+  #     expect(announcement.body).to include \
+  #       "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
+  #       "#{grade.assignment.name} in #{grade.course.name}."
+  #     expect(announcement.body).to include \
+  #       "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
+  #       "#{grade.assignment.name}</a> to view your results."
+  #   end
+  # end
 end

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -189,7 +189,8 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
     end
 
     it "creates a new announcement for the student" do
-      expect { notify }.to change { Announcement.count }.by(1)
+      skip "pending fix to individual emails"
+      # expect { notify }.to change { Announcement.count }.by(1)
     end
   end
 

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -22,10 +22,11 @@ describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
     end
 
     it "creates an announcement for the student" do
-      allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
-
-      expect { described_class.execute earned_badge: earned_badge }.to \
-        change { Announcement.count }.by 1
+      skip "pending bugfix to handle individuals"
+      # allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
+      # 
+      # expect { described_class.execute earned_badge: earned_badge }.to \
+      #   change { Announcement.count }.by 1
     end
   end
 
@@ -43,4 +44,3 @@ describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
     end
   end
 end
-

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -1,7 +1,7 @@
 require "rails_spec_helper"
 require "./app/services/creates_earned_badge/notifies_of_earned_badge"
 
-describe Services::Actions::NotifiesOfEarnedBadge , focus: true do
+describe Services::Actions::NotifiesOfEarnedBadge do
   let(:course) { earned_badge.course }
   let(:delivery) { double(:email, deliver_now: nil) }
   let(:earned_badge) { create :earned_badge, awarded_by: user }


### PR DESCRIPTION
### Status
**READY**

### Description
This PR temporarily disables Grade and Badge announcements until they can be refined to only send to single students. 

### Migrations
NO