### PR TITLE
2816 remove check sections

### DIFF
--- a/app/assets/javascripts/course_settings.js
+++ b/app/assets/javascripts/course_settings.js
@@ -16,12 +16,12 @@ $('.button-close').on('click',function(){
 // Disable settings menu button if form card feature is not checked
 function disableSettingsButton($thisInput) {
   var $thisSettingsBtn = $thisInput.closest('.form-card').find('.button-advanced-settings');
-  
+
   if ($thisInput.is(':checked')) {
     $thisSettingsBtn.prop('disabled', false);
   } else {
     $thisSettingsBtn.prop('disabled', true);
-  }  
+  }
 }
 
 $('input.has-settings-menu').change(function() {
@@ -38,6 +38,7 @@ function formDependencies() {
   var $dependentOnSection = $('.dependent-on-section');
   var $card = $dependentOnSection.parent().parent();
   var $cardHeader = $dependentOnSection.parent();
+  var $thisSettingsBtn = $card.find('.button-advanced-settings');
   var $sectionsCheckbox = $('input[id="course_has_teams"]');
 
   if($sectionsCheckbox.is(":checked")) {
@@ -47,6 +48,7 @@ function formDependencies() {
     $dependentOnSection.prop("disabled", true);
     $card.addClass("disabled");
     $cardHeader.removeClass("enabled");
+    $thisSettingsBtn.prop('disabled', true);
     $dependentOnSection.prop("checked", false)
   }
 }

--- a/app/assets/javascripts/course_settings.js
+++ b/app/assets/javascripts/course_settings.js
@@ -37,6 +37,7 @@ $('input.has-settings-menu').each(function() {
 function formDependencies() {
   var $dependentOnSection = $('.dependent-on-section');
   var $card = $dependentOnSection.parent().parent();
+  var $cardHeader = $dependentOnSection.parent();
   var $sectionsCheckbox = $('input[id="course_has_teams"]');
 
   if($sectionsCheckbox.is(":checked")) {
@@ -45,6 +46,8 @@ function formDependencies() {
   } else {
     $dependentOnSection.prop("disabled", true);
     $card.addClass("disabled");
+    $cardHeader.removeClass("enabled");
+    $dependentOnSection.prop("checked", false)
   }
 }
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR removes the check associated with section-depended features (Section Assignments and Section Leaderboard) if Sections is unchecked as well as applies the expected styling and disables the settings button. This is intended to more clearly represent that these features are dependent on Sections being enabled.

### Migrations
NO

### Steps to Test or Reproduce
Check 'Sections' feature card on Course Settings page and then enable 'Section Assignments' and/or 'Section Leaderboards' and then uncheck 'Sections' and make sure that the dependent features are no longer selected.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Instructor: Course Settings

Closes issue #2876 