### PR TITLE
2688 group comments autosave

### DIFF
--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -32,11 +32,14 @@
   # TODO: $scope should not be passed around if we want to avoid tight coupling
   getCriteria = (assignmentId, $scope)->
     _scope = $scope
-    $http.get('/api/assignments/' + assignmentId + '/criteria').success((response)->
-      angular.forEach(response.data, (criterion, index)->
-        criterionObject = new Criterion(criterion.attributes, _scope)
-        criteria.push criterionObject
-      )
+    $http.get('/api/assignments/' + assignmentId + '/criteria').then(
+      (response) ->
+        angular.forEach(response.data.data, (criterion, index)->
+          criterionObject = new Criterion(criterion.attributes, _scope)
+          criteria.push criterionObject
+        )
+      ,(response) ->
+        GradeCraftAPI.logResponse(response)
     )
 
   addCriterionGrades = (resData)->
@@ -51,45 +54,55 @@
     # This doesn't handle group criterion grades, we need to add functionality
     # to update on all group criterion grades.
     if recipientType == "student"
-      $http.put("/api/assignments/#{assignmentId}/students/#{recipientId}/criteria/#{criterion.id}/update_fields", criterion_grade: requestData).success(
-        (data, status)->
-          console.log(data)
-      )
-      .error((err)->
-        console.log(err)
+      $http.put("/api/assignments/#{assignmentId}/students/#{recipientId}/criteria/#{criterion.id}/update_fields", criterion_grade: requestData).then(
+        (response) ->
+          GradeCraftAPI.logResponse(response)
+        ,(response) ->
+          GradeCraftAPI.logResponse(response)
       )
 
   getCriterionGrades = (assignmentId, recipientType, recipientId)->
     if recipientType == "student"
-      $http.get('/api/assignments/' + assignmentId + '/students/' + recipientId + '/criterion_grades/').success((response)->
-        addCriterionGrades(response.data)
+      $http.get('/api/assignments/' + assignmentId + '/students/' + recipientId + '/criterion_grades/').then(
+        (response) ->
+          addCriterionGrades(response.data.data)
+          GradeCraftAPI.logResponse(response)
+        ,(response) ->
+          GradeCraftAPI.logResponse(response)
       )
-    else if recipientType == "group"
-      $http.get('/api/assignments/' + assignmentId + '/groups/' + recipientId + '/criterion_grades/').success((response)->
 
-        # The API sends all student information so we can add the ability to custom grade group members
-        # For now we filter to the first student's grade since all students grades are identical
-        addCriterionGrades(_.filter(response.data, { attributes: { 'student_id': response.meta.student_ids[0] }}))
+    else if recipientType == "group"
+      $http.get('/api/assignments/' + assignmentId + '/groups/' + recipientId + '/criterion_grades/').then(
+        (response) ->
+          # The API sends all student information so we can add the ability to custom grade group members
+          # For now we filter to the first student's grade since all students grades are identical
+          addCriterionGrades(_.filter(response.data.data, { attributes: { 'student_id': response.data.meta.student_ids[0] }}))
+          GradeCraftAPI.logResponse(response)
+        ,(response) ->
+          GradeCraftAPI.logResponse(response)
       )
 
   getBadges = ()->
-    $http.get('/api/badges').success((response)->
-      angular.forEach(response.data, (badge, index)->
-        courseBadge = new CourseBadge(badge.attributes)
-        badges[badge.id] = courseBadge
-      )
-      _badgesAvailable = true
+    $http.get('/api/badges').then(
+      (response) ->
+        angular.forEach(response.data.data, (badge, index)->
+          courseBadge = new CourseBadge(badge.attributes)
+          badges[badge.id] = courseBadge
+        )
+        _badgesAvailable = true
+        GradeCraftAPI.logResponse(response)
+      ,(response) ->
+        GradeCraftAPI.logResponse(response)
     )
 
   putRubricGradeSubmission = (assignmentId, recipientType, recipientId, params, returnURL)->
     scopeRoute = if recipientType == "student" then "students" else "groups"
-    $http.put("/api/assignments/#{assignmentId}/#{scopeRoute}/#{recipientId}/criterion_grades", params).success(
-      (data)->
-        console.log(data)
+    $http.put("/api/assignments/#{assignmentId}/#{scopeRoute}/#{recipientId}/criterion_grades", params).then(
+      (response) ->
+        GradeCraftAPI.logResponse(response)
         window.location = returnURL
-    ).error(
-      (data)->
-        console.log(data)
+      ,(response) ->
+        GradeCraftAPI.logResponse(response)
     )
 
   thresholdPoints = ()->

--- a/app/assets/javascripts/angular/services/RubricService.js.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.js.coffee
@@ -35,6 +35,8 @@
     $http.get('/api/assignments/' + assignmentId + '/criteria').then(
       (response) ->
         angular.forEach(response.data.data, (criterion, index)->
+          # sets off factory construction chain: Criterion -> Level -> LevelBadge
+          # that is dependent on badges being in scope
           criterionObject = new Criterion(criterion.attributes, _scope)
           criteria.push criterionObject
         )
@@ -51,10 +53,16 @@
   updateCriterion = (assignmentId, recipientType, recipientId, criterion, field)->
     requestData = {}
     requestData[field] = criterion[field]
-    # This doesn't handle group criterion grades, we need to add functionality
-    # to update on all group criterion grades.
+
     if recipientType == "student"
       $http.put("/api/assignments/#{assignmentId}/students/#{recipientId}/criteria/#{criterion.id}/update_fields", criterion_grade: requestData).then(
+        (response) ->
+          GradeCraftAPI.logResponse(response)
+        ,(response) ->
+          GradeCraftAPI.logResponse(response)
+      )
+    else if recipientType == "group"
+      $http.put("/api/assignments/#{assignmentId}/groups/#{recipientId}/criteria/#{criterion.id}/update_fields", criterion_grade: requestData).then(
         (response) ->
           GradeCraftAPI.logResponse(response)
         ,(response) ->

--- a/app/controllers/api/criterion_grades_controller.rb
+++ b/app/controllers/api/criterion_grades_controller.rb
@@ -68,12 +68,13 @@ class API::CriterionGradesController < ApplicationController
     result = cg.update_attributes(criterion_grade_params)
     if result
       render json: {
-        message: 'Criterion grade successfully updated', success: true
+        message: 'Criterion grade successfully updated', success: true,
+        status: 200
       }
     else
       render json: {
         errors: result.errors, success: false
-      }, status: :bad_request
+      }, status: 400
     end
   end
 
@@ -88,11 +89,12 @@ class API::CriterionGradesController < ApplicationController
       @criterion_grades << cg
     end
     if results.all?
-      render "api/criterion_grades/index", status: 201
+      render "api/criterion_grades/index", success: true,
+      status: 200
     else
       render json: {
         errors: results, success: false
-      }, status: :bad_request
+      }, status: 400
     end
   end
 

--- a/app/views/api/criterion_grades/_criterion_grade.json.jbuilder
+++ b/app/views/api/criterion_grades/_criterion_grade.json.jbuilder
@@ -1,0 +1,6 @@
+json.type "criterion_grades"
+json.id criterion_grade.id.to_s
+
+json.attributes do
+  json.merge! criterion_grade.attributes
+end

--- a/app/views/api/criterion_grades/group_index.json.jbuilder
+++ b/app/views/api/criterion_grades/group_index.json.jbuilder
@@ -1,10 +1,5 @@
 json.data @criterion_grades do |criterion_grade|
-  json.type "criterion_grades"
-  json.id criterion_grade.id.to_s
-
-  json.attributes do
-    json.merge! criterion_grade.attributes
-  end
+  json.partial! 'api/criterion_grades/criterion_grade', criterion_grade: criterion_grade
 end
 
 json.meta do

--- a/app/views/api/criterion_grades/index.json.jbuilder
+++ b/app/views/api/criterion_grades/index.json.jbuilder
@@ -1,8 +1,6 @@
 json.data @criterion_grades do |criterion_grade|
-  json.type "criterion_grades"
-  json.id criterion_grade.id.to_s
-
-  json.attributes do
-    json.merge! criterion_grade.attributes
-  end
+  json.partial! 'api/criterion_grades/criterion_grade', criterion_grade: criterion_grade
 end
+
+
+

--- a/app/views/api/criterion_grades/show.json.jbuilder
+++ b/app/views/api/criterion_grades/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.data do
+  json.partial! 'api/criterion_grades/criterion_grade', criterion_grade: @criterion_grade
+end
+
+
+

--- a/app/views/grades/_standard_edit.html.haml
+++ b/app/views/grades/_standard_edit.html.haml
@@ -26,7 +26,7 @@
             = f.label :feedback
             = f.text_area :feedback,
               "froala" => "froalaOptions",
-              "ng-change" => "grade.update()",
+              "ng-change" => "updateGrade()",
               "ng-model" => "grade.feedback",
               "ng-model-options" => "{ debounce: 1000 }"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,11 @@ Rails.application.routes.draw do
         put "criterion_grades", to: "criterion_grades#update"
       end
       resources :groups, only: [] do
+        resources :criteria, only: [] do
+          member do
+            put :update_fields, to: 'criterion_grades#group_update_fields'
+          end
+        end
         get 'grades', to: 'grades#group_index'
         put "criterion_grades", to: "criterion_grades#group_update"
         get 'criterion_grades', to: 'criterion_grades#group_index'


### PR DESCRIPTION
### Status
**READY**

### Description

The comment field on criterion grades has an autosave feature that does not currently work for group grading. This PR adds autosave functionality for the `CriterionGrade.comment` fields for group graded assignments.

Additionally, it adds autosave for the grade summary feedback for each of the group member's grades.

(A minor fix in the standard edit form fixes autosave for individual grades w/o rubrics, the group equivalent has it's own issue: #2748).

It also updates the $http calls from the Angular `GradeService` and `RubricService` to use the `.then` syntax.

closes #2688.

### Migrations
NO

### Steps to Test or Reproduce

As a professor, grade a group assignment with a rubric.  Without hitting submit, the text comment fields on criterion should still autosave.