### PR TITLE
2888 downcase nil bug

### DIFF
--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -67,7 +67,8 @@ class Grade < ActiveRecord::Base
   def self.for_student_email_and_assignment_id(email_address, assignment_id)
     self
       .joins(:student)
-      .where("LOWER(users.email) = :email_address", email_address: email_address.downcase)
+      .where("LOWER(users.email) = :email_address",
+              email_address: (email_address || "").downcase)
       .where(assignment_id: assignment_id)
       .first
   end

--- a/spec/active_record_spec_helper.rb
+++ b/spec/active_record_spec_helper.rb
@@ -14,6 +14,9 @@ end
 
 require "spec_helper"
 require "active_record"
+require "paper_trail/config"
+PaperTrail::Config.instance.track_associations = true
+require "paper_trail"
 require "active_support/core_ext"
 require "acts_as_list"
 require "aws-sdk"
@@ -52,7 +55,6 @@ SorceryStubbing.sorcery_reset [:user_activation], user_activation_mailer: Sorcer
 connection_info = YAML.load_file("config/database.yml")["test"]
 ActiveRecord::Base.establish_connection(connection_info)
 
-require "paper_trail"
 require "paper_trail/frameworks/rspec"
 
 # stub out Rails.env

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -232,6 +232,12 @@ describe Grade do
         described_class.for_student_email_and_assignment_id("blah", assignment.id)
       ).to be_nil
     end
+
+    it "returns nil if the specified student email is nil" do
+      expect(
+        described_class.for_student_email_and_assignment_id(nil, assignment.id)
+      ).to be_nil
+    end
   end
 
   describe ".find_or_create" do


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes an issue where the Canvas primary email address of a student is nil and trying to find a matching grade fails because the find does not handle a nil email address.

This fixes [this bug on Rollbar](https://rollbar.com/gradecraft/gradecraft-development/items/1890).

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing grades with Canvas.

Closes #2888 