### PR TITLE
2487 remove empty grades from group mass edit

### DIFF
--- a/app/presenters/assignments/grades/mass_edit_presenter.rb
+++ b/app/presenters/assignments/grades/mass_edit_presenter.rb
@@ -35,7 +35,8 @@ class Assignments::Grades::MassEditPresenter < Showtime::Presenter
 
   def grades_by_group
     assignment.groups.map do |group|
-      { group: group, grade: Grade.find_or_create(assignment.id, group.students.first.id) }
+      gradebook = Gradebook.new(assignment, group.students.first)
+      { group: group, grade: gradebook.grades.first }
     end
   end
 end

--- a/app/views/assignments/groups/grades/components/_group_table_body.haml
+++ b/app/views/assignments/groups/grades/components/_group_table_body.haml
@@ -2,7 +2,7 @@
   %tr
     %td{:style => "text-align: right"}= link_to gbg[:group].name, group_path(gbg[:group])
     %td.center
-      = f.simple_fields_for "grades_by_group[]", i do |gf|
+      = f.simple_fields_for "grades_by_group[#{i}]", i do |gf|
         - if !gbg[:grade].status
           = gf.hidden_field :status, value: "Graded"
         = gf.hidden_field :instructor_modified, value: true

--- a/spec/presenters/assignments/grades/mass_edit_presenter_spec.rb
+++ b/spec/presenters/assignments/grades/mass_edit_presenter_spec.rb
@@ -1,5 +1,5 @@
+require "rails_spec_helper"
 require "./app/presenters/assignments/grades/mass_edit_presenter"
-require "active_record_spec_helper"
 
 describe Assignments::Grades::MassEditPresenter do
   let(:assignment) { double(:assignment) }
@@ -104,12 +104,15 @@ describe Assignments::Grades::MassEditPresenter do
   describe "#grades_by_group" do
     let(:assignment_group_1) { double(:groups, group_id: 1, students: [ double(:student, id: 1) ]) }
     let(:assignment_group_2) { double(:groups, group_id: 2, students: [ double(:student, id: 2) ]) }
+    let(:grade) { double(:grade) }
 
     it "returns grades organized by group" do
       allow(assignment).to receive(:groups).and_return [ assignment_group_1, assignment_group_2 ]
       allow(assignment).to receive(:id).and_return 1
-      allow(Grade).to receive(:find_or_create).and_return double(:grade, { grade_id: 1 })
+      allow_any_instance_of(Gradebook).to receive(:grades).and_return [grade]
+
       result = subject.grades_by_group
+
       expect(result.count).to eq 2
       expect(result).to all include :group, :grade
     end


### PR DESCRIPTION
### Status
**READY**

### Description
Removes the use of `Grade.find_or_create` when mass editing group grades. This removes the early creation of grades for a group assignment.

**This PR also fixes a bug found in the view for grading the mass edit**

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Quick grade for group assignments

For #2487 
