### PR TITLE
Switch all helper specs to spec helper

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/application_helper"
+require "spec_helper"
 
 describe ApplicationHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "./app/helpers/assignments_helper"
 
 describe AssignmentsHelper do
   class Helper

--- a/spec/helpers/badges_helper_spec.rb
+++ b/spec/helpers/badges_helper_spec.rb
@@ -1,4 +1,4 @@
-require "rails_spec_helper"
+require "spec_helper"
 
 describe BadgesHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/courses_helper_spec.rb
+++ b/spec/helpers/courses_helper_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "./app/helpers/courses_helper"
 
 describe CoursesHelper do
   let(:user) { double(:user) }

--- a/spec/helpers/grades_helper_spec.rb
+++ b/spec/helpers/grades_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/grades_helper"
+require "spec_helper"
 
 describe GradesHelper do
   let(:course) { create :course }

--- a/spec/helpers/history_helper_spec.rb
+++ b/spec/helpers/history_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/history_helper"
+require "spec_helper"
 
 describe HistoryHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/link_helper"
+require "spec_helper"
 
 describe LinkHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/lms_helper_spec.rb
+++ b/spec/helpers/lms_helper_spec.rb
@@ -1,4 +1,4 @@
-require "rails_spec_helper"
+require "spec_helper"
 
 describe LMSHelper do
   describe "#lms_user_match?" do

--- a/spec/helpers/secure_token_helper_spec.rb
+++ b/spec/helpers/secure_token_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/link_helper"
+require "spec_helper"
 
 describe LinkHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -1,5 +1,4 @@
-require "rails_spec_helper"
-require "./app/helpers/submissions_helper"
+require "spec_helper"
 
 describe SubmissionsHelper do
   let(:course) { create :course }

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -1,4 +1,4 @@
-require "rails_spec_helper"
+require "spec_helper"
 
 describe TimelineHelper do
   include RSpecHtmlMatchers

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "./app/helpers/users_helper"
 
 describe UsersHelper do
   class Helper


### PR DESCRIPTION
### Status
**READY**

### Description
This PR switches all of the helper specs to use the spec_helper rather than the rails_spec_helper for efficiency purposes.
