### PR TITLE
2824 submission bug fixes

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -40,7 +40,7 @@ class InfoController < ApplicationController
   # submissions in the system
   def grading_status
     grades = current_course.grades.instructor_modified
-    submissions = current_course.submissions.includes(:assignment, :grade, :student, :group, :submission_files)
+    submissions = current_course.submissions.submitted.includes(:assignment, :grade, :student, :group, :submission_files)
     @ungraded_submissions_by_assignment = submissions.ungraded.group_by(&:assignment)
     @resubmissions_by_assignment = submissions.resubmitted.group_by(&:assignment)
     @unreleased_grades_by_assignment = grades.not_released.group_by(&:assignment)

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -9,9 +9,13 @@ module SubmissionsHelper
     "#{course.cache_key}/resubmission_count"
   end
 
-  def ungraded_submissions_count_for(course)
+  def ungraded_submissions_count_for(course, include_drafts=false)
     Rails.cache.fetch(ungraded_submissions_count_cache_key(course)) do
-      course.submissions.ungraded.count
+      if include_drafts
+        course.submissions.ungraded.count
+      else
+        course.submissions.submitted.ungraded.count
+      end
     end
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -45,7 +45,7 @@ class Submission < ActiveRecord::Base
   scope :for_student, ->(student) { where(student_id: student.id) }
   scope :for_assignment_and_student, ->(assignment_id, student_id) { where(assignment_id: assignment_id, student_id: student_id) }
   scope :for_assignment_and_group, ->(assignment_id, group_id) { where(assignment_id: assignment_id, group_id: group_id) }
-
+  scope :submitted, -> { where.not(submitted_at: nil) }
   scope :with_group, -> { where "group_id is not null" }
 
   before_validation :cache_associations
@@ -61,7 +61,7 @@ class Submission < ActiveRecord::Base
   multiple_files :submission_files
 
   def self.submitted_this_week(assignment_type)
-    assignment_type.submissions.where("submissions.updated_at > ? ", 7.days.ago).reject(&:draft?)
+    assignment_type.submissions.submitted.where("submissions.updated_at > ? ", 7.days.ago)
   end
 
   def graded_at
@@ -160,7 +160,7 @@ class Submission < ActiveRecord::Base
   end
 
   def draft?
-    link.blank? && text_comment.blank? && submission_files.empty? && submitted_at.nil?
+    submitted_at.nil?
   end
 
   def belongs_to?(user)

--- a/app/presenters/info/dashboard_course_planner_presenter.rb
+++ b/app/presenters/info/dashboard_course_planner_presenter.rb
@@ -65,6 +65,6 @@ class Info::DashboardCoursePlannerPresenter < Showtime::Presenter
   end
 
   def submitted_submissions_count(assignment)
-    assignment.submissions.reject(&:draft?).count
+    assignment.submissions.submitted.count
   end
 end

--- a/app/presenters/info/dashboard_course_planner_presenter.rb
+++ b/app/presenters/info/dashboard_course_planner_presenter.rb
@@ -63,4 +63,8 @@ class Info::DashboardCoursePlannerPresenter < Showtime::Presenter
   def submitted?(assignment)
     student.submission_for_assignment(assignment).present?
   end
+
+  def submitted_submissions_count(assignment)
+    assignment.submissions.reject(&:draft?).count
+  end
 end

--- a/app/views/info/dashboard/modules/_dashboard_instructor_assignment_list.haml
+++ b/app/views/info/dashboard/modules/_dashboard_instructor_assignment_list.haml
@@ -7,7 +7,7 @@
         %p.count.predicted-count
           = assignment.predicted_count
         %p.count.submissions-count
-          = assignment.submissions.count
+          = presenter.submitted_submissions_count(assignment)
       - if assignment.due_at?.present?
         .form_label= "Due: #{assignment.try(:due_at).strftime("%A, %B %d, %Y, at %l:%M%p")}"
   - if assignment_list.empty?

--- a/spec/factories/submission_factory.rb
+++ b/spec/factories/submission_factory.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :submission do
     association :assignment
     text_comment "needs a link, file, or text comment to be valid"
+    submitted_at Faker::Date.backward(14)
     association :student, factory: :user
 
     factory :group_submission do
@@ -64,10 +65,7 @@ FactoryGirl.define do
     end
 
     factory :draft_submission do
-      link nil
-      text_comment nil
       text_comment_draft "Dear professor, "
-      submission_files {[]}
       submitted_at nil
     end
   end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_spec_helper"
 require "./app/helpers/submissions_helper"
 
-describe SubmissionsHelper do
+describe SubmissionsHelper, focus: true do
   let(:course) { create :course }
 
   describe "#resubmission_count_for" do
@@ -25,9 +25,18 @@ describe SubmissionsHelper do
 
   describe "#ungraded_submissions_count_for" do
     let!(:submission) { create :submission, course: course }
+    let!(:draft_submission) { create :draft_submission, course: course }
 
-    it "returns the number of ungraded submissions" do
-      expect(ungraded_submissions_count_for(course)).to eq 1
+    context "when not including draft submissions" do
+      it "returns the number of ungraded draft submissions" do
+        expect(ungraded_submissions_count_for(course)).to eq 1
+      end
+    end
+
+    context "when including draft submissions" do
+      it "returns the number of ungraded submissions" do
+        expect(ungraded_submissions_count_for(course, true)).to eq 2
+      end
     end
 
     it "caches the result" do

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,7 +1,7 @@
 require "rails_spec_helper"
 require "./app/helpers/submissions_helper"
 
-describe SubmissionsHelper, focus: true do
+describe SubmissionsHelper do
   let(:course) { create :course }
 
   describe "#resubmission_count_for" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -159,10 +159,11 @@ describe Submission do
   end
 
   describe ".submitted" do
-    let!(:submitted_submission) { create(:submission) }
-    let!(:draft_submission) { create(:draft_submission) }
+    before { Submission.destroy_all }
 
     it "returns only submissions with a submitted at date" do
+      submitted_submission = create(:submission)
+      draft_submission = create(:draft_submission)
       expect(Submission.submitted).to eq [submitted_submission]
     end
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -158,6 +158,15 @@ describe Submission do
     end
   end
 
+  describe ".submitted" do
+    let!(:submitted_submission) { create(:submission) }
+    let!(:draft_submission) { create(:draft_submission) }
+
+    it "returns only submissions with a submitted at date" do
+      expect(Submission.submitted).to eq [submitted_submission]
+    end
+  end
+
   describe "#submission_files_attributes=" do
     it "supports multiple file uploads" do
       file_attribute_1 = fixture_file "test_file.txt", "txt"
@@ -324,7 +333,7 @@ describe Submission do
 
     it "returns the submissions in the order they were submitted" do
       submitted_yesterday = create(:submission, submitted_at: 1.day.ago)
-      never_submitted = create(:submission)
+      never_submitted = create(:submission, submitted_at: nil)
       just_submitted = create(:submission, submitted_at: DateTime.now)
       expect(Submission.order_by_submitted).to eq [submitted_yesterday, just_submitted, never_submitted]
     end
@@ -515,33 +524,14 @@ describe Submission do
   end
 
   describe "#draft?" do
-    it "returns false if it has a link" do
-      subject.link = "http://www.gradecraft.com"
-      subject.text_comment = nil
-      subject.submission_files.clear
-      expect(subject.draft?).to eq false
-    end
-
-    it "returns false if it has a text comment" do
-      subject.link = nil
-      subject.text_comment = "Hello"
-      subject.submission_files.clear
-      expect(subject.draft?).to eq false
-    end
-
-    it "returns false if it has a submission file" do
-      subject.save
-      subject.link = "http://www.gradecraft.com"
-      subject.text_comment = nil
-      subject.submission_files.create attributes_for(:submission_file)
-      expect(subject.draft?).to eq false
-    end
-
-    it "returns true if there is no link, text comment, or submission files" do
-      subject.link = nil
-      subject.text_comment = nil
-      subject.submission_files.clear
+    it "returns true if the submitted at date is nil" do
+      subject.submitted_at = nil
       expect(subject.draft?).to eq true
+    end
+
+    it "returns false if the submitted at date is not nil" do
+      subject.submitted_at = DateTime.now
+      expect(subject.draft?).to eq false
     end
   end
 

--- a/spec/presenters/info/dashboard_course_planner_presenter_spec.rb
+++ b/spec/presenters/info/dashboard_course_planner_presenter_spec.rb
@@ -1,0 +1,18 @@
+require "./app/presenters/info/dashboard_course_planner_presenter"
+
+describe Info::DashboardCoursePlannerPresenter do
+  let(:assignment) { build_stubbed(:assignment) }
+  let(:course) { assignment.course }
+  let(:student) { build_stubbed(:user) }
+
+  subject { described_class.new course: course, student: student, assignments: course.assignments }
+
+  describe "#submitted_submissions_count" do
+    let!(:draft_submission) { create(:draft_submission, course: course, assignment: assignment) }
+    let!(:submitted_submission) { create(:submission, course: course, assignment: assignment) }
+
+    it "returns a count for only non-draft submissions" do
+      expect(subject.submitted_submissions_count(assignment)).to eq 1
+    end
+  end
+end

--- a/spec/views/api/assignments/submissions/submissions_spec.rb
+++ b/spec/views/api/assignments/submissions/submissions_spec.rb
@@ -6,10 +6,11 @@ describe "api/assignments/submissions/submission" do
   it "includes the submission attributes" do
     render
     json = JSON.parse(response.body)
-    expect(json["data"]["attributes"].except("created_at", "updated_at")).to \
-      eq @submission.as_json(except: [:created_at, :updated_at])
+    expect(json["data"]["attributes"].except("created_at", "updated_at", "submitted_at")).to \
+      eq @submission.as_json(except: [:created_at, :updated_at, :submitted_at])
     expect(json["data"]["attributes"]["created_at"]).to eq @submission.created_at.as_json
     expect(json["data"]["attributes"]["updated_at"]).to eq @submission.updated_at.as_json
+    expect(json["data"]["attributes"]["submitted_at"]).to eq @submission.submitted_at.as_json
   end
 
   it "includes the id" do


### PR DESCRIPTION
### Status
Ready

### Description
This PR addresses a couple bugs in how draft submissions are being handled for instructors. Previously, an instructor would see ungraded draft submissions on the Grading Status page. Also, draft submissions were being included for counts on the dashboard assignments module.

### Migrations
NO

### Steps to Test or Reproduce
Create a draft submission. As an instructor, you should not see the submission as an ungraded submission from the Grading Status page. It should also not be included in the submission count for the assignment on the instructor dashboard.

Fixes #2824 