### PR TITLE
include student info in badge service call

### DIFF
--- a/app/assets/javascripts/angular/services/BadgeService.js.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.js.coffee
@@ -23,9 +23,14 @@
   #------ API Calls -----------------------------------------------------------#
 
   # GET index list of badges
-  # includes a student's predictions
+  # for students includes predictions
+  # for faculty using student id, includes badge awards and availability
   getBadges = (studentId)->
-    $http.get('/api/badges').success( (response)->
+    if studentId
+      url = '/api/students/' + studentId + '/badges'
+    else
+      url = '/api/badges'
+    $http.get(url).success( (response)->
       GradeCraftAPI.loadMany(badges, response, {"include" : ['prediction']})
       _.each(badges, (badge)->
         # add earned badge count for generic predictor


### PR DESCRIPTION
### Description

Fixes a bug where no badges were available to award to students from the grading page.  This broke when I removed the URIprefix() from the Angular API helper [here](https://github.com/UM-USElab/gradecraft-development/commit/7fb7a08c9760c528fa60d6470caec0ec2e043f4e).

This function was previously used for managing Angular routing on the student preview pages before we had an "impersonating agent", but is also still necessary for the indexing of student badges. 

As this is the only service that needs to do this, the logic has now been restored and moved within the service.