### PR TITLE
Fixed display of time on the dashboard to be twelve hour

### DIFF
--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -20,4 +20,4 @@
           %ul.assignments-due
             - presenter.assignments_due_on(event).each do |assignment|
               - if (assignment != event) && assignment.visible_for_student?(current_student)
-                %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.strftime("%H:%M%p") }
+                %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.strftime("%l:%M%p") }


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes the display of assignment due dates to be 12 hour on the dashboard