### PR TITLE
report slowest specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,11 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
   if config.files_to_run.one?
     config.default_formatter = "doc"
   end


### PR DESCRIPTION

### Description

This line will print out the 10 slowest specs at the end of the run.