### PR TITLE
Media assignments

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -154,7 +154,7 @@ class AssignmentsController < ApplicationController
       :mass_grade_type, :name, :open_at, :pass_fail, :max_submissions,
       :full_points, :purpose, :release_necessary, :hide_analytics,
       :required, :resubmissions_allowed, :show_description_when_locked,
-      :show_purpose_when_locked, :show_name_when_locked,
+      :show_purpose_when_locked, :show_name_when_locked, :media,
       :show_points_when_locked, :student_logged, :threshold_points, :use_rubric,
       :visible, :visible_when_locked, :min_group_size, :max_group_size,
       unlock_conditions_attributes: [:id, :unlockable_id, :unlockable_type, :condition_id,

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -64,9 +64,8 @@ class ChallengesController < ApplicationController
 
   def challenge_params
     params.require(:challenge).permit :name, :description, :visible, :full_points,
-      :due_at, :open_at, :accepts_submissions, :release_necessary,
-      :course, :team, :challenge, :challenge_file_ids,
-      :challenge_files_attributes, :challenge_file, :challenge_grades_attributes, :challenge_score_level,
+      :due_at, :open_at, :release_necessary, :course, :team, :challenge, :challenge_file_ids,
+      :challenge_files_attributes, :challenge_file, :challenge_grades_attributes, :challenge_score_level, :media, :include_in_timeline, 
       challenge_score_levels_attributes: [:id, :name, :points, :_destroy],
       challenge_files_attributes: [:id, file: []]
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -47,6 +47,6 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:course_id, :name, :description, :open_at,
-    :due_at, :media, :media_credit, :media_caption)
+    :due_at, :media)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -47,6 +47,6 @@ class EventsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:course_id, :name, :description, :open_at,
-    :due_at, :media, :thumbnail, :media_credit, :media_caption)
+    :due_at, :media, :media_credit, :media_caption)
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -331,27 +331,19 @@ class Assignment < ActiveRecord::Base
   end
 
   def open_before_close
-    if (due_at.present? && open_at.present?) && (due_at < open_at)
-      errors.add :base, "Due date must be after open date."
-    end
+    errors.add :base, "Due date must be after open date." if (due_at.present? && open_at.present?) && (due_at < open_at)
   end
 
   def submissions_after_due
-    if (accepts_submissions_until.present? && due_at.present?) && (accepts_submissions_until < due_at)
-      errors.add :base, "Submission accept date must be after due date."
-    end
+    errors.add :base, "Submission accept date must be after due date." if (accepts_submissions_until.present? && due_at.present?) && (accepts_submissions_until < due_at)
   end
 
   def submissions_after_open
-    if (accepts_submissions_until.present? && open_at.present?) && (accepts_submissions_until < open_at)
-      errors.add :base, "Submission accept date must be after open date."
-    end
+    errors.add :base, "Submission accept date must be after open date." if (accepts_submissions_until.present? && open_at.present?) && (accepts_submissions_until < open_at)
   end
 
   def max_more_than_min
-    if (max_group_size? && min_group_size?) && (max_group_size < min_group_size)
-      errors.add :base, "Maximum group size must be greater than minimum group size."
-    end
+    errors.add :base, "Maximum group size must be greater than minimum group size." if (max_group_size? && min_group_size?) && (max_group_size < min_group_size)
   end
 
   def zero_points_for_pass_fail

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -5,7 +5,6 @@ class Assignment < ActiveRecord::Base
   include Sanitizable
   include ScoreLevelable
   include UploadsMedia
-  include UploadsThumbnails
   include UnlockableCondition
 
   attr_accessor :current_student_grade

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -2,7 +2,6 @@ class Challenge < ActiveRecord::Base
   include Copyable
   include ScoreLevelable
   include UploadsMedia
-  include UploadsThumbnails
   include MultipleFileAttributes
 
   # grade points available to the predictor from the assignment controller
@@ -30,6 +29,7 @@ class Challenge < ActiveRecord::Base
   scope :visible, -> { where visible: TRUE }
   scope :chronological, -> { order("due_at ASC") }
   scope :alphabetical, -> { order("name ASC") }
+  scope :timelineable, -> { where include_in_timeline: true }
 
   validates_presence_of :course, :name
   validates_inclusion_of :visible, :accepts_submissions, :release_necessary,

--- a/app/models/concerns/uploads_thumbnails.rb
+++ b/app/models/concerns/uploads_thumbnails.rb
@@ -1,9 +1,0 @@
-module UploadsThumbnails
-  extend ActiveSupport::Concern
-
-  included do
-    mount_uploader :thumbnail, ThumbnailUploader
-
-    validates :thumbnail, file_size: { maximum: 2.megabytes.to_i }
-  end
-end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,5 @@
 class Event < ActiveRecord::Base
   include UploadsMedia
-  include UploadsThumbnails
 
   belongs_to :course, touch: true
 

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -14,7 +14,7 @@ class Timeline
   end
 
   def challenge_events
-    course.challenges.with_dates if course.has_team_challenges?
+    course.challenges.timelineable.with_dates if course.has_team_challenges?
   end
 
   def events_by_due_date

--- a/app/uploaders/thumbnail_uploader.rb
+++ b/app/uploaders/thumbnail_uploader.rb
@@ -1,5 +1,0 @@
-require_relative "image_uploader"
-
-class ThumbnailUploader < ImageUploader
-  process resize_and_pad: [25, 25, background = "transparent", gravity = "Center"]
-end

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -78,6 +78,8 @@
 
   %section
     %h3= "Advanced Settings"
+    
+    = render partial: "layouts/media_image_form_item", locals: { f: f, model: @assignment }
 
     .form-item
       = f.label :visible, "Visible to students"

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -79,7 +79,7 @@
   %section
     %h3= "Advanced Settings"
     
-    = render partial: "layouts/media_image_form_item", locals: { f: f, model: @assignment }
+    = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
 
     .form-item
       = f.label :visible, "Visible to students"

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -56,6 +56,8 @@
             = render partial: "challenge_score_level_fields", locals: { f: slf }
     = link_to "Add a Level", "#", class: "add-challenge-score-level button radius"
 
+  = render partial: "layouts/media_image_form_item", locals: { f: f, model: @challenge }
+  
   %section
     %h4 Attachments
     = f.simple_fields_for :challenge_files, @challenge.challenge_files.new do |cf|

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -32,9 +32,9 @@
       = f.check_box :visible
 
     .form-item
-      = f.label :check_box, "Will the #{term_for :team} submit materials?"
-      = f.check_box :accepts_submissions
-      .form_label All #{term_for :team} members will be able to submit work for their #{term_for :team} as a whole, and see their resulting grades.
+      = f.label :include_in_timeline, "Timeline"
+      = f.check_box :include_in_timeline, {"aria-describedby" => "txtIncludeInTimeline"}
+      .form_label{id: "txtIncludeInTimeline"} Can #{term_for :students} see this #{term_for :challenge} in the course timeline? Note that #{term_for :challenges} without open or due dates will be excluded automatically.
 
     .form-item
       = f.label :release_necessary, "Release necessary?"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -12,7 +12,7 @@
   .show-page-wrapper
     %section
       %h3 Event Date
-      %p= "#{@event.open_at} - #{@event.due_at}"
+      %p= " - #{@event.due_at}"
 
     %section
       %h3 Description
@@ -20,9 +20,5 @@
 
     %section
       - if @event.media.present?
-        .event-image-show-wrapper{class: ('image-with-caption' if @event.media_caption? || @event.media_credit?)}
+        .event-image-show-wrapper
           %img.event-image-show{src: @event.media}
-          - if @event.media_caption.present? || @event.media_credit.present?
-            .photo-details
-              %p.photo-caption= @event.media_caption
-              %p.photo-credit= "Credit: #{@event.media_credit}"

--- a/app/views/info/_timeline.jbuilder
+++ b/app/views/info/_timeline.jbuilder
@@ -15,16 +15,9 @@ json.set! :timeline do
       json.headline event.name
       json.text timeline_content(event)
       json.set! :asset do
-        if event.thumbnail && event.media
-          json.thumbnail event.thumbnail_url
+        if event.media
           json.media event.media_url
-        elsif event.media
-          json.media event.media_url
-        elsif event.thumbnail
-          json.thumbnail event.thumbnail_url
         end
-        json.credit event.media_credit
-        json.caption event.media_caption
       end
     end
   end

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -19,5 +19,5 @@
                 = link_to "See the Details", event
           %ul.assignments-due
             - presenter.assignments_due_on(event).each do |assignment|
-              - if assignment.visible_for_student?(current_student)
+              - if (assignment != event) && assignment.visible_for_student?(current_student)
                 %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.strftime("%H:%M%p") }

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -5,11 +5,3 @@
     %img{src: model.media, width: 40, alt: "Media Image" }
     = f.check_box :remove_media
     Remove Image
-
-.form-item
-  = f.label :media_credit, "Credit"
-  = f.text_field :media_credit
-
-.form-item
-  = f.label :media_caption, "Caption"
-  = f.text_field :media_caption

--- a/db/migrate/20161230164929_add_challenges_to_timeline.rb
+++ b/db/migrate/20161230164929_add_challenges_to_timeline.rb
@@ -1,0 +1,5 @@
+class AddChallengesToTimeline < ActiveRecord::Migration[5.0]
+  def change
+    add_column :challenges, :include_in_timeline, :boolean, default: false, null: false
+  end
+end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -56,7 +56,6 @@ def create_groups(course_name, assignment)
   @courses[course_name][:groups] = groups
 end
 
-
 # ---------------------------- Users and Courses -----------------------------#
 
 user_names = ["Ron Weasley","Fred Weasley","Harry Potter","Hermione Granger",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161216142745) do
+ActiveRecord::Schema.define(version: 20161230164929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,6 +218,7 @@ ActiveRecord::Schema.define(version: 20161216142745) do
     t.string   "thumbnail"
     t.string   "media_credit"
     t.string   "media_caption"
+    t.boolean  "include_in_timeline", default: false, null: false
   end
 
   create_table "course_analytics_exports", force: :cascade do |t|

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -29,7 +29,7 @@ describe Timeline do
     end
 
     context "with challenges for the course" do
-      let!(:challenge) { create :challenge, course: course, due_at: Date.today }
+      let!(:challenge) { create :challenge, course: course, due_at: Date.today, include_in_timeline: true }
       let!(:challenge_not_due) { create :challenge, course: course, due_at: nil }
 
       context "that accepts team challenges" do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR makes the use of media images and timelineable scopes identical across the Challenge, Assignment, and Event models. This required:
• adding the include_in_timeline boolean to the Challenge model
• reinstating media fields for assignments and challenges
• removing the thumbnail, media credit, and media caption fields (not yet removed at the database level)