### PR TITLE
pass group submission through user method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -338,7 +338,11 @@ class User < ActiveRecord::Base
   ### SUBMISSIONS
 
   def submission_for_assignment(assignment)
-    submissions.where(assignment_id: assignment.id).try(:first)
+    if self.has_group_for_assignment?(assignment)
+      self.group_for_assignment(assignment).submission_for_assignment(assignment)
+    else
+      submissions.where(assignment_id: assignment.id).try(:first)
+    end
   end
 
   ### BADGES

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -523,11 +523,24 @@ describe User do
 
   describe "#submission_for_assignment(assignment)" do
     let(:student) { create :user }
-    let(:assignment) { create :assignment}
 
     it "returns the submission for an assignment if it exists" do
+      assignment = create(:assignment)
       submission = create(:submission, assignment: assignment, student: student)
       expect(student.submission_for_assignment(assignment)).to eq(submission)
+    end
+
+    describe "when it is a group assignment" do
+      let!(:create_group) { world.create_group }
+      let(:group) { world.group }
+
+      it "returns the group submission if it exists"  do
+        assignment = create(:assignment, grade_scope: "Group")
+        FactoryGirl.create(:assignment_group, group: group, assignment: assignment)
+        FactoryGirl.create(:group_membership, student: student, group: group)
+        submission = create(:submission, assignment: assignment, student: nil, group: group)
+        expect(student.submission_for_assignment(assignment)).to eq(submission)
+      end
     end
   end
 


### PR DESCRIPTION
### Description

This PR updates the `User#submission_for_assignment` method to check if the assignment has a "Group" scope, and, if it does, defaults to `Group#submission_for_assignment`.

### Steps to Test or Reproduce

This should fix the predictor where a students is viewing an assignment whose date is passed but someone in their group created a submission. It should also might be easiest to test in the console.