### PR TITLE
Add commas to numeric fields that are missing them

### DIFF
--- a/app/views/assignments/_assignment_score_level_fields.haml
+++ b/app/views/assignments/_assignment_score_level_fields.haml
@@ -4,7 +4,7 @@
       = f.input :name, :label => "Level Name"
     .points-awarded-form.score-level-form
       = f.label :points, "Points Awarded"
-      = f.text_field :points
+      = f.text_field :points, data: {autonumeric: true, "m-dec" => "0"}
       = f.hidden_field :id
   .btn-container
     = f.hidden_field :_destroy, class: "destroy"

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -24,7 +24,7 @@
       - else
         .pass-fail-contingent
           = f.label :full_points, "Total Points Possible"
-          = f.text_field :full_points
+          = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
 
     .form-item
       - if f.object.pass_fail?
@@ -35,7 +35,7 @@
       - else
         .pass-fail-contingent
           = f.label :threshold_points, "Points Threshold"
-          = f.text_field :threshold_points
+          = f.text_field :threshold_points, data: {autonumeric: true, "m-dec" => "0"}
           .form_label If you set a points threshold above zero, any student earning fewer points will receive no points for the assignment.
 
     .form-item

--- a/app/views/challenge_grades/_form.html.haml
+++ b/app/views/challenge_grades/_form.html.haml
@@ -26,10 +26,10 @@
   %section
     .right
       %h4.text-right Points Adjustment
-      = f.input :adjustment_points
-      %br
-      = f.label :adjustment_points_feedback, "Feedback"
-      .right= f.text_area :adjustment_points_feedback
+      = f.text_field :adjustment_points, label: false, data: {autonumeric: true, "m-dec" => "0"}
+      %p
+      %h4.text-right Points Adjustment Feedback
+      = f.text_area :adjustment_points_feedback
       
     .clear
   .submit-buttons


### PR DESCRIPTION
### Status
**READY**

### Description
This PR leverages the autonumeric utility to add commas to numeric data entry form fields.

======================
Closes #2817