### PR TITLE
2867 Fixes issue with canvas api paging logic

### DIFF
--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -339,7 +339,8 @@ module ActiveLMS
       grades = []
       params = { assignment_ids: assignment_ids,
                  student_ids: "all",
-                 include: ["assignment", "course", "user"] }
+                 include: ["assignment", "course", "user"],
+                 per_page: 100 }
       client.get_data("/courses/#{course_id}/students/submissions", params) do |data|
         if grade_ids.nil?
           grades += data

--- a/lib/canvas/api.rb
+++ b/lib/canvas/api.rb
@@ -1,4 +1,5 @@
 require "httparty"
+require "active_support/core_ext/hash"
 
 module Canvas
   class API
@@ -15,7 +16,7 @@ module Canvas
     def get_data(path="/", params={})
       params.merge! access_token: access_token
       next_url = "#{self.class.base_uri}#{path}"
-      next_url += "?#{URI.encode_www_form(params)}" unless params.empty?
+      next_url += "?#{params.to_query}" unless params.empty?
       while next_url
         # Do not add the original query parameters here since they are already
         # attached to the next url in the header

--- a/lib/canvas/api.rb
+++ b/lib/canvas/api.rb
@@ -15,8 +15,11 @@ module Canvas
     def get_data(path="/", params={})
       params.merge! access_token: access_token
       next_url = "#{self.class.base_uri}#{path}"
+      next_url += "?#{URI.encode_www_form(params)}" unless params.empty?
       while next_url
-        response = self.class.get(next_url, query: params)
+        # Do not add the original query parameters here since they are already
+        # attached to the next url in the header
+        response = self.class.get(next_url, query: { access_token: access_token })
         raise ResponseError.new(response) unless response.success?
         yield response.parsed_response if block_given?
         next_url = get_next_url response

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -133,6 +133,7 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
           "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
         .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
                        "include" => ["assignment", "course", "user"],
+                       "per_page" => 100,
                        "access_token" => access_token })
         .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
     end

--- a/spec/lib/canvas/api_spec.rb
+++ b/spec/lib/canvas/api_spec.rb
@@ -63,24 +63,27 @@ describe Canvas::API, type: :disable_external_api do
 
     it "automatically traverses the pages" do
       links = <<-LINKS
-      <https://canvas.instructure.com/api/v1/courses?page=1&per_page=10>; rel="current",<https://canvas.instructure.com/api/v1/courses?page=2&per_page=10>; rel="next"
+      <https://canvas.instructure.com/api/v1/courses?enrollment_type=student&page=1&per_page=10>; rel="current",<https://canvas.instructure.com/api/v1/courses?enrollment_type=student&page=2&per_page=10>; rel="next"
       LINKS
       headers = { "Link" => links }
 
       body1 = { name: "This is a course on page 1" }
-      first_stub = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
-        .with(query: { "access_token" => access_token })
+      first_request = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
+        .with(query: { "enrollment_type" => "student", "access_token" => access_token })
         .to_return(status: 200, body: body1.to_json, headers: headers)
 
       body2 = { name: "This is a course on page 2" }
-      first_stub = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
-        .with(query: { "page" => "2", "per_page" => "10", "access_token" => access_token })
+      second_request = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
+        .with(query: { "page" => "2", "per_page" => "10", "enrollment_type" => "student",
+                       "access_token" => access_token })
         .to_return(status: 200, body: body2.to_json, headers: {})
 
       result = []
-      subject.get_data("/courses") { |course| result << course }
+      subject.get_data("/courses", enrollment_type: :student) { |course| result << course }
 
       expect(result.count).to eq 2
+      expect(first_request).to have_been_made
+      expect(second_request).to have_been_made
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
An [issue](https://rollbar.com/gradecraft/gradecraft-development/items/1771/) arose where some users would find issues when having multiple pages of data returned.

In addition, this will speed up the retrieval of grades from Canvas because it increased the page size on a per request basis.

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Authorize with Canvas
1. Link a course
1. Try and import grades for an assignment that has more than 100 grades
1. It should work without throwing an issue

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing Canvas grades

Closes #2867 
