### PR TITLE
Revise method definition to use submitted_at

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -61,7 +61,7 @@ class Submission < ActiveRecord::Base
   multiple_files :submission_files
 
   def self.submitted_this_week(assignment_type)
-    assignment_type.submissions.submitted.where("submissions.updated_at > ? ", 7.days.ago)
+    assignment_type.submissions.submitted.where("submissions.submitted_at > ? ", 7.days.ago)
   end
 
   def graded_at

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -181,16 +181,15 @@ describe Submission do
 
   describe "#submitted_this_week" do
     let(:assignment_type) { create(:assignment_type) }
-    let(:assignment) { create(:group_assignment, assignment_type: assignment_type) }
-    let(:another_assignment) { create(:group_assignment, assignment_type: assignment_type) }
-    let(:student) { create(:course_membership, :student, course: assignment.course).user }
-    let!(:submission) { create(:submission, assignment: assignment, student: student) }
-    let!(:another_submission) { create(:draft_submission, assignment: another_assignment, student: student) }
+    let(:assignment) { create(:assignment, assignment_type: assignment_type) }
+    let!(:submission) { create(:submission, assignment: assignment, submitted_at: DateTime.now - 1.day) }
 
     it "returns non-draft submissions for the past week" do
+      create(:draft_submission, assignment: assignment)
+      create(:submission, assignment: assignment, submitted_at: DateTime.now - 8.day)
       result = Submission.submitted_this_week(assignment_type)
       expect(result.count).to eq 1
-      expect(result).to eq [submission]
+      expect(result).to include submission
     end
   end
 


### PR DESCRIPTION
### Status
READY

### Description
The method `submitted_this_week` on the `Submission` model was previously based off of the `updated_at` timestamp, which potentially causes issues since the field is automatically updated.

This has been revised to compare against the `submitted_at` time.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Observe the weekly stats on the dashboard and confirm that only Submissions submitted within the past week are included in the submitted this week count.

### Impacted Areas in Application
Weekly Stats

======================
Closes #2909 
