### PR TITLE
Re-added pass fail view specs

### DIFF
--- a/spec/views/grades/_standard_edit_spec.rb
+++ b/spec/views/grades/_standard_edit_spec.rb
@@ -30,26 +30,25 @@ describe "grades/_standard_edit" do
     end
   end
 
-  describe "when an assignment is pass fail", skip: true do
+  describe "when an assignment is pass fail" do
     before(:each) do
       @assignment.update(pass_fail: true)
-    end
+    end 
 
     it "renders Pass/Fail in the points possible field when incomplete" do
       render
-      assert_select "label", text: "Raw Points (0 Points Possible)", count: 0
-      assert_select "label", text: "Pass fail status", count: 1
+      assert_select ".switch-label", text: "Pass / Fail", count: 1
     end
 
     it "renders the switch in the fail position when not yet graded" do
       render
-      assert_select ".switch-label", text: "Fail", count: 1
+      assert_select ".switch.pass-fail-contingent", data: "Fail", count: 1
     end
 
     it "renders the switch in the pass position when grade status is 'Pass'" do
       @grade.update(pass_fail_status: "Pass")
       render
-      assert_select ".switch-label", text: "Pass", count: 1
+      assert_select ".switch.pass-fail-contingent", data: "Pass", count: 1
       assert_select ".switch" do
         assert_select "#grade_pass_fail_status[value=Pass]", count: 1
       end
@@ -58,20 +57,20 @@ describe "grades/_standard_edit" do
     it "renders the switch in the fail position when the grade is 'Fail'" do
       @grade.update(pass_fail_status: "Fail")
       render
-      assert_select ".switch-label", text: "Fail", count: 1
+      assert_select ".switch.pass-fail-contingent", data: "Fail", count: 1
     end
 
     it "uses the course term for Fail when present" do
       @course.update(fail_term: "No Pass For You!")
       render
-      assert_select ".switch-label", text: "No Pass For You!", count: 1
+      assert_select ".switch.pass-fail-contingent", data: "No Pass For You!", count: 1
     end
 
     it "uses the course term for Pass when present" do
       @course.update(pass_term: "Pwned")
       @grade.update(pass_fail_status: "Pass")
       render
-      assert_select ".switch-label", text: "Pwned", count: 1
+      assert_select ".switch.pass-fail-contingent", data: "Pwned", count: 1
     end
   end
 end


### PR DESCRIPTION
### Status
**READY**

### Description
This work fixes the formerly skipped pass/fail specs on the standard grade edit view