### PR TITLE
Properly sort student leaderboard by score

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,8 +38,8 @@ class User < ActiveRecord::Base
 
   attr_accessor :password, :password_confirmation, :score, :team
 
-  scope :order_by_high_score, -> { includes(:course_memberships).order "course_memberships.score DESC" }
-  scope :order_by_low_score, -> { includes(:course_memberships).order "course_memberships.score ASC" }
+  scope :order_by_high_score, -> (course_id) { includes(:course_memberships).where(course_memberships: { course_id: course_id }).order "course_memberships.score DESC" }
+  scope :order_by_low_score, -> (course_id) { includes(:course_memberships).where(course_memberships: { course_id: course_id }).order "course_memberships.score ASC" }
   scope :students_in_team, -> (team_id, student_ids) \
     { includes(:team_memberships).where(team_memberships: { team_id: team_id, student_id: student_ids }) }
 

--- a/app/presenters/students/index_presenter.rb
+++ b/app/presenters/students/index_presenter.rb
@@ -35,8 +35,7 @@ class Students::IndexPresenter < Showtime::Presenter
 
   def students
     @students ||= IndexStudentCollection.new(User
-      .students_for_course(course, team)
-      .order_by_high_score, self)
+      .students_for_course(course, team).order_by_high_score(course), self)
   end
 
   def team_id


### PR DESCRIPTION
### Status
**READY**

### Description
Students were displaying incorrectly (out of order) on the leaderboard. Due to the scoped ordering method paying attention to scores beyond the course. 
