### PR TITLE
2770 faculty predictor graph

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.js.coffee
@@ -19,8 +19,8 @@
   #---------------- Assignment Type Point Calculations ------------------------#
 
   # multiply points by the student's assignment type weight if weighted
-  # points is optional, defaults to total_points for Assignment Type
-  weightedPoints = (assignmentType, points)->
+  # points defaults to zero for generic predictor
+  weightedPoints = (assignmentType, points=0)->
     if assignmentType.student_weightable
       points * assignmentType.student_weight
     else

--- a/app/assets/javascripts/angular/services/BadgeService.js.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.js.coffee
@@ -29,7 +29,7 @@
       GradeCraftAPI.loadMany(badges, response, {"include" : ['prediction']})
       _.each(badges, (badge)->
         # add null prediction when JSON contains no prediction
-        badge.prediction = {predicted_times_earned: badge.earned_badge_count} if !badge.prediction
+        badge.prediction = {predicted_times_earned: 0} if !badge.prediction
       )
       GradeCraftAPI.loadFromIncluded(earnedBadges,"earned_badges", response)
       GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)

--- a/app/assets/javascripts/angular/services/BadgeService.js.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.js.coffee
@@ -28,8 +28,9 @@
     $http.get(GradeCraftAPI.uriPrefix(studentId) + 'badges').success( (response)->
       GradeCraftAPI.loadMany(badges, response, {"include" : ['prediction']})
       _.each(badges, (badge)->
+        badge.earned_badge_count = 0 if !badge.earned_badge_count
         # add null prediction when JSON contains no prediction
-        badge.prediction = {predicted_times_earned: 0} if !badge.prediction
+        badge.prediction = {predicted_times_earned: badge.earned_badge_count} if !badge.prediction
       )
       GradeCraftAPI.loadFromIncluded(earnedBadges,"earned_badges", response)
       GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)

--- a/app/assets/javascripts/angular/services/BadgeService.js.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.js.coffee
@@ -28,6 +28,7 @@
     $http.get(GradeCraftAPI.uriPrefix(studentId) + 'badges').success( (response)->
       GradeCraftAPI.loadMany(badges, response, {"include" : ['prediction']})
       _.each(badges, (badge)->
+        # add earned badge count for generic predictor
         badge.earned_badge_count = 0 if !badge.earned_badge_count
         # add null prediction when JSON contains no prediction
         badge.prediction = {predicted_times_earned: badge.earned_badge_count} if !badge.prediction

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -160,7 +160,7 @@
       )
     _.each(badges,(badge)->
         # disregard for generic predictor
-        if badge.total_earned_point
+        if badge.total_earned_points
           total += badge.total_earned_points
       )
     _.each(challenges,(challenge)->

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -159,7 +159,9 @@
         total += assignmentTypePointTotal(assignmentType,true,true,false)
       )
     _.each(badges,(badge)->
-        total += badge.total_earned_points
+        # disregard for generic predictor
+        if badge.total_earned_point
+          total += badge.total_earned_points
       )
     _.each(challenges,(challenge)->
         total += challenge.grade.score

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -65,7 +65,7 @@ $card-margin-1 : 3px
       stroke: black
       shape-rendering: scripEdges
     text
-      font-size: $predictor-font-size-4
+      font-size: $predictor-font-size-6
   #svg-graph-points-earned
     fill: $color-green-3
   #svg-graph-points-predicted


### PR DESCRIPTION
### Status
**READY**

### Description

D3 controls the presentation of graph axis values based on the given available space, but the size of the point values in GC, coupled with the tight space on the faculty predictor rendered these numbers overlapping.  

I have fixed this for now by reducing the point size for this text across all predictors, there may be a more nuanced solution but I don't find the smaller size looks bad on the student predictor, let me know if you disagree.

I have also fixed in several places the calculation of earned and predicted points for the generic predictor.  There were several silent errors created by the removal of the NullObjects, which added zeroed out properties into the JSON to mimic the student predictor. These are now better handled within the Angular code.

closes #2770 