### PR TITLE
add delayed event angular helper

### DIFF
--- a/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
+++ b/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
@@ -4,31 +4,31 @@
 # It can be cancelled and updated before fire,
 # or fired immediately, cancelling the standing delayed event.
 
-angular.module('helpers').factory('DelayedEvent', ['$timeout', ($timeout)->
+angular.module('helpers').factory('DebounceQueue', ['$timeout', ($timeout)->
 
   queueStore = {}
   TIME_TO_DELAY = 3500
 
-  addQueue = (type, id, event, args=[], immediate=false)->
+  addEvent = (type, id, event, args=[], immediate=false)->
     queueStore[type] = queueStore[type] || {}
 
     if immediate is true
-      cancelQueue(type, id)
+      cancelEvent(type, id)
       event.apply(null, args)
     else
-      cancelQueue(type, id)
+      cancelEvent(type, id)
       queueStore[type][id.to_s] = $timeout(() ->
         event.apply(null, args)
       , TIME_TO_DELAY)
 
 
-  cancelQueue = (type, id)->
+  cancelEvent = (type, id)->
     return false if !queueStore[type]
     $timeout.cancel(queueStore[type][id.to_s])
 
   return {
-    addQueue: addQueue
-    cancelQueue: cancelQueue
+    addEvent: addEvent
+    cancelEvent: cancelEvent
   }
 ])
 

--- a/app/assets/javascripts/angular/helpers/delayedEvent.js.coffee
+++ b/app/assets/javascripts/angular/helpers/delayedEvent.js.coffee
@@ -1,0 +1,34 @@
+# Debounce manager used to auto update items
+#
+# Each item is given a unique timeout stored by type and id.
+# It can be cancelled and updated before fire,
+# or fired immediately, cancelling the standing delayed event.
+
+angular.module('helpers').factory('DelayedEvent', ['$timeout', ($timeout)->
+
+  queueStore = {}
+  TIME_TO_DELAY = 3500
+
+  addQueue = (type, id, event, args=[], immediate=false)->
+    queueStore[type] = queueStore[type] || {}
+
+    if immediate is true
+      cancelQueue(type, id)
+      event.apply(null, args)
+    else
+      cancelQueue(type, id)
+      queueStore[type][id.to_s] = $timeout(() ->
+        event.apply(null, args)
+      , TIME_TO_DELAY)
+
+
+  cancelQueue = (type, id)->
+    return false if !queueStore[type]
+    $timeout.cancel(queueStore[type][id.to_s])
+
+  return {
+    addQueue: addQueue
+    cancelQueue: cancelQueue
+  }
+])
+

--- a/app/assets/javascripts/angular/services/StudentSubmissionService.js.coffee
+++ b/app/assets/javascripts/angular/services/StudentSubmissionService.js.coffee
@@ -1,11 +1,16 @@
-@gradecraft.factory 'StudentSubmissionService', ['GradeCraftAPI', 'DelayedEvent', '$http', (GradeCraftAPI, DelayedEvent, $http) ->
+@gradecraft.factory 'StudentSubmissionService', ['GradeCraftAPI', 'DebounceQueue', '$http', (GradeCraftAPI, DebounceQueue, $http) ->
 
   self = this
   submission = {}
 
   queueSaveDraftSubmission = (assignmentId, immediate=false) ->
+    # cancel update if the student has cleared out the text_comment_draft
+    unless submission.text_comment_draft
+      DebounceQueue.cancelEvent("submissions", assignmentId)
+      return
+
     # using assignmentId for queue id since we are not assured to have a submission.id
-    DelayedEvent.addQueue("submissions", assignmentId, saveDraftSubmission, [assignmentId], immediate)
+    DebounceQueue.addEvent("submissions", assignmentId, saveDraftSubmission, [assignmentId], immediate)
 
   saveDraftSubmission = (assignmentId) ->
     if submission.id? then updateDraftSubmission(assignmentId) else createDraftSubmission(assignmentId)


### PR DESCRIPTION
### Status
**READY**

### Description

This PR extracts the queue logic from the student submission service to be used by other services.

I am submitting this PR in advance of a need I have for a single service to handle multiple updates (one per each criterion grade in a rubric).  This PR takes the pattern from the student submission debounce logic and expands it to handle a object store of queued events. It also removes the logic to a helper to reduce boilerplate within the services.

Each event is given a type and an id, so that timeout events are stored per object type and unique id, avoiding cross-cancelling of events.

Ideally each id would be the objects id, but this may not be possible when creating new objects.  In the refactor for instance, the submission is stored by assignment id, since this id is passed in. I'm open to other ways of solving this. 