### PR TITLE
report errors on failed grade save

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -51,7 +51,7 @@ class GradesController < ApplicationController
     else # failure
       redirect_to edit_grade_path(grade),
         alert: "#{grade.student.name}'s #{grade.assignment.name} was not successfully "\
-          "submitted! Please try again."
+          "submitted! #{grade.errors.full_messages.first}"
     end
   end
 

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -1,5 +1,5 @@
 .pageContent
-  = render partial: "layouts/alerts", locals: { model: @grade, display_flash: false }
+  = render partial: "layouts/alerts", locals: { model: @grade }
 
   = render partial: "submissions/assignment_guidelines", locals: { assignment: @grade.assignment }
 


### PR DESCRIPTION
### Status
**READY**

### Description

Adds an error message when there is a failure saving a grade.

### Steps to Test or Reproduce

You will need to submit a grade that won't save to see the message. I was able to do this by submitting a grade file with a filename over 50 chars, but there might be other errors that can be triggered.

![screen shot 2016-11-28 at 12 08 10 pm](https://cloud.githubusercontent.com/assets/1138350/20678068/5d97e196-b563-11e6-86b1-f5b353a82625.png)

closes #2659
