### PR TITLE
style grade levels inline on assignment edit form

### DIFF
--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -350,8 +350,8 @@ input:checked + .rubric-switch-handle:before
 .rubric-switch-handle.round:before
   border-radius: 50%
 
-// assignment levels form
-.assignment-level-container
+// score levels form (assignment and challenge edit)
+.score-level-container
   display: flex
   justify-content: space-between
   align-items: center
@@ -362,7 +362,7 @@ input:checked + .rubric-switch-handle:before
 .level-form-container
   width: 90%
 
-.assignment-level-form
+.score-level-form
   display: inline-block
   margin-right: 1em
   @media (max-width: $media-medium-max)
@@ -373,7 +373,7 @@ input:checked + .rubric-switch-handle:before
     margin-right: 0
 
 .simple_form section 
-  .assignment-level-form label
+  .score-level-form label
     width: auto
     text-align: left
     margin-bottom: 0
@@ -381,7 +381,7 @@ input:checked + .rubric-switch-handle:before
     font-size: 0.8rem
     @media (max-width: $media-medium-max)
       display: block
-  .assignment-level-form input[type=text]
+  .score-level-form input[type=text]
     width: 12rem
     @media (max-width: $media-medium-max)
       width: 100%

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -349,3 +349,39 @@ input:checked + .rubric-switch-handle:before
 
 .rubric-switch-handle.round:before
   border-radius: 50%
+
+// assignment levels form
+.assignment-level-container
+  display: flex
+  justify-content: space-between
+  align-items: center
+  margin: 0.5em 0
+  background-color: $color-grey-7
+  padding: 0.5em
+
+.level-form-container
+  width: 90%
+
+.assignment-level-form
+  display: inline-block
+  margin-right: 1em
+  @media (max-width: $media-medium-max)
+    width: 45%
+  @media (max-width: $media-small-max)
+    width: 80%
+    display: block
+    margin-right: 0
+
+.simple_form section 
+  .assignment-level-form label
+    width: auto
+    text-align: left
+    margin-bottom: 0
+    vertical-align: middle
+    font-size: 0.8rem
+    @media (max-width: $media-medium-max)
+      display: block
+  .assignment-level-form input[type=text]
+    width: 12rem
+    @media (max-width: $media-medium-max)
+      width: 100%

--- a/app/views/assignments/_assignment_score_level_fields.haml
+++ b/app/views/assignments/_assignment_score_level_fields.haml
@@ -1,11 +1,11 @@
-.assignment-level-container
+.score-level-container
   .level-form-container
-    .level-name-form.assignment-level-form
+    .level-name-form.score-level-form
       = f.input :name, :label => "Level Name"
-    .points-awarded-form.assignment-level-form
+    .points-awarded-form.score-level-form
       = f.label :points, "Points Awarded"
       = f.text_field :points
       = f.hidden_field :id
   .btn-container
     = f.hidden_field :_destroy, class: "destroy"
-    = link_to "Remove Level", "#", class: "remove-assignment-score-level button"
+    %button.button.remove-assignment-score-level{role: "button", type: "button"} Remove Level

--- a/app/views/assignments/_assignment_score_level_fields.haml
+++ b/app/views/assignments/_assignment_score_level_fields.haml
@@ -1,10 +1,11 @@
-.panel
-  .columns
-    = f.input :name, :label => "Level Name"
-  .columns
-    = f.label :points, "Points Awarded"
-    = f.text_field :points
-    = f.hidden_field :id
-  .right
+.assignment-level-container
+  .level-form-container
+    .level-name-form.assignment-level-form
+      = f.input :name, :label => "Level Name"
+    .points-awarded-form.assignment-level-form
+      = f.label :points, "Points Awarded"
+      = f.text_field :points
+      = f.hidden_field :id
+  .btn-container
     = f.hidden_field :_destroy, class: "destroy"
-    = link_to "Remove Level", "#", class: "remove-assignment-score-level button right"
+    = link_to "Remove Level", "#", class: "remove-assignment-score-level button"

--- a/app/views/challenges/_challenge_score_level_fields.haml
+++ b/app/views/challenges/_challenge_score_level_fields.haml
@@ -1,9 +1,10 @@
-.columns.panel
-  %span.columns
-    = f.input :name, :label => "Level Name"
-  %span.columns
-    = f.label :points, "Points Awarded"
-    = f.text_field :points, data: {autonumeric: true, "m-dec" => "0"}
-  %span.columns
+.score-level-container
+  .level-form-container
+    .level-name-form.score-level-form
+      = f.input :name, :label => "Level Name"
+    .points-awarded-form.score-level-form
+      = f.label :points, "Points Awarded"
+      = f.text_field :points, data: {autonumeric: true, "m-dec" => "0"}
+  .btn-container
     = f.hidden_field :_destroy, class: "destroy"
-    = link_to "Remove Level", '#', class: "remove-challenge-score-level button radius right"
+    %button.button.remove-challenge-score-level{role: "button", type: "button"} Remove Level


### PR DESCRIPTION
### Status
**READY**

### Description
This PR styles grade levels on assignment edit form as such:
<img width="1001" alt="screen shot 2017-01-17 at 11 17 00 am" src="https://cloud.githubusercontent.com/assets/12573921/22028879/b257805a-dca6-11e6-89e6-36ff593e19bb.png">


### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment edit page: instructor side

Closes issue #2873 
