### PR TITLE
Fix grade and badge announcements

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -2,7 +2,8 @@ class AnnouncementsController < ApplicationController
   include AnnouncementsHelper
 
   def index
-    @announcements = Announcement.where(course_id: current_course.id)
+    @announcements = Announcement.where(course_id: current_course.id,
+                                        recipient_id: [nil, current_user.id])
   end
 
   def show

--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -162,7 +162,7 @@ class EarnedBadgesController < ApplicationController
 
   def send_earned_badge_notifications
     @valid_earned_badges.each do |earned_badge|
-      # EarnedBadgeAnnouncement.create earned_badge
+      EarnedBadgeAnnouncement.create earned_badge
       NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
       logger.info "Sent an earned badge notification for EarnedBadge ##{earned_badge[:id]}"
     end

--- a/app/models/abilities/announcement_ability.rb
+++ b/app/models/abilities/announcement_ability.rb
@@ -2,7 +2,9 @@ module AnnouncementAbility
   def define_announcement_abilities(user, course)
     can :read, Announcement do |announcement|
       announcement.course.nil? || (announcement.course == course &&
-        announcement.course.users.include?(user))
+        (announcement.recipient.present? ?
+          announcement.recipient == user :
+          announcement.course.users.include?(user)))
     end
 
     can :create, Announcement do |announcement|

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,6 +1,7 @@
 class Announcement < ActiveRecord::Base
   belongs_to :author, class_name: "User"
   belongs_to :course
+  belongs_to :recipient, class_name: "User"
   has_many :states, class_name: "AnnouncementState", dependent: :destroy
 
   validates :author, presence: true

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -19,12 +19,13 @@ class Announcement < ActiveRecord::Base
   def self.read_count_for(user, course)
     AnnouncementState
       .joins(:announcement)
-      .where(announcements: { course_id: course.id })
+      .where(announcements: { course_id: course.id, recipient_id: [nil, user.id] })
       .where(user_id: user.id).count
   end
 
   def self.unread_count_for(user, course)
-    Announcement.where(course_id: course.id).count - read_count_for(user, course)
+    Announcement.where(course_id: course.id, recipient_id: [nil, user.id]).count -
+      read_count_for(user, course)
   end
 
   def abstract(words=25)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -9,6 +9,11 @@ class Announcement < ActiveRecord::Base
   validates :course, presence: true
   validates :title, presence: true
 
+  scope :for_course_or_recipient, ->(course_id, recipient_id) do
+    query = where(course_id: course_id)
+    query = query.where(recipient_id: recipient_id) unless recipient_id.nil?
+    query
+  end
   default_scope { order "created_at DESC" }
 
   def self.read_count_for(user, course)
@@ -61,6 +66,7 @@ class Announcement < ActiveRecord::Base
 
   def unread_count
     return 0 if course.nil?
+    return 1 - read_count if recipient.present?
     course.users.count - read_count
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -9,11 +9,6 @@ class Announcement < ActiveRecord::Base
   validates :course, presence: true
   validates :title, presence: true
 
-  scope :for_course_or_recipient, ->(course_id, recipient_id) do
-    query = where(course_id: course_id)
-    query = query.where(recipient_id: recipient_id) unless recipient_id.nil?
-    query
-  end
   default_scope { order "created_at DESC" }
 
   def self.read_count_for(user, course)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -27,7 +27,9 @@ class Announcement < ActiveRecord::Base
   end
 
   def deliver!
-    if course
+    if !recipient.nil?
+      AnnouncementMailer.announcement_email(self, recipient).deliver_now
+    elsif !course.nil?
       course.users.each do |user|
         AnnouncementMailer.announcement_email(self, user).deliver_now
       end

--- a/app/models/earned_badge_announcement.rb
+++ b/app/models/earned_badge_announcement.rb
@@ -25,10 +25,11 @@ class EarnedBadgeAnnouncement
   end
 
   def params
-    { course_id: earned_badge.course_id,
-      author_id: earned_badge.awarded_by_id,
-      body:      body,
-      title:     title
+    { course_id:    earned_badge.course_id,
+      author_id:    earned_badge.awarded_by_id,
+      recipient_id: earned_badge.student_id,
+      body:         body,
+      title:        title
     }
   end
 

--- a/app/models/grade_announcement.rb
+++ b/app/models/grade_announcement.rb
@@ -26,10 +26,11 @@ class GradeAnnouncement
   end
 
   def params
-    { course_id: grade.course_id,
-      author_id: grade.graded_by_id,
-      body:      body,
-      title:     title
+    { course_id:    grade.course_id,
+      author_id:    grade.graded_by_id,
+      recipient_id: grade.student_id,
+      body:         body,
+      title:        title
     }
   end
 

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -42,7 +42,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def notify_grade_released
-    # GradeAnnouncement.create @grade
+    GradeAnnouncement.create @grade
     NotificationMailer.grade_released(@grade.id).deliver_now
   end
 end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -8,7 +8,7 @@ module Services
       executed do |context|
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
-          # EarnedBadgeAnnouncement.create earned_badge
+          EarnedBadgeAnnouncement.create earned_badge
           NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
         end
       end

--- a/db/migrate/20161107123814_add_recipient_id_to_announcements.rb
+++ b/db/migrate/20161107123814_add_recipient_id_to_announcements.rb
@@ -1,0 +1,6 @@
+class AddRecipientIdToAnnouncements < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :announcements, :recipient, references: :users, index: true
+    add_foreign_key :announcements, :users, column: :recipient_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102180020) do
+ActiveRecord::Schema.define(version: 20161107123814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,14 +27,16 @@ ActiveRecord::Schema.define(version: 20161102180020) do
   end
 
   create_table "announcements", force: :cascade do |t|
-    t.string   "title",      null: false
-    t.text     "body",       null: false
-    t.integer  "author_id",  null: false
-    t.integer  "course_id",  null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "title",        null: false
+    t.text     "body",         null: false
+    t.integer  "author_id",    null: false
+    t.integer  "course_id",    null: false
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.integer  "recipient_id"
     t.index ["author_id"], name: "index_announcements_on_author_id", using: :btree
     t.index ["course_id"], name: "index_announcements_on_course_id", using: :btree
+    t.index ["recipient_id"], name: "index_announcements_on_recipient_id", using: :btree
   end
 
   create_table "assignment_files", force: :cascade do |t|
@@ -234,6 +236,7 @@ ActiveRecord::Schema.define(version: 20161102180020) do
     t.string   "role",                           default: "student", null: false
     t.boolean  "instructor_of_record",           default: false
     t.integer  "earned_grade_scheme_element_id"
+    t.index ["course_id", "user_id"], name: "index_course_memberships_on_course_id_and_user_id", unique: true, using: :btree
     t.index ["course_id", "user_id"], name: "index_courses_users_on_course_id_and_user_id", using: :btree
     t.index ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
   end
@@ -256,7 +259,7 @@ ActiveRecord::Schema.define(version: 20161102180020) do
     t.string   "team_leader_term",                                        default: "TA",                         null: false
     t.string   "group_term",                                              default: "Group",                      null: false
     t.boolean  "accepts_submissions",                                     default: true,                         null: false
-    t.boolean  "teams_visible",                                           default: false,                        null: false
+    t.boolean  "teams_visible",                                           default: true,                         null: false
     t.string   "weight_term",                                             default: "Multiplier",                 null: false
     t.decimal  "default_weight",                  precision: 4, scale: 1, default: "1.0"
     t.string   "tagline"
@@ -292,6 +295,7 @@ ActiveRecord::Schema.define(version: 20161102180020) do
     t.boolean  "has_character_names",                                     default: false,                        null: false
     t.string   "time_zone",                                               default: "Eastern Time (US & Canada)"
     t.boolean  "has_multipliers",                                         default: false,                        null: false
+    t.index ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree
   end
 
   create_table "criteria", force: :cascade do |t|
@@ -799,6 +803,7 @@ ActiveRecord::Schema.define(version: 20161102180020) do
   add_foreign_key "announcement_states", "users"
   add_foreign_key "announcements", "courses"
   add_foreign_key "announcements", "users", column: "author_id"
+  add_foreign_key "announcements", "users", column: "recipient_id"
   add_foreign_key "earned_badges", "users", column: "awarded_by_id"
   add_foreign_key "flagged_users", "courses"
   add_foreign_key "flagged_users", "users", column: "flagged_id"

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -55,6 +55,14 @@ describe AnnouncementsController do
         get :index
         expect(assigns(:announcements)).to eq [announcement]
       end
+
+      it "does not list announcements that are for another recipient" do
+        create :announcement, :for_recipient, course_id: @course.id
+
+        get :index
+
+        expect(assigns(:announcements)).to eq [announcement]
+      end
     end
 
     describe "POST #create" do

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -130,10 +130,9 @@ describe EarnedBadgesController do
           controller.instance_eval { send_earned_badge_notifications }
         end
 
-        it "should create an announcement" do
-          skip "pending bugfix to handle individuals"
-          # expect { controller.instance_eval { send_earned_badge_notifications }}.to \
-          #   change { Announcement.count }.by 2
+        xit "should create an announcement" do
+          expect { controller.instance_eval { send_earned_badge_notifications }}.to \
+            change { Announcement.count }.by 2
         end
       end
 

--- a/spec/controllers/earned_badges_controller_spec.rb
+++ b/spec/controllers/earned_badges_controller_spec.rb
@@ -130,7 +130,7 @@ describe EarnedBadgesController do
           controller.instance_eval { send_earned_badge_notifications }
         end
 
-        xit "should create an announcement" do
+        it "should create an announcement" do
           expect { controller.instance_eval { send_earned_badge_notifications }}.to \
             change { Announcement.count }.by 2
         end

--- a/spec/factories/announcement_factory.rb
+++ b/spec/factories/announcement_factory.rb
@@ -4,5 +4,9 @@ FactoryGirl.define do
     body { Faker::Lorem.paragraph(2) }
     association :course
     association :author, factory: :user
+
+    trait :for_recipient do
+      association :recipient, factory: :user
+    end
   end
 end

--- a/spec/models/abilities/announcement_ability_spec.rb
+++ b/spec/models/abilities/announcement_ability_spec.rb
@@ -15,6 +15,20 @@ describe Ability do
       expect(subject).to be_able_to(:read, announcement)
     end
 
+    context "with a single recipient announcement" do
+      it "is viewable only by the recipient" do
+        announcement = build :announcement, course: course, recipient: student
+
+        expect(subject).to be_able_to(:read, announcement)
+      end
+
+      it "is not viewable by someone else" do
+        announcement = build :announcement, :for_recipient, course: course
+
+        expect(subject).to_not be_able_to(:read, announcement)
+      end
+    end
+
     it "is creatable by any staff for the course" do
       professor_course_membership = create :professor_course_membership,
         course: course

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -151,6 +151,19 @@ describe Announcement do
       create :announcement_state, announcement: subject, user: subject.author
       expect(Announcement.read_count_for(subject.author, subject.course)).to eq 1
     end
+
+    context "with announcements for a specific recipient" do
+      let!(:recipient_announcement) { create :announcement, :for_recipient,
+                                      course: subject.course }
+      let(:recipient) { recipient_announcement.recipient }
+
+      it "returns the number of read announcements for a specific student and course" do
+        create :announcement_state, announcement: subject, user: recipient
+        create :announcement_state, announcement: recipient_announcement, user: recipient
+
+        expect(Announcement.read_count_for(recipient, subject.course)).to eq 2
+      end
+    end
   end
 
   describe ".unread_count_for" do
@@ -160,6 +173,15 @@ describe Announcement do
       CourseMembership.create  course_id: subject.course.id,
         user_id: subject.author.id, role: "student"
       expect(Announcement.unread_count_for(subject.author, subject.course)).to eq 1
+    end
+
+    context "with announcements for a specific recipient" do
+      let!(:recipient_announcement) { create :announcement, course: subject.course,
+                                      recipient: subject.author }
+
+      it "returns the number of unread announcements for a specific student and course" do
+        expect(Announcement.unread_count_for(subject.author, subject.course)).to eq 2
+      end
     end
   end
 

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -89,23 +89,6 @@ describe Announcement do
     end
   end
 
-  describe ".for_course_or_recipient" do
-    let!(:announcement1) { create :announcement, course: course }
-    let!(:announcement2) { create :announcement, course: course, recipient: recipient }
-    let(:course) { create :course }
-    let(:recipient) { create :user }
-
-    it "returns the announcement for the course only if the recipient is nil" do
-      expect(described_class.for_course_or_recipient(course.id, nil)).to \
-        include announcement1, announcement2
-    end
-
-    it "returns the announcement only for the recipient if that is set" do
-      expect(described_class.for_course_or_recipient(course.id, recipient.id)).to \
-        eq [announcement2]
-    end
-  end
-
   describe "#read_count" do
     it "is the number of users for the course who have not read the announcement" do
       announcement = create :announcement

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -11,6 +11,7 @@ describe EarnedBadgeAnnouncement do
       expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
       expect(announcement.course).to eq earned_badge.course
       expect(announcement.author).to eq user
+      expect(announcement.recipient).to eq earned_badge.student
       expect(announcement.title).to \
         eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
       expect(announcement.body).to include \

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -1,26 +1,25 @@
 require "rails_spec_helper"
 
 describe EarnedBadgeAnnouncement do
-  skip "pending bugfix to handle individuals"
-  # let(:announcement) { Announcement.unscoped.last }
-  # let(:course) { earned_badge.course }
-  # let(:earned_badge) { create :earned_badge, awarded_by: user }
-  # let(:user) { create :user }
-  # 
-  # describe ".create" do
-  #   it "creates an announcement for the earned badge" do
-  #     expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
-  #     expect(announcement.course).to eq earned_badge.course
-  #     expect(announcement.author).to eq user
-  #     expect(announcement.title).to \
-  #       eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
-  #     expect(announcement.body).to include \
-  #       "<p>Congratulations #{earned_badge.student.first_name}!</p>"
-  #     expect(announcement.body).to include \
-  #       "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
-  #     expect(announcement.body).to include \
-  #       "<p>Check out your new "\
-  #       "<a href='http://localhost:5000/badges'>badge</a>.</p>"
-  #   end
-  # end
+  let(:announcement) { Announcement.unscoped.last }
+  let(:course) { earned_badge.course }
+  let(:earned_badge) { create :earned_badge, awarded_by: user }
+  let(:user) { create :user }
+
+  describe ".create" do
+    it "creates an announcement for the earned badge" do
+      expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq earned_badge.course
+      expect(announcement.author).to eq user
+      expect(announcement.title).to \
+        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
+      expect(announcement.body).to include \
+        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
+      expect(announcement.body).to include \
+        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
+      expect(announcement.body).to include \
+        "<p>Check out your new "\
+          "<a href='http://localhost:5000/badges'>badge</a>.</p>"
+    end
+  end
 end

--- a/spec/models/grade_announcement_spec.rb
+++ b/spec/models/grade_announcement_spec.rb
@@ -10,6 +10,7 @@ describe GradeAnnouncement do
       expect { described_class.create grade }.to change { Announcement.count }.by 1
       expect(announcement.course).to eq grade.course
       expect(announcement.author).to eq grade.graded_by
+      expect(announcement.recipient).to eq grade.student
       expect(announcement.title).to eq \
         "#{grade.course.course_number} - #{grade.assignment.name} Graded"
       expect(announcement.body).to include \

--- a/spec/models/grade_announcement_spec.rb
+++ b/spec/models/grade_announcement_spec.rb
@@ -1,24 +1,23 @@
 require "rails_spec_helper"
 
 describe GradeAnnouncement do
-  skip "pending bugfix to handle individuals"
-  # let(:announcement) { Announcement.unscoped.last }
-  # let(:grade) { create :grade, graded_by: user }
-  # let(:user) { create :user }
-  # 
-  # describe ".create" do
-  #   it "creates an announcement for the grade" do
-  #     expect { described_class.create grade }.to change { Announcement.count }.by 1
-  #     expect(announcement.course).to eq grade.course
-  #     expect(announcement.author).to eq grade.graded_by
-  #     expect(announcement.title).to eq \
-  #       "#{grade.course.course_number} - #{grade.assignment.name} Graded"
-  #     expect(announcement.body).to include \
-  #       "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
-  #       "#{grade.assignment.name} in #{grade.course.name}."
-  #     expect(announcement.body).to include \
-  #       "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
-  #       "#{grade.assignment.name}</a> to view your results."
-  #   end
-  # end
+  let(:announcement) { Announcement.unscoped.last }
+  let(:grade) { create :grade, graded_by: user }
+  let(:user) { create :user }
+
+  describe ".create" do
+    it "creates an announcement for the grade" do
+      expect { described_class.create grade }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq grade.course
+      expect(announcement.author).to eq grade.graded_by
+      expect(announcement.title).to eq \
+        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+      expect(announcement.body).to include \
+        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
+          "#{grade.assignment.name} in #{grade.course.name}."
+      expect(announcement.body).to include \
+        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
+          "#{grade.assignment.name}</a> to view your results."
+    end
+  end
 end

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -188,9 +188,8 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
       notify
     end
 
-    it "creates a new announcement for the student" do
-      skip "pending fix to individual emails"
-      # expect { notify }.to change { Announcement.count }.by(1)
+    xit "creates a new announcement for the student" do
+      expect { notify }.to change { Announcement.count }.by(1)
     end
   end
 

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
       notify
     end
 
-    xit "creates a new announcement for the student" do
+    it "creates a new announcement for the student" do
       expect { notify }.to change { Announcement.count }.by(1)
     end
   end

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -21,12 +21,11 @@ describe Services::Actions::NotifiesOfEarnedBadge do
       described_class.execute earned_badge: earned_badge
     end
 
-    it "creates an announcement for the student" do
-      skip "pending bugfix to handle individuals"
-      # allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
-      # 
-      # expect { described_class.execute earned_badge: earned_badge }.to \
-      #   change { Announcement.count }.by 1
+    xit "creates an announcement for the student" do
+      allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
+
+      expect { described_class.execute earned_badge: earned_badge }.to \
+        change { Announcement.count }.by 1
     end
   end
 

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -21,7 +21,7 @@ describe Services::Actions::NotifiesOfEarnedBadge do
       described_class.execute earned_badge: earned_badge
     end
 
-    xit "creates an announcement for the student" do
+    it "creates an announcement for the student" do
       allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
 
       expect { described_class.execute earned_badge: earned_badge }.to \


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes an issue with `Grade` and `EarnedBadge` announcements. Previously, when announcements for those resources were created, all users in the course got a new announcement in their announcement list that a `Grade` or `EarnedBadge` was awarded to them.

This fixes that issue by adding the functionality for allowing `Announcement`s to have a single recipient. The announcements for `Grade` and `EarnedBadge` are created with a single recipient (the student) for those announcements.

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
Integrate earned badges with announcements | [2635](https://github.com/UM-USElab/gradecraft-development/pull/2635)
Integrate grades with announcements | [2607](https://github.com/UM-USElab/gradecraft-development/pull/2607)

### Migrations
YES

### Steps to Test or Reproduce

1. Log in as an instructor or admin
1. Assign a grade for an assignment to a student
1. Log in as the assignment and view announcement
1. Log in as another student assigned to that same assignment
1. Notice that they do not have the announcement

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grading
* Assigning earned badges
* Announcements
