### PR TITLE
fixed read state hover

### DIFF
--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -34,12 +34,12 @@
         %a
           %i.fa.fa-check
         .display-on-hover.hover-style
-          This feedback has been <strong>viewed</strong> by the #{term_for :student}.
+          This feedback has been <strong>marked as read</strong> by the #{term_for :student}.
       - elsif grade.feedback_reviewed?
         %a
           %i.fa.fa-eye
         .display-on-hover.hover-style
-          This feedback has been <strong>marked as read</strong> by the #{term_for :student}.
+          This feedback has been <strong>viewed</strong> by the #{term_for :student}.
 
     %td= grade.status
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where the icons were correct, but the hover state description of grade read states were incorrect.