### PR TITLE
always downcase custom terms before check

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/article_assignment_content.js.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/article_assignment_content.js.coffee
@@ -9,5 +9,8 @@
     link: (scope, el, attr)->
       scope.articleCompleted = ()->
         PredictorService.articleCompleted(@article)
+
+      scope.termFor = (term)->
+        PredictorService.termFor(term)
   }
 ]

--- a/app/assets/javascripts/angular/helpers/serviceHelpers.js.coffee
+++ b/app/assets/javascripts/angular/helpers/serviceHelpers.js.coffee
@@ -13,7 +13,7 @@ angular.module('helpers').factory('GradeCraftAPI', ()->
   }
 
   termFor = (article)->
-    _termFor[article]
+    _termFor[article.toLowerCase()]
 
   setTermFor = (article,term)->
     _termFor[article] = term

--- a/app/assets/javascripts/angular/services/PredictorService.js.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.js.coffee
@@ -136,6 +136,7 @@
     # Always treats badges as if they "count"
     return false if article.type == "badges"
     return true if article.grade.pass_fail_status == "Fail"
+    return false if article.grade.pass_fail_status == "Pass"
     return true if article.grade.score == 0 ||
       article.is_closed_without_submission == true ||
       article.is_closed_by_condition == true


### PR DESCRIPTION
### Status
**READY**

### Description

Graded Pass/Fail assignments were not displaying in the predictor.

This fix down-cases all custom terms to make sure they match the store, and adds a missing connection between the article view partial and the termFor method in the helper.

![screen shot 2017-02-09 at 1 37 09 pm](https://cloud.githubusercontent.com/assets/1138350/22797608/e0c3535a-eecc-11e6-9f96-93e1e571c9da.png)
