### PR TITLE
2805-remove-descriptions-index-tables

### DIFF
--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -126,17 +126,13 @@
   .earned-column
     width: 100px
 
-  .button-bar li a.button
-    display: block
-    margin: .25em
-    border-radius: 0.1875rem
-    @media (max-width: 800px)
-      display: inline-block
+  .button-bar
+    text-align: right
 
   .button-bar li:not(:last-of-type) a.button
     @media (max-width: $media-medium-max)
       margin-right: 0
-    @media (max-width: 800px)
+    @media (max-width: $media-small-max)
       margin-right: .5rem
 
   .badge-icon

--- a/app/views/badges/_index_staff.haml
+++ b/app/views/badges/_index_staff.haml
@@ -10,7 +10,6 @@
         %th.points-column Point Value
         %th.lock-icon-column Locked?
         %th.earned_column Earned
-        %th.description-column Description
         %th.button-column
 
     %tbody.sort-badges
@@ -42,11 +41,6 @@
             // Badge Count
             %td
               = render partial: "badges/components/count", locals: { badge: badge, count: presenter.earned_badges_count(badge) }
-
-            // Description
-            %td
-              = render partial: "badges/components/description",
-                locals: { badge: badge, title: link_to(badge.name, badge_path(badge)) }
 
             // Buttons
             %td

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -2,7 +2,6 @@
   %thead
     %tr
       %th Name
-      %th Description
       %th{"data-dynatable-sorts" => "numericScore"} Max Points
       %th{"data-dynatable-sorts" => "dueDate"} Due
       %th{:style => "display: none"} Due Date
@@ -15,7 +14,6 @@
     - @challenges.chronological.alphabetical.each do |challenge|
       %tr
         %td= link_to challenge.name, challenge
-        %td= link_to "See Description", challenge
         %td= points challenge.full_points
         %td= challenge.due_at
         %td{:style => "display: none"}

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -10,7 +10,6 @@
     %thead
       %tr
         %th{:width => "20%"} Name
-        %th Description
         %th Open date
         %th Close date
         %th{:style => "min-width: 200px"}
@@ -19,7 +18,6 @@
       - @events.each do |event|
         %tr
           %td= link_to event.name, event
-          %td= raw event.description
           %td= event.open_at
           %td= event.due_at
           %td


### PR DESCRIPTION
### Status
**READY**

### Description
This PR removes the description column from the index tables, preventing the tables from becoming illegible and requiring the user to click the name of the event/badge/challenge to read more.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Badge index, challenge index, event index

Closes #2805 