### PR TITLE
Fix uncaught exception thrown in CSVGradeImporter

### DIFF
--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -29,7 +29,7 @@ class CSVGradeImporter
             append_unsuccessful row, "Grade not specified"
             next
           end
-          if assignment.pass_fail? && !is_valid_pass_fail_grade(row.grade)
+          if !is_valid_grade? assignment, row.grade
             append_unsuccessful row, "Grade is invalid"
             next
           end
@@ -103,12 +103,13 @@ class CSVGradeImporter
     end
   end
 
-  def is_valid_pass_fail_grade(grade)
+  def is_valid_grade?(assignment, grade)
     begin
-      score = Integer(grade || "")  # vs to_i, since we don't want to cast to an int if it's invalid
-      return PASS_FAIL_GRADE_VALUES.include?(score)
+      score = Integer(grade || "")
+      return PASS_FAIL_GRADE_VALUES.include?(score) if assignment.pass_fail?
+      true
     rescue ArgumentError
-      return false
+      false
     end
   end
 

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -47,7 +47,7 @@ describe Grades::ImportersController do
         it "renders any errors that have occured" do
           post :upload, params: { assignment_id: world.assignment.id, importer_provider_id: :csv, file: file }
 
-          expect(response.body).to include "3 Grades Not Imported"
+          expect(response.body).to include "4 Grades Not Imported"
           expect(response.body).to include "Student not found in course"
         end
       end

--- a/spec/fixtures/files/grades.csv
+++ b/spec/fixtures/files/grades.csv
@@ -1,4 +1,5 @@
 First Name,Last Name,Email,Score,Feedback
 Robert,Plant,robert@example.com,4000,"You did great!"
+That,Guy,that.guy@somewhere.com,1369.897959,
 Jimmy,Page,jimmy,3000,
 John,Bohnem,john@example.com, ,

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -28,7 +28,7 @@ describe CSVGradeImporter do
 
         it "is unsuccessful if the student does not exist" do
           result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 3
+          expect(result.unsuccessful.count).to eq 4
           expect(result.unsuccessful.first[:errors]).to eq "Student not found in course"
         end
       end
@@ -140,7 +140,7 @@ describe CSVGradeImporter do
           allow_any_instance_of(Grade).to receive(:valid?).and_return false
           allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])
           result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 3
+          expect(result.unsuccessful.count).to eq 4
           expect(result.unsuccessful.first[:errors]).to eq "The grade is not cool"
         end
 


### PR DESCRIPTION
### Status
READY

### Description
If the assignment is not of pass/fail type and a non-integer grade is found, the import will fail.

See [this](https://rollbar.com/gradecraft/gradecraft-development/items/1918/) Rollbar error for additional details.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Ensure that invalid grades do not cause the import to fail. They should be marked as invalid on the summary screen with the error message: "Grade is invalid"

### Impacted Areas in Application
Grade Import

======================
Closes #2999
