### PR TITLE
use GradeService in earned badge directive

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -1,11 +1,11 @@
-@gradecraft.directive 'gradeEarnedBadgesSelect', ['BadgeService', (BadgeService) ->
+@gradecraft.directive 'gradeEarnedBadgesSelect', ['GradeService', 'BadgeService', (GradeService, BadgeService) ->
   AwardedBadgesCtrl = [()->
     vm = this
     vm.BadgeService = BadgeService
     BadgeService.getBadges(vm.studentId)
 
     vm.badgeEarnedForGrade = (badge)->
-      BadgeService.studentEarnedBadgeForGrade(vm.studentId, badge.id, vm.gradeId)
+      BadgeService.studentEarnedBadgeForGrade(vm.studentId, badge.id, GradeService.grade.id)
 
     vm.badgeAvailable = (badge)->
       badge.available_for_student || vm.badgeEarnedForGrade(badge)
@@ -19,7 +19,7 @@
         BadgeService.deleteEarnedBadge(earnedBadge)
         badge.available_for_student = true
       else
-        BadgeService.createEarnedBadge(badge.id, vm.studentId, vm.gradeId)
+        BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grade.id)
   ]
 
   {
@@ -28,7 +28,6 @@
     controllerAs: 'vm',
     scope: {
       studentId: '@'
-      gradeId: '@'
     },
     templateUrl: 'grades/earned_badges_select.html'
   }

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -22,7 +22,7 @@
   %grade-file-uploader(ng-if='!vm.isGroupGrade')
   %grade-feedback-text-input
 
-  %grade-earned-badges-select(ng-if='!vm.isGroupGrade' student-id='{{vm.recipientId}}' grade-id='{{vm.gradeService.grade.id}}')
+  %grade-earned-badges-select(ng-if='!vm.isGroupGrade' student-id='{{vm.recipientId}}')
   %hr.grading-divider
 
 .right
@@ -32,5 +32,5 @@
 
 .clear
 %hr.grading-divider
-%span.italic 
+%span.italic
   %grade-last-updated


### PR DESCRIPTION
### Status
**READY**

### Description

A bug has been discovered when awarding badges on the new grade page -- we were creating a bad request by not supplying a grade id.

It seems that the `grade.id` is not guaranteed to update via Angular magic when passed directly  to the `gradeEarnedBadgesSelect` directive.   This solution uses the `GradeService` aa a dependency, so that the id is bound correctly and available when the badge is awarded.