### PR TITLE
guard against no assignment description

### DIFF
--- a/app/views/assignments/importers/assignments.html.haml
+++ b/app/views/assignments/importers/assignments.html.haml
@@ -16,7 +16,7 @@
         - @assignments.each do |assignment|
           %tr
             %td= assignment["name"]
-            %td= assignment["description"].html_safe
+            %td= assignment["description"].html_safe if assignment["description"]
             %td= assignment["due_at"]
             %td= assignment["points_possible"]
             %td.center= check_box_tag "assignment_ids[]", assignment["id"], false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-assignments-command']" }


### PR DESCRIPTION
### Description

I think this should guard against [the error occurring](https://rollbar.com/gradecraft/gradecraft-development/items/1815/) on an import.

The problem seems to come from an assignment without a description. I can't test this in dev, but since it's a VIP bug I thought I'd through this out there to try since it's a quick fix.

