### PR TITLE
2664-level-overview-bug

### DIFF
--- a/app/views/info/dashboard/modules/_dashboard_instructor_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_instructor_grading_scheme.haml
@@ -6,7 +6,7 @@
     .meter
       .level-name #{element.name} #{points element.lowest_points}
       %span.student-count= element.count_students_earned
-    - if current_course.student_count > 0
+    - if current_course.graded_student_count > 0
       .fill-bar.bar_magic{:style => "width: #{(element.count_students_earned) / (current_course.graded_student_count).to_f * 100}%;"}
 
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR addresses a bug that we were unable to replicate in development but should safeguard against the fill showing if a class has levels but no students.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Instructor dashboard

Closes issue #2664 