### PR TITLE
2944 add user constraints

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.6.6)
+    faker (1.7.2)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -312,7 +312,7 @@ GEM
       ruby_parser (~> 3.5)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    i18n (0.7.0)
+    i18n (0.8.0)
     ims-lti (1.1.13)
       builder
       oauth (>= 0.4.5, < 0.6)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,8 @@ class User < ActiveRecord::Base
   email_regex = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   validates :username, presence: true,
-                    length: { maximum: 50 }
+                    length: { maximum: 50 },
+                    uniqueness: { case_sensitive: false }
   validates :email, presence: true,
                     format: { with: email_regex },
                     uniqueness: { case_sensitive: false }

--- a/db/migrate/20170203175241_add_unique_indexes_to_user.rb
+++ b/db/migrate/20170203175241_add_unique_indexes_to_user.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexesToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_index :users, :username, unique: true
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20170203181526_add_not_null_to_users.rb
+++ b/db/migrate/20170203181526_add_not_null_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotNullToUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :users, :email, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203175241) do
+ActiveRecord::Schema.define(version: 20170203181526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -745,7 +745,7 @@ ActiveRecord::Schema.define(version: 20170203175241) do
 
   create_table "users", force: :cascade do |t|
     t.string   "username",                                                               null: false
-    t.string   "email"
+    t.string   "email",                                                                  null: false
     t.string   "crypted_password"
     t.string   "salt"
     t.datetime "created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110174401) do
+ActiveRecord::Schema.define(version: 20170203175241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -782,10 +782,12 @@ ActiveRecord::Schema.define(version: 20170110174401) do
     t.boolean  "admin",                           default: false
     t.string   "time_zone",                       default: "Eastern Time (US & Canada)"
     t.index ["activation_token"], name: "index_users_on_activation_token", using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["kerberos_uid"], name: "index_users_on_kerberos_uid", using: :btree
     t.index ["last_logout_at", "last_activity_at"], name: "index_users_on_last_logout_at_and_last_activity_at", using: :btree
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token", using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", using: :btree
+    t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 
   create_table "version_associations", force: :cascade do |t|

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,8 +7,8 @@ FactoryGirl.define do
 
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    username { Faker::Internet.user_name }
-    email { Faker::Internet.email }
+    username { Faker::Internet.unique.user_name }
+    email { Faker::Internet.unique.email }
     password { "secret" }
 
     # Define course_memberships with an optional role

--- a/spec/features/creating_a_new_user_spec.rb
+++ b/spec/features/creating_a_new_user_spec.rb
@@ -30,7 +30,7 @@ feature "creating a new user" do
 
     context "for a UM student" do
       scenario "successfully" do
-        username = Faker::Internet.user_name
+        username = Faker::Internet.unique.user_name
         user = build(:user, email: "#{username}@umich.edu")
         within(".pageContent #tab2") do
           NewUserPage.new(user)


### PR DESCRIPTION
### Status
READY

### Description
In the efforts of consolidating all of our user create/update logic by using the `CreatesOrUpdatesUser` service, we need to ensure that usernames are unique if we intend to search for existing users using `find_by_insensitive_username`.

This PR adds the unique constraint to the username on both the database as well as on the ActiveRecord model as a validation. It also updates the email validations to be consistent in both places.

Since there was no way to ensure the unique generation of usernames and emails using the current version of the Faker gem, I updated to the latest. This allows us to use the following syntax in the user factory, which prevents the sporadic spec failures I was having:

```
username { Faker::Internet.unique.user_name }
email { Faker::Internet.unique.email }
```

### Related PRs
Required for #2758, if we intend to continue merging user lookup by username into the `CreatesOrUpdatesUser` service.

### Deploy Notes
Current database data may need to be cleaned up before the unique constraint can be applied, specifically if there are duplicate usernames.

### Gem dependencies
- UPDATED Faker from 1.6.6 to 1.7.2

### Migrations
YES

### Steps to Test or Reproduce
Ensure that users cannot be created with duplicate emails or usernames (case-insensitive)

======================
Closes #2944 
