### PR TITLE
add info to confirm message

### DIFF
--- a/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
+++ b/app/assets/javascripts/angular/controllers/GradeRubricCtrl.js.coffee
@@ -209,10 +209,17 @@
       grade:            $scope.gradeParams(),
     }
 
+  confirmMessage = ()->
+    message = "Are you sure you want to submit the grade for this assignment?"
+    if _.every($scope.criteria, "selectedLevel")
+      message
+    else
+      message + " You still have criteria without a selected level."
+
   $scope.submitGrade = (returnURL)->
     if !$scope.grade.status
       return alert "You must select a grade status before you can submit this grade"
-    if confirm "Are you sure you want to submit the grade for this assignment?"
+    if confirm confirmMessage()
       RubricService.putRubricGradeSubmission($scope.assignment, $scope.gradedRubricParams(), returnURL)
 
   $scope.froalaOptions = {

--- a/app/assets/javascripts/angular/factories/Criterion.js.coffee
+++ b/app/assets/javascripts/angular/factories/Criterion.js.coffee
@@ -121,10 +121,9 @@
     create: ()->
       Restangular.all('criteria').post(@params())
         .then (response)=>
-          criterion = response.existing_criterion
-          @id = criterion.id
+          @id = response.id
           @$scope.countSavedCriterion()
-          @addLevels(criterion.levels)
+          @addLevels(response.levels)
 
     modify: (form)->
       if form.$valid


### PR DESCRIPTION
### Description

Addresses two bugs:

  * Adds information to the confirm message when not all criterion have a selected level.
  * fixes the criterion factory error for the rubric design page when a new criterion is added.

### Steps to Test or Reproduce

Grade a student with the Rubric Grading page, do not select a level for all criterion, check the message in the alert box when you click "Submit Grade".  Repeat with all criterion selected.

Design a new rubric criterion, the levels should show up immediately.

closes #2680 
closes #2679