### PR TITLE
Recalculate all scores for a course on update

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -76,6 +76,7 @@ class CoursesController < ApplicationController
     authorize! :update, @course
     respond_to do |format|
       if @course.update_attributes(course_params)
+        @course.recalculate_student_scores if add_team_score_to_student_changed?
         bust_course_list_cache current_user
         format.html do
           redirect_to edit_course_path(@course),
@@ -146,5 +147,10 @@ class CoursesController < ApplicationController
   def use_current_course
     @course = current_course
     authorize! :update, @course
+  end
+
+  def add_team_score_to_student_changed?
+    course_params[:add_team_score_to_student].present? &&
+      (@course.add_team_score_to_student != course_params[:add_team_score_to_student])
   end
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -190,6 +190,18 @@ describe CoursesController do
         post :update, params: { id: course.id, course: params }
         expect(response).to render_template(:edit)
       end
+
+      it "recalculates scores in the course if add_team_score_to_student changed" do
+        params = { add_team_score_to_student: true }
+        expect_any_instance_of(Course).to receive(:recalculate_student_scores)
+        post :update, params: { id: course.id, course: params }
+      end
+
+      it "does not recalculate scores in the course if add_team_score_to_student didn't change" do
+        params = { name: "new name" }
+        expect_any_instance_of(Course).to_not receive(:recalculate_student_scores)
+        post :update, params: { id: course.id, course: params }
+      end
     end
 
     describe "POST recalculate_student_scores" do


### PR DESCRIPTION
### Status
READY

### Description
To ensure that there are no potential issues with cached scores, whenever the `add_team_score_to_student` flag changes all scores in the course should be recalculated.

Fixes #1249 

### Migrations
NO

### Steps to Test or Reproduce
The ScoreRecalculator job should run for every grade associated with the course, if the `add_team_score_to_student` field changes.