### PR TITLE
Add LTI Setting field to Course Setup

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -269,7 +269,7 @@ class User < ActiveRecord::Base
     course_elements = course.grade_scheme_elements.order_by_lowest_points.to_a
 
     current_element = self.grade_for_course(course)
-    current_element_index = course_elements.index{ |item| item[:level] == current_element[:level] }
+    current_element_index = course_elements.index{ |item| item == current_element }
 
     element = send("#{direction}_element_level", course_elements, current_element_index)
   end

--- a/app/views/integrations/_index.html.haml
+++ b/app/views/integrations/_index.html.haml
@@ -3,8 +3,8 @@
     %img{src: "/images/canvas-logo.png"}
   .card-block= integration_card_for(:canvas, @course)
   
--# .card{style: "height: 350px;"}
--#   .card-cap
--#     %img{src: "/images/canvas-logo.png"}
--#   .card_block
--#     = render partial: "integrations/courses/lti_card", locals: { f: f }
+.card{style: "height: 350px;"}
+  .card-cap
+    %img{src: "/images/canvas-logo.png"}
+  .card_block
+    = render partial: "integrations/courses/lti_card", locals: { f: f }

--- a/app/views/integrations/_index.html.haml
+++ b/app/views/integrations/_index.html.haml
@@ -1,10 +1,12 @@
-.card{style: "height: 350px;"}
+.card.left{style: "height: 350px;"}
   .card-cap
     %img{src: "/images/canvas-logo.png"}
   .card-block= integration_card_for(:canvas, @course)
   
-.card{style: "height: 350px;"}
+.card.left{style: "height: 350px;"}
   .card-cap
-    %img{src: "/images/canvas-logo.png"}
-  .card_block
+    %h1.center.bold.inverse LTI
+  .card-block
     = render partial: "integrations/courses/lti_card", locals: { f: f }
+
+.clear

--- a/app/views/integrations/courses/_lti_card.haml
+++ b/app/views/integrations/courses/_lti_card.haml
@@ -1,5 +1,4 @@
 %h4.card-title LTI Integration
-%p.card-text An open-source LMS from Instructure.
-%p.card-text Import assignments, students, and grades from Canvas and keep them in sync.
+%p.card-text Enter the LTI ID from the Tool Consumer you'd like to pair GradeCraft with
 
 = f.input :lti_uid, label: "LTI ID"


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug in the leveling display under conditions where the level name is absent. It also re-adds the LTI setting form.