### PR TITLE
3021 Overridden Course Attributes From LTI

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -35,7 +35,7 @@ class UserSessionsController < ApplicationController
       and return unless result.success?
 
     @user = result[:user]
-    @course = Services::CreatesOrUpdatesCourseFromLTI.create_or_update(auth_hash)[:course]
+    @course = Services::CreatesOrUpdatesCourseFromLTI.create_or_update(auth_hash, false)[:course]
     if !@user || !@course
       lti_error_notification
       flash[:alert] = t("sessions.create.error")

--- a/app/services/creates_or_updates_course_from_lti.rb
+++ b/app/services/creates_or_updates_course_from_lti.rb
@@ -6,8 +6,8 @@ module Services
   class CreatesOrUpdatesCourseFromLTI
     extend LightService::Organizer
 
-    def self.create_or_update(auth_hash)
-      with(auth_hash: auth_hash)
+    def self.create_or_update(auth_hash, update_existing=true)
+      with(auth_hash: auth_hash, update_existing: update_existing)
         .reduce(
           Actions::ParseCourseAttributesFromAuthHash,
           Actions::CreatesOrUpdatesCourseByUID

--- a/app/services/creates_or_updates_user_from_lti/creates_or_updates_course_by_uid.rb
+++ b/app/services/creates_or_updates_user_from_lti/creates_or_updates_course_by_uid.rb
@@ -3,13 +3,13 @@ module Services
     class CreatesOrUpdatesCourseByUID
       extend LightService::Action
 
-      expects :course_attributes
+      expects :course_attributes, :update_existing
       promises :course
 
       executed do |context|
         course_attributes = context.course_attributes.merge(year: Date.today.year)
         course = Course.find_or_initialize_by(lti_uid: course_attributes[:lti_uid])
-        course.update! course_attributes
+        course.update!(course_attributes) unless !context.update_existing && course.persisted?
         context[:course] = course
       end
     end

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -45,7 +45,7 @@ describe UserSessionsController do
       allow(subject).to receive(:auth_hash).and_return params
       allow(user_create_result).to receive(:success?).and_return true
       allow(Services::CreatesOrUpdatesUserFromLTI).to receive(:create_or_update).with(params).and_return user_create_result
-      allow(Services::CreatesOrUpdatesCourseFromLTI).to receive(:create_or_update).with(params).and_return({ course: course })
+      allow(Services::CreatesOrUpdatesCourseFromLTI).to receive(:create_or_update).with(params, false).and_return({ course: course })
     end
 
     context "when there is no context role" do

--- a/spec/services/creates_or_updates_course_from_lti_spec.rb
+++ b/spec/services/creates_or_updates_course_from_lti_spec.rb
@@ -16,14 +16,19 @@ describe Services::CreatesOrUpdatesCourseFromLTI do
   end
 
   describe ".create_or_update" do
-    it "parses user attributes from the auth hash" do
+    it "parses course attributes from the auth hash" do
       expect(Services::Actions::ParseCourseAttributesFromAuthHash).to receive(:execute).and_call_original
       described_class.create_or_update auth_hash
     end
 
-    it "decides if a user gets created or updated" do
+    it "decides if a course gets created or updated" do
       expect(Services::Actions::CreatesOrUpdatesCourseByUID).to receive(:execute).and_call_original
       result = described_class.create_or_update auth_hash
+    end
+
+    it "decides if an existing course gets updated if provided" do
+      expect(Services::Actions::CreatesOrUpdatesCourseByUID).to receive(:execute).and_call_original
+      result = described_class.create_or_update auth_hash, false
     end
   end
 end

--- a/spec/services/creates_or_updates_user_from_lti/creates_or_updates_course_by_uid_spec.rb
+++ b/spec/services/creates_or_updates_user_from_lti/creates_or_updates_course_by_uid_spec.rb
@@ -11,37 +11,50 @@ describe Services::Actions::CreatesOrUpdatesCourseByUID do
   end
 
   it "expects course attributes" do
-    expect { described_class.execute }.to \
+    expect { described_class.execute update_existing: true }.to \
       raise_error LightService::ExpectedKeysNotInContextError
   end
 
-  it "promises the course" do
-    result = described_class.execute course_attributes: course_attributes
-    expect(result).to have_key :course
+  it "expects a value for update existing" do
+    expect { described_class.execute course_attributes: course_attributes }.to \
+      raise_error LightService::ExpectedKeysNotInContextError
   end
 
-  context "when the course does not exist" do
-    it "creates a course" do
-      expect{ described_class.execute course_attributes: course_attributes }.to change(Course, :count).by(1)
+  context "when an existing course should be updated" do
+    let(:params) { { course_attributes: course_attributes, update_existing: true } }
+
+    it "creates the course if one is not found" do
+      expect{ described_class.execute params }.to change(Course, :count).by(1)
     end
 
-    it "sets the course attributes" do
-      described_class.execute course_attributes: course_attributes
-      course = Course.unscoped.last
-      expect(course).to have_attributes course_attributes
-    end
-  end
-
-  context "when the course exists" do
-    let!(:course) { create :course, lti_uid: "cosc111" }
-
-    it "does not create a new course" do
-      expect{ described_class.execute course_attributes: course_attributes }.to_not change(Course, :count)
-    end
-
-    it "updates the course attributes" do
-      described_class.execute course_attributes: course_attributes
+    it "updates the course if it is found" do
+      course = create :course, lti_uid: "cosc111"
+      described_class.execute params
       expect(course.reload).to have_attributes course_attributes
+    end
+
+    it "promises the course" do
+      result = described_class.execute params
+      expect(result).to have_key :course
+    end
+  end
+
+  context "when an existing course should not be updated" do
+    let(:params) { { course_attributes: course_attributes, update_existing: false } }
+
+    it "creates the course if one is not found" do
+      expect{ described_class.execute params }.to change(Course, :count).by(1)
+    end
+
+    it "does not update the course if it is found" do
+      course = create :course, lti_uid: "cosc111"
+      described_class.execute params
+      expect(course.reload).to_not have_attributes course_attributes.except(:lti_uid)
+    end
+
+    it "promises the course" do
+      result = described_class.execute params
+      expect(result).to have_key :course
     end
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
If the user is authenticating via LTI, we want to ensure that course attributes are not overridden if the course already exists in Gradecraft.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Ensure that course attributes are not overridden when authenticating via LTI for a course that has a matching `lti_uid` in Gradecraft.

======================
Closes #3021 
