### PR TITLE
add impersonating? to current_course logic

### DIFF
--- a/lib/current_scopes.rb
+++ b/lib/current_scopes.rb
@@ -6,7 +6,8 @@ module CurrentScopes
 
   def current_course
     return unless current_user
-    @__current_course ||= CourseRouter.current_course_for(current_user, session[:course_id])
+    user = impersonating? ? impersonating_agent : current_user
+    @__current_course ||= CourseRouter.current_course_for(user, session[:course_id])
   end
 
   def current_student
@@ -25,5 +26,4 @@ module CurrentScopes
   def current_student=(student)
     @__current_student = student
   end
-
 end


### PR DESCRIPTION
### Status
**READY**

### Description
 
Adds a query in the `current_course` scope to check the session for an impersonating user. If present, use this user to determine `current_course_for(user,...)`

I think this is the best way to ensure that student previews remain inside the professor's course, without affecting any student sessions.  It's possible though that there are other ways to circumnavigate the permissions that would normally restrict what the professors could view.

closes #2926 
