### PR TITLE
inline svg mask for firefox

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -6,7 +6,7 @@
       %rect{"x"=>"0", "y"=>"0", "width"=>"100%", "height"=>"100%", "fill"=>"url(#pattern-stripe)"}
   %g{"id" => "svg-grade-levels"}
   %g{"id" => "svg-points"}
-    %rect#svg-graph-points-predicted-locked{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedLockedBarWidth()}}", "height"=>"20"}
+    %rect#svg-graph-points-predicted-locked{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedLockedBarWidth()}}", "height"=>"20", "mask"=>"url(#mask-stripe)"}
     %rect#svg-graph-points-predicted{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgPredictedBarWidth()}}", "height"=>"20"}
     %rect#svg-graph-points-earned{"x"=>"10", "y"=>"40", "ng-attr-width"=>"{{svgEarnedBarWidth()}}", "height"=>"20"}
   %g{"id" => "svg-grade-level-text"}
@@ -20,7 +20,7 @@
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Total Predicted: {{allPointsPredicted() | number}} (left to earn: {{allPointsPredicted() - allPointsEarned() | number}})
     %g{"ng-if"=>"lockedPointsPredicted() > 0",  "id" => "svg-predicted-locked-key", "transform" => "translate(10,120)"}
-      %rect.key{"width"=>"20", "height"=>"20"}
+      %rect.key{"width"=>"20", "height"=>"20", "mask"=>"url(#mask-stripe)"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Verdana"}
         Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -72,26 +72,24 @@ $card-margin-1 : 3px
     fill: $color-blue-3
   #svg-graph-points-predicted-locked
     fill: $color-blue-3
-    mask: url(#mask-stripe)
   #svg-earned-key
     transform: translate(10px,90px)
     .key
       fill: $color-green-3
-      width: 20
-      height: 20
+      width: 20px
+      height: 20px
   #svg-predicted-key
     transform: translate(230px,90px)
     .key
       fill: $color-blue-3
-      width: 20
-      height: 20
+      width: 20px
+      height: 20px
   #svg-predicted-locked-key
     transform: translate(10px,120px)
     .key
       fill: $color-blue-3
-      mask: url(#mask-stripe)
-      width: 20
-      height: 20
+      width: 20px
+      height: 20px
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold


### PR DESCRIPTION
Moves svg mask in-line to fix Firefox. Something about rendering in sass (perhaps the additional prefix version?) broke the connection to the mask.