### PR TITLE
styling update to calendar widget

### DIFF
--- a/app/assets/stylesheets/components/_datepicker.sass
+++ b/app/assets/stylesheets/components/_datepicker.sass
@@ -18,6 +18,24 @@
 	.ui-datepicker-next
 		right: 2px
 
+	button.ui-datepicker-current
+		opacity: 1
+		font-weight: 700
+
+	.ui-state-default
+		background: $color-grey-7
+
+	.ui-state-active
+		border: 1px solid $color-blue-3
+		background: $color-blue-3
+		color: $color-white
+
+	table tr:nth-child(even)
+		background-color: inherit
+
+	table tr 
+		border-bottom: none
+
 .ui-timepicker-div
   .ui-widget-header
     margin-bottom: 8px

--- a/app/assets/stylesheets/components/_tables.sass
+++ b/app/assets/stylesheets/components/_tables.sass
@@ -11,7 +11,7 @@ table
   border-collapse: collapse
 
   tr:nth-child(even)
-    background-color: $color-grey-7 !important
+    background-color: $color-grey-7
 
   tr
     border-bottom: 1px solid $color-grey-6


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updates the styling of the Now button and some minimal additional styling to the calendar that helps it feel more unified with GC UI.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* calendar widget usage (any object with due date field)

<img width="288" alt="screen shot 2017-02-27 at 10 05 18 am" src="https://cloud.githubusercontent.com/assets/12573921/23367396/1e07fa4a-fcd8-11e6-942d-fd8584fce3d7.png">

======================
Closes #2810 
