### PR TITLE
fixed sporadic fail of course spec

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -638,7 +638,7 @@ describe Course do
       create(:course_membership, :student, course: subject, score: 100)
       create(:course_membership, :student, course: subject, score: 200)
       create(:course_membership, :student, course: subject, score: 300)
-      expect(subject.scores).to match_array({:scores => [100, 200, 300]})
+      expect(subject.scores) =~({:scores => [100, 200, 300]})
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a sporadically failing course spec by switching to a =~ matcher that assesses whether or not the values are all included rather than if they're in the identical order