### PR TITLE
allow smartnumber to accept empty string

### DIFF
--- a/app/assets/javascripts/angular/directives/common/smartNumber.coffee
+++ b/app/assets/javascripts/angular/directives/common/smartNumber.coffee
@@ -13,9 +13,6 @@
         if inputValue == '-' || inputValue == '0-'
           modelCtrl.$setViewValue('-')
           inputValue = 0
-        else if inputValue == ''
-          modelCtrl.$setViewValue('')
-          inputValue = 0
         else
           modelCtrl.$setViewValue($filter('number')(inputValue))
 

--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -25,7 +25,7 @@
           total += assignment.grade.final_points
       else if ! assignment.pass_fail && ! assignment.closed_without_submission
         if !(assignment.is_closed_without_submission || assignment.is_closed_by_condition)
-          total += assignment.prediction.predicted_points
+          total += assignment.prediction.predicted_points || 0
     )
     total
 

--- a/app/assets/javascripts/angular/services/ChallengeService.coffee
+++ b/app/assets/javascripts/angular/services/ChallengeService.coffee
@@ -24,7 +24,7 @@
         if challenge.grade.score > 0
           total += challenge.grade.score
         else
-          total += challenge.prediction.predicted_points
+          total += challenge.prediction.predicted_points || 0
       )
     total
 


### PR DESCRIPTION
### Status
**EXPERIMENTAL, NEEDS TESTING**

### Description

This may be a simpler solution that the one I proposed for smart number.  It will require managing models fields which require non-null values from elsewhere, but could ultimately save some of the headaches associated with smart-number by reducing it further rather than trying to add functionality. 

I have tested it with the predictor -- it fixes a bug introduced in [this commit](https://github.com/UM-USElab/gradecraft-development/commit/0c4f4cc3b6211e4d6e3f4fff96835811646aac54) where the field breaks sincronicity with the model. I needed to update a couple summing functions to work with non-integer items but this was much easier than handling everything through the smart-number directive.

@jonathoy I would like to know if this solution works for your use case with GSE, if it does we can run through the other instances tomorrow and verify that they still work as well.

### Related PRs

#3033
#3038

### Todos
- [ ] Test with all uses of smart-number
