### PR TITLE
fix fields updated in announcement bugfix

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -236,7 +236,6 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.string   "role",                           default: "student", null: false
     t.boolean  "instructor_of_record",           default: false
     t.integer  "earned_grade_scheme_element_id"
-    t.index ["course_id", "user_id"], name: "index_course_memberships_on_course_id_and_user_id", unique: true, using: :btree
     t.index ["course_id", "user_id"], name: "index_courses_users_on_course_id_and_user_id", using: :btree
     t.index ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
   end
@@ -259,7 +258,7 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.string   "team_leader_term",                                        default: "TA",                         null: false
     t.string   "group_term",                                              default: "Group",                      null: false
     t.boolean  "accepts_submissions",                                     default: true,                         null: false
-    t.boolean  "teams_visible",                                           default: true,                         null: false
+    t.boolean  "teams_visible",                                           default: false,                         null: false
     t.string   "weight_term",                                             default: "Multiplier",                 null: false
     t.decimal  "default_weight",                  precision: 4, scale: 1, default: "1.0"
     t.string   "tagline"


### PR DESCRIPTION
There were a couple changes in the scheme from #2654 `Fix grade and badge announcements` that weren't in the migration.

This purpose of this PR is to remove these changes from the schema. 