### PR TITLE
2621 refactor confirm earned

### DIFF
--- a/app/controllers/api/earned_badges_controller.rb
+++ b/app/controllers/api/earned_badges_controller.rb
@@ -1,7 +1,21 @@
 require_relative "../../services/creates_earned_badge"
 
 class API::EarnedBadgesController < ApplicationController
-  before_action :ensure_staff?
+  skip_before_action :require_login, only: :confirm_earned
+  before_action :ensure_staff?, except: :confirm_earned
+
+  # Used for Badges Backpack integration
+  # GET /api/courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned
+  def confirm_earned
+    @course = Course.find_by_id(params[:course_id])
+    @badge = @course.badges.find_by_id(params[:badge_id]) unless @course.nil?
+
+    if @badge.present? && @badge.earned_badges.find_by_id(params[:id]).present?
+      head 200
+    else
+      render json: { message: "Earned badge not found", success: false }, status: 404
+    end
+  end
 
   # POST /api/earned_badges
   def create

--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -4,10 +4,9 @@ class EarnedBadgesController < ApplicationController
   # Earned badges are to badges what grades are to assignments - the record of
   # how what and how a student performed
 
-  skip_before_action :require_login, only: [:confirm_earned]
   before_action :ensure_not_observer?
-  before_action :ensure_staff?, except: [:confirm_earned, :new, :create]
-  before_action :find_badge, except: [:confirm_earned]
+  before_action :ensure_staff?, except: [:new, :create]
+  before_action :find_badge
   before_action :find_earned_badge, only: [:show, :edit, :update, :destroy ]
 
   def index
@@ -100,19 +99,6 @@ class EarnedBadgesController < ApplicationController
     expire_fragment "earned_badges"
     redirect_to @badge,
       notice: "The #{@badge.name} #{term_for :badge} has been taken away from #{@student_name}."
-  end
-
-  # Used for Badges Backpack integration
-  # GET /courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned
-  def confirm_earned
-    @course = Course.find(params[:course_id])
-    @badge = @course.badges.find(params[:badge_id])
-    @earned_badge = @badge.earned_badges.where(id: params[:id]).first
-    if @earned_badge.present?
-      render nothing: true, status: 200
-    else
-      redirect_to root_path
-    end
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,11 +195,6 @@ Rails.application.routes.draw do
     post :recalculate_student_scores, on: :member
     get :badges, on: :member
     get :change, on: :member
-    resources :badges do
-      resources :earned_badges do
-        get :confirm_earned, on: :member
-      end
-    end
   end
 
   resources :course_memberships, only: [:create, :delete, :destroy]
@@ -351,6 +346,8 @@ Rails.application.routes.draw do
     resources :badges, only: :index
     put "course_memberships/confirm_onboarding", to: "course_memberships#confirm_onboarding"
     resources :earned_badges, only: [:create, :destroy]
+    get "courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned", to: "earned_badges#confirm_earned",
+      as: :earned_badge_confirm
     resources :grades, only: :update do
       resources :earned_badges, only: :create, module: :grades do
         delete :delete_all, on: :collection

--- a/spec/controllers/api/earned_badges_controller_spec.rb
+++ b/spec/controllers/api/earned_badges_controller_spec.rb
@@ -1,41 +1,11 @@
 require "rails_spec_helper"
 
-describe API::EarnedBadgesController do
+describe API::EarnedBadgesController, focus: true do
   let(:world) { World.create.with(:course, :student, :grade, :badge) }
   let(:professor) { create(:course_membership, :professor, course: world.course).user }
 
   context "as professor" do
     before(:each) { login_user(professor) }
-
-    describe "GET confirm_earned" do
-      let(:course) { create(:course) }
-      let(:badge) { create(:badge, course: course) }
-      let(:earned_badge) { create(:earned_badge, badge: badge, course: course) }
-
-      it "returns a 404 if the course was not found" do
-        params = { course_id: "2", badge_id: badge.id, id: earned_badge.id }
-        get :confirm_earned, params: params
-        expect(response.status).to eq 404
-      end
-
-      it "returns a 404 if the badge was not found" do
-        params = { course_id: course.id, badge_id: "2", id: earned_badge.id }
-        get :confirm_earned, params: params
-        expect(response.status).to eq 404
-      end
-
-      it "returns a 404 if the earned badge was not found" do
-        params = { course_id: course.id, badge_id: badge.id, id: "2" }
-        get :confirm_earned, params: params
-        expect(response.status).to eq 404
-      end
-
-      it "returns a 200 if the earned badge is found" do
-        params = { course_id: course.id, badge_id: badge.id, id: earned_badge.id }
-        get :confirm_earned, params: params
-        expect(response.status).to eq 200
-      end
-    end
 
     describe "POST create" do
       it "creates a new student badge from params" do
@@ -60,6 +30,38 @@ describe API::EarnedBadgesController do
         delete :destroy, params: params
         expect(JSON.parse(response.body)).to \
           eq({"message" => "Earned badge failed to delete", "success" => false})
+      end
+    end
+  end
+
+  context "as an unauthenticated user" do
+    describe "GET confirm_earned" do
+      let(:course) { create(:course) }
+      let(:badge) { create(:badge, course: course) }
+      let(:earned_badge) { create(:earned_badge, badge: badge, course: course) }
+
+      it "returns a 404 if the course was not found" do
+        params = { course_id: "0", badge_id: badge.id, id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 404 if the badge was not found" do
+        params = { course_id: course.id, badge_id: "0", id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 404 if the earned badge was not found" do
+        params = { course_id: course.id, badge_id: badge.id, id: "0" }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 200 if the earned badge is found" do
+        params = { course_id: course.id, badge_id: badge.id, id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 200
       end
     end
   end

--- a/spec/controllers/api/earned_badges_controller_spec.rb
+++ b/spec/controllers/api/earned_badges_controller_spec.rb
@@ -7,13 +7,42 @@ describe API::EarnedBadgesController do
   context "as professor" do
     before(:each) { login_user(professor) }
 
+    describe "GET confirm_earned" do
+      let(:course) { create(:course) }
+      let(:badge) { create(:badge, course: course) }
+      let(:earned_badge) { create(:earned_badge, badge: badge, course: course) }
+
+      it "returns a 404 if the course was not found" do
+        params = { course_id: "2", badge_id: badge.id, id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 404 if the badge was not found" do
+        params = { course_id: course.id, badge_id: "2", id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 404 if the earned badge was not found" do
+        params = { course_id: course.id, badge_id: badge.id, id: "2" }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 404
+      end
+
+      it "returns a 200 if the earned badge is found" do
+        params = { course_id: course.id, badge_id: badge.id, id: earned_badge.id }
+        get :confirm_earned, params: params
+        expect(response.status).to eq 200
+      end
+    end
+
     describe "POST create" do
       it "creates a new student badge from params" do
-          params = { earned_badge:
-                     { badge_id: world.badge.id, student_id: world.student.id }}
-          expect{ post :create, params: params.merge(format: :json) }.to \
-            change {EarnedBadge.count}.by(1)
-        end
+        params = { earned_badge: { badge_id: world.badge.id, student_id: world.student.id } }
+        expect { post :create, params: params.merge(format: :json) }.to \
+          change { EarnedBadge.count }.by(1)
+      end
     end
 
     describe "DELETE destroy" do

--- a/spec/controllers/api/earned_badges_controller_spec.rb
+++ b/spec/controllers/api/earned_badges_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_spec_helper"
 
-describe API::EarnedBadgesController, focus: true do
+describe API::EarnedBadgesController do
   let(:world) { World.create.with(:course, :student, :grade, :badge) }
   let(:professor) { create(:course_membership, :professor, course: world.course).user }
 


### PR DESCRIPTION
### Status
READY

### Description
This PR is a clean up of the backpack connect API endpoint that is needed to validate an earned badge.

The endpoint has been moved to the API namespace, under the existing EarnedBadgesController. Tests were also added and the logic was also revised to handle nil cases better.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Given a valid `course_id`, `badge_id`, and `id` (for earned badge), the response should be a 200 if the earned badge exists and a 404 if it does not exist.

GET /api/courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned

======================
Closes #2621
