### PR TITLE
Fixes an issue with the assignment show view grade history

### DIFF
--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -61,7 +61,7 @@ module Submissions::GradeHistory
   def last_item(history, object_type, changeset_key)
     history.sort { |h| h.version.id }
            .reverse { |h| h.changeset["object"] == object_type &&
-                         h.changeset.keys.include?(changeset_key) }.find
+                         h.changeset.keys.include?(changeset_key) }.first
   end
 
   def last_change?(history, history_item, object_type, changeset_key)


### PR DESCRIPTION
### Status
**READY**

### Description
Change the retrieval of the last history item to return one object instead of an enumerator. This fixes this change https://github.com/UM-USElab/gradecraft-development/commit/a8b4ffa06b1c74845b52e04b039dbbeafda2123f#diff-bc646629a66392f005369f81e66ca184L63 where `find` returns an enumerator and `first` returns a single element.

This fixes this [Rollbar issue](https://rollbar.com/gradecraft/gradecraft-development/items/1848/)

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
rubocop_gods | [2778](https://github.com/UM-USElab/gradecraft-development/pull/2778)

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grade history
* Assignment show page
