### PR TITLE
Fix unlocks bug when the pass fail  assessment doesn't have a grade t…

### DIFF
--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -193,6 +193,7 @@ class UnlockCondition < ActiveRecord::Base
 
   def check_passed_condition(student)
     grade = student.grade_for_assignment_id(condition_id).first
+    return false unless grade.present?
     grade.pass_fail_status == "Pass"
   end
 


### PR DESCRIPTION
…o compare against

### Status
**READY**

This PR fixes a situation where students being assessed against a pass/fail condition hit a bug if they hadn't yet created a grade.