### PR TITLE
Fix integrations index bug

### DIFF
--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -36,10 +36,6 @@
       = f.label :status, "Active?"
       = f.check_box :status
       .form_label Is this an active course?
-  -# .form-item
-  -#   = f.label :accepts_submissions, "Submissions"
-  -#   = f.check_box :accepts_submissions, {"aria-describedby" => "txtAcceptSubmission"}
-  -#   .form_label{id: "txtAcceptSubmission"} Will you be using GradeCraft to accept assignment submissions?  
 
 %section
   %h4.uppercase Enable Features

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -71,15 +71,11 @@
         %button.button-advanced-settings= glyph(:cog) + "Settings"
       .advanced-settings-card
         %a.button-close= glyph(:times)
-        = f.label :total_weights, "How many multipliers do #{term_for :students} have to allocate?"
-        = f.input :total_weights, {"aria-describedby" => "txtMultiplierCount", input_html: { min: 1 }}
+        = f.input :total_weights, {"aria-describedby" => "txtMultiplierCount", :label => "How many multipliers do #{term_for :students} have to allocate?" }
         = f.input :weights_close_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @assignment.try(:open_at) }, :label => "What date must they make this decision by?"
-        = f.label :max_weights_per_assignment_type, "Maximum Per #{term_for :assignment_type}"
-        = f.input :max_weights_per_assignment_type, {"aria-describedby" => "txtMaxPerAssignment", input_html: { min: 1 }}
-        = f.label :max_assignment_types_weighted, "Is there a maximum number of assignment types they can weight?"
-        = f.input :max_assignment_types_weighted, {"aria-describedby" => "txtMaxWeighted", input_html: { min: 1 }}
-        = f.label :weight_term, "What do you want to call these weights/multipliers?"
-        = f.text_field :weight_term, {"aria-describedby" => "txtWeightTerm"}
+        = f.input :max_weights_per_assignment_type, {"aria-describedby" => "txtMaxPerAssignment", input_html: { min: 1 } }
+        = f.input :max_assignment_types_weighted, {"aria-describedby" => "txtMaxWeighted", input_html: { min: 1 }, :label => "Is there a maximum number of assignment types they can weight?" }
+        = f.input :weight_term, {"aria-describedby" => "txtWeightTerm", :label => "What do you want to call these weights/multipliers?"}
 
 
     .form-card

--- a/app/views/courses/_integrations.haml
+++ b/app/views/courses/_integrations.haml
@@ -1,0 +1,12 @@
+.card.left{style: "height: 350px;"}
+  .card-cap
+    %img{src: "/images/canvas-logo.png"}
+  .card-block= integration_card_for(:canvas, @course)
+  
+.card.left{style: "height: 350px;"}
+  .card-cap
+    %h1.center.bold.inverse LTI
+  .card-block
+    = render partial: "integrations/courses/lti_card", locals: { f: f }
+
+.clear

--- a/app/views/courses/_integrations.haml
+++ b/app/views/courses/_integrations.haml
@@ -1,10 +1,5 @@
 .card.left{style: "height: 350px;"}
   .card-cap
-    %img{src: "/images/canvas-logo.png"}
-  .card-block= integration_card_for(:canvas, @course)
-  
-.card.left{style: "height: 350px;"}
-  .card-cap
     %h1.center.bold.inverse LTI
   .card-block
     = render partial: "integrations/courses/lti_card", locals: { f: f }

--- a/app/views/courses/edit.html.haml
+++ b/app/views/courses/edit.html.haml
@@ -20,7 +20,7 @@
       .ui-tabs-panel#tab2{role: "tabpanel", "aria-hidden" => false }
         = render partial: "courses/course_details", locals: { f: f }
       .ui-tabs-panel#tab3{role: "tabpanel", "aria-hidden" => false }
-        = render partial: "integrations/index", locals: { f: f }
+        = render partial: "courses/integrations", locals: { f: f }
       .ui-tabs-panel#tab4{role: "tabpanel", "aria-hidden" => false }
         = render partial: "courses/student_onboarding_setup", locals: { f: f }
       .ui-tabs-panel#tab5{role: "tabpanel", "aria-hidden" => false }

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -3,10 +3,4 @@
     %img{src: "/images/canvas-logo.png"}
   .card-block= integration_card_for(:canvas, @course)
 
-.card.left{style: "height: 350px;"}
-  .card-cap
-    %h1.center.bold.inverse LTI
-  .card-block
-    = render partial: "integrations/courses/lti_card", locals: { f: f }
-
 .clear

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -2,7 +2,7 @@
   .card-cap
     %img{src: "/images/canvas-logo.png"}
   .card-block= integration_card_for(:canvas, @course)
-  
+
 .card.left{style: "height: 350px;"}
   .card-cap
     %h1.center.bold.inverse LTI


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes an [issue](https://rollbar.com/gradecraft/gradecraft-development/items/1766) with the Integrations#index view.

The issue is because the `Integrations#index` view was renamed as a partial in [this commit](https://github.com/UM-USElab/gradecraft-development/commit/5887c5554a47209b329647de281bd75e514bbd17#diff-62cc7bdf39fa36559c4a1d1b7b9155ce) which was causing Rails to raise an `ActionController::UnknownFormat` error since there was no layout file.

In addition, I removed the LTI section for integrations from [this commit](https://github.com/UM-USElab/gradecraft-development/commit/b7d9d796069104c303d26c905153c3ff37b1b3a8#diff-62cc7bdf39fa36559c4a1d1b7b9155ce) as it's partial was expecting a form variable that was not available and so I did not know what to provide it. **This will need to be added back in in a future PR**.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* `/integrations`
