### PR TITLE
Allow nil on team challenge score

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -35,7 +35,7 @@ class Challenge < ActiveRecord::Base
   validates_inclusion_of :visible, :accepts_submissions, :release_necessary,
   in: [true, false], message: "must be true or false"
 
-  validates_with PositivePointsValidator, attributes: [:full_points]
+  validates_with PositivePointsValidator, attributes: [:full_points], allow_nil: true
   validates_with OpenBeforeCloseValidator, attributes: [:due_at, :open_at]
 
   def has_levels?


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where instructors were unable to create new challenges without assigning points to them

### Migrations
NO

### Steps to Test or Reproduce
Create a new challenge. Don't assign any points to it. Click submit. You should be successfully redirected to the challenge show page. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Challenge creation

======================
Closes #2998 
