### PR TITLE
hide-info-icon

### DIFF
--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -293,6 +293,8 @@ $card-margin-1 : 3px
     margin: 0
   &.focus-article
     outline: 3px solid $color-blue-3
+    @media (max-width: $media-medium-max)
+      outline: none
 
 .predictor-article-title
   background-color: $color-blue-3
@@ -309,6 +311,8 @@ $card-margin-1 : 3px
     right: -3px
     font-size: $predictor-font-size-3
     cursor: pointer
+    @media (max-width: $media-medium-max)
+      display: none
 
 .predictor-article-title-stripe
   background-color: $color-blue-5
@@ -550,8 +554,6 @@ $card-margin-1 : 3px
   .predictor-article-card
     width: $card-width-1
     margin: $card-margin-1
-    .info-icon
-      display: none
   .collapse-arrow.doubled
     margin: 35px 0 0 0
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR hides info icon and outline of selected article on medium devices and smaller when the side panel closes.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grade Predictor on tablets/mobile devices

Closes issue #2872 