### PR TITLE
limit check/uncheck to items within the table

### DIFF
--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -57,6 +57,20 @@ $(".select-none").click(function(e){
 
 });
 
+// select all but only within the table
+$(".table-select-all").click(function(e){
+  var $link = $(this);
+  e.preventDefault();
+  $link.parents("table").find('input[type="checkbox"]').prop('checked', 'checked').trigger('change');
+});
+
+// select none, but only within the table
+$(".table-select-none").click(function(e){
+  var $link = $(this);
+  e.preventDefault();
+  $link.parents("table").find('input[type="checkbox"]').prop('checked', false).trigger('change');
+});
+
 $(".assignmentType").collapse({
   show: function() {
     // The context of 'this' is applied to
@@ -120,7 +134,7 @@ jQuery(function(){
         t.slice(0,100)+'<span>... </span><a href="#" class="more">More</a>'+
         '<span style="display:none;">'+ t.slice(100,t.length)+' <a href="#" class="less">Less</a></span>'
     );
-  }); 
+  });
   $('a.more', minimized_elements).click(function(event){
       event.preventDefault();
       $(this).hide().prev().hide();

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -20,37 +20,37 @@
             %th{scope: "col", "data-dynatable-no-sort" => "true", :width => "20%" }
               %span.sr-only Actions
             %th{"data-dynatable-no-sort" => "true", :width => "120px" }
-              %button.button.select-all{role: "button", type: "button"}= "Check"
-              %button.button.select-none{role: "button", type: "button"}= "Uncheck"
-          %tbody
-            - grades.each do |grade|
-              - student = grade.student
-              - team = student.team_for_course(course) if student
-              - group = grade.group
-              %tr
-                - if assignment.is_individual?
-                  %td= link_to student.first_name, student_path(student)
-                  %td= link_to student.last_name, student_path(student)
-                  - if course.has_teams?
-                    %td
-                      - if student.present? && team.present?
-                        = link_to team.name, team
-                - elsif assignment.has_groups?
-                  %td= link_to group.try(:name), group_path(group)
-                %td= points grade.score
-                %td= raw grade.feedback
-                %td
-                  .right
-                    %ul.button-bar
-                      - if assignment.is_individual?
-                        %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
-                      - elsif assignment.has_groups?
-                        %li= link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
-                %td
-                  .center
-                    %label
-                      %span.sr-only Select grade to update status
-                      = check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-#{grade_type}-#{assignment.name}-grades-command']" }, id: "grade_id_#{assignment.id}-#{grade.id}"
+              %button.button.table-select-all{role: "button", type: "button"}= "Check"
+              %button.button.table-select-none{role: "button", type: "button"}= "Uncheck"
+        %tbody
+          - grades.each do |grade|
+            - student = grade.student
+            - team = student.team_for_course(course) if student
+            - group = grade.group
+            %tr
+              - if assignment.is_individual?
+                %td= link_to student.first_name, student_path(student)
+                %td= link_to student.last_name, student_path(student)
+                - if course.has_teams?
+                  %td
+                    - if student.present? && team.present?
+                      = link_to team.name, team
+              - elsif assignment.has_groups?
+                %td= link_to group.try(:name), group_path(group)
+              %td= points grade.score
+              %td= raw grade.feedback
+              %td
+                .right
+                  %ul.button-bar
+                    - if assignment.is_individual?
+                      %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                    - elsif assignment.has_groups?
+                      %li= link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
+              %td
+                .center
+                  %label
+                    %span.sr-only Select grade to update status
+                    = check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-#{grade_type}-#{assignment.name}-grades-command']" }, id: "grade_id_#{assignment.id}-#{grade.id}"
 
       .submit-buttons
         .right


### PR DESCRIPTION
### Description

Limits jquery "check/uncheck" button action to items within the table.

note: I added a new jquery function, because I didn't want to affect other selectors handled by the old one. I'm also not sure if the view partial is used on other pages, if so, we should make sure it works as intended there.

I also outdented the table body in the partial, please verify that this is the proper indentation; it seems to work both ways.

### Steps to Test or Reproduce

1. Make sure that there are grades ready to be released for several different assignments. 
2. Go to the Grading Status page 
3. Click "Check" in table header for the first assignment
4. Observe that all only grades in that assignment have been selected

======================
Closes #2696 
