### PR TITLE
grade service update score for status change

### DIFF
--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -24,6 +24,9 @@ class API::GradesController < ApplicationController
     end
     changes = grade.changes
     if grade.save
+      if GradeProctor.new(grade).viewable?
+        GradeUpdaterJob.new(grade_id: grade.id).enqueue
+      end
       grade.squish_history!
       render json: { message: {changes: changes}, success: true }
     else

--- a/app/services/creates_grade/saves_grade.rb
+++ b/app/services/creates_grade/saves_grade.rb
@@ -2,7 +2,7 @@ module Services
   module Actions
     class SavesGrade
       extend LightService::Action
-      
+
       expects :grade
       promises :update_grade, :student_visible_status
 
@@ -10,7 +10,9 @@ module Services
         grade = context[:grade]
         context.fail_with_rollback!("The grade is invalid and cannot be saved", error_code: 422) \
           unless grade.save
-        context[:update_grade] = grade.previous_changes[:raw_points].present? && grade.graded_or_released?
+        context[:update_grade] = (grade.previous_changes[:raw_points].present? ||
+                                  grade.previous_changes[:status].present?) &&
+                                  grade.graded_or_released?
         context[:student_visible_status] = GradeProctor.new(grade).viewable?
         # warning: LightService doesn't set context keys to false, will be nil !
       end


### PR DESCRIPTION
### Status

**pending spec results**

### Description

October changes to the Grade service `SavesGrade` action limited running grade updater jobs to changes in raw points. This broke updates from the `API::CriterionGradesController` and possibly others.

This PR adds a change to the status as a reason to run a `GradeUpdaterJob` for any grade built through the service pipeline. It also adds a `GradeUpdaterJob` to `API::GradesController#update`, in case this was also a culprit for not updating course scores.

closes #2724 