### PR TITLE
2488 remove empty grades

### DIFF
--- a/db/migrate/20161220170436_remove_predicted_score_from_grades.rb
+++ b/db/migrate/20161220170436_remove_predicted_score_from_grades.rb
@@ -1,0 +1,5 @@
+class RemovePredictedScoreFromGrades < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :grades, :predicted_score
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -422,7 +422,6 @@ ActiveRecord::Schema.define(version: 20170203181526) do
     t.text     "admin_notes"
     t.integer  "graded_by_id"
     t.integer  "team_id"
-    t.integer  "predicted_score",            default: 0,     null: false
     t.boolean  "instructor_modified",        default: false
     t.string   "pass_fail_status"
     t.boolean  "is_custom_value",            default: false

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -35,15 +35,23 @@ namespace :grades do
     desc "Deletes any grade that has a predicted score greater than 0"
     task delete_predicted_grades: :environment do
       grades = Grade.where("predicted_score > 0")
-      puts "Deleting #{pluralize grades.count, "predicted grade"}..."
+      puts "Deleting #{ActionController::Base.helpers.pluralize grades.count, "predicted grade"}..."
       grades.destroy_all
     end
 
     desc "Deletes any grade without raw points or feedback"
     task delete_empty_grades: :environment do
       grades = Grade.where(raw_points: nil, feedback: nil)
-      puts "Deleting #{pluralize grades.count, "empty grade"}..."
+      puts "Deleting #{ActionController::Base.helpers.pluralize grades.count, "empty grade"}..."
       grades.destroy_all
+    end
+
+    desc "Update grades without a graded by id to be graded by user id 1"
+    task update_ungraded_grades: :environment do
+      user = User.find 1
+      grades = Grade.where(graded_by_id: nil)
+      puts "Updating #{ActionController::Base.helpers.pluralize grades.count, "ungraded grade"} with user #{user.name}..."
+      grades.update_all(graded_by_id: user.id)
     end
   end
 end

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -30,4 +30,13 @@ namespace :grades do
       prediction.save
     end
   end
+
+  namespace :remove_empty_grades do
+    desc "Deletes any grade that has a predicted score greater than 0"
+    task delete_predicted_grades: :environment do
+      grades = Grade.where("predicted_score > 0")
+      puts "Deleting #{pluralize grades.count, "predicted grade"}..."
+      grades.destroy_all
+    end
+  end
 end

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -38,5 +38,12 @@ namespace :grades do
       puts "Deleting #{pluralize grades.count, "predicted grade"}..."
       grades.destroy_all
     end
+
+    desc "Deletes any grade without raw points or feedback"
+    task delete_empty_grades: :environment do
+      grades = Grade.where(raw_points: nil, feedback: nil)
+      puts "Deleting #{pluralize grades.count, "empty grade"}..."
+      grades.destroy_all
+    end
   end
 end

--- a/lib/tasks/grades.rake
+++ b/lib/tasks/grades.rake
@@ -53,5 +53,12 @@ namespace :grades do
       puts "Updating #{ActionController::Base.helpers.pluralize grades.count, "ungraded grade"} with user #{user.name}..."
       grades.update_all(graded_by_id: user.id)
     end
+
+    desc "Update grades without a graded at timestamp to be graded by their updated at timestamp"
+    task update_missing_timestamps: :environment do
+      grades = Grade.where(graded_at: nil)
+      puts "Updating #{ActionController::Base.helpers.pluralize grades.count, "grade"} with missing timestamps..."
+      grades.update_all("graded_at=updated_at")
+    end
   end
 end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -171,7 +171,6 @@ describe Grade do
     it "saves the grades as zero" do
       subject.save!
       expect(subject.raw_points).to be 0
-      expect(subject.predicted_score).to be <= 1
       expect(subject.final_points).to be 0
       expect(subject.full_points).to be 0
     end


### PR DESCRIPTION
### Status
**HOLD**

### Description
This PR cleans up several grade related items to remove ungraded grades and grades with predicted scores.

**This should be merged in after #2487 or having a `Grade.find_or_create` will create additional grades that these migrations are trying to clean up**

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
#2487 | [link](https://github.com/UM-USElab/gradecraft-development/issues/2487)

### Deploy Notes

**Do not run the migration before these rake tasks are run.**

After this is merged into production, run the following tasks in this order:

1. `bundle exec rake grades:remove_empty_grades:delete_predicted_grades`
1. `bundle exec rake grades:remove_empty_grades:delete_empty_grades`
1. `bundle exec rake grades:remove_empty_grades:update_ungraded_grades`
1. `bundle exec rake grades:remove_empty_grades:update_missing_timestamps`

After these are run a new task can be created to remove all of the jobs under `grades:remove_empty_grades`

### Migrations
YES (Do not run before rake tasks are run)

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grading

Closes #2488