### PR TITLE
2889 - Html safe bug for imported assignments

### DIFF
--- a/app/views/grades/importers/assignments.html.haml
+++ b/app/views/grades/importers/assignments.html.haml
@@ -13,7 +13,7 @@
       - @assignments.each do |assignment|
         %tr
           %td= assignment["name"]
-          %td= assignment["description"].html_safe
+          %td= (assignment["description"] || "").html_safe
           %td= assignment["due_at"]
           %td= assignment["points_possible"]
           %td


### PR DESCRIPTION
### Status
**READY**

### Description
Ensures that the assignment description for an imported `Assignment` is not `nil` before calling `#html_safe` on it.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Importing assignments from Canvas

======================
Closes #2889 
