### PR TITLE
2779 analytics for small courses

### DIFF
--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -200,6 +200,10 @@ class Assignments::Presenter < Showtime::Presenter
       .order_by_name, self)
   end
 
+  def viewable_analytics?(user)
+    AnalyticsProctor.new.viewable?(user, course) && !assignment.hide_analytics?
+  end
+
   class AssignmentStudentCollection
     include Enumerable
 

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -117,10 +117,6 @@ class Assignments::Presenter < Showtime::Presenter
     )
   end
 
-  def hide_analytics?
-    !course.show_analytics? || assignment.hide_analytics?
-  end
-
   def individual_assignment?
     assignment.is_individual?
   end

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -87,6 +87,10 @@ class Assignments::Presenter < Showtime::Presenter
     has_viewable_submission?(submission, user)
   end
 
+  def has_viewable_analytics?(user)
+    AnalyticsProctor.new.viewable?(user, course) && !assignment.hide_analytics?
+  end
+
   def has_teams?
     course.has_teams?
   end
@@ -194,10 +198,6 @@ class Assignments::Presenter < Showtime::Presenter
     @students ||= AssignmentStudentCollection.new(User
       .students_being_graded_for_course(course, team)
       .order_by_name, self)
-  end
-
-  def viewable_analytics?(user)
-    AnalyticsProctor.new.viewable?(user, course) && !assignment.hide_analytics?
   end
 
   class AssignmentStudentCollection

--- a/app/proctors/analytics_proctor.rb
+++ b/app/proctors/analytics_proctor.rb
@@ -1,0 +1,9 @@
+# defines the the viewable conditions for analytics
+class AnalyticsProctor
+  MINIMUM_STUDENT_COUNT = 20
+
+  def viewable?(user, course)
+    return true if user.is_staff? course
+    course.student_count >= MINIMUM_STUDENT_COUNT
+  end
+end

--- a/app/proctors/analytics_proctor.rb
+++ b/app/proctors/analytics_proctor.rb
@@ -4,6 +4,6 @@ class AnalyticsProctor
 
   def viewable?(user, course)
     return true if user.is_staff? course
-    course.student_count >= MINIMUM_STUDENT_COUNT
+    course.show_analytics? && (course.student_count >= MINIMUM_STUDENT_COUNT)
   end
 end

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -8,7 +8,7 @@
         = render partial: "grades/grade_content", locals: { grade: presenter.grade_for(current_student) }
         %hr.dotted
 
-      - if !presenter.hide_analytics?
+      - if presenter.viewable_analytics? current_student
         %section
           %h2 Class Analytics
           - if presenter.assignment.has_groups?
@@ -17,7 +17,7 @@
             = render partial: "grades/analytics/individual_analytics", locals: { presenter: presenter }
           %hr.dotted
 
-    - if presenter.has_viewable_submission_for?(current_student)
+    - if presenter.has_viewable_submission_for? current_student
       %section
         %h2 My Submission
         = render partial: "submissions/submission_content",

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -8,7 +8,7 @@
         = render partial: "grades/grade_content", locals: { grade: presenter.grade_for(current_student) }
         %hr.dotted
 
-      - if presenter.viewable_analytics? current_student
+      - if presenter.has_viewable_analytics? current_student
         %section
           %h2 Class Analytics
           - if presenter.assignment.has_groups?

--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -22,7 +22,7 @@
       - if current_course.grade_scheme_elements.present?
         .panel.dashboard-module.grading-scheme-module= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
 
-      - if current_course.show_analytics?
+      - if AnalyticsProctor.new.viewable? current_student, current_course
         .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_grade_distribution"
 
       - if current_course.has_badges?

--- a/app/views/rubrics/components/_rubric_table.haml
+++ b/app/views/rubrics/components/_rubric_table.haml
@@ -1,7 +1,7 @@
 .download-link= link_to glyph("file-excel-o") + "Download Rubric", export_assignment_rubrics_path(presenter.assignment.id, format: :csv)
 
 - if include_grade_info
-  - if presenter.viewable_analytics?(student)
+  - if presenter.has_viewable_analytics?(student)
     .class-analytics-toggle
       %h4.class-analytics-label Show class analytics
       %label.rubric-switch-socket

--- a/app/views/rubrics/components/_rubric_table.haml
+++ b/app/views/rubrics/components/_rubric_table.haml
@@ -1,7 +1,7 @@
 .download-link= link_to glyph("file-excel-o") + "Download Rubric", export_assignment_rubrics_path(presenter.assignment.id, format: :csv)
 
 - if include_grade_info
-  - if !presenter.assignment.hide_analytics? 
+  - if presenter.viewable_analytics?(student)
     .class-analytics-toggle
       %h4.class-analytics-label Show class analytics
       %label.rubric-switch-socket

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -8,18 +8,19 @@
 #instructor-dashboard.show-student
   .flex-col-30.tablet-col-1
     .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_avatar"
-    
+
     - if current_course.student_weighted?
       .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_assignment_weights"
-    
+
     .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_weekly_stats", locals:  { presenter: Info::DashboardWeeklyStatsPresenter.new(course: current_course, student: current_student) }
 
   .flex-col-40.tablet-col-2
     - if current_course.grade_scheme_elements.present?
       .panel.dashboard-module.grading-scheme-module= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
 
-  .flex-col-30.tablet-col-3
-    .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_grade_distribution"
+  - if AnalyticsProctor.new.viewable? current_student, current_course
+    .flex-col-30.tablet-col-3
+      .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_grade_distribution"
 
     - if current_course.has_badges?
       .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_badges"

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -200,4 +200,28 @@ describe Assignments::Presenter do
       subject.has_viewable_submission_for?(user)
     end
   end
+
+  describe "#viewable_analytics?" do
+    let(:user) { double(:user) }
+    let(:analytics_proctor) { double(:analytics_proctor) }
+
+    before(:each) { allow(AnalyticsProctor).to receive(:new).and_return analytics_proctor }
+
+    it "returns true if it's viewable according to the analytics proctor and hide_analytics? is false" do
+      allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return true
+      allow(assignment).to receive(:hide_analytics?).and_return false
+      expect(subject.viewable_analytics?(user)).to be_truthy
+    end
+
+    it "returns false if it's viewable according to the analytics proctor and hide_analytics? is true" do
+      allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return true
+      allow(assignment).to receive(:hide_analytics?).and_return true
+      expect(subject.viewable_analytics?(user)).to be_falsey
+    end
+
+    it "returns false if it's not viewable according to the analytics proctor" do
+      allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return false
+      expect(subject.viewable_analytics?(user)).to be_falsey
+    end
+  end
 end

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -181,7 +181,7 @@ describe Assignments::Presenter do
     end
   end
 
-  describe "#viewable_analytics?" do
+  describe "#has_viewable_analytics?" do
     let(:user) { double(:user) }
     let(:analytics_proctor) { double(:analytics_proctor) }
 
@@ -190,18 +190,18 @@ describe Assignments::Presenter do
     it "returns true if it's viewable according to the analytics proctor and hide_analytics? is false" do
       allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return true
       allow(assignment).to receive(:hide_analytics?).and_return false
-      expect(subject.viewable_analytics?(user)).to be_truthy
+      expect(subject.has_viewable_analytics?(user)).to be_truthy
     end
 
     it "returns false if it's viewable according to the analytics proctor and hide_analytics? is true" do
       allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return true
       allow(assignment).to receive(:hide_analytics?).and_return true
-      expect(subject.viewable_analytics?(user)).to be_falsey
+      expect(subject.has_viewable_analytics?(user)).to be_falsey
     end
 
     it "returns false if it's not viewable according to the analytics proctor" do
       allow(analytics_proctor).to receive(:viewable?).with(user, course).and_return false
-      expect(subject.viewable_analytics?(user)).to be_falsey
+      expect(subject.has_viewable_analytics?(user)).to be_falsey
     end
   end
 end

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -77,26 +77,6 @@ describe Assignments::Presenter do
     end
   end
 
-  describe "#show_analytics?" do
-    it "is hidden if the course does not hide analytics but the assignment does" do
-      allow(course).to receive(:show_analytics?).and_return true
-      allow(assignment).to receive(:hide_analytics?).and_return true
-      expect(subject.hide_analytics?).to eq true
-    end
-
-    it "is hidden if the assignment does not hide analytics but the course does" do
-      allow(course).to receive(:show_analytics?).and_return false
-      allow(assignment).to receive(:hide_analytics?).and_return false
-      expect(subject.hide_analytics?).to eq true
-    end
-
-    it "is hidden if both the assignment and course hide analytics" do
-      allow(course).to receive(:show_analytics?).and_return false
-      allow(assignment).to receive(:hide_analytics?).and_return true
-      expect(subject.hide_analytics?).to eq true
-    end
-  end
-
   describe "#grade_with_rubric?" do
     it "is not to be used if the assignment doesn't grade with a rubric" do
       allow(assignment).to receive(:grade_with_rubric?).and_return false

--- a/spec/proctors/analytics_proctor_spec.rb
+++ b/spec/proctors/analytics_proctor_spec.rb
@@ -1,0 +1,41 @@
+require_relative "../../app/proctors/analytics_proctor"
+
+describe AnalyticsProctor do
+  subject { described_class.new }
+  let(:user) { double(:staff) }
+  let(:course) { double(:course) }
+
+  before { stub_const("MINIMUM_STUDENT_COUNT", 20) }
+
+  context "as a staff member" do
+    describe "viewable?" do
+      it "returns true if the student count is less than the minimum count" do
+        allow(user).to receive(:is_staff?).and_return true
+        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT-1
+        expect(subject.viewable? user, course).to be_truthy
+      end
+
+      it "returns true if the student count is greater than or equal to the minimum count" do
+        allow(user).to receive(:is_staff?).and_return true
+        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT
+        expect(subject.viewable? user, course).to be_truthy
+      end
+    end
+  end
+
+  context "as a student" do
+    describe "viewable?" do
+      it "returns false if the student count is less than the minimum count" do
+        allow(user).to receive(:is_staff?).and_return false
+        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT-1
+        expect(subject.viewable? user, course).to be_falsey
+      end
+
+      it "returns true if the student count is greater than or equal to the minimum count" do
+        allow(user).to receive(:is_staff?).and_return false
+        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT
+        expect(subject.viewable? user, course).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/proctors/analytics_proctor_spec.rb
+++ b/spec/proctors/analytics_proctor_spec.rb
@@ -25,16 +25,29 @@ describe AnalyticsProctor do
 
   context "as a student" do
     describe "viewable?" do
-      it "returns false if the student count is less than the minimum count" do
-        allow(user).to receive(:is_staff?).and_return false
-        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT-1
-        expect(subject.viewable? user, course).to be_falsey
+      context "when show_analytics? for the course is true" do
+        before(:each) { allow(course).to receive(:show_analytics?).and_return true }
+
+        it "returns false if the student count is less than the minimum count" do
+          allow(user).to receive(:is_staff?).and_return false
+          allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT-1
+          expect(subject.viewable? user, course).to be_falsey
+        end
+
+        it "returns true if the student count is greater than or equal to the minimum count" do
+          allow(user).to receive(:is_staff?).and_return false
+          allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT
+          expect(subject.viewable? user, course).to be_truthy
+        end
       end
 
-      it "returns true if the student count is greater than or equal to the minimum count" do
-        allow(user).to receive(:is_staff?).and_return false
-        allow(course).to receive(:student_count).and_return MINIMUM_STUDENT_COUNT
-        expect(subject.viewable? user, course).to be_truthy
+      context "when show_analytics? for the course is false" do
+        before(:each) { allow(course).to receive(:show_analytics?).and_return false }
+
+        it "returns false if the student count is less than the minimum count" do
+          allow(user).to receive(:is_staff?).and_return false
+          expect(subject.viewable? user, course).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
### Status
READY

### Description
This PR addresses the need to conditionally hide various analytics components when the course size is small, specifically when the number of students is less than twenty.

The following are suppressed for a student when the condition holds true:

1. The box plot on the dashboard, titled Points Distribution (also when previewing as student)
2. The various charts that appear on the assignments show page, when the assignment is not rubric-graded
3. The Show Class Analytics switch on the assignments show page, when the assignment is rubric-graded

I have consolidated the logic for determining visibility in an `AnalyticsProctor`.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
(Easy way) Delete a single course_membership for Course.first (GC101 - Course with Teams & Badges with Points) and test as a student. At this point GC101 should have 19 students.

Visit the assignments show page, both for a rubric-graded assignment and one that is not. For the former, you should not see a switch to Show Class Analytics. For the latter, you should not see any of the various analytics charts.

The box plot should also be suppressed on the dashboard.

======================
Closes #2779 
