### PR TITLE
2901 - Empty Grade History

### DIFF
--- a/app/presenters/submissions/grade_history.rb
+++ b/app/presenters/submissions/grade_history.rb
@@ -30,16 +30,14 @@ module Submissions::GradeHistory
       .include do |history_item, history|
         viewable = true
 
-        if history_item.changeset["object"] == "Grade" &&
-            history_item.version.event == "update" &&
-            only_student_visible_grades
+        if history_item.changeset["object"] == "Grade" && only_student_visible_grades
 
           version = history_item.version.reify
           viewable = GradeProctor.new(version).viewable?
 
-          # Make the change viewable if the grade was updated first but then it
-          # was released. This displays the changeset where the grade was updated
-          if !viewable
+          if !viewable && ["update", "create"].include?(history_item.version.event)
+            # Make the change viewable if the grade was updated first but then it
+            # was released. This displays the changeset where the grade was updated
             last_raw_points_change = last_change?(history, history_item, "Grade",
                                                   "raw_points")
 


### PR DESCRIPTION
### Status
**READY**

### Description
This fixes an issue when the instructor visits the edit grade page but does not enter a grade, the history item of "created grade" shows in the student's history. The history timeline now checks the grade created event and applies the grade proctor logic to that as well.

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

1. Login as a student
1. Submit a submission for an assignment
1. Login as an instructor for the student
1. Visit the grade page for the student and assignment
1. Login as a student
1. Visit the assignment page and notice that the history item for the grade is not present

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grading submissions

Closes #2901 
