### PR TITLE
Replace the use of eval in breadcrumbs

### DIFF
--- a/app/views/breadcrumbs/_breadcrumbs.haml
+++ b/app/views/breadcrumbs/_breadcrumbs.haml
@@ -3,6 +3,6 @@
     - if breadcrumb.link?
       %li
         -# evaluate expressions from breadcrumbs_trail.rb
-        = link_to eval(%{ "#{ breadcrumb.label }" }), breadcrumb.url
+        = link_to instance_eval(%{ "#{ breadcrumb.label }" }), breadcrumb.url
     - else
-      %li= eval %{ "#{ breadcrumb.label }" }
+      %li= html_escape %{ "#{ breadcrumb.label }" }


### PR DESCRIPTION
### Status
**READY**

### Description
We don't sanitize the names of objects in the app, and so when we use them in the breadcrumbs special characters result in broken pages. This switches to using html_escape and instance_eval to display the elements of breadcrumbs. 