### PR TITLE
Don't check for lateness if resubmission

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -52,7 +52,7 @@ class SubmissionsController < ApplicationController
     respond_to do |format|
       if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) &&
         Services::DeletesSubmissionDraftContent.for(submission).success?
-        submission.check_and_set_late_status!
+        submission.check_and_set_late_status! unless submission.will_be_resubmitted?
         path = assignment.has_groups? ? { group_id: submission.group_id } :
           { student_id: submission.student_id }
         redirect_to = assignment_submission_path(assignment, submission, path)

--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -40,5 +40,5 @@
         %li.save-draft-button.button{"assignment_id"=>"#{presenter.assignment.id}"}
         %li= f.button :submit,
           "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
-          data: { confirm: ("This submission will be late. Continue?" if presenter.submission_will_be_late?) }, class: "ng-cloak"
+          data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }, class: "ng-cloak"
         %li= link_to glyph("times-circle") + "Cancel", assignment_path(presenter.assignment), class: "button ng-cloak"

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -37,5 +37,5 @@
     %ul
       %li= f.button :submit,
         "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
-        data: { confirm: ("This submission will be late. Continue?" if presenter.submission_will_be_late?) }
+        data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }
       %li= link_to glyph("times-circle") + "Cancel", assignment_path(presenter.assignment), class: "button"

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -115,9 +115,16 @@ describe SubmissionsController do
         post :update, params: { assignment_id: assignment.id, id: submission, submission: params }, format: :json
       end
 
-      it "checks if the submission is late" do
+      it "checks if the submission is late if it is not a resubmission" do
         params = attributes_for(:submission)
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
+      end
+
+      it "does not check if the submission is late if it is a resubmission" do
+        params = attributes_for(:submission)
+        allow_any_instance_of(Submission).to receive(:will_be_resubmitted?).and_return true
+        expect_any_instance_of(Submission).to_not receive(:check_and_set_late_status!)
         post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
       end
     end
@@ -198,9 +205,16 @@ describe SubmissionsController do
         expect(submission.reload.submitted_at).to be > current_time
       end
 
-      it "checks if the submission is late" do
+      it "checks if the submission is late if it is not a resubmission" do
         params = attributes_for(:submission).merge({ assignment_id: assignment.id })
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
+      end
+
+      it "does not check if the submission is late if it is a resubmission" do
+        params = attributes_for(:submission)
+        allow_any_instance_of(Submission).to receive(:will_be_resubmitted?).and_return true
+        expect_any_instance_of(Submission).to_not receive(:check_and_set_late_status!)
         post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
       end
 


### PR DESCRIPTION
### Status
READY

### Description
If a submission is a resubmission, it should not be checked for lateness.

Fixes #2874 

### Migrations
NO

### Steps to Test or Reproduce
Resubmit a submission. The late flag on the submission should not change regardless of the new submitted_at time.