### PR TITLE
guard against missing assignments

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentService.js.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.js.coffee
@@ -52,7 +52,7 @@
           assignment.is_closed_by_condition = false
           _.each(assignment.conditional_assignment_ids, (id)->
             a = _.find(assignments, {id: id})
-            if a.is_closed_without_submission == true
+            if a && a.is_closed_without_submission == true
               assignment.is_closed_by_condition = true
           )
       )


### PR DESCRIPTION
### Status
**READY**

### Description

Fixes a bug in the predictor when an assignment is a condition but it not present in the assignments.

## Before:

![screen shot 2017-01-05 at 10 47 17 am](https://cloud.githubusercontent.com/assets/1138350/21688124/a798c316-d339-11e6-8632-bf2d684181f5.png)

## After:

![screen shot 2017-01-05 at 11 20 19 am](https://cloud.githubusercontent.com/assets/1138350/21688103/9cd1f9d4-d339-11e6-8349-e7f884865ca8.png)
