### PR TITLE
2939 downcase nil bug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,7 +125,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_insensitive_email(email)
-    where("LOWER(email) = :email", email: email.downcase).first
+    where("LOWER(email) = :email", email: (email || "").downcase).first
   end
 
   def self.find_by_insensitive_username(username)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_insensitive_username(username)
-    where("LOWER(username) = :username", username: username.downcase).first
+    where("LOWER(username) = :username", username: (username || "").downcase).first
   end
 
   def self.email_exists?(email)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,6 +46,10 @@ describe User do
     it "should return the user no matter what the case the username is in" do
       expect(User.find_by_insensitive_username(student.username.upcase)).to eq student
     end
+
+    it "returns nil if the specified email is nil" do
+      expect(described_class.find_by_insensitive_email(nil)).to be_nil
+    end
   end
 
   describe ".email_exists?" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,7 +34,11 @@ describe User do
 
   describe ".find_by_insensitive_email" do
     it "should return the user no matter what the case the email address is in" do
-      expect(User.find_by_insensitive_email(student.email.upcase)).to eq student
+      expect(described_class.find_by_insensitive_email(student.email.upcase)).to eq student
+    end
+
+    it "returns nil if the specified email is nil" do
+      expect(described_class.find_by_insensitive_email(nil)).to be_nil
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
Allows for a `nil` email when calling `User.find_by_insensitive_email` and for a `nil` username when calling `User.find_by_insensitive_username`.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing grades with Canvas users that do not have usernames

======================
Closes #2939 
