### PR TITLE
2889 html safe bug

### DIFF
--- a/app/views/assignments/importers/assignments.html.haml
+++ b/app/views/assignments/importers/assignments.html.haml
@@ -16,7 +16,7 @@
         - @assignments.each do |assignment|
           %tr
             %td= assignment["name"]
-            %td= assignment["description"].html_safe if assignment["description"]
+            %td= (assignment["description"] || "").html_safe
             %td= assignment["due_at"]
             %td= assignment["points_possible"]
             %td.center= check_box_tag "assignment_ids[]", assignment["id"], false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-assignments-command']" }

--- a/app/views/layouts/_alerts.haml
+++ b/app/views/layouts/_alerts.haml
@@ -2,7 +2,7 @@
 - if display_flash
   - flash.each do |name, message|
     %div{ class: "alert-box #{name}" }
-      = message.html_safe
+      = (message || "").html_safe
       %a{ href: "#", class: "close", "aria-label" => "close" }
         = "&times;".html_safe
 


### PR DESCRIPTION
### Status
**READY**

### Description
Ensures that the assignment description is an empty string instead of `nil` before wrapping it with an `#html_safe` call.

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

1. Link Canvas course id 127990
2. Import an assignment
3. There should not be an error

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing assignments from Canvas

======================
Closes #2899
