### PR TITLE
3007 ordered levels

### DIFF
--- a/app/assets/javascripts/angular/controllers/RubricCtrl.coffee
+++ b/app/assets/javascripts/angular/controllers/RubricCtrl.coffee
@@ -4,14 +4,11 @@
   $scope.courseBadges = RubricFactoryService.badges
   $scope.criteria = RubricFactoryService.criteria
 
-  $scope.savedCriterionCount = 0
-
   $scope.init = (rubricId, assignmentId, pointTotal)->
     $scope.rubricId = rubricId
     $scope.assignmentId = assignmentId
     $scope.pointTotal = parseInt(pointTotal)
     $scope.services()
-
 
   $scope.services = () ->
     # because getting Criteria requires badges from $scope
@@ -54,9 +51,6 @@
   $scope.pointsOverage = ()->
     $scope.pointsDifference() < 0
 
-  $scope.countSavedCriterion = () ->
-    $scope.savedCriterionCount += 1
-
   $scope.newCriterion = ()->
     m = new Criterion(null, $scope)
     $scope.criteria.push m
@@ -93,7 +87,7 @@
 
   # send the criterion order to the server with ids
   $scope.updateCriterionOrder = ()->
-    if $scope.savedCriterionCount > 0
+    if RubricFactoryService.criteria.length > 0
       $http.put("/criteria/update_order", criterion_order: $scope.orderedCriteria()).success(
       )
       .error(

--- a/app/assets/javascripts/angular/factories/Criterion.coffee
+++ b/app/assets/javascripts/angular/factories/Criterion.coffee
@@ -122,7 +122,6 @@
       Restangular.all('criteria').post(@params())
         .then (response)=>
           @id = response.id
-          @$scope.countSavedCriterion()
           @addLevels(response.levels)
 
     modify: (form)->

--- a/app/exporters/rubric_exporter.rb
+++ b/app/exporters/rubric_exporter.rb
@@ -25,7 +25,7 @@ class RubricExporter
   def level_data_for(criterion)
     level_data = []
     # add the levels for the criteria
-    criterion.levels.ordered.inject(level_data) do |memo, level|
+    criterion.levels.ordered.sorted.inject(level_data) do |memo, level|
       memo << "#{level.name} (#{level.points} points) #{level.description}"
     end
   end

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -9,7 +9,7 @@ module AssignmentsHelper
   end
 
   def find_earned_rubric_grade(criterion, student_id)
-    criterion.levels.ordered.to_a.index{|level| level.earned_for?(student_id)}
+    criterion.levels.ordered.sorted.to_a.index{|level| level.earned_for?(student_id)}
   end
 
   # Ten percent higher than threshold for highest level

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -10,6 +10,7 @@ class Level < ActiveRecord::Base
   validates :name, presence: true, length: { maximum: 30 }
 
   scope :ordered, -> { order("points ASC") }
+  scope :sorted, -> { order("sort_order ASC")}
 
   def above_expectations?
     # We treat criterion without a 'meets expectations' level as if none

--- a/app/views/rubrics/components/_criteria.haml
+++ b/app/views/rubrics/components/_criteria.haml
@@ -4,7 +4,7 @@
       %h5.criterion-name= "#{criterion.name}: " "#{points criterion.max_points} Points"
       %p.criterion-description= criterion.description
 
-    - criterion.levels.ordered.reverse.each_with_index do |level, lindex|
+    - criterion.levels.ordered.sorted.reverse.each_with_index do |level, lindex|
       .level-block{:class => ("meets-expectations-cutoff" if level.meets_expectations)}
         - if level.meets_expectations
           %p.meets-expectations-tag Meets expectations #{glyph('long-arrow-up')}

--- a/app/views/rubrics/components/_criteria_graded.haml
+++ b/app/views/rubrics/components/_criteria_graded.haml
@@ -5,7 +5,7 @@
       %p.criterion-description= criterion.description
 
     %ul.level-tabs.rubric-levels{:role => "tablist"}
-      - criterion.levels.ordered.each_with_index do |level, tindex|
+      - criterion.levels.ordered.sorted.each_with_index do |level, tindex|
         %li.level-tab.rubric-level{:class => ("earned" if level.earned_for?(student.id)), id: "tab-#{cindex}-#{tindex}", :role => "tab", "aria-controls" => "tabpanel-#{cindex}-#{tindex}", "aria-selected" => (level.earned_for?(student.id) ? "true" : "false"), "tabindex" => (level.earned_for?(student.id) ? "0" : "-1")}
           - if level.earned_for?(student.id)
             = glyph("check")
@@ -15,7 +15,7 @@
               %p.graded-students= "#{pluralize(level.criterion_grades(current_user).size, 'student')} earned this level"
 
     .tab-panel-container{"data-start-index" => find_earned_rubric_grade(criterion, student.id)}
-      - criterion.levels.ordered.each_with_index do |level, lindex|
+      - criterion.levels.ordered.sorted.each_with_index do |level, lindex|
         .tab-panel{:class => ("earned selected" if level.earned_for?(student.id)), :id => "tabpanel-#{cindex}-#{lindex}", :role => "tabpanel", "aria-labelledby" => "tab-#{cindex}-#{lindex}"}
           .tab-panel-header
             - if level.earned_for?(student.id)

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -1,30 +1,30 @@
 require "rails_spec_helper"
 
-describe Level , focus: true do
+describe Level do
   let(:level) { create :level }
   subject { level }
 
   describe "sort order" do
-    let(:l1) { create :level, points: 100, sort_order: 2 }
-    let(:l2) { create :level, points: 1, sort_order: 3 }
-    let(:l3) { create :level, points: 100, sort_order: 1 }
+    let(:level_1) { create :level, points: 100, sort_order: 2 }
+    let(:level_2) { create :level, points: 1, sort_order: 3 }
+    let(:level_3) { create :level, points: 100, sort_order: 1 }
     let(:criterion) { create :criterion }
 
     before do
       criterion.levels.destroy_all
-      criterion.levels << [l1,l2,l3]
+      criterion.levels << [level_1,level_2,level_3]
     end
 
     it "orders by points" do
-      expect(criterion.levels.ordered.first).to eq(l2)
+      expect(criterion.levels.ordered.first).to eq(level_2)
     end
 
     it "sorts by sort_order" do
-      expect(criterion.levels.sorted).to eq([l3,l1,l2])
+      expect(criterion.levels.sorted).to eq([level_3,level_1,level_2])
     end
 
     it "can be scoped to order by points, and secondarily by sort_order" do
-      expect(criterion.levels.ordered.sorted).to eq([l2,l3,l1])
+      expect(criterion.levels.ordered.sorted).to eq([level_2,level_3,level_1])
     end
   end
 

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -1,8 +1,32 @@
 require "rails_spec_helper"
 
-describe Level do
+describe Level , focus: true do
   let(:level) { create :level }
   subject { level }
+
+  describe "sort order" do
+    let(:l1) { create :level, points: 100, sort_order: 2 }
+    let(:l2) { create :level, points: 1, sort_order: 3 }
+    let(:l3) { create :level, points: 100, sort_order: 1 }
+    let(:criterion) { create :criterion }
+
+    before do
+      criterion.levels.destroy_all
+      criterion.levels << [l1,l2,l3]
+    end
+
+    it "orders by points" do
+      expect(criterion.levels.ordered.first).to eq(l2)
+    end
+
+    it "sorts by sort_order" do
+      expect(criterion.levels.sorted).to eq([l3,l1,l2])
+    end
+
+    it "can be scoped to order by points, and secondarily by sort_order" do
+      expect(criterion.levels.ordered.sorted).to eq([l2,l3,l1])
+    end
+  end
 
   describe "#above_expectations?" do
     it "is false if points are equal to or below expectations" do
@@ -58,8 +82,8 @@ describe Level do
   end
 
   describe "#hide_analytics?" do
-    let(:criterion) { build :criterion, rubric: rubric }
     let(:rubric) { build :rubric }
+    let(:criterion) { build :criterion, rubric: rubric }
     subject { build :level, criterion: criterion }
 
     it "is hidden if the course and assignment are set to hide analytics" do


### PR DESCRIPTION
### Status
**READY**

### Description

This adds a secondary scope to Levels based on the `sort_order`, so that levels with the same points value can be definitively ordered.

It also fixes a small bug in the rubric design page in order to always permit ordering of criteria on the design page.

The way to order levels is now: `levels.ordered.sorted` where ordered is by `points`, and sorted is by `sort_order`.  This naming can be better addressed in a future pr along with a migration to change `sort_order` to the more standardized `order`.

closes #3007 

### Deploy Notes

No interface has been added for ordering Levels, this will have to be done through the console on production.

Please verify in the locations where levels are displayed.

