### PR TITLE
2706 predictor graph unlocks

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -15,6 +15,9 @@
       scope.allPointsPredicted = ()->
         PredictorService.allPointsPredicted()
 
+      scope.lockedPointsPredicted = ()->
+        PredictorService.lockedPointsPredicted()
+
       scope.predictedGradeLevel = ()->
         PredictorService.predictedGradeLevel()
 
@@ -105,11 +108,15 @@
         width = scope.GraphsStats().scale(PredictorService.allPointsEarned())
         width = width || 0
 
-      # Calculetes width for Predicted Points (blue) bar
+      # Calculetes width for Predicted Points (blue) bar, minus the locked points
       scope.svgPredictedBarWidth = ()->
-        width = scope.GraphsStats().scale(PredictorService.allPointsPredicted())
+        width = scope.GraphsStats().scale(PredictorService.allPointsPredicted() - PredictorService.lockedPointsPredicted())
         width = width || 0
 
+      # Calculates width for Predicted Locked Points (light-blue) bar
+      scope.svgPredictedLockedBarWidth = ()->
+        width = scope.GraphsStats().scale(PredictorService.allPointsPredicted())
+        width = width || 0
 
       # render!
       scope.renderGradeLevelGraph()

--- a/app/assets/javascripts/angular/services/PredictorService.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.coffee
@@ -153,6 +153,10 @@
     total += challengesPredictedPoints()
     total
 
+  lockedPointsPredicted = ()->
+    subset = _.where(assignments, {is_locked: true})
+    total = AssignmentService.assignmentsSubsetPredictedPoints(subset)
+
   # Total points actually earned to date
   allPointsEarned = ()->
     total = 0
@@ -200,6 +204,7 @@
       articleNoPoints: articleNoPoints
       postPredictedArticle: postPredictedArticle
       allPointsPredicted: allPointsPredicted
+      lockedPointsPredicted: lockedPointsPredicted
       allPointsEarned: allPointsEarned
       predictedGradeLevel: predictedGradeLevel
 

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -14,11 +14,11 @@
       %rect.key{"width"=>"20", "height"=>"20"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Total Predicted: {{allPointsPredicted() | number}} (left to earn: {{allPointsPredicted() - allPointsEarned() | number}})
-    %g{"id" => "svg-predicted-locked-key", "transform" => "translate(10,120)"}
+    %g{"ng-if"=>"lockedPointsPredicted() > 0",  "id" => "svg-predicted-locked-key", "transform" => "translate(10,120)"}
       %rect.key{"width"=>"20", "height"=>"20"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
-    %g{"id" => "svg-predicted-grade", "transform" => "translate(10,130)"}
+    %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}
       %text.description
         Predicted Final Grade:
         {{predictedGradeLevel()}}

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -1,6 +1,7 @@
 %svg{"id" => "predictor-graph-svg"}
   %g{"id" => "svg-grade-levels"}
   %g{"id" => "svg-points"}
+    %rect#svg-graph-points-predicted-locked{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedLockedBarWidth()}}", "height"=>"20"}
     %rect#svg-graph-points-predicted{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedBarWidth()}}", "height"=>"20"}
     %rect#svg-graph-points-earned{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgEarnedBarWidth()}}", "height"=>"20"}
   %g{"id" => "svg-grade-level-text"}
@@ -13,6 +14,10 @@
       %rect.key{"width"=>"20", "height"=>"20"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Total Predicted: {{allPointsPredicted() | number}} (left to earn: {{allPointsPredicted() - allPointsEarned() | number}})
+    %g{"id" => "svg-predicted-locked-key", "transform" => "translate(10,120)"}
+      %rect.key{"width"=>"20", "height"=>"20"}
+      %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
+        Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,130)"}
       %text.description
         Predicted Final Grade:

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -1,4 +1,9 @@
 %svg{"id" => "predictor-graph-svg"}
+  %defs
+    %pattern{"id"=>"pattern-stripe", "width"=>"4", "height"=>"4", "patternUnits"=>"userSpaceOnUse", "patternTransform"=>"rotate(45)"}
+      %rect{"width"=>"2", "height"=>"4", "transform"=>"translate(0,0)" ,"fill"=>"white"}
+    %mask{"id"=>"mask-stripe"}
+      %rect{"x"=>"0", "y"=>"0", "width"=>"100%", "height"=>"100%", "fill"=>"url(#pattern-stripe)"}
   %g{"id" => "svg-grade-levels"}
   %g{"id" => "svg-points"}
     %rect#svg-graph-points-predicted-locked{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedLockedBarWidth()}}", "height"=>"20"}

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -57,7 +57,7 @@ $card-margin-1 : 3px
 
 #predictor-graph-svg
   width: 100%
-  height: 140px
+  height: 180px
   background-color: $color-white
   .grade-point-axis
     path, line
@@ -70,6 +70,8 @@ $card-margin-1 : 3px
     fill: $color-green-3
   #svg-graph-points-predicted
     fill: $color-blue-3
+  #svg-graph-points-predicted-locked
+    fill: $color-blue-4
   #svg-earned-key
     transform: translate(10px,90px)
     .key
@@ -82,10 +84,16 @@ $card-margin-1 : 3px
       fill: $color-blue-3
       width: 20
       height: 20
+  #svg-predicted-locked-key
+    transform: translate(10px,120px)
+    .key
+      fill: $color-blue-4
+      width: 20
+      height: 20
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold
-    transform: translate(10px, 130px)
+    transform: translate(10px, 170px)
 
 
 // ICONS AND TOOLTIPS

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -71,7 +71,8 @@ $card-margin-1 : 3px
   #svg-graph-points-predicted
     fill: $color-blue-3
   #svg-graph-points-predicted-locked
-    fill: $color-blue-4
+    fill: $color-blue-3
+    mask: url(#mask-stripe)
   #svg-earned-key
     transform: translate(10px,90px)
     .key
@@ -87,7 +88,8 @@ $card-margin-1 : 3px
   #svg-predicted-locked-key
     transform: translate(10px,120px)
     .key
-      fill: $color-blue-4
+      fill: $color-blue-3
+      mask: url(#mask-stripe)
       width: 20
       height: 20
   #svg-predicted-grade

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -93,7 +93,7 @@ $card-margin-1 : 3px
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold
-    transform: translate(10px, 170px)
+    transform: translate(10px, 165px)
 
 
 // ICONS AND TOOLTIPS

--- a/app/assets/stylesheets/utilities/_mixins.sass
+++ b/app/assets/stylesheets/utilities/_mixins.sass
@@ -107,9 +107,11 @@
     #svg-keys
       font-size: $predictor-font-size-4
     #svg-predicted-key
-      transform: translate(10px,120px)
+      transform: translate(10px,112px)
+    #svg-predicted-locked-key
+      transform: translate(10px,135px)
     #svg-predicted-grade
-      transform: translate(10px, 160px)
+      transform: translate(10px, 175px)
 
 // mixin for all rubric level form fields
 @mixin rubric-level-input


### PR DESCRIPTION
### Description

This PR separates the predicted points for the  locked assignments from the unlocked assignments in the grade predictor graph, so students can see which points they intend to earn that still require an unlock for completion.

closes #2706 

### Todos

@chcholman, @mariehooper I would like a little feedback on the UX before merge. I'm not totally happy with the key, but I'm not sure what would be a better solution. Here's the problem:

![screen shot 2017-02-16 at 9 25 55 am](https://cloud.githubusercontent.com/assets/1138350/23025552/5daf2d30-f42c-11e6-87c2-c9921e5f30f9.png)


  * I feel like the locked (light blue) should be at the right end of the graph, since unlocked/predicted (dark blue) are closer to completion (green).
  * I feel like calculating out "Total Predicted" is ultimately the most useful number to show a student, but labeling the dark blue as "Total Predicted" is misleading since this number includes "all the blue", and labeling the light blue as "Total Predicted" would also be confusing.
  * I feel listing **Earned** AND **Predicted/Unlocked** AND **Predicted/Locked** AND **Total Predicted** AND **Predicted Final Grade** might be too much clutter in the key unless we redesign the key so that it is visually better separated from the graph above and the predictor below.
  * I want the Locked Predicted Points to only show if it is greater than zero (visible in the graph).
  * This is all coupled with the fact that these are svg elements, and so responsive design solutions take a lot of work to work in all browsers. Any solution that has elements left aligned will be much simpler than trying to mimic a float (think absolute positions, with `<g>` widths subject to numbers 0 to 100,000+).

One Solution that I've considered: turn the color key for "Total Predicted" into a diagonally bisected square, half light blue, half dark blue.

