### PR TITLE
2742 submission constraint fixes

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -52,8 +52,8 @@ class Submission < ActiveRecord::Base
 
   validates :link, format: URI::regexp(%w(http https)), allow_blank: true
   validates_length_of :link, maximum: 255
-  validates :assignment, presence: true, uniqueness: { scope: :student,
-    message: "should only have one submission per student" }
+  validates :assignment, presence: true, uniqueness: { scope: [:student, :group],
+    message: "should only have one submission per student or group" }, allow_nil: true
   validates_with SubmissionValidator
 
   clean_html :text_comment

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -179,8 +179,6 @@ class Submission < ActiveRecord::Base
   end
 
   def student_xor_group
-    unless student.nil? ^ group.nil?
-      errors.add(:base, "must have either a student_id or group_id, but not both")
-    end
+    errors.add(:base, "must have either a student_id or group_id, but not both") unless student.nil? ^ group.nil?
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -50,6 +50,7 @@ class Submission < ActiveRecord::Base
 
   before_validation :cache_associations
 
+  validate :student_xor_group
   validates :link, format: URI::regexp(%w(http https)), allow_blank: true
   validates_length_of :link, maximum: 255
   validates :assignment, presence: true, uniqueness: { scope: [:student, :group],
@@ -175,5 +176,11 @@ class Submission < ActiveRecord::Base
   def cache_associations
     self.assignment_id ||= assignment.id
     self.course_id ||= assignment.course_id
+  end
+
+  def student_xor_group
+    unless student.nil? ^ group.nil?
+      errors.add(:base, "must have either a student_id or group_id, but not both")
+    end
   end
 end

--- a/db/migrate/20161216142745_add_unique_group_index_to_submissions.rb
+++ b/db/migrate/20161216142745_add_unique_group_index_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddUniqueGroupIndexToSubmissions < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :submissions, [:assignment_id, :group_id]
+    add_index :submissions, [:assignment_id, :group_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161209225205) do
+ActiveRecord::Schema.define(version: 20161216142745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -652,7 +652,7 @@ ActiveRecord::Schema.define(version: 20161209225205) do
     t.datetime "submitted_at"
     t.boolean  "late",               default: false, null: false
     t.text     "text_comment_draft"
-    t.index ["assignment_id", "group_id"], name: "index_submissions_on_assignment_id_and_group_id", using: :btree
+    t.index ["assignment_id", "group_id"], name: "index_submissions_on_assignment_id_and_group_id", unique: true, using: :btree
     t.index ["assignment_id", "student_id"], name: "index_submissions_on_assignment_id_and_student_id", unique: true, using: :btree
     t.index ["assignment_id"], name: "index_submissions_on_assignment_id", using: :btree
     t.index ["assignment_type"], name: "index_submissions_on_assignment_type", using: :btree

--- a/spec/controllers/api/assignments/submissions_controller_spec.rb
+++ b/spec/controllers/api/assignments/submissions_controller_spec.rb
@@ -16,7 +16,7 @@ describe API::Assignments::SubmissionsController do
 
     describe "#show" do
       context "when the submission exists" do
-        let!(:submission) { create(:submission, assignment: assignment, text_comment_draft: "I love", group_id: assignment_group.group_id) }
+        let!(:submission) { create(:group_submission, assignment: assignment, text_comment_draft: "I love", group_id: assignment_group.group_id) }
 
         it "returns a 200 ok" do
           get :show, params: params, format: :json

--- a/spec/controllers/assignments/groups_controller_spec.rb
+++ b/spec/controllers/assignments/groups_controller_spec.rb
@@ -23,7 +23,7 @@ describe Assignments::GroupsController do
     describe "GET grade" do
       it "assigns params" do
         group = create(:group)
-        submission = create(:submission, assignment: @assignment, group: group)
+        submission = create(:group_submission, assignment: @assignment, group: group)
         @assignment.groups << group
         group.students << @student
         get :grade, params: { assignment_id: @assignment.id, id: group.id }

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -93,7 +93,7 @@ describe SubmissionsController do
       end
 
       it "checks if the submission is late" do
-        params = attributes_for(:submission)
+        params = attributes_for(:submission).merge!(student_id: student.id)
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
         post :create, params: { assignment_id: assignment.id, submission: params }
       end

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -4,6 +4,11 @@ FactoryGirl.define do
     text_comment "needs a link, file, or text comment to be valid"
     association :student, factory: :user
 
+    factory :group_submission do
+      group
+      student nil
+    end
+
     factory :submission_with_submission_files do
       submission_files { create_list(:present_submission_file, 2) }
     end

--- a/spec/features/grading_a_group_assignment_spec.rb
+++ b/spec/features/grading_a_group_assignment_spec.rb
@@ -11,7 +11,7 @@ feature "grading a group assignment" do
     let!(:group) { create :group, course: course, name: "Group Name", approved: "Approved" }
     let!(:assignment_group) { create :assignment_group, group: group, assignment: assignment }
     let!(:group_membership) { create :group_membership, student: student, group: group }
-    let!(:submission) { create :submission, course: course, assignment: assignment, group: group }
+    let!(:submission) { create :group_submission, course: course, assignment: assignment, group: group }
 
     before(:each) do
       login_as professor

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -134,7 +134,7 @@ describe Group do
   describe "#submission_for_assignment(assignment)" do
     it "returns the group's submission for an assignment" do
       assignment = create(:assignment, grade_scope: "Group")
-      submission = create(:submission, group: subject, assignment: assignment)
+      submission = create(:group_submission, group: subject, assignment: assignment)
       expect(subject.submission_for_assignment(assignment)).to eq(submission)
     end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -49,6 +49,13 @@ describe Submission do
     it "allows multiple individual submissions to be created" do
       expect{create_list(:submission, 3)}.not_to raise_error
     end
+
+    it "requires either a group id or student id but not both" do
+      expect(build_stubbed(:submission)).to be_valid
+      expect(build_stubbed(:group_submission)).to be_valid
+      expect(build_stubbed(:submission, student: nil, group: nil)).not_to be_valid
+      expect(build_stubbed(:submission, student: build_stubbed(:user), group: build_stubbed(:group))).not_to be_valid
+    end
   end
 
   it_behaves_like "a historical model", :submission, link: "http://example.org"

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -30,13 +30,15 @@ describe Submission do
     it "restricts duplicate submissions for a given student on an assignment" do
       submission = create(:submission)
       expect{create(:submission, assignment: submission.assignment,
-        student: submission.student)}.to raise_error ActiveRecord::RecordInvalid
+        student: submission.student)}.to raise_error ActiveRecord::RecordInvalid,
+        /should only have one submission per student or group/
     end
 
     it "restricts duplicate submissions for a given group on an assignment" do
       submission = create(:group_submission)
       expect{create(:group_submission, assignment: submission.assignment,
-        group: submission.group)}.to raise_error ActiveRecord::RecordInvalid
+        group: submission.group)}.to raise_error ActiveRecord::RecordInvalid,
+        /should only have one submission per student or group/
     end
 
     it "allows multiple group submissions to be created" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -150,7 +150,7 @@ describe Submission do
     let!(:course_membership) { create(:student_course_membership, user: student, course: assignment.course) }
     let!(:assignment_group) { create(:assignment_group, assignment: assignment) }
     let!(:group_membership) { create(:group_membership, student: student, group: assignment_group.group) }
-    let!(:submission) { create(:submission, assignment: assignment, group: assignment_group.group) }
+    let!(:submission) { create(:group_submission, assignment: assignment, group: assignment_group.group) }
 
     it "returns the submission for the group and assignment" do
       result = Submission.for_assignment_and_group(assignment.id, assignment_group.group_id).first
@@ -301,6 +301,7 @@ describe Submission do
     end
 
     it "returns one submission for a group resubmissions" do
+      subject = build(:group_submission)
       student1 = create(:user)
       student2 = create(:user)
       group = create(:group, assignments: [subject.assignment])
@@ -404,9 +405,9 @@ describe Submission do
   end
 
   describe "#submitter_id" do
-    let(:submission) { create :submission, group_id: 20, student_id: 30 }
-
     context "submission uses groups" do
+      let(:submission) { build_stubbed :group_submission, group_id: 20 }
+
       it "returns the group id" do
         allow(submission.assignment).to receive(:has_groups?) { true }
         expect(submission.submitter_id).to eq 20
@@ -414,13 +415,14 @@ describe Submission do
     end
 
     context "submissions doesn't use groups" do
+      let(:submission) { build_stubbed :submission, student_id: 30 }
+
       it "returns the student" do
         allow(submission.assignment).to receive(:has_groups?) { false }
         expect(submission.submitter_id).to eq 30
       end
     end
   end
-
 
   describe "#check_and_set_late_status!" do
     context "when the assignment has a due_at date" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -27,10 +27,25 @@ describe Submission do
       expect(subject.errors[:base]).to include "Submission cannot be empty"
     end
 
-    it "permits only one submission per user, per assignment" do
-      course_submission = create(:submission)
-      expect{create(:submission, assignment: course_submission.assignment,
-        student: course_submission.student)}.to raise_error ActiveRecord::RecordInvalid
+    it "restricts duplicate submissions for a given student on an assignment" do
+      submission = create(:submission)
+      expect{create(:submission, assignment: submission.assignment,
+        student: submission.student)}.to raise_error ActiveRecord::RecordInvalid
+    end
+
+    it "restricts duplicate submissions for a given group on an assignment" do
+      submission = create(:group_submission)
+      expect{create(:group_submission, assignment: submission.assignment,
+        group: submission.group)}.to raise_error ActiveRecord::RecordInvalid
+    end
+
+    it "allows multiple group submissions to be created" do
+      group = create(:group)
+      expect{create_list(:group_submission, 3, group: group)}.not_to raise_error
+    end
+
+    it "allows multiple individual submissions to be created" do
+      expect{create_list(:submission, 3)}.not_to raise_error
     end
   end
 

--- a/spec/services/creates_grade/associates_submission_with_grade_spec.rb
+++ b/spec/services/creates_grade/associates_submission_with_grade_spec.rb
@@ -39,7 +39,7 @@ describe Services::Actions::AssociatesSubmissionWithGrade do
   describe "with a group in the context" do
     it "adds the group submission_id to the grade" do
       context[:group] = world.group
-      submission = create(:submission, assignment: world.assignment, group: world.group)
+      submission = create(:group_submission, assignment: world.assignment, group: world.group)
       result = described_class.execute context
       expect(result[:grade].submission_id).to eq submission.id
     end

--- a/spec/views/submissions/show_group_spec.rb
+++ b/spec/views/submissions/show_group_spec.rb
@@ -17,7 +17,7 @@ describe "submissions/show" do
   let(:course) { create(:course) }
   let(:assignment) { build(:group_assignment, course: course) }
   let(:group) { create(:group, course: course) }
-  let(:submission) { create(:submission, course: course, assignment: assignment, group: group) }
+  let(:submission) { create(:group_submission, course: course, assignment: assignment, group: group) }
   let(:student) { create(:student_course_membership, course: course).user }
 
   before do


### PR DESCRIPTION
### Status
Ready

### Description
This PR addresses a few issues that were discovered with a newly added `Submission` constraint. This should also fix the failing specs on master.

The constraint limited submissions to being one per assignment and student. However, the default behavior for the ActiveRecord constraint was to validate against `nil` values. This prevented multiple group submissions from being created, since a group submission is defined as being a `Submission` with a `group_id` but no `student_id`.

Additional changes were also made to the database as well as the `Submission` model to ensure that no more than one group submission can exist per assignment.

Finally, there is a newly added ActiveRecord constraint that dictates that a `Submission` is valid if it has either a non-nil value for `student_id` or `group_id`, but not both.

**If there is the possibility that there is preexisting production data that would not fit this constraint, a rake task should be included to clean this up**

Fixes #2742

### Deploy Notes
Since we define a group submission as being a `Submission` with a `group_id` but no `student_id`, and an individual `Submission` as being one with `student_id` but no `group_id`, we should make sure that there is no preexisting data that would violate this.

### Migrations
YES

### Steps to Test or Reproduce
- Verify that for any given student, one and only one `Submission` can be created on an individual assignment
- Verify that for any given group, one and only one `Submission` can be created on a group assignment
- Ensure that a `Submission` that is considered invalid cannot be created, e.g. it must have either a `group_id` or `student_id`, but not both