### PR TITLE
Remove Highest Points from GSE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ group :development, :test do
   gem 'pry'
   gem 'pry-byebug'
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'jasmine-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
       rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bson (4.1.1)
     builder (3.2.3)
     byebug (9.0.5)
@@ -133,6 +135,7 @@ GEM
     dalli (2.7.6)
     database_cleaner (1.5.3)
     db-query-matchers (0.6.0)
+    debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.1.1)
@@ -629,6 +632,7 @@ DEPENDENCIES
   autoprefixer-rails
   aws-sdk (~> 2)
   better_errors
+  binding_of_caller
   cancancan
   capybara
   capybara-select2

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -21,12 +21,7 @@
 
       # Invalid because it is in direct conflict with another level
       if element.lowest_points == currentElement.lowest_points
-        currentElement.validationError = "This level has the same point threshold as another level."
-
-      # Invalid because it is within one point of another level
-      if element.lowest_points - 1 == currentElement.lowest_points ||
-          element.lowest_points + 1 == currentElement.lowest_points
-        currentElement.validationError = "This level is within one point of another level."
+        currentElement.validationError = "This level has the same point threshold as another level"
 
   removeElement = (currentElement) ->
     if currentElement.lowest_points == 0 && isOnlyZeroThreshold(currentElement)

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -49,7 +49,7 @@
 
   addZeroThreshold = () ->
     zeroElement = _newElement()
-    zeroElement.level = "Not yet on board"
+    zeroElement.level = "Not yet on the board"
     zeroElement.lowest_points = 0
     gradeSchemeElements.push(zeroElement)
     validateElements()  # ensure zero threshold does not conflict with existing

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -54,7 +54,7 @@
 
   addZeroThreshold = () ->
     zeroElement = _newElement()
-    zeroElement.level = "Not yet defined"
+    zeroElement.level = "Not yet on board"
     zeroElement.lowest_points = 0
     gradeSchemeElements.push(zeroElement)
     validateElements()  # ensure zero threshold does not conflict with existing

--- a/app/assets/javascripts/angular/services/PredictorService.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.coffee
@@ -12,7 +12,7 @@
 
   #------ GRADE SCHEME ELEMENTS -----------------------------------------------#
 
-  gradeSchemeElements = GradeSchemeElementsService.elements
+  gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
 
   totalPoints = ()->
     GradeSchemeElementsService.totalPoints()

--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -5,7 +5,7 @@ class API::GradeSchemeElementsController < ApplicationController
   def index
     @grade_scheme_elements = current_course
                              .grade_scheme_elements
-                             .order_by_highest_points.select(
+                             .order_by_points_desc.select(
                                :id,
                                :lowest_points,
                                :highest_points,

--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -2,13 +2,13 @@
 # earn course wide levels and grades
 class API::GradeSchemeElementsController < ApplicationController
 
+  # GET /api/grade_scheme_elements
   def index
     @grade_scheme_elements = current_course
                              .grade_scheme_elements
                              .order_by_points_desc.select(
                                :id,
                                :lowest_points,
-                               :highest_points,
                                :letter,
                                :level)
     if @grade_scheme_elements.present?

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -5,7 +5,7 @@ class GradeSchemeElementsController < ApplicationController
 
   def index
     @grade_scheme_elements = current_course
-                             .grade_scheme_elements.order_by_highest_points
+                             .grade_scheme_elements.order_by_points_desc
   end
 
   def edit
@@ -27,7 +27,7 @@ class GradeSchemeElementsController < ApplicationController
     @course = current_course
     @total_points = current_course.total_points
     @grade_scheme_elements =  current_course
-                              .grade_scheme_elements.order_by_highest_points.select(
+                              .grade_scheme_elements.order_by_points_desc.select(
                                 :id,
                                 :level,
                                 :lowest_points,

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -32,7 +32,6 @@ class GradeSchemeElementsController < ApplicationController
                                 :level,
                                 :lowest_points,
                                 :letter,
-                                :highest_points,
                                 :course_id)
   end
 
@@ -55,7 +54,6 @@ class GradeSchemeElementsController < ApplicationController
             :level,
             :lowest_points,
             :letter,
-            :highest_points,
             :course_id)
         end
       else
@@ -75,42 +73,11 @@ class GradeSchemeElementsController < ApplicationController
 
   def grade_scheme_element_params
     params.require(:grade_scheme_element).permit :id, :letter, :lowest_points,
-      :highest_points, :level, :description, :course_id, unlock_conditions_attributes: [:id, :unlockable_id, :unlockable_type, :condition_id, :condition_type, :condition_state, :condition_value, :condition_date, :_destroy]
+      :level, :description, :course_id, unlock_conditions_attributes: [:id, :unlockable_id, :unlockable_type, :condition_id, :condition_type, :condition_state, :condition_value, :condition_date, :_destroy]
   end
 
   def grade_scheme_elements_attributes_params
-    fix_grade_scheme_elements_attributes_params
     params.permit grade_scheme_elements_attributes: [:id, :letter, :lowest_points,
-      :highest_points, :level, :description, :course_id]
-  end
-
-  # Clean up the grade_scheme_elements_attributes param and modify
-  # highest_points for each Element to be one point lower than the next level's
-  # lowest_points.
-  def fix_grade_scheme_elements_attributes_params
-    gse_attributes = params["grade_scheme_elements_attributes"]
-
-    gse_attributes.sort_by! { |e| e["lowest_points"].to_i }
-
-    # Make sure first element's lowest_points is zero
-    if gse_attributes.first["lowest_points"].to_i != 0
-      gse_attributes.unshift({
-        "level"=>"-", "lowest_points"=>0, "letter"=>"", "highest_points"=>0
-      })
-    end
-
-    gse_attributes.each_with_index do |gse, i|
-      next_gse = gse_attributes[i+1]
-      if next_gse.nil?
-        # Make sure last element's highest_points is course's max points
-        if gse["lowest_points"].to_i < @course.total_points.to_i
-          gse["highest_points"] = @course.total_points.to_i
-        else
-          gse["highest_points"] = gse["highest_points"].to_i + 1
-        end
-      else
-        gse["highest_points"] = next_gse["lowest_points"].to_i - 1
-      end
-    end
+      :level, :description, :course_id]
   end
 end

--- a/app/exporters/grade_scheme_exporter.rb
+++ b/app/exporters/grade_scheme_exporter.rb
@@ -3,8 +3,7 @@ class GradeSchemeExporter
     CSV.generate do |csv|
       csv << baseline_headers
       course.grade_scheme_elements.each do |gse|
-        csv << [ gse.id, gse.letter, gse.level,
-          gse.lowest_points, gse.highest_points ]
+        csv << [gse.id, gse.letter, gse.level, gse.lowest_points]
       end
     end
   end
@@ -12,6 +11,6 @@ class GradeSchemeExporter
   private
 
   def baseline_headers
-    ["Level ID", "Letter Grade", "Level Name", "Lowest Points", "Highest Points" ]
+    ["Level ID", "Letter Grade", "Level Name", "Lowest Points"]
   end
 end

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -17,19 +17,19 @@ module AssignmentsHelper
     if current_course.grade_scheme_elements.empty?
       current_course.total_points
     else
-      (current_course.grade_scheme_elements.order_by_highest_points[0].lowest_points * 110) / 100
+      (current_course.grade_scheme_elements.order_by_points_desc[0].lowest_points * 110) / 100
     end
   end
 
   def percent_of_total_points(level_index)
-    ((current_course.grade_scheme_elements.order_by_highest_points[level_index].lowest_points).to_f / total_available_points.to_f * 100).round(2)
+    ((current_course.grade_scheme_elements.order_by_points_desc[level_index].lowest_points).to_f / total_available_points.to_f * 100).round(2)
   end
 
   def level_letter_grade(level_index)
-    current_course.grade_scheme_elements.order_by_highest_points[level_index].letter
+    current_course.grade_scheme_elements.order_by_points_desc[level_index].letter
   end
 
   def level_point_threshold(level_index)
-    current_course.grade_scheme_elements.order_by_highest_points[level_index].lowest_points
+    current_course.grade_scheme_elements.order_by_points_desc[level_index].lowest_points
   end
 end

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -60,12 +60,12 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def check_and_update_student_earned_level
-    course.grade_scheme_elements.order_by_lowest_points.map { |gse| gse.unlock!(user) }
+    course.grade_scheme_elements.order_by_points_asc.map { |gse| gse.unlock!(user) }
     update_attributes earned_grade_scheme_element_id: earned_grade_scheme_element.try(:id)
   end
 
   def earned_grade_scheme_element(grade_scheme_elements=nil)
-    elements = grade_scheme_elements || course.grade_scheme_elements.order_by_lowest_points
+    elements = grade_scheme_elements || course.grade_scheme_elements.order_by_points_asc
     element_earned = nil
 
     elements.sort_by{ |element| element.lowest_points }.each_with_index do |gse, index|

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -8,8 +8,8 @@ class GradeSchemeElement < ActiveRecord::Base
   validates_presence_of :lowest_points, :course
 
   scope :for_course, -> (course_id) { where(course_id: course_id) }
-  scope :order_by_lowest_points, -> { order "lowest_points ASC" }
-  scope :order_by_highest_points, -> { order "lowest_points DESC" }
+  scope :order_by_points_asc, -> { order "lowest_points ASC" }
+  scope :order_by_points_desc, -> { order "lowest_points DESC" }
 
   def self.default
     GradeSchemeElement.new(level: "Not yet on board")
@@ -17,7 +17,7 @@ class GradeSchemeElement < ActiveRecord::Base
 
   def self.next_highest_element(element)
     nextElement = nil
-    ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_lowest_points
+    ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
     ordered_course_elements.each_with_index do |currentElement, i|
       if element == currentElement
         nextElement = ordered_course_elements[i+1]

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -58,14 +58,19 @@ class GradeSchemeElement < ActiveRecord::Base
   end
 
   def next_highest_element
-    GradeSchemeElement.next_highest_element self
+    @next_highest_element ||= GradeSchemeElement.next_highest_element self
+  end
+
+  # The highest point value for the element
+  def highest_points
+    return Float::INFINITY if next_highest_element.nil?
+    next_highest_element.lowest_points - 1
   end
 
   # Calculating the points that covers this element
   # Returns infinity if the element has the highest ordered point value in the course
   def range
-    return Float::INFINITY if next_highest_element.nil?
-    (next_highest_element.lowest_points - 1).to_f - lowest_points.to_f
+    highest_points.to_f - lowest_points.to_f
   end
 
   def within_range?(score)

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -15,6 +15,18 @@ class GradeSchemeElement < ActiveRecord::Base
     GradeSchemeElement.new(level: "Not yet on board")
   end
 
+  def self.next_highest_element(element)
+    nextElement = nil
+    ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_lowest_points
+    ordered_course_elements.each_with_index do |currentElement, i|
+      if element == currentElement
+        nextElement = ordered_course_elements[i+1]
+        break
+      end
+    end
+    nextElement
+  end
+
   # Getting the name of the Grade Scheme Element - the Level if it's present,
   # the Letter if not
   def name
@@ -29,27 +41,34 @@ class GradeSchemeElement < ActiveRecord::Base
     end
   end
 
-  # Calculating the points that covers this element
-  def range
-    highest_points.to_f - lowest_points.to_f
-  end
-
   # Figuring out how many points a student has to earn the next level
   def points_to_next_level(student, course)
-    # if high points, +1
-    highest_points - student.score_for_course(course) + 1
+    return 0 if next_highest_element.nil?
+    next_highest_element.lowest_points - student.score_for_course(course)
   end
 
   # Calculating how far a student is through this level
   def progress_percent(student)
-    ((student.score_for_course(course) - lowest_points) / range) * 100
-  end
-
-  def within_range?(score)
-    score >= lowest_points && score <= highest_points
+    return 100 if range == Float::INFINITY
+    ((student.score_for_course(course).to_f - lowest_points.to_f) / range) * 100
   end
 
   def count_students_earned
     course.course_memberships.being_graded.where(earned_grade_scheme_element_id: self.id).count
+  end
+
+  def next_highest_element
+    GradeSchemeElement.next_highest_element self
+  end
+
+  # Calculating the points that covers this element
+  # Returns infinity if the element has the highest ordered point value in the course
+  def range
+    return Float::INFINITY if next_highest_element.nil?
+    next_highest_element.lowest_points.to_f - lowest_points.to_f
+  end
+
+  def within_range?(score)
+    score >= lowest_points && score <= highest_points
   end
 end

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -65,7 +65,7 @@ class GradeSchemeElement < ActiveRecord::Base
   # Returns infinity if the element has the highest ordered point value in the course
   def range
     return Float::INFINITY if next_highest_element.nil?
-    next_highest_element.lowest_points.to_f - lowest_points.to_f
+    (next_highest_element.lowest_points - 1).to_f - lowest_points.to_f
   end
 
   def within_range?(score)

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -16,15 +16,15 @@ class GradeSchemeElement < ActiveRecord::Base
   end
 
   def self.next_highest_element(element)
-    nextElement = nil
+    next_element = nil
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
-    ordered_course_elements.each_with_index do |currentElement, i|
-      if element == currentElement
-        nextElement = ordered_course_elements[i+1]
+    ordered_course_elements.each_with_index do |current_element, i|
+      if element == current_element
+        next_element = ordered_course_elements[i+1]
         break
       end
     end
-    nextElement
+    next_element
   end
 
   # Getting the name of the Grade Scheme Element - the Level if it's present,

--- a/app/models/grade_scheme_element_scoring_extension.rb
+++ b/app/models/grade_scheme_element_scoring_extension.rb
@@ -1,6 +1,6 @@
 module GradeSchemeElementScoringExtension
   def for_score(score)
-    elements = unscope(:order).order_by_lowest_points
+    elements = unscope(:order).order_by_points_asc
     unless elements.empty?
       earned_element = elements.find { |element| element.within_range?(score) }
       earned_element ||= elements.last if score > elements.last.highest_points

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,7 +236,7 @@ class User < ActiveRecord::Base
   end
 
   def get_element_level(course, direction)
-    course_elements = course.grade_scheme_elements.order_by_lowest_points.to_a
+    course_elements = course.grade_scheme_elements.order_by_points_asc.to_a
 
     current_element = self.grade_for_course(course)
     current_element_index = course_elements.index{ |item| item == current_element }

--- a/app/presenters/info/dashboard_grading_scheme_presenter.rb
+++ b/app/presenters/info/dashboard_grading_scheme_presenter.rb
@@ -20,12 +20,12 @@ class Info::DashboardGradingSchemePresenter < Showtime::Presenter
   end
 
   def course_elements
-    GradeSchemeElement.for_course(course).order_by_lowest_points
+    GradeSchemeElement.for_course(course).order_by_points_asc
   end
 
   # showing first element of grading scheme if current score does not reflect a level
   def first_element
-    GradeSchemeElement.for_course(course).order_by_lowest_points.first
+    GradeSchemeElement.for_course(course).order_by_points_asc.first
   end
 
   def current_element

--- a/app/presenters/students/index_presenter.rb
+++ b/app/presenters/students/index_presenter.rb
@@ -39,7 +39,7 @@ class Students::IndexPresenter < Showtime::Presenter
   end
 
   def grade_scheme_elements
-    @grade_scheme_elements ||= course.grade_scheme_elements.order_by_lowest_points
+    @grade_scheme_elements ||= course.grade_scheme_elements.order_by_points_asc
   end
 
   def student_ids

--- a/app/views/grade_scheme_elements/_index_student.haml
+++ b/app/views/grade_scheme_elements/_index_student.haml
@@ -11,7 +11,7 @@
             %span= points element.lowest_points
             - if element.unlock_conditions.present?
               = render partial: "unlock_icons", locals: { student: current_student, gse: element }
-      - elsif current_student.score_for_course(current_course) >= element.highest_points && element.is_unlocked_for_student?(current_student)
+      - elsif current_student.score_for_course(current_course) > element.highest_points && element.is_unlocked_for_student?(current_student)
         .progress.bar_magic.success.center
           .meter
             %i.fa.fa-star

--- a/app/views/info/dashboard/modules/_dashboard_instructor_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_instructor_grading_scheme.haml
@@ -1,7 +1,7 @@
 .chart-labels
   %span Level
   %span.right # of Students
-- current_course.grade_scheme_elements.order_by_highest_points.each do |element|
+- current_course.grade_scheme_elements.order_by_points_desc.each do |element|
   .progress.bar_magic
     .meter
       .level-name #{element.name} #{points element.lowest_points}

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -121,7 +121,6 @@ puts "Children must be taught how to think, not what to think. ― Margaret Mead
       e.letter = letter
       e.level = levels[i]
       e.lowest_points = points.first
-      e.highest_points = points.last
     end
   end
   puts_success :course, course_name, :grade_sceme_elements_created

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -66,7 +66,7 @@ describe GradeSchemeElementsController do
           letter: "B", level: "Snail", lowest_points: nil,
           course_id: course.id}], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
         put :mass_update, params: params, format: :json
-        expect(grade_scheme_element.reload.highest_points).to eq(100000)
+        expect(grade_scheme_element.reload).to eq grade_scheme_element
         expect(response.status).to eq(500)
       end
     end

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -50,8 +50,8 @@ describe GradeSchemeElementsController do
       it "updates the grade scheme elements all at once" do
         params = { "grade_scheme_elements_attributes" => [{
           id: grade_scheme_element.id, letter: "C", level: "Sea Slug", lowest_points: 0,
-          highest_points: 100000, course_id: course.id }, { id: GradeSchemeElement.new.id,
-          letter: "B", level: "Snail", lowest_points: 100001, highest_points: 200000,
+          course_id: course.id }, { id: GradeSchemeElement.new.id,
+          letter: "B", level: "Snail", lowest_points: 100001,
           course_id: course.id }], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
         put :mass_update, params: params, format: :json
         expect(course.reload.grade_scheme_elements.count).to eq(2)
@@ -62,8 +62,8 @@ describe GradeSchemeElementsController do
         grade_scheme_element_2 = create(:grade_scheme_element, course: course)
         params = { "grade_scheme_elements_attributes" => [{
           id: grade_scheme_element.id, letter: "C", level: "Sea Slugs Galore", lowest_points: 0,
-          highest_points: 100010, course_id: course.id }, { id: GradeSchemeElement.new.id,
-          letter: "B", level: "Snail", lowest_points: nil, highest_points: 200000,
+          course_id: course.id }, { id: GradeSchemeElement.new.id,
+          letter: "B", level: "Snail", lowest_points: nil,
           course_id: course.id}], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
         put :mass_update, params: params, format: :json
         expect(grade_scheme_element.reload.highest_points).to eq(100000)
@@ -74,16 +74,17 @@ describe GradeSchemeElementsController do
     it "recalculates scores for all students in the course" do
       params = { "grade_scheme_elements_attributes" => [{
         id: grade_scheme_element.id, letter: "C", level: "Sea Slug", lowest_points: 0,
-        highest_points: 100000, course_id: course.id }, { id: GradeSchemeElement.new.id,
-        letter: "B", level: "Snail", lowest_points: 100001, highest_points: 200000,
+        course_id: course.id }, { id: GradeSchemeElement.new.id,
+        letter: "B", level: "Snail", lowest_points: 100001,
         course_id: course.id }], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
-      expect{ put :mass_update, params: params, format: :json }.to change { queue(ScoreRecalculatorJob).size }.by(course.students.count)
+      expect{ put :mass_update, params: params, format: :json }.to \
+        change { queue(ScoreRecalculatorJob).size }.by(course.students.count)
     end
 
     describe "GET export_structure" do
       it "retrieves the export_structure download" do
         get :export_structure, params: { id: course.id }, format: :csv
-        expect(response.body).to include("Level ID,Letter Grade,Level Name,Lowest Points,Highest Points")
+        expect(response.body).to include("Level ID,Letter Grade,Level Name,Lowest Points")
       end
     end
   end

--- a/spec/exporters/course_grade_exporter_spec.rb
+++ b/spec/exporters/course_grade_exporter_spec.rb
@@ -19,7 +19,7 @@ describe CourseGradeExporter do
       @students = course.students
       create(:course_membership, :student, course: course, user: @student_2, score: 120000)
       create(:grade_scheme_element, course: course, level: "Amazing", letter: "B-")
-      create(:grade_scheme_element, course: course, lowest_points: 100001, highest_points: 200000, level: "Phenomenal", letter: "B")
+      create(:grade_scheme_element, course: course, lowest_points: 100001, level: "Phenomenal", letter: "B")
 
       csv = CSV.new(subject.final_grades_for_course(course)).read
       expect(csv.length).to eq 3
@@ -42,7 +42,5 @@ describe CourseGradeExporter do
       expect(csv[1][8]).to eq "#{@student.id}"
       expect(csv[2][8]).to eq "#{@student_2.id}"
     end
-
   end
-
 end

--- a/spec/factories/grade_scheme_element_factory.rb
+++ b/spec/factories/grade_scheme_element_factory.rb
@@ -5,21 +5,18 @@ FactoryGirl.define do
 
     factory :grade_scheme_element_high do
       lowest_points 10000
-      highest_points 20000
       letter { "A" }
       level { "Amazing" }
     end
 
     factory :grade_scheme_element_low do
       lowest_points 0
-      highest_points 9999
       letter { "F" }
       level { "Awful" }
     end
 
     factory :grade_scheme_element_highest do
       lowest_points 20001
-      highest_points 30000
       letter { "A+" }
       level { "Ahhhmazing" }
     end

--- a/spec/factories/grade_scheme_element_factory.rb
+++ b/spec/factories/grade_scheme_element_factory.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :grade_scheme_element do
     association :course
     lowest_points 0
-    highest_points 100000
 
     factory :grade_scheme_element_high do
       lowest_points 10000
@@ -17,13 +16,12 @@ FactoryGirl.define do
       letter { "F" }
       level { "Awful" }
     end
-    
-    factory :grade_scheme_element_highest do 
+
+    factory :grade_scheme_element_highest do
       lowest_points 20001
       highest_points 30000
       letter { "A+" }
       level { "Ahhhmazing" }
     end
-
   end
 end

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -27,12 +27,9 @@ describe AssignmentsHelper do
     let(:course) { create :course}
     let(:assignment_type) {create :assignment_type, course: course}
     let(:level_index) {1}
-    let!(:high) { create(:grade_scheme_element, lowest_points: 2001,
-                         highest_points: 3000, letter: "A", course: course) }
-    let!(:low) { create(:grade_scheme_element, lowest_points: 100,
-                        highest_points: 1000, letter: "C", course: course) }
-    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001,
-                           highest_points: 2000, letter: "B", course: course) }
+    let!(:high) { create(:grade_scheme_element, lowest_points: 2001, letter: "A", course: course) }
+    let!(:low) { create(:grade_scheme_element, lowest_points: 100, letter: "C", course: course) }
+    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001, letter: "B", course: course) }
 
     before(:each) do
      allow(helper).to receive(:current_course).and_return course
@@ -52,14 +49,14 @@ describe AssignmentsHelper do
        expect(percent_of_total_points).to eq(45.48)
       end
     end
-    
+
     describe "level_letter_grade" do
       it "returns letter of selected grade scheme element" do
         level_letter_grade = helper.level_letter_grade(level_index)
         expect(level_letter_grade).to eq("B")
       end
     end
-    
+
     describe "level_point_threshold" do
       it "returns point threshold of selected grade scheme element" do
         level_point_threshold = helper.level_point_threshold(level_index)

--- a/spec/models/course_membership/student_score_recalculation_spec.rb
+++ b/spec/models/course_membership/student_score_recalculation_spec.rb
@@ -4,7 +4,7 @@ describe CourseMembership do
   let(:course_membership) { build(:course_membership, :student, course: course, user: student) }
   let(:course) { build(:course) }
   let(:student) { build(:user) }
-  let!(:gse) { create(:grade_scheme_element, course: course, lowest_points: 8000, highest_points: 9000) }
+  let!(:gse) { create(:grade_scheme_element, course: course, lowest_points: 8000) }
 
   describe "#recalculate_and_update_student_score" do
     subject { course_membership.recalculate_and_update_student_score }
@@ -48,8 +48,8 @@ describe CourseMembership do
   end
 
   describe "#earned_grade_scheme_element" do
-    let!(:low_gse) { create(:grade_scheme_element, course: course, lowest_points: 7000, highest_points: 7999) }
-    let!(:high_gse) { create(:grade_scheme_element, course: course, lowest_points: 9001, highest_points: 10000) }
+    let!(:low_gse) { create(:grade_scheme_element, course: course, lowest_points: 7000) }
+    let!(:high_gse) { create(:grade_scheme_element, course: course, lowest_points: 9001) }
 
     it "returns the element that matches the highest points the student has earned" do
       allow(course_membership).to receive(:score) { 8200 }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -115,12 +115,9 @@ describe Course do
   end
 
   describe "#grade_scheme_elements" do
-    let!(:high) { create(:grade_scheme_element, lowest_points: 2001,
-                         highest_points: 3000, course: subject) }
-    let!(:low) { create(:grade_scheme_element, lowest_points: 100,
-                        highest_points: 1000, course: subject) }
-    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001,
-                           highest_points: 2000, course: subject) }
+    let!(:high) { create(:grade_scheme_element, lowest_points: 2001, course: subject) }
+    let!(:low) { create(:grade_scheme_element, lowest_points: 100, course: subject) }
+    let!(:middle) { create(:grade_scheme_element, lowest_points: 1001, course: subject) }
 
     describe "#for_score" do
       it "returns the grade scheme element that falls within that points range" do
@@ -151,7 +148,7 @@ describe Course do
 
       it "does not include other courses" do
         another_course = create :course
-        create :grade_scheme_element, lowest_points: 0, highest_points: 100, course: another_course
+        create :grade_scheme_element, lowest_points: 0, course: another_course
 
         result = subject.grade_scheme_elements.for_score(99)
 

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -4,7 +4,7 @@ describe GradeSchemeElement do
   let(:student) { build_stubbed :user }
   let(:course) { build_stubbed :course }
 
-  subject { create :grade_scheme_element, course: course }
+  subject { create :grade_scheme_element, lowest_points: 1000, course: course }
 
   before do
     create :course_membership, :student, user: student, course: course, score: 82, earned_grade_scheme_element_id: subject.id
@@ -27,20 +27,18 @@ describe GradeSchemeElement do
   end
 
   describe ".next_highest_element" do
-    let!(:grade_scheme_element) { create :grade_scheme_element, lowest_points: 0, course: course }
-
     context "when there is a grade scheme element with a higher point threshold" do
       let!(:next_grade_scheme_element) { create :grade_scheme_element, lowest_points: 5000, course: course }
 
       it "returns the next highest element" do
-        expect(GradeSchemeElement.next_highest_element(grade_scheme_element)).to \
+        expect(GradeSchemeElement.next_highest_element(subject)).to \
           eq next_grade_scheme_element
       end
     end
 
     context "when there is not a grade scheme element with a higher point threshold" do
       it "returns nil" do
-        expect(GradeSchemeElement.next_highest_element(grade_scheme_element)).to be_nil
+        expect(GradeSchemeElement.next_highest_element(subject)).to be_nil
       end
     end
   end
@@ -175,7 +173,7 @@ describe GradeSchemeElement do
 
       it "returns the range for the current level" do
         allow(subject).to receive(:next_highest_element).and_return next_highest_element
-        expect(subject.range).to eq next_highest_element.lowest_points.to_f - subject.lowest_points.to_f
+        expect(subject.range).to eq 233
       end
     end
   end

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -95,7 +95,7 @@ describe GradeSchemeElement do
 
     context "when the current element does not have the highest point threshold" do
       let(:next_highest_element) { double :element, lowest_points: 100 }
-      subject { build :grade_scheme_element, lowest_points: 0, course: course }
+      subject { create :grade_scheme_element, lowest_points: 0, course: course }
 
       it "returns the difference between the next highest element's point threshold and
       the student's current total score" do
@@ -114,7 +114,7 @@ describe GradeSchemeElement do
     end
 
     context "when the current level does not have the highest point threshold" do
-      subject { build :grade_scheme_element, lowest_points: 0, course: course }
+      subject { create :grade_scheme_element, lowest_points: 0, course: course }
 
       it "returns the percent complete value for the student" do
         allow(subject).to receive(:range).and_return 100
@@ -124,7 +124,7 @@ describe GradeSchemeElement do
   end
 
   describe "#within_range?" do
-    subject { build :grade_scheme_element, lowest_points: 1000, highest_points: 1999 }
+    subject { create :grade_scheme_element, lowest_points: 1000, course: course }
 
     it "returns true if the score is between the low and high ranges" do
       expect(subject).to be_within_range 1500
@@ -142,7 +142,14 @@ describe GradeSchemeElement do
       expect(subject).to_not be_within_range 999
     end
 
-    it "returns false if the score is higher the high range" do
+    it "returns true when the element has the highest point threshold
+      and is greater than the low range" do
+      expect(subject).to be_within_range 2000
+    end
+
+    it "returns false if the element is not the highest point threshold
+      and is greater than the low range" do
+      create :grade_scheme_element, lowest_points: 2000, course: course
       expect(subject).to_not be_within_range 2000
     end
   end

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -1,14 +1,13 @@
 require "active_record_spec_helper"
 
 describe GradeSchemeElement do
+  let(:student) { build_stubbed :user }
+  let(:course) { build_stubbed :course }
 
-  let(:student) { create :user }
-  let(:course) { create :course}
-
-  subject { create(:grade_scheme_element, course: course) }
+  subject { create :grade_scheme_element, course: course }
 
   before do
-    create(:course_membership, :student, user: student, course: course, score: 82, earned_grade_scheme_element_id: subject.id )
+    create :course_membership, :student, user: student, course: course, score: 82, earned_grade_scheme_element_id: subject.id
   end
 
   context "validations" do
@@ -24,6 +23,25 @@ describe GradeSchemeElement do
     it "is invalid without a course" do
       subject.course = nil
       expect(subject).to be_invalid
+    end
+  end
+
+  describe ".next_highest_element" do
+    let!(:grade_scheme_element) { create :grade_scheme_element, lowest_points: 0, course: course }
+
+    context "when there is a grade scheme element with a higher point threshold" do
+      let!(:next_grade_scheme_element) { create :grade_scheme_element, lowest_points: 5000, course: course }
+
+      it "returns the next highest element" do
+        expect(GradeSchemeElement.next_highest_element(grade_scheme_element)).to \
+          eq next_grade_scheme_element
+      end
+    end
+
+    context "when there is not a grade scheme element with a higher point threshold" do
+      it "returns nil" do
+        expect(GradeSchemeElement.next_highest_element(grade_scheme_element)).to be_nil
+      end
     end
   end
 
@@ -69,34 +87,46 @@ describe GradeSchemeElement do
     end
   end
 
-  describe "#range" do
-    it "returns the difference between the high range and the low range" do
-      subject.highest_points = 100
-      subject.lowest_points = 0
-      expect(subject.range).to eq(100)
-    end
-  end
-
   describe "#points_to_next_level(student, course)" do
-    it "returns the difference between the current level high range and the student's
-    total score + 1 point - the value to achieve the next level" do
-      subject.highest_points = 100
-      subject.course = course
-      expect(subject.points_to_next_level(student, course)).to eq(19)
+    context "when the current element has the highest point threshold" do
+      it "returns 0" do
+        allow(subject).to receive(:next_highest_element).and_return nil
+        expect(subject.points_to_next_level(student, course)).to eq 0
+      end
+    end
+
+    context "when the current element does not have the highest point threshold" do
+      let(:next_highest_element) { double :element, lowest_points: 100 }
+      subject { build :grade_scheme_element, lowest_points: 0, course: course }
+
+      it "returns the difference between the next highest element's point threshold and
+      the student's current total score" do
+        allow(subject).to receive(:next_highest_element).and_return next_highest_element
+        expect(subject.points_to_next_level(student, course)).to eq(18)
+      end
     end
   end
 
   describe "#progress_percent(student)" do
-    it "returns the level's percent complete value for the student" do
-      subject.highest_points = 100
-      subject.lowest_points = 0
-      subject.course = course
-      expect(subject.progress_percent(student)).to eq(82)
+    context "when the current element is has the highest point threshold" do
+      it "returns one hundred (100)" do
+        allow(subject).to receive(:range).and_return Float::INFINITY
+        expect(subject.progress_percent(student)).to eq 100
+      end
+    end
+
+    context "when the current level does not have the highest point threshold" do
+      subject { build :grade_scheme_element, lowest_points: 0, course: course }
+
+      it "returns the percent complete value for the student" do
+        allow(subject).to receive(:range).and_return 100
+        expect(subject.progress_percent(student)).to eq 82
+      end
     end
   end
 
   describe "#within_range?" do
-    subject { build(:grade_scheme_element, lowest_points: 1000, highest_points: 1999) }
+    subject { build :grade_scheme_element, lowest_points: 1000, highest_points: 1999 }
 
     it "returns true if the score is between the low and high ranges" do
       expect(subject).to be_within_range 1500
@@ -122,6 +152,31 @@ describe GradeSchemeElement do
   describe "#count_students_earned" do
     it "returns the number of students who have earned this grade scheme element" do
       expect(subject.count_students_earned).to eq(1)
+    end
+  end
+
+  describe "#next_highest_element" do
+    it "returns the next highest level relative to itself" do
+      expect(GradeSchemeElement).to receive(:next_highest_element).with(subject)
+      subject.next_highest_element
+    end
+  end
+
+  describe "#range" do
+    context "when the current level has the highest points threshold in the course" do
+      it "returns infinity" do
+        allow(subject).to receive(:next_highest_element).and_return nil
+        expect(subject.range).to eq Float::INFINITY
+      end
+    end
+
+    context "when the current level does not have the highest points threshold in the course" do
+      let(:next_highest_element) { double :element, lowest_points: 1234 }
+
+      it "returns the range for the current level" do
+        allow(subject).to receive(:next_highest_element).and_return next_highest_element
+        expect(subject.range).to eq next_highest_element.lowest_points.to_f - subject.lowest_points.to_f
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -347,7 +347,7 @@ describe User do
 
     it "returns the grade scheme element that matches the students score for the course" do
       create(:course_membership, :student, course: course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, highest_points: 120000)
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000)
       expect(student.grade_for_course(course)).to eq(gse)
     end
   end
@@ -357,7 +357,7 @@ describe User do
 
     it "returns the grade scheme level name that matches the student's score for the course" do
       create(:course_membership, :student, course: course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, highest_points: 120000, level: "Meh")
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, level: "Meh")
       expect(student.grade_level_for_course(course)).to eq("Meh")
     end
   end
@@ -367,7 +367,7 @@ describe User do
 
     it "returns the grade scheme letter name that matches the student's score for the course" do
       create(:course_membership, :student, course: course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, highest_points: 120000, letter: "Q")
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
       expect(student.grade_letter_for_course(course)).to eq("Q")
     end
   end
@@ -377,9 +377,9 @@ describe User do
 
     it "returns the next level above a student's current score for the course" do
       create(:course_membership, :student, course: course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, highest_points: 120000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, highest_points: 150000, letter: "R")
-      gse_2 = create(:grade_scheme_element, course: course, lowest_points: 150001, highest_points: 180000, letter: "S")
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
+      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, letter: "R")
+      gse_2 = create(:grade_scheme_element, course: course, lowest_points: 150001, letter: "S")
       expect(student.get_element_level(course, :next)).to eq(gse_1)
     end
   end
@@ -389,8 +389,8 @@ describe User do
 
     it "returns the next level above a student's current score for the course" do
       create(:course_membership, :student, course: course, user: student, score: 100000)
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, highest_points: 120000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, highest_points: 150000, letter: "R")
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
+      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, letter: "R")
       expect(student.points_to_next_level(course)).to eq(20001)
     end
   end

--- a/spec/presenters/info/dashboard_grading_scheme_presenter_spec.rb
+++ b/spec/presenters/info/dashboard_grading_scheme_presenter_spec.rb
@@ -2,61 +2,61 @@ require "active_record_spec_helper"
 require "./app/presenters/info/dashboard_grading_scheme_presenter.rb"
 
 describe Info::DashboardGradingSchemePresenter do
-  before do 
+  before do
     @course = create(:course)
     @student = create(:user)
     @grade_scheme_element_1 = create(:grade_scheme_element_high, course: @course)
-    @grade_scheme_element_2 = create(:grade_scheme_element_low, course: @course)  
-    @grade_scheme_element_3 = create(:grade_scheme_element_highest, course: @course, lowest_points: 20001, highest_points: 30000)
+    @grade_scheme_element_2 = create(:grade_scheme_element_low, course: @course)
+    @grade_scheme_element_3 = create(:grade_scheme_element_highest, course: @course)
     @course_membership = create(:course_membership, :student, user: @student, course: @course, score: 20000, earned_grade_scheme_element_id: @grade_scheme_element_1.id)
   end
-  
+
   subject { described_class.new course: @course, student: @student }
-  
+
   describe "#score_for_course" do
     it "returns the student's score for this course" do
       expect(subject.score_for_course).to eq 20000
     end
   end
-  
-  describe "#course_elements" do 
-    it "returns the grading scheme elements in the course" do 
+
+  describe "#course_elements" do
+    it "returns the grading scheme elements in the course" do
       expect(subject.course_elements).to eq([@grade_scheme_element_2, @grade_scheme_element_1, @grade_scheme_element_3])
     end
   end
-  
-  describe "#first_element" do 
-    it "returns the first item in the grading scheme" do 
+
+  describe "#first_element" do
+    it "returns the first item in the grading scheme" do
       expect(subject.first_element).to eq(@grade_scheme_element_2)
     end
   end
-  
-  describe "#current_element" do 
-    it "returns the element the student is currently on" do 
+
+  describe "#current_element" do
+    it "returns the element the student is currently on" do
       expect(subject.current_element).to eq(@grade_scheme_element_1)
     end
   end
-  
-  describe "#next_element" do 
-    it "returns the next element the student needs to achieve" do 
+
+  describe "#next_element" do
+    it "returns the next element the student needs to achieve" do
       expect(subject.next_element).to eq(@grade_scheme_element_3)
     end
   end
-  
-  describe "#previous_element" do 
-    it "returns the previous_element the student earned" do 
+
+  describe "#previous_element" do
+    it "returns the previous_element the student earned" do
       expect(subject.previous_element).to eq(@grade_scheme_element_2)
     end
   end
-  
-  describe "#points_to_next_level" do 
-    it "returns the number of points the student needs to earn to get to the next level" do 
+
+  describe "#points_to_next_level" do
+    it "returns the number of points the student needs to earn to get to the next level" do
       expect(subject.points_to_next_level).to eq 1
     end
   end
-  
-  describe "#progress_percent" do 
-    it "returns the perentage completion of the current level" do 
+
+  describe "#progress_percent" do
+    it "returns the perentage completion of the current level" do
       expect(subject.progress_percent).to eq 100.00
     end
   end


### PR DESCRIPTION
### Status
READY

### Description
In addition to removing the _within one point_ validation on the GradeSchemeElements mass_edit page, we should try to remove/reduce our use of `highest_points` in its current state as much as possible.

By explicitly calculating the upper limits of a level, we aim to follow this refactor up by removing the `highest_points` column altogether on the GradeSchemeElement table. See `grade_scheme_element.rb` for revisions related to the calculation of ranges and upper-limits.

This PR also fixes a preexisting bug in master where the upper point limit for the highest GSE was being set incorrectly.

We may also want to consider renaming and/or adding a unique constraint to `lowest_points` and `course` in order to maintain data integrity, since there is currently only client-side validation stopping an instructor from creating multiple GSEs with the same point threshold for a given course.

### Related PRs
- One to rename column/add unique constraint to `lowest_points`, `course`, if desired
- One to remove `highest_points` column, when ready

### Todos
- [ ] Update documentation, if needed

### Gem dependencies
- ADDED `binding_of_caller` for debugging, which was similarly done in #3034 

### Migrations
NO

### Steps to Test or Reproduce
- Ensure that editing and saving GradeSchemeElements works as expected
- Ensure that GSE-related views for students and instructors render as expected
- Verify that points to next level, progress percentage bars, and other statistics are correct

### Impacted Areas in Application
GradeSchemeElements

======================
Closes #3048 
Closes #3064 
