### PR TITLE
2710 Conditionally Hide Download All Submissions Option

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -109,6 +109,10 @@ class Assignment < ActiveRecord::Base
     grade_scope=="Group"
   end
 
+  def has_submitted_submissions?
+    submissions.reject(&:draft?).any?
+  end
+
   # Custom point total if the class has weighted assignments
   def full_points_for_student(student)
     return 0 unless full_points

--- a/app/views/assignments/buttons/_submissions_exports.html.haml
+++ b/app/views/assignments/buttons/_submissions_exports.html.haml
@@ -1,14 +1,15 @@
-- if assignment.has_groups?
-  %li= link_to glyph("file-zip-o") + "Download Group Submissions",
-    submissions_exports_path(assignment_id: assignment.id,
-    use_groups: true),
+- if assignment.has_submitted_submissions?
+  - if assignment.has_groups?
+    %li= link_to glyph("file-zip-o") + "Download Group Submissions",
+      submissions_exports_path(assignment_id: assignment.id,
+      use_groups: true),
+      method: :post
+  - elsif team
+    %li= link_to glyph("file-zip-o") + "Download Team Submissions",
+      submissions_exports_path(assignment_id: assignment.id,
+      team_id: team.id),
+      method: :post
+  - else
+    %li.hide-for-small= link_to glyph("file-zip-o") + "Download All Submissions",
+    submissions_exports_path(assignment_id: assignment.id),
     method: :post
-- elsif team
-  %li= link_to glyph("file-zip-o") + "Download Team Submissions",
-    submissions_exports_path(assignment_id: assignment.id,
-    team_id: team.id),
-    method: :post
-- else
-  %li.hide-for-small= link_to glyph("file-zip-o") + "Download All Submissions",
-  submissions_exports_path(assignment_id: assignment.id),
-  method: :post

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -1011,6 +1011,24 @@ describe Assignment do
     end
   end
 
+  describe "#has_submitted_submissions?" do
+    let!(:draft_submission) { create(:draft_submission, assignment: subject) }
+
+    context "when there are submitted submissions" do
+      let!(:submitted_submission) { create(:submission, assignment: subject) }
+
+      it "returns true" do
+        expect(subject.has_submitted_submissions?).to eq true
+      end
+    end
+
+    context "when there are no submitted submissions" do
+      it "returns false" do
+        expect(subject.has_submitted_submissions?).to eq false
+      end
+    end
+  end
+
   describe "#soon?" do
     it "is not soon if there is no due date" do
       subject.due_at = nil


### PR DESCRIPTION
### Status
READY

### Description
Previously a professor could go to the Assignment Show page, click on Options, and be presented with the option to "Download All Submissions" even if no submissions existed. This resulted in export jobs showing on the Course Data Exports page that would never change to "Complete" status.

This bug prevents the option from showing if there are no viewable submissions.

Fixes #2710 

### Migrations
NO

### Steps to Test or Reproduce
Select an assignment, click on Options in the upper right-hand corner and you should expect to see "Download All Submissions" if and only if there are submitted submissions for the assignment.