### PR TITLE
2630 misc ui updates

### DIFF
--- a/app/assets/stylesheets/components/_breadcrumbs.sass
+++ b/app/assets/stylesheets/components/_breadcrumbs.sass
@@ -12,14 +12,10 @@ ul.breadcrumbs
     list-style-type: none
     display: inline
     color: $color-grey-4
+    &:not(:last-of-type)::after
+      content: "/ "
+      margin: 0 0.2rem
 
-    a
-      float: left
-      margin-right: .5rem
-      
-      &:after
-        content: " / "
-      
-      &:hover, &.active
+    a:hover, &.active
         color: $color-blue-3
         text-decoration: underline

--- a/app/assets/stylesheets/components/_breadcrumbs.sass
+++ b/app/assets/stylesheets/components/_breadcrumbs.sass
@@ -13,7 +13,7 @@ ul.breadcrumbs
     display: inline
     color: $color-grey-4
     &:not(:last-of-type)::after
-      content: "/ "
+      content: "/"
       margin: 0 0.2rem
 
     a:hover, &.active

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -86,6 +86,8 @@
     .badge-icon
       width: 100%
       max-width: 120px
+      &.unearned, &.unavailable
+        opacity: 1 !important
 
     .badge-description
       max-width: 50%

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -438,12 +438,6 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('#{ term_for :students }')
   end
 
-  def students_flagged
-    breadcrumb('Dashboard', dashboard_path)
-    breadcrumb('#{ term_for :students }', students_path)
-    breadcrumb('Flagged #{ term_for :students }', flagged_students_path)
-  end
-
   def students_show
     breadcrumb('Dashboard', dashboard_path)
     breadcrumb('#{ term_for :students }', students_path)

--- a/db/migrate/20161108202754_change_team_term_default.rb
+++ b/db/migrate/20161108202754_change_team_term_default.rb
@@ -1,0 +1,5 @@
+class ChangeTeamTermDefault < ActiveRecord::Migration[5.0]
+  def change
+    change_column :courses, :team_term, :string, default: "Section", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,7 +250,7 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.boolean  "has_badges",                                              default: false,                        null: false
     t.boolean  "has_teams",                                               default: false,                        null: false
     t.string   "student_term",                                            default: "Student",                    null: false
-    t.string   "team_term",                                               default: "Team",                       null: false
+    t.string   "team_term",                                               default: "Section",                       null: false
     t.text     "course_rules"
     t.boolean  "status",                                                  default: true,                         null: false
     t.datetime "weights_close_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161107123814) do
+ActiveRecord::Schema.define(version: 20161108202754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,7 +250,7 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.boolean  "has_badges",                                              default: false,                        null: false
     t.boolean  "has_teams",                                               default: false,                        null: false
     t.string   "student_term",                                            default: "Student",                    null: false
-    t.string   "team_term",                                               default: "Section",                       null: false
+    t.string   "team_term",                                               default: "Section",                    null: false
     t.text     "course_rules"
     t.boolean  "status",                                                  default: true,                         null: false
     t.datetime "weights_close_at"
@@ -258,7 +258,7 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.string   "team_leader_term",                                        default: "TA",                         null: false
     t.string   "group_term",                                              default: "Group",                      null: false
     t.boolean  "accepts_submissions",                                     default: true,                         null: false
-    t.boolean  "teams_visible",                                           default: false,                         null: false
+    t.boolean  "teams_visible",                                           default: false,                        null: false
     t.string   "weight_term",                                             default: "Multiplier",                 null: false
     t.decimal  "default_weight",                  precision: 4, scale: 1, default: "1.0"
     t.string   "tagline"
@@ -294,7 +294,6 @@ ActiveRecord::Schema.define(version: 20161107123814) do
     t.boolean  "has_character_names",                                     default: false,                        null: false
     t.string   "time_zone",                                               default: "Eastern Time (US & Canada)"
     t.boolean  "has_multipliers",                                         default: false,                        null: false
-    t.index ["lti_uid"], name: "index_courses_on_lti_uid", using: :btree
   end
 
   create_table "criteria", force: :cascade do |t|

--- a/spec/features/creating_a_new_challenge_spec.rb
+++ b/spec/features/creating_a_new_challenge_spec.rb
@@ -13,21 +13,21 @@ feature "creating a new challenge" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Team Challenges"
+        click_link "Section Challenges"
       end
 
       within(".context_menu") do
-        click_link "New Team Challenge"
+        click_link "New Section Challenge"
       end
 
       expect(current_path).to eq new_challenge_path
 
       within(".pageContent") do
-        fill_in "Name", with: "New Team Challenge Name"
-        click_button "Create Team Challenge"
+        fill_in "Name", with: "New Section Challenge Name"
+        click_button "Create Section Challenge"
       end
 
-      expect(page).to have_notification_message("notice", "Challenge New Team Challenge Name successfully created")
+      expect(page).to have_notification_message("notice", "Challenge New Section Challenge Name successfully created")
     end
   end
 end

--- a/spec/features/creating_a_new_team_spec.rb
+++ b/spec/features/creating_a_new_team_spec.rb
@@ -2,7 +2,7 @@ require "rails_spec_helper"
 
 feature "creating a new team" do
   context "as a professor" do
-    let(:course) { create :course, has_teams: true}
+    let(:course) { create :course, has_teams: true }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
 
@@ -13,21 +13,22 @@ feature "creating a new team" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Teams"
+        click_link "Sections"
       end
 
       within(".context_menu") do
-        click_link "New Team"
+        click_link "New Section"
       end
 
       expect(current_path).to eq new_team_path
 
       within(".pageContent") do
-        fill_in "Name", with: "New Team Name"
-        click_button "Create Team"
+        fill_in "Name", with: "New Section Name"
+        click_button "Create Section"
       end
-
-      expect(page).to have_notification_message("notice", "Team New Team Name successfully created")
+      
+      expect(current_path).to eq team_path(Team.last)
+      expect(page).to have_content("New Section Name")
     end
   end
 end

--- a/spec/features/deleting_a_challenge_spec.rb
+++ b/spec/features/deleting_a_challenge_spec.rb
@@ -5,7 +5,7 @@ feature "deleting a challenge" do
     let(:course) { create :course, has_team_challenges: true}
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
-    let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
+    let!(:challenge) { create :challenge, name: "Section Challenge Name", course: course }
 
     before(:each) do
       login_as professor
@@ -14,7 +14,7 @@ feature "deleting a challenge" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Team Challenges"
+        click_link "Section Challenges"
       end
 
       expect(current_path).to eq challenges_path
@@ -23,7 +23,7 @@ feature "deleting a challenge" do
         click_link "Delete"
       end
 
-      expect(page).to have_notification_message("notice", "Challenge Team Challenge Name successfully deleted")
+      expect(page).to have_notification_message("notice", "Challenge Section Challenge Name successfully deleted")
     end
   end
 end

--- a/spec/features/deleting_a_team_spec.rb
+++ b/spec/features/deleting_a_team_spec.rb
@@ -5,7 +5,7 @@ feature "deleting a team" do
     let(:course) { create :course, has_teams: true }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
-    let!(:team) { create :team, name: "Team Name", course: course }
+    let!(:team) { create :team, name: "Section Name", course: course }
 
     before(:each) do
       login_as professor
@@ -14,7 +14,7 @@ feature "deleting a team" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Teams"
+        click_link "Section"
       end
 
       expect(current_path).to eq teams_path
@@ -23,7 +23,7 @@ feature "deleting a team" do
         click_link "Delete"
       end
 
-      expect(page).to have_notification_message("notice", "Team Team Name successfully deleted")
+      expect(page).to have_notification_message("notice", "Section Section Name successfully deleted")
     end
   end
 end

--- a/spec/features/editing_a_challenge_spec.rb
+++ b/spec/features/editing_a_challenge_spec.rb
@@ -5,7 +5,7 @@ feature "editing a challenge" do
     let(:course) { create :course, has_team_challenges: true}
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
-    let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
+    let!(:challenge) { create :challenge, name: "Section Challenge Name", course: course }
 
     before(:each) do
       login_as professor
@@ -14,13 +14,13 @@ feature "editing a challenge" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Team Challenges"
+        click_link "Section Challenges"
       end
 
       expect(current_path).to eq challenges_path
 
       within(".pageContent") do
-        click_link "Team Challenge Name"
+        click_link "Section Challenge Name"
       end
 
       expect(current_path).to eq challenge_path(challenge.id)
@@ -30,11 +30,11 @@ feature "editing a challenge" do
       end
 
       within(".pageContent") do
-        fill_in "Name", with: "Edited Team Challenge Name"
-        click_button "Update Team Challenge"
+        fill_in "Name", with: "Edited Section Challenge Name"
+        click_button "Update Section Challenge"
       end
 
-      expect(page).to have_notification_message("notice", "Challenge Edited Team Challenge Name successfully updated")
+      expect(page).to have_notification_message("notice", "Challenge Edited Section Challenge Name successfully updated")
     end
   end
 end

--- a/spec/features/editing_a_team_challenge_grade_spec.rb
+++ b/spec/features/editing_a_team_challenge_grade_spec.rb
@@ -5,8 +5,8 @@ feature "editing a team challenge grade" do
     let(:course) { create :course, has_team_challenges: true }
     let(:professor) { create :user }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
-    let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
-    let!(:team) { create :team, name: "Team Name", course: course }
+    let!(:challenge) { create :challenge, name: "Section Challenge Name", course: course }
+    let!(:team) { create :team, name: "Section Name", course: course }
     let!(:challenge_grade) { create :challenge_grade, team: team, challenge: challenge, score: 100 }
 
     before(:each) do
@@ -16,13 +16,13 @@ feature "editing a team challenge grade" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Team Challenges"
+        click_link "Section Challenges"
       end
 
       expect(current_path).to eq challenges_path
 
       within(".pageContent") do
-        click_link "Team Challenge Name"
+        click_link "Section Challenge Name"
       end
 
       expect(current_path).to eq challenge_path(challenge.id)
@@ -39,7 +39,7 @@ feature "editing a team challenge grade" do
       end
       
       expect(current_path).to eq challenge_path(challenge.id)
-      expect(page).to have_notification_message("notice", "Team Name's Grade for Team Challenge Name Team Challenge successfully updated")
+      expect(page).to have_notification_message("notice", "Section Name's Grade for Section Challenge Name Section Challenge successfully updated")
     end
   end
 end

--- a/spec/features/editing_a_team_spec.rb
+++ b/spec/features/editing_a_team_spec.rb
@@ -5,7 +5,7 @@ feature "editing a team" do
     let(:course) { create :course, has_teams: true }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
     let(:professor) { create :user }
-    let!(:team) { create :team, name: "Team Name", course: course }
+    let!(:team) { create :team, name: "Section Name", course: course }
 
     before(:each) do
       login_as professor
@@ -14,13 +14,13 @@ feature "editing a team" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Teams"
+        click_link "Sections"
       end
 
       expect(current_path).to eq teams_path
 
       within(".pageContent") do
-        click_link "Team Name"
+        click_link "Section Name"
       end
 
       expect(current_path).to eq team_path(team.id)
@@ -30,11 +30,13 @@ feature "editing a team" do
       end
 
       within(".pageContent") do
-        fill_in "Name", with: "Edited Team Name"
-        click_button "Update Team"
+        fill_in "Name", with: "Edited Section Name"
+        click_button "Update Section"
       end
-
-      expect(page).to have_notification_message("notice", "Team Edited Team Name successfully updated")
+      
+      expect(current_path).to eq team_path(team)
+      
+      expect(page).to have_content("Edited Section Name")
     end
   end
 end

--- a/spec/features/grading_a_team_challenge_spec.rb
+++ b/spec/features/grading_a_team_challenge_spec.rb
@@ -5,8 +5,8 @@ feature "grading a team challenge" do
     let(:course) { create :course, has_team_challenges: true }
     let(:professor) { create :user }
     let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
-    let!(:challenge) { create :challenge, name: "Team Challenge Name", course: course }
-    let!(:team) { create :team, name: "Team Name", course: course }
+    let!(:challenge) { create :challenge, name: "Section Challenge Name", course: course }
+    let!(:team) { create :team, name: "Section Name", course: course }
 
     before(:each) do
       login_as professor
@@ -15,13 +15,13 @@ feature "grading a team challenge" do
 
     scenario "successfully" do
       within(".sidebar-container") do
-        click_link "Team Challenges"
+        click_link "Section Challenges"
       end
 
       expect(current_path).to eq challenges_path
 
       within(".pageContent") do
-        click_link "Team Challenge Name"
+        click_link "Section Challenge Name"
       end
 
       expect(current_path).to eq challenge_path(challenge.id)
@@ -36,7 +36,7 @@ feature "grading a team challenge" do
         fill_in("challenge_grade_score", with: 100)
         click_button "Submit Grade"
       end
-      expect(page).to have_notification_message("notice", "Team Name's Grade for Team Challenge Name Team Challenge successfully graded")
+      expect(page).to have_notification_message("notice", "Section Name's Grade for Section Challenge Name Section Challenge successfully graded")
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -326,8 +326,8 @@ describe Course do
       expect(subject.team_term).to eq("Horde")
     end
 
-    it "returns Team if no team_term is present" do
-      expect(subject.team_term).to eq("Team")
+    it "returns Section if no team_term is present" do
+      expect(subject.team_term).to eq("Section")
     end
   end
 

--- a/spec/views/api/challenges/index_spec.rb
+++ b/spec/views/api/challenges/index_spec.rb
@@ -44,7 +44,7 @@ describe "api/challenges/index" do
   it "renders term for challenges" do
     render
     @json = JSON.parse(response.body)
-    expect(@json["meta"]["term_for_challenges"]).to eq("Team tsallenzes")
+    expect(@json["meta"]["term_for_challenges"]).to eq("Section tsallenzes")
   end
 
   it "includes allow_updates" do


### PR DESCRIPTION
### Status
**READY**

### Description
- [x] Remove underline under the breadcrumb slashes
- [x] Make the opacity full on badges on instructor side regardless of earned/awarded
- [x] Change name of ‘Teams’ everywhere to ‘Sections’ (updated `team_term` default in schema)

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Instructor badge show page 
* Instructor pages with breadcrumbs
* Instructor team pages
