### PR TITLE
3049 checkbox award badges

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -4,18 +4,21 @@
     vm.BadgeService = BadgeService
     BadgeService.getBadges(vm.studentId)
 
-    vm.badgeEarnedForGrade = (badge)->
+    # Has the student currently earned this badge on this grade?
+    vm.badgeIsEarnedForGrade = (badge)->
       BadgeService.studentEarnedBadgeForGrade(vm.studentId, badge.id, GradeService.grade.id)
 
-    vm.badgeAvailable = (badge)->
-      badge.available_for_student || vm.badgeEarnedForGrade(badge)
+    # Can the badge be awarded or unawarded for this grade?
+    vm.badgeIsActionable = (badge)->
+      badge.available_for_student || vm.badgeIsEarnedForGrade(badge)
 
-    vm.badgeAwardable = (badge)->
-      badge.available_for_student && !vm.badgeEarnedForGrade(badge)
+    # Can the badge be awarded for this grade?
+    vm.badgeIsAwardable = (badge)->
+      badge.available_for_student && !vm.badgeIsEarnedForGrade(badge)
 
     vm.awardBadge = (badge)->
-      return if !vm.badgeAvailable(badge)
-      if earnedBadge = vm.badgeEarnedForGrade(badge)
+      return if !vm.badgeIsActionable(badge)
+      if earnedBadge = vm.badgeIsEarnedForGrade(badge)
         BadgeService.deleteEarnedBadge(earnedBadge)
         badge.available_for_student = true
       else

--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -16,6 +16,13 @@
     vm.badgeIsAwardable = (badge)->
       badge.available_for_student && !vm.badgeIsEarnedForGrade(badge)
 
+    # For accessibility, each checkbox must have a label with a unique id
+    vm.inputId = (badge)->
+      badge.name.toLowerCase().replace(/[\W]/g,"-") + badge.id
+
+    # ACTION: toggle the badge award on this grade.
+    #  - award if unawarded
+    #  - remove if currently awarded
     vm.awardBadge = (badge)->
       return if !vm.badgeIsActionable(badge)
       if earnedBadge = vm.badgeIsEarnedForGrade(badge)

--- a/app/assets/javascripts/angular/services/BadgeService.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.coffee
@@ -20,6 +20,10 @@
   studentEarnedBadgeForGrade = (studentId, badgeId, gradeId)->
     _.find(earnedBadges,{ badge_id: parseInt(badgeId), grade_id: parseInt(gradeId) })
 
+  setBadgeIsUpdating = (badgeId, isUpdating=true)->
+    badge = _.find(badges, {id: badgeId})
+    badge.isUpdating = isUpdating
+
   #------ API Calls -----------------------------------------------------------#
 
   # GET index list of badges
@@ -59,6 +63,7 @@
 
   # currently creates explictly for a student and a grade
   createEarnedBadge = (badgeId, studentId, gradeId)->
+    setBadgeIsUpdating(badgeId)
     requestParams = {
       "student_id": studentId,
       "badge_id": badgeId,
@@ -70,19 +75,23 @@
         if response.status == 201
           GradeCraftAPI.addItem(earnedBadges, "earned_badges", response.data)
         GradeCraftAPI.logResponse(response)
-
+        setBadgeIsUpdating(badgeId, false)
       ,(response)-> # error
         GradeCraftAPI.logResponse(response)
+        setBadgeIsUpdating(badgeId, false)
     )
 
   deleteEarnedBadge = (earnedBadge)->
+    setBadgeIsUpdating(earnedBadge.badge_id)
     $http.delete("/api/earned_badges/#{earnedBadge.id}").then(
       (response)-> # success
         if response.status == 200
+          setBadgeIsUpdating(earnedBadge.badge_id, false)
           GradeCraftAPI.deleteItem(earnedBadges, earnedBadge)
         GradeCraftAPI.logResponse(response)
 
       ,(response)-> # error
+        setBadgeIsUpdating(earnedBadge.badge_id, false)
         GradeCraftAPI.logResponse(response)
     )
 

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,12 +1,16 @@
 %section.badge-index-section(ng-if="vm.BadgeService.badges.length > 0")
   .grade-section-label Award {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
-  .badge-award-container(ng-repeat="badge in vm.BadgeService.badges"
-  ng-click="vm.awardBadge(badge)"
+
+  %label.badge-award-container(for="{{vm.inputId(badge)}}"
+  ng-click="vm.awardBadge(badge)" ng-repeat="badge in vm.BadgeService.badges"
   ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
   )
-    .badge-award-checkmark
+    .badge-award-checkmark(id="{{vm.inputId(badge)}}")
       %input(ng-if="vm.badgeIsActionable(badge)" type="checkbox" ng-checked="vm.badgeIsEarnedForGrade(badge)")
-    .badge-award-image
+    .badge-award-image(ng-if="!badge.isUpdating")
       %img(ng-src="{{badge.icon}}")
+    .badge-award-is-updating(ng-if="badge.isUpdating")
+      %i.fa.fa-spinner.fa-spin.fa-fw
+
     .badge-award-name {{badge.name}}
 .clear

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -2,11 +2,16 @@
   .grade-section-label Award {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
 
   %label.badge-award-container(for="{{vm.inputId(badge)}}"
-  ng-click="vm.awardBadge(badge)" ng-repeat="badge in vm.BadgeService.badges"
+  ng-repeat="badge in vm.BadgeService.badges"
   ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
   )
-    .badge-award-checkmark(id="{{vm.inputId(badge)}}")
-      %input(ng-if="vm.badgeIsActionable(badge)" type="checkbox" ng-checked="vm.badgeIsEarnedForGrade(badge)")
+    .badge-award-checkmark
+      %input(id="{{vm.inputId(badge)}}"
+      ng-if="vm.badgeIsActionable(badge)"
+      type="checkbox"
+      ng-checked="vm.badgeIsEarnedForGrade(badge)"
+      ng-click="vm.awardBadge(badge)"
+    )
     .badge-award-image(ng-if="!badge.isUpdating")
       %img(ng-src="{{badge.icon}}")
     .badge-award-is-updating(ng-if="badge.isUpdating")

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -12,10 +12,8 @@
       ng-checked="vm.badgeIsEarnedForGrade(badge)"
       ng-click="vm.awardBadge(badge)"
     )
-    .badge-award-image(ng-if="!badge.isUpdating")
+    .badge-award-image
       %img(ng-src="{{badge.icon}}")
-    .badge-award-is-updating(ng-if="badge.isUpdating")
-      %i.fa.fa-spinner.fa-spin.fa-fw
 
     .badge-award-name {{badge.name}}
 .clear

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,10 +1,12 @@
 %section.badge-index-section(ng-if="vm.BadgeService.badges.length > 0")
   .grade-section-label Award {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
-  .badge-icon-container.badge-award-button(ng-repeat="badge in vm.BadgeService.badges"
+  .badge-award-container(ng-repeat="badge in vm.BadgeService.badges"
   ng-click="vm.awardBadge(badge)"
-  ng-class='{"unavailable":!vm.badgeAvailable(badge), "awardable":vm.badgeAwardable(badge), "awarded":vm.badgeEarnedForGrade(badge)}'
+  ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
   )
-    %input.award-badge-checkbox(ng-if="vm.badgeAwardable(badge)" type="checkbox" ng-checked="vm.badgeEarnedForGrade(badge)")
-    %img.badge-icon(ng-src="{{badge.icon}}")
-    %p.badge-name {{badge.name}}
-
+    .badge-award-checkmark
+      %input(ng-if="vm.badgeIsActionable(badge)" type="checkbox" ng-checked="vm.badgeIsEarnedForGrade(badge)")
+    .badge-award-image
+      %img(ng-src="{{badge.icon}}")
+    .badge-award-name {{badge.name}}
+.clear

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,14 +1,10 @@
-%section.badge-index-section{'ng-if'=>'vm.BadgeService.badges.length > 0'}
-  .grade-section-label Award Earned {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
-  .badge-icon-container.badge-award-button{'ng-repeat'=>'badge in vm.BadgeService.badges',
-    'ng-click'=>'vm.awardBadge(badge)',
-    'ng-class'=>'{"unavailable":!vm.badgeAvailable(badge), "awardable":vm.badgeAwardable(badge), "awarded":vm.badgeEarnedForGrade(badge)}',
-    }
-    %img.badge-icon{'ng-src'=>'{{badge.icon}}'}
-
+%section.badge-index-section(ng-if="vm.BadgeService.badges.length > 0")
+  .grade-section-label Award {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
+  .badge-icon-container.badge-award-button(ng-repeat="badge in vm.BadgeService.badges"
+  ng-click="vm.awardBadge(badge)"
+  ng-class='{"unavailable":!vm.badgeAvailable(badge), "awardable":vm.badgeAwardable(badge), "awarded":vm.badgeEarnedForGrade(badge)}'
+  )
+    %input.award-badge-checkbox(ng-if="vm.badgeAwardable(badge)" type="checkbox" ng-checked="vm.badgeEarnedForGrade(badge)")
+    %img.badge-icon(ng-src="{{badge.icon}}")
     %p.badge-name {{badge.name}}
-    .status-icon
-      %i.fa.fa-fw.fa-star{'ng-show'=>'vm.badgeEarnedForGrade(badge)'}
-    .status-icon-hover
-      %i.fa.fa-fw.fa-minus-circle{'ng-show'=>'vm.badgeEarnedForGrade(badge)'}
-      %i.fa.fa-fw.fa-plus-circle{'ng-show'=>'vm.badgeAwardable(badge)'}
+

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -141,38 +141,6 @@
     display: block
     margin: 0 auto
 
-// Award Earned Badges on Grading Page
-.badge-icon-container.badge-award-button
-  cursor: pointer
-  .status-icon, .status-icon-hover
-    position: absolute
-    top: 0px
-    right: 0px
-    height: 28px
-    width: 28px
-    border-radius: 50%
-    font-size: 2rem
-    color: $color-yellow-1
-    .fa-fw
-      text-align: left
-
-  &.unavailable
-    cursor: default
-    img
-      cursor: default
-    opacity: .5
-    &:hover
-      .status-icon-hover
-        display: none
-
-  .status-icon-hover
-    display: none
-  &:hover
-    .status-icon
-      display: none
-    .status-icon-hover
-      display: block
-
 ul.earned-badge-list
   list-style-type: none
   padding-left: 0
@@ -185,3 +153,12 @@ ul.earned-badge-list
 .earned-badge-table-img
   vertical-align: middle
   width: 20px
+
+// Award Earned Badges on Grading Page
+.badge-icon-container.badge-award-button
+  cursor: pointer
+  &.unavailable
+    cursor: default
+    img
+      cursor: default
+    opacity: .5

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -176,7 +176,7 @@ ul.earned-badge-list
   width: 1rem
   float: left
 
-.badge-award-image, .badge-award-is-updating
+.badge-award-image
   width: 50px
   height: 50px
   float: left

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -155,10 +155,31 @@ ul.earned-badge-list
   width: 20px
 
 // Award Earned Badges on Grading Page
-.badge-icon-container.badge-award-button
+.badge-award-container
+  float: left
+  margin: 1rem
+  width: 29%
+  vertical-align: top
   cursor: pointer
+  img
+    width: 40px
   &.unavailable
     cursor: default
     img
       cursor: default
     opacity: .5
+
+.badge-award-checkmark
+  margin: 0.55rem
+  width: 1rem
+  float: left
+
+.badge-award-image
+  width: 50px
+  float: left
+
+.badge-award-name
+  font-size: .7rem
+  margin: 0.55rem 0 0 0.55rem
+
+

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -176,12 +176,15 @@ ul.earned-badge-list
   width: 1rem
   float: left
 
-.badge-award-image
+.badge-award-image, .badge-award-is-updating
   width: 50px
+  height: 50px
   float: left
+  font-size: 1.5rem
 
 .badge-award-name
   font-size: .7rem
   margin: 0.55rem 0 0 0.55rem
+  display: inline-block
 
 

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -170,6 +170,8 @@ ul.earned-badge-list
     opacity: .5
 
 .badge-award-checkmark
+  input
+    cursor: pointer
   margin: 0.55rem
   width: 1rem
   float: left


### PR DESCRIPTION
### Status
**READY**

### Description

Rebuilds the `gradeEarnedBadgesSelect` directive and corresponding template to match proposed style and behavior.  Includes checkbox functionality. 

![screen shot 2017-03-02 at 2 42 00 pm](https://cloud.githubusercontent.com/assets/1138350/23523867/75b81916-ff56-11e6-9a25-10bb2c44afa2.png)

### To Test

Award badges on a grade, verify that they persist. Verify on reload awarded badges are shown with a checkmark in the checkbox.

closes #3049 