### PR TITLE
2554 grade next group

### DIFF
--- a/app/controllers/assignments/groups_controller.rb
+++ b/app/controllers/assignments/groups_controller.rb
@@ -27,7 +27,6 @@ class Assignments::GroupsController < ApplicationController
 
     # @mz TODO: add specs
     enqueue_multiple_grade_update_jobs(grade_ids)
-
     if params[:redirect_to_next_grade].present?
       path = path_for_next_group_grade @assignment, @group
     else

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -78,7 +78,7 @@ class GroupsController < ApplicationController
   end
 
   def potential_team_members
-    current_course.students.where.not(id: current_user.id)
+    current_course.students.where.not(id: current_user.id).order_by_name
   end
 
   def find_group

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -105,9 +105,9 @@ module Gradable
   def next_ungraded_group(group)
     return nil unless has_groups?
     if accepts_submissions?
-      ungraded = ungraded_groups_with_submissions(group).sort { |g1,g2| g1.name <=> g2.name }
+      ungraded = ungraded_groups_with_submissions(group).sort_by(&:name)
     else
-      ungraded = ungraded_groups(group).sort { |g1,g2| g1.name <=> g2.name }
+      ungraded = ungraded_groups(group).sort_by(&:name)
     end
     i = ungraded.map(&:id).index(group.id)
     i && i < ungraded.length - 1 ? ungraded[i + 1] : nil

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -94,19 +94,22 @@ module Gradable
   end
 
   def ungraded_groups_with_submissions(group_to_include=nil)
-    included_ids = group_to_include.present? ? group_to_include.students.pluck(:id) : []
-    ungraded_students_with_submissions(included_ids).map { |student| student.group_for_assignment(self) }.uniq
+    return nil unless accepts_submissions?
+    if group_to_include.present?
+      ungraded_groups(group_to_include) & Group.find(submissions.pluck(:group_id) << group_to_include.id)
+    else
+      ungraded_groups & Group.find(submissions.pluck(:group_id))
+    end
   end
 
   def next_ungraded_group(group)
-    if has_groups?
-      if accepts_submissions?
-        ungraded = ungraded_groups_with_submissions(group).sort { |g1,g2| g1.name <=> g2.name }
-      else
-        ungraded = ungraded_groups(group).sort { |g1,g2| g1.name <=> g2.name }
-      end
-      i = ungraded.map(&:id).index(group.id)
-      i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
+    return nil unless has_groups?
+    if accepts_submissions?
+      ungraded = ungraded_groups_with_submissions(group).sort { |g1,g2| g1.name <=> g2.name }
+    else
+      ungraded = ungraded_groups(group).sort { |g1,g2| g1.name <=> g2.name }
     end
+    i = ungraded.map(&:id).index(group.id)
+    i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -71,7 +71,7 @@ module Gradable
     else
       students = course.students.order_by_name
     end
-    students - (User.find(grades.graded.pluck(:student_id)) - User.find(ids_to_include))
+    students - (User.find(grades.graded_or_released.pluck(:student_id)) - User.find(ids_to_include))
   end
 
   def ungraded_students_with_submissions(ids_to_include=[], team=nil)
@@ -88,8 +88,8 @@ module Gradable
     i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
   end
 
-  def ungraded_groups()
-    # groups - groups with grades
+  def ungraded_groups
+    ungraded_students.map { |student| student.group_for_assignment(self) }.uniq
   end
 
   def next_ungraded_group(group)

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -99,9 +99,9 @@ module Gradable
   def next_ungraded_group(group)
     if has_groups?
       if accepts_submissions?
-        ungraded = ungraded_groups.sort { |g1,g2| g1.name <=> g2.name }
-      else
         ungraded = ungraded_groups_with_submissions.sort { |g1,g2| g1.name <=> g2.name }
+      else
+        ungraded = ungraded_groups.sort { |g1,g2| g1.name <=> g2.name }
       end
       i = ungraded.map(&:id).index(group.id)
       i && i < ungraded.length - 1 ? ungraded[i + 1] : nil

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -87,4 +87,18 @@ module Gradable
     i = ungraded.map(&:id).index(student.id)
     i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
   end
+
+  def ungraded_groups()
+    # groups - groups with grades
+  end
+
+  def next_ungraded_group(group)
+    if has_groups?
+      if accepts_submissions?
+        # groups with submissions, no grades
+      else
+        # groups with no grades
+      end
+    end
+  end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -99,10 +99,12 @@ module Gradable
   def next_ungraded_group(group)
     if has_groups?
       if accepts_submissions?
-        # groups with submissions, no grades
+        ungraded = ungraded_groups.sort { |g1,g2| g1.name <=> g2.name }
       else
-        # groups with no grades
+        ungraded = ungraded_groups_with_submissions.sort { |g1,g2| g1.name <=> g2.name }
       end
+      i = ungraded.map(&:id).index(group.id)
+      i && i < ungraded.length - 1 ? ungraded[i + 1] : nil
     end
   end
 end

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -92,6 +92,10 @@ module Gradable
     ungraded_students.map { |student| student.group_for_assignment(self) }.uniq
   end
 
+  def ungraded_groups_with_submissions
+    ungraded_students_with_submissions.map { |student| student.group_for_assignment(self) }.uniq
+  end
+
   def next_ungraded_group(group)
     if has_groups?
       if accepts_submissions?

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -49,7 +49,7 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def groups
-    Assignments::GroupPresenter.wrap(assignment.groups, :group, { assignment: assignment })
+    Assignments::GroupPresenter.wrap(assignment.groups.order_by_name, :group, { assignment: assignment })
   end
 
   def group_assignment?
@@ -166,7 +166,7 @@ class Assignments::Presenter < Showtime::Presenter
   def student_logged?(user)
     assignment.student_logged? && assignment.open? && user.is_student?(course)
   end
-  
+
   def submission_for_assignment(student)
     student.submission_for_assignment(assignment)
   end
@@ -192,13 +192,13 @@ class Assignments::Presenter < Showtime::Presenter
   def team
     @team ||= teams.find_by(id: properties[:team_id])
   end
-  
+
   def students
     @students ||= AssignmentStudentCollection.new(User
       .students_being_graded_for_course(course, team)
       .order_by_name, self)
   end
-  
+
   class AssignmentStudentCollection
     include Enumerable
 
@@ -213,7 +213,7 @@ class Assignments::Presenter < Showtime::Presenter
       @students.each { |student| yield AssignmentStudentDecorator.new(student, presenter) }
     end
   end
-  
+
   class AssignmentStudentDecorator < SimpleDelegator
     attr_reader :presenter
 

--- a/app/views/assignments/groups/_standard_edit.html.haml
+++ b/app/views/assignments/groups/_standard_edit.html.haml
@@ -25,4 +25,6 @@
   .submit-buttons
     %ul
       %li= f.button :submit, "Submit Grades", class: "button"
+      - unless @group.students.first.grade_for_assignment(@assignment).try(:is_graded?)
+        %li= f.button :submit, "Submit and Grade Next", name: "redirect_to_next_grade", class: "button"
       %li= link_to raw("<i class='fa fa-times-circle fa-fw'></i> Cancel"), assignment_path(@assignment), class: 'button'

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -4,7 +4,7 @@
   = render partial: "submissions/assignment_guidelines", locals: { assignment: @assignment }
 
   %hr.dotted
-  %h4.uppercase #{term_for :students}
+  %h4.uppercase #{term_for :students} in the #{term_for :group} "#{@group.name}"
   %ul
     - @group.students.each do |s|
       %li= link_to s.name, student_path(s)

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,9 +22,9 @@
         = f.association :students, :collection => @other_students, as: :select, :label => "#{term_for :students}"
         .form_label= "You (#{current_student.name }) will be automatically included in this group."
     - elsif current_user_is_student?
-      .form-item= f.association :students, :collection => current_course.students, as: :select, :label => "#{term_for :students}"
+      .form-item= f.association :students, :collection => current_course.students.order_by_name, as: :select, :label => "#{term_for :students}"
     - if current_user_is_staff?
-      .form-item= f.association :students, :collection => current_course.students, as: :select, :label => "#{term_for :students}"
+      .form-item= f.association :students, :collection => current_course.students.order_by_name, as: :select, :label => "#{term_for :students}"
     .form_label{id: "txtStudentName"} Enter a fellow student's name to add them to this #{term_for :group}. Only one student needs to create the #{term_for :group}, after which all #{term_for :group} members will be able to submit work, see submitted materials, and see instructor grades and feedback.
 
   = render partial: "groups/proposal_section", locals: { f: f }

--- a/db/samples/assignment_types.rb
+++ b/db/samples/assignment_types.rb
@@ -44,6 +44,20 @@ assignments can be graded.",
   }
 }
 
+@assignment_types[:group_grading] = {
+  quotes: {
+    assignment_type_created: "The least we can do is give them a chance to go \
+to school, fulfill that hope, \
+and become who and what they are meant to be.  - Michelle Obama"
+  },
+  attributes: {
+    name: "Group Grading Settings",
+    description: "This category should include all of the different ways \
+assignments can be graded for a group.",
+    position: 1
+  }
+}
+
 @assignment_types[:submissions] = {
   quotes: {
     assignment_type_created: "Creativity is the process of having original \

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -369,12 +369,19 @@ is for. Did you learn nothing from my chemistry class? - Walter H. White",
   student_submissions: true
 }
 
+#------------------------------------------------------------------------------#
+
+#                        Group Assignment Type
+
+#------------------------------------------------------------------------------#
+
+
 @assignments[:group_grade_assignment] = {
   quotes: {
     assignment_created: "I'm sorry, if you were right, I'd agree with you. - \
 Robin Williams",
   },
-  assignment_type: :grading,
+  assignment_type: :group_grading,
   assign_groups: true,
   attributes: {
     name: "Group Assignment + Standard Edit",
@@ -391,7 +398,7 @@ Robin Williams",
 think they're not - because the thing they were good at at school wasn't \
 valued, or was actually stigmatized. - Sir Ken Robinson",
   },
-  assignment_type: :grading,
+  assignment_type: :group_grading,
   assign_groups: true,
   attributes: {
     name: "Group Assignment + Submissions",
@@ -413,7 +420,7 @@ do not stop.― Confucius",
 people, To assist the nature of all things, Without daring to meddle. - Lao \
 Tzu"
   },
-  assignment_type: :grading,
+  assignment_type: :group_grading,
   assign_groups: true,
   attributes: {
     name: "Group Assignment + Rubric Edit",
@@ -428,7 +435,7 @@ Tzu"
   quotes: {
     assignment_created: nil,
   },
-  assignment_type: :grading,
+  assignment_type: :group_grading,
   assign_groups: false,
   attributes: {
     name: "No Groups Assigned, Group Assignment",

--- a/spec/factories/assignment_factory.rb
+++ b/spec/factories/assignment_factory.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :assignment do
     name { Faker::Lorem.word }
     association :course
-    association :assignment_type
+    assignment_type { association :assignment_type, course: course }
     description { Faker::Lorem.sentence }
     full_points { Faker::Number.number(5) }
     required false

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,11 +1,15 @@
 FactoryGirl.define do
   factory :group do
-    before(:create) do |group|
-      (0..3).each { group.students << create(:user) }
-      group.assignments << create(:assignment, grade_scope: "Group")
-    end
     association :course, factory: :course
+    before(:create) do |group|
+      (0..3).each { group.students << create(:student_course_membership, course: group.course).user }
+      group.assignments << create(:assignment, grade_scope: "Group", course: group.course)
+    end
     name { Faker::Lorem.word }
     approved "Pending"
+
+    factory :approved_group do
+      approved "Approved"
+    end
   end
 end

--- a/spec/features/editing_a_group_spec.rb
+++ b/spec/features/editing_a_group_spec.rb
@@ -3,20 +3,8 @@ require "rails_spec_helper"
 feature "editing a group" do
   context "as a professor" do
     let(:course) { create :course }
-    let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
-    let(:professor) { create :user }
-    let!(:assignment) { create :assignment, grade_scope: "Group", course: course, min_group_size: 2 }
-    let(:student_1) { create :user, first_name: "Hermione", last_name: "Granger"}
-    let!(:course_membership_2) { create :student_course_membership, user: student_1, course: course }
-    let(:student_2) { create :user, first_name: "Ron", last_name: "Weasley"}
-    let(:student_3) { create :user, first_name: "George", last_name: "Weasley"}
-    let!(:course_membership_3) { create :student_course_membership, user: student_2, course: course }
-    let!(:course_membership_4) { create :student_course_membership, user: student_3, course: course }
-    let!(:group) { create :group, course: course, name: "Group!", approved: "Approved" }
-    let!(:assignment_group) { create :assignment_group, group: group, assignment: assignment }
-    let!(:group_membership) { create :group_membership, student: student_1, group: group }
-    let!(:group_membership_2) { create :group_membership, student: student_2, group: group }
-    let!(:group_membership_2) { create :group_membership, student: student_3, group: group }
+    let(:professor) { create(:professor_course_membership, course: course).user }
+    let!(:group) { create :approved_group, course: course, name: "Group!" }
 
     before(:each) do
       login_as professor

--- a/spec/features/reviewing_a_group_spec.rb
+++ b/spec/features/reviewing_a_group_spec.rb
@@ -3,20 +3,8 @@ require "rails_spec_helper"
 feature "reviewing a group" do
   context "as a professor" do
     let(:course) { create :course }
-    let!(:course_membership) { create :professor_course_membership, user: professor, course: course }
-    let(:professor) { create :user }
-    let!(:assignment) { create :assignment, grade_scope: "Group", course: course, min_group_size: 2 }
-    let(:student_1) { create :user, first_name: "Hermione", last_name: "Granger"}
-    let!(:course_membership_2) { create :student_course_membership, user: student_1, course: course }
-    let(:student_2) { create :user, first_name: "Ron", last_name: "Weasley"}
-    let(:student_3) { create :user, first_name: "George", last_name: "Weasley"}
-    let!(:course_membership_3) { create :student_course_membership, user: student_2, course: course }
-    let!(:course_membership_4) { create :student_course_membership, user: student_3, course: course }
+    let(:professor) { create(:professor_course_membership, course: course).user }
     let!(:group) { create :group, course: course, name: "Group!", approved: "Pending" }
-    let!(:assignment_group) { create :assignment_group, group: group, assignment: assignment }
-    let!(:group_membership) { create :group_membership, student: student_1, group: group }
-    let!(:group_membership_2) { create :group_membership, student: student_2, group: group }
-    let!(:group_membership_2) { create :group_membership, student: student_3, group: group }
 
     before(:each) do
       login_as professor

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -808,7 +808,7 @@ describe Assignment do
     end
   end
 
-  describe "Gradable Concern" do
+  describe "Gradable Concern" , focus: true do
     describe "#high_score" do
       before { subject.save }
 
@@ -837,24 +837,51 @@ describe Assignment do
       end
     end
 
-    describe "ungraded_students" do
-      before do
-        subject.save
-        s1 = create(:student_course_membership, course: subject.course).user
-        s2 = create(:student_course_membership, course: subject.course).user
-        s3 = create(:student_course_membership, course: subject.course).user
-        s4 = create(:student_course_membership, course: subject.course).user
-        subject.grades.create student_id: s1.id, raw_points: 8, status: "Graded"
-        subject.grades.create student_id: s2.id, raw_points: 8, status: "Released"
-        subject.grades.create student_id: s3.id, raw_points: 5, status: "In Progress"
+    describe "ungraded student methods" do
+      let!(:student_1) { create(:student_course_membership, course: subject.course).user }
+      let!(:student_2) { create(:student_course_membership, course: subject.course).user }
+      let!(:student_3) { create(:student_course_membership, course: subject.course).user }
+      let!(:student_4) { create(:student_course_membership, course: subject.course).user }
+
+      describe "#ungraded_students" do
+
+        before do
+          subject.save
+          subject.grades.create student_id: student_1.id, raw_points: 8, status: "Graded"
+          subject.grades.create student_id: student_2.id, raw_points: 8, status: "Released"
+          subject.grades.create student_id: student_3.id, raw_points: 5, status: "In Progress"
+        end
+
+        it "returns all students without a 'Graded' or 'Released' grade for the assignment" do
+          expect(subject.ungraded_students.count).to eq(2)
+        end
+
+        it "can add graded student for determining the 'next student'" do
+          expect(subject.ungraded_students([student_1.id]).count).to eq(3)
+          expect(subject.ungraded_students([student_1.id,student_2.id]).count).to eq(4)
+        end
       end
 
-      it "returns all students without a 'Graded' or 'Released' grade for the assignment" do
-       expect(subject.ungraded_students.count).to eq(2)
+      describe "#ungraded_students_with_submissions" do
+
+        before do
+          subject.save
+          create :submission, assignment: subject, student: student_3
+          create :submission, assignment: subject, student: student_4
+        end
+
+        it "returns all students without a 'Graded' or 'Released' grade for the assignment" do
+          expect(subject.ungraded_students_with_submissions.count).to eq(2)
+        end
+
+        it "can add graded student for determining the 'next student'" do
+          expect(subject.ungraded_students_with_submissions([student_1.id]).count).to eq(3)
+          expect(subject.ungraded_students_with_submissions([student_1.id,student_2.id]).count).to eq(4)
+        end
       end
     end
 
-    describe "next_ungraded_student" do
+    describe "#next_ungraded_student" do
 
       %w"Zenith Apex Middleton".each do |name|
         let!(name.downcase.to_sym) do
@@ -875,10 +902,6 @@ describe Assignment do
 
         it "returns nil for the last student" do
           expect(subject.next_ungraded_student(zenith)).to be_nil
-        end
-
-        it "returns nil for student without a submission" do
-          expect(subject.next_ungraded_student(middleton)).to be_nil
         end
 
         it "filters to team members if team present" do
@@ -918,44 +941,58 @@ describe Assignment do
 
     context "group assignments" do
 
-      let(:g1) {create :approved_group, name: "A Group",course: subject.course}
-      let(:g2) {create :approved_group, name: "Z Group",course: subject.course}
-      let(:g3) {create :approved_group, name: "M Group",course: subject.course}
+      let!(:group_1) {create :approved_group, name: "A Group",course: subject.course}
+      let!(:group_2) {create :approved_group, name: "Z Group",course: subject.course}
+      let!(:group_3) {create :approved_group, name: "M Group",course: subject.course}
 
       before do
         subject.update(grade_scope: "Group")
-        subject.groups << [g1,g2,g3]
+        subject.groups << [group_1, group_2, group_3]
       end
 
-      describe "ungraded_groups" do
+      describe "#ungraded_groups" do
+        before do
+          group_1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
+        end
+
         it "returns all ungraded groups" do
-          g1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
           expect(subject.ungraded_groups.count).to eq(2)
+        end
+
+        it "can add graded group for determining the 'next group'" do
+          expect(subject.ungraded_groups(group_1).count).to eq(3)
         end
       end
 
-      describe "ungrade_groups_with_submissions" do
+      describe "ungraded_groups_with_submissions" do
+        before do
+          group_1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
+          create :submission, assignment: subject, student: group_1.students.first
+          create :submission, assignment: subject, student: group_2.students.first
+        end
+
         it "returns all ungraded groups that have submitted" do
-          g1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
-          create :submission, assignment: subject, student: g1.students.first
-          create :submission, assignment: subject, student: g2.students.first
-          expect(subject.ungraded_groups_with_submissions).to eq([g2])
+          expect(subject.ungraded_groups_with_submissions).to eq([group_2])
+        end
+
+        it "can add graded group for determining the 'next group'" do
+          expect(subject.ungraded_groups_with_submissions(group_1).count).to eq(2)
         end
       end
 
       describe "next_ungraded_group" do
         context "when accepting submissions" do
           before do
-            create :submission, assignment: subject, student: g1.students.first
-            create :submission, assignment: subject, student: g2.students.first
+            create :submission, assignment: subject, student: group_1.students.first
+            create :submission, assignment: subject, student: group_2.students.first
           end
 
           it "returns the next ungraded group with a submission" do
-            expect(subject.next_ungraded_group(g1)).to eq(g2)
+            expect(subject.next_ungraded_group(group_1)).to eq(group_2)
           end
 
           it "returns nil for the last group with a submission" do
-            expect(subject.next_ungraded_group(g2)).to eq(nil)
+            expect(subject.next_ungraded_group(group_2)).to eq(nil)
           end
         end
 
@@ -963,11 +1000,11 @@ describe Assignment do
           before { subject.update accepts_submissions: false }
 
           it "returns the next ungraded group" do
-            expect(subject.next_ungraded_group(g3)).to eq(g2)
+            expect(subject.next_ungraded_group(group_3)).to eq(group_2)
           end
 
           it "returns nil for the last group" do
-            expect(subject.next_ungraded_group(g2)).to eq(nil)
+            expect(subject.next_ungraded_group(group_2)).to eq(nil)
           end
         end
       end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -914,34 +914,40 @@ describe Assignment do
       end
     end
 
-    describe "ungraded_groups" do
-      it "returns all ungraded groups" do
-        subject.update(grade_scope: "Group")
-        g1 = create :approved_group, course: subject.course
-        g2 = create :approved_group, course: subject.course
-        subject.groups << [g1,g2]
-        g1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
-        expect(subject.ungraded_groups).to eq([g2])
-      end
-    end
+    context "group assignments" do
 
-    describe "ungrade_groups_with_submissions" do
-      it "returns all ungraded groups that have submitted" do
+      let(:g1) {create :approved_group, name: "A Group",course: subject.course}
+      let(:g2) {create :approved_group, name: "Z Group",course: subject.course}
+      let(:g3) {create :approved_group, name: "M Group",course: subject.course}
+
+      before do
         subject.update(grade_scope: "Group")
-        g1 = create :approved_group, course: subject.course
-        g2 = create :approved_group, course: subject.course
-        g3 = create :approved_group, course: subject.course
         subject.groups << [g1,g2,g3]
-        create :submission, assignment: subject, student: g1.students.first
-        create :submission, assignment: subject, student: g2.students.first
-        g2.students.each {|s| create(:released_grade, assignment: subject, student: s)}
-        expect(subject.ungraded_groups_with_submissions).to eq([g1])
+        g1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
       end
-    end
 
-    describe "next_ungraded_group" do
-      it "returns the next ungraded group" do
+      describe "ungraded_groups" do
+        it "returns all ungraded groups" do
+          expect(subject.ungraded_groups.count).to eq(2)
+        end
+      end
 
+      describe "ungrade_groups_with_submissions" do
+        it "returns all ungraded groups that have submitted" do
+          create :submission, assignment: subject, student: g1.students.first
+          create :submission, assignment: subject, student: g2.students.first
+          expect(subject.ungraded_groups_with_submissions).to eq([g2])
+        end
+      end
+
+      describe "next_ungraded_group" do
+        it "returns the next ungraded group" do
+          expect(subject.next_ungraded_group(g3)).to eq(g2)
+        end
+
+        it "returns nil for the last group" do
+          expect(subject.next_ungraded_group(g2)).to eq(nil)
+        end
       end
     end
   end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -808,7 +808,7 @@ describe Assignment do
     end
   end
 
-  describe "Gradable Concern" , focus: true do
+  describe "Gradable Concern" do
     describe "#high_score" do
       before { subject.save }
 
@@ -967,8 +967,8 @@ describe Assignment do
       describe "ungraded_groups_with_submissions" do
         before do
           group_1.students.each {|s| create(:released_grade, assignment: subject, student: s)}
-          create :submission, assignment: subject, student: group_1.students.first
-          create :submission, assignment: subject, student: group_2.students.first
+          create :submission, assignment: subject, student: nil, group: group_1
+          create :submission, assignment: subject, student: nil, group: group_2
         end
 
         it "returns all ungraded groups that have submitted" do
@@ -983,8 +983,8 @@ describe Assignment do
       describe "next_ungraded_group" do
         context "when accepting submissions" do
           before do
-            create :submission, assignment: subject, student: group_1.students.first
-            create :submission, assignment: subject, student: group_2.students.first
+            create :submission, assignment: subject, student: nil, group: group_1
+            create :submission, assignment: subject, student: nil, group: group_2
           end
 
           it "returns the next ungraded group with a submission" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -925,6 +925,20 @@ describe Assignment do
       end
     end
 
+    describe "ungrade_groups_with_submissions" do
+      it "returns all ungraded groups that have submitted" do
+        subject.update(grade_scope: "Group")
+        g1 = create :approved_group, course: subject.course
+        g2 = create :approved_group, course: subject.course
+        g3 = create :approved_group, course: subject.course
+        subject.groups << [g1,g2,g3]
+        create :submission, assignment: subject, student: g1.students.first
+        create :submission, assignment: subject, student: g2.students.first
+        g2.students.each {|s| create(:released_grade, assignment: subject, student: s)}
+        expect(subject.ungraded_groups_with_submissions).to eq([g1])
+      end
+    end
+
     describe "next_ungraded_group" do
       it "returns the next ungraded group" do
 

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -41,10 +41,10 @@ describe Assignments::Presenter do
 
   describe "#groups" do
     it "wraps the assignment groups in an Assignment::GroupPresenter" do
-      groups = [double(:group), double(:group)]
+      groups = double(:groups, order_by_name: [double(:group), double(:group)])
       allow(assignment).to receive(:groups).and_return groups
       expect(subject.groups.map(&:class).uniq).to eq [Assignments::GroupPresenter]
-      expect(subject.groups.first.group).to eq groups.first
+      expect(subject.groups.first.group).to eq groups.order_by_name.first
     end
   end
 


### PR DESCRIPTION
### Description

Adds the ability to grade the next group, similar to grading the next student.

  * adds some more (ugly) methods to the Gradable concern which returns next ungraded group
  * cleans up some of the ordering for students and groups that used to be a default scope
  * moves sample assignments with groups into their own assignment type

closes #2554 

### Migrations

NO

### Steps to Test or Reproduce

Grade some group assignments, and submit with the "Submit and Grade Next" button.

Add some group submissions to a Group Assignment that accepts submissions, and repeat.
