### PR TITLE
2567 Add error message for users with no courses

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.sass
+++ b/app/assets/stylesheets/pages/_dashboard.sass
@@ -45,7 +45,7 @@
 
   .stacked-module
     flex: 1 auto
-  
+
   &.show-student
     padding: .25rem 1rem
 
@@ -251,7 +251,7 @@ ul.badge-grid
       display: inline-block
       list-style-type: none
       margin: 0
-      a.button 
+      a.button
         margin: 0
 
 /* Makes the box plot responsive */
@@ -396,3 +396,15 @@ ul.assignments-due
 #instructor-dashboard
   .weekly-stats-module
     max-height: 180px
+
+/* Styles the message for a user has no course memberships */
+.message-container
+  background-color: $color-white
+  max-width: 400px
+  border-radius: 1rem
+  opacity: .6
+  padding: 1rem
+  position: absolute
+  top: 50%
+  left: 50%
+  transform: translate(-50%, -50%)

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -9,13 +9,17 @@ class InfoController < ApplicationController
 
   # Displays student and instructor dashboard
   def dashboard
-    @events = Timeline.new(current_course).events_by_due_date
-    render :dashboard, Info::DashboardCoursePlannerPresenter.build({
-      student: current_student,
-      assignments: current_course.assignments.chronological.includes(:assignment_type, :unlock_conditions),
-      course: current_course,
-      view_context: view_context
-    })
+    presenter = nil
+    if current_user.course_memberships.any?
+      @events = Timeline.new(current_course).events_by_due_date
+      presenter = Info::DashboardCoursePlannerPresenter.build({
+        student: current_student,
+        assignments: current_course.assignments.chronological.includes(:assignment_type, :unlock_conditions),
+        course: current_course,
+        view_context: view_context
+      })
+    end
+    render :dashboard, presenter unless presenter.nil?
   end
 
   # Display the grade predictor

--- a/app/views/info/_without_course_memberships.haml
+++ b/app/views/info/_without_course_memberships.haml
@@ -1,0 +1,11 @@
+.message-container
+  %h1 You don't belong to any courses in GradeCraft!
+  %p.message
+    If you're a student, ask your instructor to add you to their course site.
+    %br
+    %br
+    If you're an instructor, email
+    %a{href: "mailto:help@gradecraft.com"} help@gradecraft.com
+    to have them create a course shell for you.
+  .return-link
+    %a{href: "#{logout_url}"} Log me out..

--- a/app/views/info/dashboard.html.haml
+++ b/app/views/info/dashboard.html.haml
@@ -1,1 +1,4 @@
-#dashboard-timeline= render partial: "info/dashboard/#{current_user.role(current_course)}_dashboard", locals: { presenter: presenter }
+- if current_user.course_memberships.any?
+  #dashboard-timeline= render partial: "info/dashboard/#{current_user.role(current_course)}_dashboard", locals: { presenter: presenter }
+- else
+  = render partial: "without_course_memberships"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,21 +11,27 @@
     = csrf_meta_tags
     = yield(:head)
 
-  %body(class="#{body_class}")
-    = render partial: "layouts/top_bar", locals: { presenter: Navigation::CourseInfoPresenter.new(course: current_course, student: current_student) }
-    - if current_user
-      %a.nav-flyout-contentmask
-      .inner-wrap
-        - if current_user_is_staff?
-          = render partial: "layouts/staff"
-        - else
-          = render partial: "layouts/student"
-    - else
-      = render partial: "layouts/public"
+  - if current_user && !current_user.course_memberships.any?
+    %body
+      = render partial: "layouts/content"
+    = render partial: "layouts/help/uservoice"
+  - else
+    %body(class="#{body_class}")
+      = render partial: "layouts/top_bar", locals: { presenter: Navigation::CourseInfoPresenter.new(course: current_course, student: current_student) }
+      - if current_user
+        %a.nav-flyout-contentmask
+        .inner-wrap
+          - if current_user_is_staff?
+            = render partial: "layouts/staff"
+          - else
+            = render partial: "layouts/student"
+      - else
+        = render partial: "layouts/public"
     = render partial: "layouts/help/uservoice"
     .footer
       = render partial: "layouts/footer"
-    = render partial: "layouts/background"
-    = render partial: "layouts/google_analytics"
-    = javascript_include_tag "application", "data-turbolinks-track" => true
-    = yield(:scripts)
+
+  = render partial: "layouts/background"
+  = render partial: "layouts/google_analytics"
+  = javascript_include_tag "application", "data-turbolinks-track" => true
+  = yield(:scripts)


### PR DESCRIPTION
<img width="1345" alt="screen shot 2016-12-20 at 9 48 07 am" src="https://cloud.githubusercontent.com/assets/17604722/21354820/778b62e8-c699-11e6-8592-5e2a9331627c.png">

### Status
**READY**

### Description
Previously if a user tried to log onto GradeCraft without having any course memberships, they would encounter an error. This PR presents said user with a friendly message informing them on what next steps they should take in order to obtain access.

Closes #2567 

### Migrations
NO

### Steps to Test or Reproduce
Try to log onto GradeCraft as a user with no course memberships.
