### PR TITLE
2924 meets expectations

### DIFF
--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -516,7 +516,7 @@ h4.notice
 
 // styles for ungraded rubric view
 .rubric.rubric-ungraded
-  .tab-panel
+  .level-block
     border-bottom: 1px solid $color-grey-6
     padding: 0.5rem 0.5rem 1.2rem 0.5rem
     &:last-child

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -518,7 +518,7 @@ h4.notice
 .rubric.rubric-ungraded
   .tab-panel
     border-bottom: 1px solid $color-grey-6
-    padding: 0.5rem
+    padding: 0.5rem 0.5rem 1.2rem 0.5rem
     &:last-child
       border-bottom: none
     &.meets-expectations-cutoff

--- a/app/views/rubrics/components/_criteria.haml
+++ b/app/views/rubrics/components/_criteria.haml
@@ -5,7 +5,7 @@
       %p.criterion-description= criterion.description
 
     - criterion.levels.ordered.reverse.each_with_index do |level, lindex|
-      .tab-panel.selected{:class => ("meets-expectations-cutoff" if level.meets_expectations)}
+      .level-block{:class => ("meets-expectations-cutoff" if level.meets_expectations)}
         - if level.meets_expectations
           %p.meets-expectations-tag Meets expectations #{glyph('long-arrow-up')}
         = render partial: "rubrics/components/level", locals: { level: level, student: student, include_grade_info: false }


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updates styling on ungraded rubric to prevent text from overlapping the meets expectations cutoff label as well as updates class names on this rubric to make it clear that no tab panel behavior should be expected.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Ungraded rubric

======================
Closes #2924 
