### PR TITLE
Allow copying of team_memberships

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -58,7 +58,7 @@ class CoursesController < ApplicationController
 
   def copy
     authorize! :read, @course
-    duplicated = @course.copy(params[:copy_type], {})
+    duplicated = @course.copy(params[:copy_type])
     if duplicated.save
       if !current_user_is_admin? && current_user.role(duplicated).nil?
         duplicated.course_memberships.create(user: current_user, role: current_role)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -92,11 +92,11 @@ class Course < ActiveRecord::Base
 
   def copy(copy_type, attributes={})
     if copy_type != "with_students"
-      copy_with_associations(attributes={lti_uid: nil}, [])
+      copy_with_associations(attributes.merge(lti_uid: nil), [])
     else
       begin
         Course.skip_callback(:create, :after, :create_admin_memberships)
-        copy_with_associations(attributes={lti_uid: nil}, [:course_memberships, :teams])
+        copy_with_associations(attributes.merge(lti_uid: nil), [:course_memberships, :teams])
       ensure
         Course.set_callback(:create, :after, :create_admin_memberships)
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -96,7 +96,7 @@ class Course < ActiveRecord::Base
     else
       begin
         Course.skip_callback(:create, :after, :create_admin_memberships)
-        copy_with_associations(attributes={lti_uid: nil}, [:course_memberships])
+        copy_with_associations(attributes={lti_uid: nil}, [:course_memberships, :teams])
       ensure
         Course.set_callback(:create, :after, :create_admin_memberships)
       end

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -45,6 +45,10 @@ class CourseMembership < ActiveRecord::Base
     course_membership.save
   end
 
+  def copy(attributes={})
+    ModelCopier.new(self).copy(attributes: attributes.merge(score: 0))
+  end
+
   def recalculate_and_update_student_score
     update_attribute :score, recalculated_student_score
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,4 +1,6 @@
 class Team < ActiveRecord::Base
+  include Copyable
+
   validates_presence_of :course, :name
   validates :name, uniqueness: { case_sensitive: false, scope: :course_id }
 
@@ -28,6 +30,11 @@ class Team < ActiveRecord::Base
   scope :order_by_challenge_grade_score, -> { order("challenge_grade_score DESC")}
   scope :order_by_rank, -> { order("rank ASC")}
   scope :alpha, -> { order("name ASC") }
+
+  def copy(attributes={})
+    ModelCopier.new(self).copy(attributes: attributes,
+      associations: [{ team_memberships: { team_id: :id }}])
+  end
 
   def self.find_by_course_and_name(course_id, name)
     where(course_id: course_id)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -31,14 +31,14 @@ class Team < ActiveRecord::Base
   scope :order_by_rank, -> { order("rank ASC")}
   scope :alpha, -> { order("name ASC") }
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
-      associations: [{ team_memberships: { team_id: :id }}])
-  end
-
   def self.find_by_course_and_name(course_id, name)
     where(course_id: course_id)
       .where("LOWER(name) = :name", name: name.downcase).first
+  end
+
+  def copy(attributes={})
+    ModelCopier.new(self).copy(attributes: attributes.merge(challenge_grade_score: nil, average_score: 0),
+      associations: [{ team_memberships: { team_id: :id }}])
   end
 
   # How many students are on the team

--- a/app/models/team_membership.rb
+++ b/app/models/team_membership.rb
@@ -1,5 +1,7 @@
 # @mz TODO: add course_id attribute to team_memberships
 class TeamMembership < ActiveRecord::Base
+  include Copyable
+
   belongs_to :team
   belongs_to :student, class_name: "User"
 

--- a/spec/models/course_membership_spec.rb
+++ b/spec/models/course_membership_spec.rb
@@ -1,6 +1,27 @@
 require "active_record_spec_helper"
 
 describe CourseMembership do
+  describe "#copy" do
+    let(:course_membership) { build :course_membership }
+    subject { course_membership.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq course_membership
+    end
+
+    it "overrides the specified attributes" do
+      attributes = { role: "some other role" }
+      subject = course_membership.copy attributes
+      expect(subject.role).to eq attributes[:role]
+    end
+
+    it "resets the values for the scores" do
+      course_membership = build_stubbed :course_membership, score: 0
+      subject = course_membership.copy
+      expect(subject.score).to be_zero
+    end
+  end
+
   describe ".create_or_update_from_lti" do
     let(:user) { build_stubbed(:user) }
     let(:course) { create(:course) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -81,6 +81,13 @@ describe Course do
       duplicated = subject.copy "with_students"
       expect(duplicated.reload.users).to include student
     end
+
+    it "copies the teams" do
+      team = create :team, course: subject
+      duplicated = subject.copy "with_students"
+      expect(duplicated.teams.size).to eq 1
+      expect(duplicated.teams.map(&:course_id)).to eq [duplicated.id]
+    end
   end
 
   describe "#grade_scheme_elements" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -61,6 +61,18 @@ describe Course do
       expect(subject.grade_scheme_elements.size).to eq 1
       expect(subject.grade_scheme_elements.map(&:course_id)).to eq [subject.id]
     end
+
+    it "overrides the specified attributes" do
+      attributes = { tagline: "Behold, the greatest course of all!" }
+      subject = course.copy nil, attributes
+      expect(subject.tagline).to eq attributes[:tagline]
+    end
+
+    it "resets the lti uid to nil" do
+      course = build_stubbed :course, lti_uid: "test_uid"
+      duplicated = course.copy nil
+      expect(duplicated.lti_uid).to be_nil
+    end
   end
 
   describe "#copy with students" do
@@ -87,6 +99,18 @@ describe Course do
       duplicated = subject.copy "with_students"
       expect(duplicated.teams.size).to eq 1
       expect(duplicated.teams.map(&:course_id)).to eq [duplicated.id]
+    end
+
+    it "overrides the specified attributes" do
+      attributes = { tagline: "This course will blow your mind!" }
+      duplicated = subject.copy "with_students", attributes
+      expect(duplicated.tagline).to eq attributes[:tagline]
+    end
+
+    it "resets the lti uid to nil" do
+      subject = build_stubbed :course, lti_uid: "test_uid"
+      duplicated = subject.copy "with_students"
+      expect(duplicated.lti_uid).to be_nil
     end
   end
 

--- a/spec/models/team_membership_spec.rb
+++ b/spec/models/team_membership_spec.rb
@@ -10,6 +10,15 @@ describe TeamMembership do
     end
   end
 
+  describe "#copy" do
+    let(:team_membership) { build :team_membership }
+    subject { team_membership.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq team_membership
+    end
+  end
+
   describe ".for_course" do
     it "returns all the team memberships for a specific course" do
       course = create(:course)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -32,6 +32,19 @@ describe Team do
       expect(subject.team_memberships.size).to eq 1
       expect(subject.team_memberships.map(&:team_id)).to eq [subject.id]
     end
+
+    it "overrides the specified attributes" do
+      attributes = { rank: 9 }
+      subject = team.copy attributes
+      expect(subject.rank).to eq attributes[:rank]
+    end
+
+    it "resets the values for the scores" do
+      team = build_stubbed :team, challenge_grade_score: 100, average_score: 100
+      subject = team.copy
+      expect(subject.challenge_grade_score).to be_zero
+      expect(subject.average_score).to be_zero
+    end
   end
 
   describe ".find_by_course_and_name" do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -19,6 +19,21 @@ describe Team do
     end
   end
 
+  describe "#copy" do
+    let(:team) { build :team }
+    subject { team.copy }
+
+    it "makes a duplicated copy of itself" do
+      expect(subject).to_not eq team
+    end
+
+    it "copies the team memberships" do
+      create :team_membership, team: team
+      expect(subject.team_memberships.size).to eq 1
+      expect(subject.team_memberships.map(&:team_id)).to eq [subject.id]
+    end
+  end
+
   describe ".find_by_course_and_name" do
     let(:team) { create :team }
 


### PR DESCRIPTION
### Status
READY

### Description
This PR addresses the desire to to copy `team_memberships` when a course is copied with students.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Copy a course that has team memberships, with the students. The duplicated course should also have the team memberships.

### Impacted Areas in Application
Course copy + Students

======================
Closes #2913 
