### PR TITLE
2487 remove find or create

### DIFF
--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -79,7 +79,6 @@ class Assignments::GradesController < ApplicationController
       redirect_to mass_edit_assignment_groups_grades_path and return
     end
 
-    @assignment_type = @assignment.assignment_type
     @assignment_score_levels = @assignment.assignment_score_levels.order_by_points
 
     if params[:team_id].present?

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -5,7 +5,6 @@ class Assignments::GradesController < ApplicationController
   before_action :ensure_student?, only: :self_log
   before_action :save_referer, only: :edit_status
   before_action :find_assignment, only: [:edit_status, :mass_edit, :mass_update, :self_log, :delete_all]
-  before_action :find_grades_for_assignment, only: :delete_all
 
   # GET /assignments/:assignment_id/grades/edit_status
   # For changing the status of a group of grades passed in grade_ids
@@ -115,7 +114,14 @@ class Assignments::GradesController < ApplicationController
   # DELETE /assignments/:assignment_id/grades/delete_all
   # Delete grades for a given assignment id
   def delete_all
-    @grades.each do |grade|
+    if params[:team_id].present?
+      team = current_course.teams.find_by(id: params[:team_id])
+      students = current_course.students_being_graded_by_team(team).order_by_name
+    else
+      students = current_course.students_being_graded.order_by_name
+    end
+
+    Gradebook.new(@assignment, students).existing_grades.each do |grade|
       grade.destroy
       ScoreRecalculatorJob.new(user_id: grade.student_id, course_id: current_course.id).enqueue
     end
@@ -180,15 +186,5 @@ class Assignments::GradesController < ApplicationController
 
   def find_assignment
     @assignment = current_course.assignments.find(params[:assignment_id])
-  end
-
-  def find_grades_for_assignment
-    if params[:team_id].present?
-      @team = current_course.teams.find_by(id: params[:team_id])
-      @students = current_course.students_being_graded_by_team(@team).order_by_name
-    else
-      @students = current_course.students_being_graded.order_by_name
-    end
-    @grades = Grade.find_or_create_grades(@assignment.id, @students.pluck(:id))
   end
 end

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -5,7 +5,7 @@ class Assignments::GradesController < ApplicationController
   before_action :ensure_student?, only: :self_log
   before_action :save_referer, only: :edit_status
   before_action :find_assignment, only: [:edit_status, :mass_edit, :mass_update, :self_log, :delete_all]
-  before_action :find_grades_for_assignment, only: [:mass_edit, :delete_all]
+  before_action :find_grades_for_assignment, only: :delete_all
 
   # GET /assignments/:assignment_id/grades/edit_status
   # For changing the status of a group of grades passed in grade_ids
@@ -72,7 +72,7 @@ class Assignments::GradesController < ApplicationController
       })
   end
 
-  # GET /assignments/:assignment_id/grades/export/mass_edit
+  # GET /assignments/:assignment_id/grades/mass_edit
   # Quickly grading a single assignment for all students
   def mass_edit
     if @assignment.has_groups?
@@ -83,13 +83,12 @@ class Assignments::GradesController < ApplicationController
 
     if params[:team_id].present?
       @team = current_course.teams.find_by(id: params[:team_id])
-      @students = current_course.students_being_graded_by_team(@team).order_by_name
+      students = current_course.students_being_graded_by_team(@team).order_by_name
     else
-      @students = current_course.students_being_graded.order_by_name
+      students = current_course.students_being_graded.order_by_name
     end
 
-    @grades = Grade.find_or_create_grades(@assignment.id, @students.pluck(:id))
-    @grades = @grades.sort_by { |grade| [ grade.student.last_name, grade.student.first_name ] }
+    @grades = Gradebook.new(@assignment, students).grades
   end
 
   # PUT /assignments/:assignment_id/grades/mass_update

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,12 +1,12 @@
 require "cancan"
-require_dependency "abilities/announcement_ability"
-require_dependency "abilities/assignment_type_weight_ability"
-require_dependency "abilities/challenge_grade_ability"
-require_dependency "abilities/course_ability"
-require_dependency "abilities/grade_ability"
-require_dependency "abilities/submission_ability"
-require_dependency "abilities/submission_file_ability"
-require_dependency "abilities/earned_badge_ability"
+require_relative "abilities/announcement_ability"
+require_relative "abilities/assignment_type_weight_ability"
+require_relative "abilities/challenge_grade_ability"
+require_relative "abilities/course_ability"
+require_relative "abilities/grade_ability"
+require_relative "abilities/submission_ability"
+require_relative "abilities/submission_file_ability"
+require_relative "abilities/earned_badge_ability"
 
 class Ability
   include CanCan::Ability

--- a/app/models/gradebook.rb
+++ b/app/models/gradebook.rb
@@ -1,15 +1,16 @@
 class Gradebook
-  attr_reader :students
+  attr_reader :assignment, :students
 
-  def initialize(*students)
+  def initialize(assignment, *students)
+    @assignment = assignment
     @students = [students].flatten
   end
 
   def grade(student)
-    grades.find { |g| g.student_id == student.id }
+    grades.find { |g| g.assignment_id = assignment.id && g.student_id == student.id }
   end
 
   def grades
-    @grades ||= Grade.where(student_id: students.map(&:id))
+    @grades ||= Grade.where(assignment_id: assignment.id, student_id: students.map(&:id))
   end
 end

--- a/app/models/gradebook.rb
+++ b/app/models/gradebook.rb
@@ -1,0 +1,15 @@
+class Gradebook
+  attr_reader :students
+
+  def initialize(*students)
+    @students = [students].flatten
+  end
+
+  def grade(student)
+    grades.find { |g| g.student_id == student.id }
+  end
+
+  def grades
+    @grades ||= Grade.where(student_id: students.map(&:id))
+  end
+end

--- a/app/models/gradebook.rb
+++ b/app/models/gradebook.rb
@@ -7,10 +7,10 @@ class Gradebook
   end
 
   def grade(student)
-    grades.find { |g| g.assignment_id = assignment.id && g.student_id == student.id }
+    existing_grades.find { |g| g.assignment_id = assignment.id && g.student_id == student.id }
   end
 
-  def grades
-    @grades ||= Grade.where(assignment_id: assignment.id, student_id: students.map(&:id))
+  def existing_grades
+    @existing_grades ||= Grade.where(assignment_id: assignment.id, student_id: students.map(&:id))
   end
 end

--- a/app/models/gradebook.rb
+++ b/app/models/gradebook.rb
@@ -10,7 +10,22 @@ class Gradebook
     existing_grades.find { |g| g.assignment_id = assignment.id && g.student_id == student.id }
   end
 
+  def grades
+    (existing_grades + missing_grades).sort_by { |grade| [grade.student.last_name,
+                                                          grade.student.first_name] }
+  end
+
   def existing_grades
     @existing_grades ||= Grade.where(assignment_id: assignment.id, student_id: students.map(&:id))
+  end
+
+  private
+
+  def missing_grades
+    students_without_grades.map { |s| Grade.new(assignment_id: assignment.id, student_id: s.id) }
+  end
+
+  def students_without_grades
+    students.reject { |s| existing_grades.map(&:student_id).include?(s.id) }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module GradeCraft
   class Application < Rails::Application
     config.time_zone = "America/Detroit"
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(#{config.root}/lib #{config.root}/app/models/abilities)
 
     config.assets.precompile += %w(.svg .eot .otf .woff .ttf)
     config.filter_parameters += [:password]

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -79,19 +79,19 @@ describe Assignments::GradesController do
       it "assigns params" do
         get :mass_edit, params: { assignment_id: assignment.id }
         expect(assigns(:assignment)).to eq(assignment)
-        expect(assigns(:assignment_type)).to eq(assignment.assignment_type)
         expect(assigns(:assignment_score_levels)).to eq(assignment.assignment_score_levels)
         expect(assigns(:grades)).to eq([grade])
-        expect(assigns(:students)).to eq([student])
         expect(response).to render_template(:mass_edit)
       end
 
-      it "creates missing grades and orders grades by student name" do
-        student_2 = create(:user, last_name: "zzimmer", first_name: "aaron")
-        student_3 = create(:user, last_name: "zzimmer", first_name: "zoron")
-        [student_2,student_3].each {|s| s.courses << course }
-        expect { get :mass_edit, params: { assignment_id: assignment.id }}.to \
-          change { Grade.count }.by(2)
+      it "orders grades by student name" do
+        student_2 = create(:user, last_name: "zzimmer", first_name: "aaron", courses: [course])
+        create :grade, assignment: assignment, student: student_2
+        student_3 = create(:user, last_name: "zzimmer", first_name: "zoron", courses: [course])
+        create :grade, assignment: assignment, student: student_3
+
+        get :mass_edit, params: { assignment_id: assignment.id }
+
         expect(assigns(:grades)[1].student).to eq(student_2)
         expect(assigns(:grades)[2].student).to eq(student_3)
       end
@@ -100,8 +100,9 @@ describe Assignments::GradesController do
         it "assigns params" do
           team = create(:team, course: course)
           team.students << student
+
           get :mass_edit, params: { assignment_id: assignment.id, team_id: team.id }
-          expect(assigns(:students)).to eq([student])
+
           expect(assigns(:team)).to eq(team)
         end
       end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -39,21 +39,21 @@ describe Gradebook do
     end
   end
 
-  describe "#grades" do
+  describe "#existing_grades" do
     let(:student1) { create :user }
     let(:student2) { create :user }
     subject { described_class.new(assignment, student1, student2) }
 
-    it "returns all the grades for the assignment and students" do
+    it "returns all the exising grades for the assignment and students" do
       grade = create :grade, assignment: assignment, student: student2
 
-      expect(subject.grades).to eq [grade]
+      expect(subject.existing_grades).to eq [grade]
     end
 
-    it "only includes grades for the specified assignment" do
+    it "only includes existing grades for the specified assignment" do
       grade = create :grade, student: student2
 
-      expect(subject.grades).to be_empty
+      expect(subject.existing_grades).to be_empty
     end
   end
 

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -2,30 +2,38 @@ require "active_record_spec_helper"
 require "db_query_matchers"
 
 describe Gradebook do
+  let(:assignment) { create :assignment }
+
   describe "#initialize" do
     let!(:student1) { create :user }
     let!(:student2) { create :user }
 
+    it "initializes with an assignment" do
+      subject = described_class.new assignment
+
+      expect(subject.assignment).to eq assignment
+    end
+
     it "initializes with a student array" do
-      subject = described_class.new [student1, student2]
+      subject = described_class.new assignment, [student1, student2]
 
       expect(subject.students).to eq [student1, student2]
     end
 
     it "initializes with a single student" do
-      subject = described_class.new student1
+      subject = described_class.new assignment, student1
 
       expect(subject.students).to eq [student1]
     end
 
     it "initializes with a student list" do
-      subject = described_class.new student1, student2
+      subject = described_class.new assignment, student1, student2
 
       expect(subject.students).to eq [student1, student2]
     end
 
     it "initializes with a query" do
-      subject = described_class.new User.where(id: student1.id)
+      subject = described_class.new assignment, User.where(id: student1.id)
 
       expect(subject.students).to eq [student1]
     end
@@ -34,24 +42,36 @@ describe Gradebook do
   describe "#grades" do
     let(:student1) { create :user }
     let(:student2) { create :user }
-    subject { described_class.new(student1, student2) }
+    subject { described_class.new(assignment, student1, student2) }
 
-    it "returns all the grades for the students" do
-      grade = create :grade, student: student2
+    it "returns all the grades for the assignment and students" do
+      grade = create :grade, assignment: assignment, student: student2
 
       expect(subject.grades).to eq [grade]
+    end
+
+    it "only includes grades for the specified assignment" do
+      grade = create :grade, student: student2
+
+      expect(subject.grades).to be_empty
     end
   end
 
   describe "#grade" do
     let(:student1) { create :user }
     let(:student2) { create :user }
-    subject { described_class.new(student1, student2) }
+    subject { described_class.new(assignment, student1, student2) }
 
     it "returns a grade for a specific student" do
-      grade = create :grade, student: student2
+      grade = create :grade, assignment: assignment, student: student2
 
       expect(subject.grade(student2)).to eq grade
+    end
+
+    it "does not return the grade if the assignment is not the same" do
+      grade = create :grade, student: student2
+
+      expect(subject.grade(student2)).to be_nil
     end
 
     it "does not hit the database for multiple grades" do

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -1,0 +1,67 @@
+require "active_record_spec_helper"
+require "db_query_matchers"
+
+describe Gradebook do
+  describe "#initialize" do
+    let!(:student1) { create :user }
+    let!(:student2) { create :user }
+
+    it "initializes with a student array" do
+      subject = described_class.new [student1, student2]
+
+      expect(subject.students).to eq [student1, student2]
+    end
+
+    it "initializes with a single student" do
+      subject = described_class.new student1
+
+      expect(subject.students).to eq [student1]
+    end
+
+    it "initializes with a student list" do
+      subject = described_class.new student1, student2
+
+      expect(subject.students).to eq [student1, student2]
+    end
+
+    it "initializes with a query" do
+      subject = described_class.new User.where(id: student1.id)
+
+      expect(subject.students).to eq [student1]
+    end
+  end
+
+  describe "#grades" do
+    let(:student1) { create :user }
+    let(:student2) { create :user }
+    subject { described_class.new(student1, student2) }
+
+    it "returns all the grades for the students" do
+      grade = create :grade, student: student2
+
+      expect(subject.grades).to eq [grade]
+    end
+  end
+
+  describe "#grade" do
+    let(:student1) { create :user }
+    let(:student2) { create :user }
+    subject { described_class.new(student1, student2) }
+
+    it "returns a grade for a specific student" do
+      grade = create :grade, student: student2
+
+      expect(subject.grade(student2)).to eq grade
+    end
+
+    it "does not hit the database for multiple grades" do
+      subject.grade(student2)
+
+      expect { subject.grade(student1) }.to_not make_database_queries
+    end
+
+    it "returns nil for a student who is not in the gradebook" do
+      expect(subject.grade(student2)).to be_nil
+    end
+  end
+end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -57,6 +57,35 @@ describe Gradebook do
     end
   end
 
+  describe "#grades" do
+    let(:student1) { create :user, first_name: "John", last_name: "Doe" }
+    let(:student2) { create :user, first_name: "Jane", last_name: "Doe" }
+    subject { described_class.new(assignment, student1, student2) }
+
+    it "includes the existing grades" do
+      grade1 = create :grade, assignment: assignment, student: student1
+      grade2 = create :grade, assignment: assignment, student: student2
+
+      expect(subject.grades.count).to eq 2
+      expect(subject.grades).to include grade1
+      expect(subject.grades).to include grade2
+    end
+
+    it "adds any missing grades" do
+      grade = create :grade, assignment: assignment, student: student1
+
+      expect(subject.grades.count).to eq 2
+      expect(subject.grades).to include grade
+      expect(subject.grades.select(&:new_record?).count).to eq 1
+    end
+
+    it "sorts the grades by student names" do
+      grade = create :grade, assignment: assignment, student: student1
+
+      expect(subject.grades.map(&:student)).to eq [student2, student1]
+    end
+  end
+
   describe "#grade" do
     let(:student1) { create :user }
     let(:student2) { create :user }


### PR DESCRIPTION
### Status
**READY**

### Description
Removes the early creation of `Grade`s for mass editing grades for an assignment as well as the deletion of all grades.

Previous to this PR, grades for a students in a course were created in advanced by just visiting `assignments/grades#mass_edit`. Now, a new object called a `Gradebook` was created in order to gather all existing grades for students as well as **initializing** grades for an `Assignment` and `Student`.

### Related
#2487

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* `/assignments/:assignment_id/grades/mass_edit`
* `/assignments/:assignment_id/grades/delete_all`
