### PR TITLE
restrict user creation to courses that have paid

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -129,7 +129,7 @@ class CoursesController < ApplicationController
       :assignment_weight_type, :has_submissions, :teams_visible,
       :weight_term, :fail_term, :pass_term, :time_zone,
       :max_weights_per_assignment_type, :assignments,
-      :accepts_submissions, :tagline, :office, :phone,
+      :accepts_submissions, :tagline, :office, :phone, :has_paid,
       :class_email, :twitter_handle, :twitter_hashtag, :location, :office_hours,
       :meeting_times, :assignment_term, :challenge_term, :badge_term, :gameful_philosophy,
       :team_score_average, :has_team_challenges, :team_leader_term,

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -36,6 +36,10 @@
       = f.label :status, "Active?"
       = f.check_box :status
       .form_label Is this an active course?
+    .form-item
+      = f.label :has_paid, "Has Paid?"
+      = f.check_box :has_paid
+      .form_label If this course is not at Michigan, has it been paid for? This affects whether or not instructors can add users. 
 
 %section
   %h2 Enable Features

--- a/app/views/observers/_buttons.html.haml
+++ b/app/views/observers/_buttons.html.haml
@@ -1,4 +1,5 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+      - if current_user_is_admin? || current_course.has_paid?
+        %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"

--- a/app/views/staff/_buttons.haml
+++ b/app/views/staff/_buttons.haml
@@ -1,6 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+      - if current_user_is_admin? || current_course.has_paid?
+        %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
       - if @staff_member.present?
         %li= link_to_unless_current glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"

--- a/app/views/users/_buttons.haml
+++ b/app/views/users/_buttons.haml
@@ -1,8 +1,9 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
-      %li= link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
+      - if current_user_is_admin? || current_course.has_paid?
+        %li= link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        %li= link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
       - if @user.present? && @user.persisted?
         %li= link_to decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
         - if @user.is_staff?(current_course)

--- a/db/migrate/20170309154739_add_has_paid_to_course.rb
+++ b/db/migrate/20170309154739_add_has_paid_to_course.rb
@@ -1,0 +1,5 @@
+class AddHasPaidToCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :has_paid, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203181526) do
+ActiveRecord::Schema.define(version: 20170309154739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 20170203181526) do
     t.boolean  "has_character_names",                                     default: false,                        null: false
     t.string   "time_zone",                                               default: "Eastern Time (US & Canada)"
     t.boolean  "has_multipliers",                                         default: false,                        null: false
+    t.boolean  "has_paid",                                                default: true,                         null: false
   end
 
   create_table "criteria", force: :cascade do |t|

--- a/spec/factories/course_factory.rb
+++ b/spec/factories/course_factory.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     course_number { Faker::Internet.domain_word }
     semester "Fall"
     has_badges false
+    has_paid false
 
     factory :course_with_weighting do
       total_weights 6

--- a/spec/views/students/index_spec.rb
+++ b/spec/views/students/index_spec.rb
@@ -3,15 +3,14 @@ require "rails_spec_helper"
 include CourseTerms
 
 describe "students/index" do
-  let(:course) { create :course }
-  let(:current_user) { create(:course_membership, :professor, course: course).user }
-  let(:presenter) { Students::IndexPresenter.new({ course: course, current_user: current_user }) }
+  let(:current_course) { create :course }
+  let(:current_user) { create(:course_membership, :professor, course: current_course).user }
+  let(:presenter) { Students::IndexPresenter.new({ course: current_course, current_user: current_user }) }
   let(:student1) { create(:course_membership, :student, course: course).user }
   let(:student2) { create(:course_membership, :student, course: course).user }
 
   before(:each) do
-    allow(view).to receive(:current_course).and_return(@course)
-    allow(view).to receive(:current_user).and_return(@student_1)
+    allow(view).to receive(:current_course).and_return(current_course)
     allow(view).to receive(:presenter).and_return presenter
     allow(view).to receive(:term_for).with(:students).and_return "Students"
   end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR restricts user creation to accounts that have paid by not displaying the create or import buttons in the views. Once this is deployed to production and beta, we'll change the default for courses having paid to false. 

### Migrations
YES 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* User creation