### PR TITLE
bugfix for pass/fail grade show presenter

### DIFF
--- a/app/views/grades/_grade_content.haml
+++ b/app/views/grades/_grade_content.haml
@@ -11,7 +11,7 @@
   = render partial: "grades/components/threshold", locals: { grade: grade }
 
 - if grade.assignment.pass_fail?
-  = render partial: "grades/components/pass_fail", locals: { presenter: Assignments::StudentPresenter.new(student: current_student, assignment_types: current_course.assignment_types.ordered.includes(:assignments), course: current_course ), assignment: grade.assignment }
+  = render partial: "grades/components/pass_fail", locals: { presenter: Assignments::StudentPresenter.new(student: grade.student, assignment_types: current_course.assignment_types.ordered.includes(:assignments), course: current_course ), assignment: grade.assignment }
 - else
   = render partial: "grades/components/score", locals: { grade: grade, assignment_type: grade.assignment_type, assignment: grade.assignment }
 

--- a/app/views/grades/components/_pass_fail.haml
+++ b/app/views/grades/components/_pass_fail.haml
@@ -1,4 +1,4 @@
 - if GradeProctor.new(presenter.grade_for(assignment)).viewable?
-  %p= presenter.grade_for(assignment).pass_fail_status
+  %p.bold= presenter.grade_for(assignment).pass_fail_status
 - else
   %p.italic= "#{term_for :pass}/#{term_for :fail}"


### PR DESCRIPTION
### Status
**READY**

### Description

This fixes the grade show page for pass/fail grades, professor context.  

I believe the only other access point for this partial is as a student from `/views/assignments/_show_student.haml`, and so this solution should not break anything, but I wouldn't mind confirmation that this is the best solution.  All of the info loaded into the presenter is used solely to render `presenter.grade_for(assignment).pass_fail_status`, perhaps we could simply pass in the grade itself from both contexts?