### PR TITLE
2936 import pass fail grades

### DIFF
--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -20,7 +20,6 @@ class Grades::ImportersController < ApplicationController
     @assignments = syllabus.assignments(params[:id])
   end
 
-  # rubocop:disable AndOr
   # GET /assignments/:assignment_id/grades/download
   # Sends a CSV file to the user with the current grades for all students
   # in the course for the asisgnment

--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -53,11 +53,11 @@ class CSVGradeImporter
   end
 
   def assign_grade(row, grade)
-    grade.raw_points = row.grade
     grade.feedback = row.feedback
     grade.status = "Graded" if grade.status.nil?
     grade.instructor_modified = true
     grade.graded_at = DateTime.now
+    set_grade_score row, grade
   end
 
   def create_grade(row, assignment, student)
@@ -85,6 +85,16 @@ class CSVGradeImporter
       successful << grade
     else
       append_unsuccessful row, grade.errors.full_messages.join(", ")
+    end
+  end
+
+  def set_grade_score(row, grade)
+    if grade.assignment.pass_fail?
+      score = Integer(row.grade) rescue nil # to_i converts non-ints to 0
+      grade.pass_fail_status = "Pass" if score == 1
+      grade.pass_fail_status = "Fail" if score == 0
+    else
+      grade.raw_points = row.grade
     end
   end
 

--- a/app/views/grades/importers/_import_results_table.html.haml
+++ b/app/views/grades/importers/_import_results_table.html.haml
@@ -1,10 +1,11 @@
+- term_for_score = @assignment.pass_fail? ? "Pass / Fail Status" : "Score"
 %table.dynatable
   %thead
     %tr
       %th First Name
       %th Last Name
       %th Email
-      %th{ "data-dynatable-sorts" => "rawScore" } Score
+      %th{ "data-dynatable-sorts" => "rawScore" }= term_for_score
       %th Feedback
   %tbody
     - grades.each do |grade|
@@ -12,5 +13,8 @@
         %td= link_to grade.student.first_name, student_path(grade.student)
         %td= link_to grade.student.last_name, student_path(grade.student)
         %td= link_to grade.student.email, student_path(grade.student)
-        %td= grade.raw_points
+        - if @assignment.pass_fail?
+          %td= term_for grade.try(:pass_fail_status)
+        - else
+          %td= grade.raw_points
         %td= grade.feedback

--- a/spec/fixtures/files/pass_fail_grades.csv
+++ b/spec/fixtures/files/pass_fail_grades.csv
@@ -2,3 +2,5 @@ First Name,Last Name,Email,Score,Feedback
 Robert,Plant,robert@example.com,1,"Rock on!"
 Lindsey,Buckingham,lindsey,0,
 John,Frusciante,john.frusciante@rhcp.com, ,
+Don,Henley,don.henley@eagles.com,2
+Steve,Perry,steve.perry@journey.com,"pass"

--- a/spec/fixtures/files/pass_fail_grades.csv
+++ b/spec/fixtures/files/pass_fail_grades.csv
@@ -1,0 +1,4 @@
+First Name,Last Name,Email,Score,Feedback
+Robert,Plant,robert@example.com,1,"Rock on!"
+Lindsey,Buckingham,lindsey,0,
+John,Frusciante,john.frusciante@rhcp.com, ,

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -55,6 +55,13 @@ describe CSVGradeImporter do
             expect(result.successful.last).to eq grade
           end
 
+          it "rejects the row if the grade is unrecognized" do
+            allow(subject).to receive(:set_grade_score).and_raise ArgumentError
+            result = subject.import(course, assignment)
+            expect(result.unsuccessful.count).to eq 3
+            expect(result.unsuccessful.pluck(:errors)).to include "Row contains invalid data"
+          end
+
           it "updates the grade if it is already there" do
             create :grade, assignment: assignment, student: student, pass_fail_status: "Fail"
             subject.import(course, assignment)

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -55,11 +55,18 @@ describe CSVGradeImporter do
             expect(result.successful.last).to eq grade
           end
 
-          it "rejects the row if the grade is unrecognized" do
-            allow(subject).to receive(:set_grade_score).and_raise ArgumentError
+          it "contains an unsuccessful row if the grade is not valid" do
+            create :user, email: "don.henley@eagles.com", courses: [course], role: :student
             result = subject.import(course, assignment)
-            expect(result.unsuccessful.count).to eq 3
-            expect(result.unsuccessful.pluck(:errors)).to include "Row contains invalid data"
+            expect(result.unsuccessful.count).to eq 4
+            expect(result.unsuccessful.pluck(:errors)).to include "Grade is invalid"
+          end
+
+          it "contains an unsuccessful row if the grade is not valid" do
+            create :user, email: "steve.perry@journey.com", courses: [course], role: :student
+            result = subject.import(course, assignment)
+            expect(result.unsuccessful.count).to eq 4
+            expect(result.unsuccessful.pluck(:errors)).to include "Grade is invalid"
           end
 
           it "updates the grade if it is already there" do

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -39,15 +39,53 @@ describe CSVGradeImporter do
           create :course_membership, :student, user_id: student.id, course_id: course.id
         end
 
-        it "creates the grade if it is not there" do
-          result = subject.import(course, assignment)
-          grade = Grade.unscoped.last
-          expect(grade.raw_points).to eq 4000
-          expect(grade.feedback).to eq "You did great!"
-          expect(grade.status).to eq "Graded"
-          expect(grade.instructor_modified).to eq true
-          expect(result.successful.count).to eq 1
-          expect(result.successful.last).to eq grade
+        context "when the assignment is of pass/fail type" do
+          let(:assignment) { create :assignment, course: course, pass_fail: true }
+          let(:file) { fixture_file "pass_fail_grades.csv", "text/csv" }
+
+          it "creates the grade if it is not there" do
+            result = subject.import(course, assignment)
+            grade = Grade.unscoped.last
+            expect(grade.raw_points).to eq 0
+            expect(grade.pass_fail_status).to eq "Pass"
+            expect(grade.feedback).to eq "Rock on!"
+            expect(grade.status).to eq "Graded"
+            expect(grade.instructor_modified).to eq true
+            expect(result.successful.count).to eq 1
+            expect(result.successful.last).to eq grade
+          end
+
+          it "updates the grade if it is already there" do
+            create :grade, assignment: assignment, student: student, pass_fail_status: "Fail"
+            subject.import(course, assignment)
+            grade = Grade.last
+            expect(grade.raw_points).to eq 0
+            expect(grade.pass_fail_status).to eq "Pass"
+            expect(grade.feedback).to eq "Rock on!"
+            expect(grade.graded_at).to_not be_nil
+          end
+        end
+
+        context "when the assignment is not pass/fail type" do
+          it "creates the grade if it is not there" do
+            result = subject.import(course, assignment)
+            grade = Grade.unscoped.last
+            expect(grade.raw_points).to eq 4000
+            expect(grade.feedback).to eq "You did great!"
+            expect(grade.status).to eq "Graded"
+            expect(grade.instructor_modified).to eq true
+            expect(result.successful.count).to eq 1
+            expect(result.successful.last).to eq grade
+          end
+
+          it "updates the grade if it is already there" do
+            create :grade, assignment: assignment, student: student, raw_points: 1000
+            subject.import(course, assignment)
+            grade = Grade.last
+            expect(grade.raw_points).to eq 4000
+            expect(grade.feedback).to eq "You did great!"
+            expect(grade.graded_at).to_not be_nil
+          end
         end
 
         it "timestamps the grade" do
@@ -55,15 +93,6 @@ describe CSVGradeImporter do
           result = subject.import(course, assignment)
           grade = Grade.unscoped.last
           expect(grade.graded_at).to be > current_time
-        end
-
-        it "updates the grade if it is already there" do
-          create :grade, assignment: assignment, student: student, raw_points: 1000
-          subject.import(course, assignment)
-          grade = Grade.last
-          expect(grade.raw_points).to eq 4000
-          expect(grade.feedback).to eq "You did great!"
-          expect(grade.graded_at).to_not be_nil
         end
 
         it "does not update the grade if the grade and the feedback are the same as the one being imported" do


### PR DESCRIPTION
### Status
READY

### Description
Since the import grade process does not currently account for Pass/Fail type assignments, we want to be able to upload a score of 1 or 0 to specify whether the student has passed or failed, respectively.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
For any given Pass/Fail type assignment, you should be able to Import Grades via CSV and input a 0 or 1 for the score to specify the status.

### Impacted Areas in Application
Grade Import via CSV

======================
Closes #2936
