### PR TITLE
2842 sporadic userscontroller upload fail

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+require_relative "../importers/student_importers/csv_student_importer"
 require_relative "../services/cancels_course_membership"
 require_relative "../services/creates_or_updates_user"
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -138,24 +138,25 @@ describe UsersController do
       let(:file) { fixture_file "users.csv", "text/csv" }
       before { create :team, course: @course, name: "Zeppelin" }
 
-      # Sporadic failure!
       it "renders the results from the import" do
-        skip "pending fix"
         post :upload, params: { file: file }
+
         expect(response).to render_template :import_results
         expect(response.body).to include "3 Students Imported Successfully"
-        expect(response.body).to include "jimmy@example.com"
-        expect(response.body).to include "robert@example.com"
+        expect(response.body).to include "csv_jimmy@example.com"
+        expect(response.body).to include "csv_robert@example.com"
         expect(response.body).to include "whitespace@example.com"
       end
 
       it "renders any errors that have occured" do
         user = User.create first_name: "Jimmy", last_name: "Page",
-          email: "jimmy@example.com", username: "jimmy", password: "blah"
+          email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
         user.update_attribute :username, "1" * 51
+
         post :upload, params: { file: file }
+
         expect(response.body).to include "1 Student Not Imported"
-        expect(response.body).to include "Jimmy,Page,jimmy,jimmy@example.com"
+        expect(response.body).to include "Jimmy,Page,jimmy,csv_jimmy@example.com"
         expect(response.body).to include "Username is too long"
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -150,13 +150,13 @@ describe UsersController do
 
       it "renders any errors that have occured" do
         user = User.create first_name: "Jimmy", last_name: "Page",
-          email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
+          email: "csv_jimmy@example.com", username: "csv_jimmy", password: "blah"
         user.update_attribute :username, "1" * 51
 
         post :upload, params: { file: file }
 
         expect(response.body).to include "1 Student Not Imported"
-        expect(response.body).to include "Jimmy,Page,jimmy,csv_jimmy@example.com"
+        expect(response.body).to include "Jimmy,Page,csv_jimmy,csv_jimmy@example.com"
         expect(response.body).to include "Username is too long"
       end
 

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,4 +1,4 @@
 First Name,Last Name,Username,Email,Team Name
   leading,trailing  ,whitespace, whitespace@example.com , ,
-Robert,Plant,robert,csv_robert@example.com,
-Jimmy,Page,jimmy,csv_jimmy@example.com,Zeppelin
+Robert,Plant,csv_robert,csv_robert@example.com,
+Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -1,4 +1,4 @@
 First Name,Last Name,Username,Email,Team Name
   leading,trailing  ,whitespace, whitespace@example.com , ,
-Robert,Plant,robert,robert@example.com,
-Jimmy,Page,jimmy,jimmy@example.com,Zeppelin
+Robert,Plant,robert,csv_robert@example.com,
+Jimmy,Page,jimmy,csv_jimmy@example.com,Zeppelin

--- a/spec/importers/student_importers/csv_student_importer_spec.rb
+++ b/spec/importers/student_importers/csv_student_importer_spec.rb
@@ -1,4 +1,5 @@
 require "rails_spec_helper"
+require "./app/importers/student_importers/csv_student_importer"
 
 describe CSVStudentImporter do
   before(:all) { User.destroy_all }
@@ -22,7 +23,7 @@ describe CSVStudentImporter do
 
         it "creates the student accounts" do
           subject.import course
-          expect(user.email).to eq "jimmy@example.com"
+          expect(user.email).to eq "csv_jimmy@example.com"
           expect(user.crypted_password).to_not be_blank
           expect(user.course_memberships.first.course).to eq course
           expect(user.course_memberships.first.role).to eq "student"
@@ -38,7 +39,7 @@ describe CSVStudentImporter do
 
         it "does not create the student membership if it already exists" do
           user = User.create first_name: "Jimmy", last_name: "Page",
-              email: "jimmy@example.com", username: "jimmy", password: "blah"
+              email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
           user.course_memberships.create course_id: course.id, role: "student"
           expect { subject.import course }.to_not raise_error
         end
@@ -46,7 +47,7 @@ describe CSVStudentImporter do
         it "adds the students to the team if the team exists" do
           subject.import course
           expect(team.name).to eq "Zeppelin"
-          expect(team.students.first.email).to eq "jimmy@example.com"
+          expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "handles empty fields with whitespace" do
@@ -56,16 +57,16 @@ describe CSVStudentImporter do
 
         it "just adds the student to the team if the student already exists" do
           User.create first_name: "Jimmy", last_name: "Page",
-              email: "jimmy@example.com", username: "jimmy", password: "blah"
+              email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
           subject.import course
-          expect(team.students.first.email).to eq "jimmy@example.com"
+          expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "creates the team and adds the student if the team does not exist" do
           Team.unscoped.last.destroy
           subject.import course
           expect(team.name).to eq "Zeppelin"
-          expect(team.students.first.email).to eq "jimmy@example.com"
+          expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "does not add the student to the team if a team is not specified" do
@@ -87,7 +88,7 @@ describe CSVStudentImporter do
 
         it "contains an unsuccessful row if the user is not valid" do
           user = User.create first_name: "Jimmy", last_name: "Page",
-              email: "jimmy@example.com", username: "jimmy", password: "blah"
+              email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
           user.update_attribute :username, ""
           result = subject.import course
           expect(result.successful.count).to eq 2


### PR DESCRIPTION
### Status
**READY**

### Description
This PR reactivates the sporadic failing spec for `UsersController#upload` and attempts to fix it. The issue was that the user for `robert@example.com`, the name and email address was changed for them in some other spec and it bled into this spec.

I changed the usernames and the email addresses for the user information within the `users.csv` fixture file so it will be unique for these specs. Therefore the expectations of the email address should be correct.

### Migrations
NO

Closes #2842
