### PR TITLE
2243 quick add grade letter levels

### DIFF
--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -9,8 +9,11 @@
     templateUrl: 'grade_scheme_elements/element.html'
     restrict: 'E'
     link: (scope, element, attrs) ->
+      # Set as invalid to disable submit, since we don't want the user to create elements
+      # on this page without lowest_points values
       scope.addElement = () ->
         GradeSchemeElementsService.addElement(@gradeSchemeElement)
+        @setFormIsInvalid()(true)
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -5,29 +5,20 @@
   {
     scope:
       gradeSchemeElement: '='
-      setFormIsInvalid: '&'
+      updateFormValidity: '&'
+      index: '@'
     templateUrl: 'grade_scheme_elements/element.html'
     restrict: 'E'
     link: (scope, element, attrs) ->
-      # Set as invalid to disable submit, since we don't want the user to create elements
-      # on this page without lowest_points values
       scope.addElement = () ->
         GradeSchemeElementsService.addElement(@gradeSchemeElement)
-        @setFormIsInvalid()(true)
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)
-        scope.setValidity()
+        @updateFormValidity()
 
       scope.validateElements = () ->
         GradeSchemeElementsService.validateElements()
-        scope.setValidity()
-
-      # Sets the validity on the parent
-      scope.setValidity = () ->
-        result = _.find(GradeSchemeElementsService.gradeSchemeElements, (element) ->
-          element.validationError?
-        )
-        @setFormIsInvalid()(result?)
+        @updateFormValidity()
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -5,7 +5,7 @@
   {
     scope:
       gradeSchemeElement: '='
-      setHasInvalidElements: '&'
+      setFormIsInvalid: '&'
     templateUrl: 'grade_scheme_elements/element.html'
     restrict: 'E'
     link: (scope, element, attrs) ->
@@ -25,6 +25,6 @@
         result = _.find(GradeSchemeElementsService.gradeSchemeElements, (element) ->
           element.validationError?
         )
-        @setHasInvalidElements()(result?)
+        @setFormIsInvalid()(result?)
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -14,9 +14,14 @@
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)
+        scope.setValidity()
 
       scope.validateElements = () ->
         GradeSchemeElementsService.validateElements()
+        scope.setValidity()
+
+      # Sets the validity on the parent
+      scope.setValidity = () ->
         result = _.find(GradeSchemeElementsService.gradeSchemeElements, (element) ->
           element.validationError?
         )

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -7,7 +7,7 @@
 
     vm.loading = true
     vm.gradeSchemeElements = null
-    vm.hasInvalidElements = false
+    vm.formIsInvalid = false
 
     vm.addElement = () ->
       GradeSchemeElementsService.addElement()
@@ -17,12 +17,13 @@
         window.location.href = '/grade_scheme_elements/'
       )
 
-    vm.setHasInvalidElements = (value) ->
-      vm.hasInvalidElements = value
+    vm.setFormIsInvalid = (value) ->
+      vm.formIsInvalid = value
 
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false
       vm.gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
+      GradeSchemeElementsService.validateElements()
     )
   ]
 

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -15,6 +15,10 @@
     vm.postGradeSchemeElements = () ->
       GradeSchemeElementsService.postGradeSchemeElements('/grade_scheme_elements/')
 
+    vm.deleteGradeSchemeElements = () ->
+      if confirm "Are you sure you want to delete all grade scheme elements?"
+        GradeSchemeElementsService.deleteGradeSchemeElements('/grade_scheme_elements/')
+
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false
       vm.gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
@@ -31,7 +35,8 @@
       # For manually triggering form validation by child directives
       ctrl.updateFormValidity = () ->
         _.each(ctrl.gradeSchemeElements, (element, index) ->
-          scope.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
+          if scope.gradeSchemeElementsForm["point_threshold_#{index}"]?
+            scope.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
         )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -7,25 +7,19 @@
 
     vm.loading = true
     vm.gradeSchemeElements = null
-    vm.formIsInvalid = false
 
     # Add first element
     vm.addElement = () ->
       GradeSchemeElementsService.addElement()
-      vm.formIsInvalid = true
 
     vm.postGradeSchemeElements = () ->
       GradeSchemeElementsService.postGradeSchemeElements().then(() ->
         window.location.href = '/grade_scheme_elements/'
       )
 
-    vm.setFormIsInvalid = (value) ->
-      vm.formIsInvalid = value
-
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false
       vm.gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
-      GradeSchemeElementsService.validateElements()
     )
   ]
 
@@ -35,5 +29,11 @@
     controllerAs: 'vm'
     restrict: 'EA'
     templateUrl: 'grade_scheme_elements/main.html'
+    link: (scope, element, attrs, ctrl) ->
+      # For manually triggering form validation by child directives
+      ctrl.updateFormValidity = () ->
+        _.each(ctrl.gradeSchemeElements, (element, index) ->
+          scope.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
+        )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -13,8 +13,8 @@
       GradeSchemeElementsService.addElement()
 
     vm.postGradeSchemeElements = () ->
-      GradeSchemeElementsService.postGradeSchemeElements().success(() ->
-        window.location.href = '/grade_scheme_elements/'  # redirect on success
+      GradeSchemeElementsService.postGradeSchemeElements().then(() ->
+        window.location.href = '/grade_scheme_elements/'
       )
 
     vm.setHasInvalidElements = (value) ->

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -9,8 +9,10 @@
     vm.gradeSchemeElements = null
     vm.formIsInvalid = false
 
+    # Add first element
     vm.addElement = () ->
       GradeSchemeElementsService.addElement()
+      vm.formIsInvalid = true
 
     vm.postGradeSchemeElements = () ->
       GradeSchemeElementsService.postGradeSchemeElements().then(() ->

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -13,7 +13,9 @@
       GradeSchemeElementsService.addElement()
 
     vm.postGradeSchemeElements = () ->
-      GradeSchemeElementsService.postGradeSchemeElements()
+      GradeSchemeElementsService.postGradeSchemeElements().success(() ->
+        window.location.href = '/grade_scheme_elements/'  # redirect on success
+      )
 
     vm.setHasInvalidElements = (value) ->
       vm.hasInvalidElements = value

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -13,9 +13,7 @@
       GradeSchemeElementsService.addElement()
 
     vm.postGradeSchemeElements = () ->
-      GradeSchemeElementsService.postGradeSchemeElements().then(() ->
-        window.location.href = '/grade_scheme_elements/'
-      )
+      GradeSchemeElementsService.postGradeSchemeElements('/grade_scheme_elements/')
 
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
@@ -7,14 +7,13 @@
     vm.isUsingGradeLetters = undefined
     vm.isUsingPlusMinusGrades = undefined
     vm.addLevelsBelowF = undefined
-    vm.levelsBelowF = undefined
+    vm.additionalLevels = undefined
 
     vm.postGradeSchemeElements = () ->
       GradeSchemeElementsSetupService.postGradeSchemeElements(
         vm.isUsingGradeLetters,
         vm.isUsingPlusMinusGrades,
-        vm.addLevelsBelowF,
-        vm.levelsBelowF,
+        vm.additionalLevels,
         '/grade_scheme_elements/mass_edit'
       )
   ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
@@ -4,7 +4,7 @@
   GradeSchemeElementsSetupCtrl = [() ->
     vm = this
 
-    vm.isUsingGradeLetters = true
+    vm.isUsingGradeLetters = undefined
     vm.isUsingPlusMinusGrades = undefined
     vm.addLevelsBelowF = undefined
     vm.levelsBelowF = undefined

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
@@ -14,8 +14,8 @@
         vm.isUsingGradeLetters,
         vm.isUsingPlusMinusGrades,
         vm.addLevelsBelowF,
-        vm.levelsBelowF).then(() ->
-        window.location.href = '/grade_scheme_elements/mass_edit'
+        vm.levelsBelowF,
+        '/grade_scheme_elements/mass_edit'
       )
   ]
 

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/setup.coffee
@@ -1,0 +1,29 @@
+# Main entry point for rendering and handling the initial GSE setup questions
+@gradecraft.directive 'gradeSchemeElementsSetup',
+['GradeSchemeElementsSetupService', (GradeSchemeElementsSetupService) ->
+  GradeSchemeElementsSetupCtrl = [() ->
+    vm = this
+
+    vm.isUsingGradeLetters = true
+    vm.isUsingPlusMinusGrades = undefined
+    vm.addLevelsBelowF = undefined
+    vm.levelsBelowF = undefined
+
+    vm.postGradeSchemeElements = () ->
+      GradeSchemeElementsSetupService.postGradeSchemeElements(
+        vm.isUsingGradeLetters,
+        vm.isUsingPlusMinusGrades,
+        vm.addLevelsBelowF,
+        vm.levelsBelowF).then(() ->
+        window.location.href = '/grade_scheme_elements/mass_edit'
+      )
+  ]
+
+  {
+    bindToController: true
+    controller: GradeSchemeElementsSetupCtrl
+    controllerAs: 'vm'
+    restrict: 'EA'
+    templateUrl: 'grade_scheme_elements/setup.html'
+  }
+]

--- a/app/assets/javascripts/angular/main.coffee
+++ b/app/assets/javascripts/angular/main.coffee
@@ -22,6 +22,12 @@
   $compileProvider.debugInfoEnabled(false)
 ])
 
+@gradecraft.config(['$ariaProvider', ($ariaProvider)->
+  $ariaProvider.config({
+    ariaRequired: false
+  })
+]);
+
 @gradecraft.directive "modalDialog", ->
   restrict: "E"
   scope:

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -112,6 +112,16 @@
         GradeCraftAPI.logResponse(error)
     )
 
+  deleteGradeSchemeElements = (redirectUrl=null) ->
+    $http.delete('/api/grade_scheme_elements/').then(
+      (response) ->
+        GradeCraftAPI.logResponse(response)
+        window.location.href = redirectUrl if redirectUrl?
+      , (error) ->
+        alert('Failed to delete grade scheme elements.')
+        GradeCraftAPI.logResponse(error)
+    )
+
   {
     gradeSchemeElements: gradeSchemeElements
     removeElement: removeElement
@@ -120,6 +130,7 @@
     validateElements: validateElements
     getGradeSchemeElements: getGradeSchemeElements
     postGradeSchemeElements: postGradeSchemeElements
+    deleteGradeSchemeElements: deleteGradeSchemeElements
     totalPoints: totalPoints
   }
 ]

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -43,22 +43,26 @@
       validateElements() if gradeSchemeElements.length > 0
 
   # Add a new element after the selected element, if one was given
-  addElement = (currentElement) ->
+  addElement = (currentElement, attributes=null) ->
     if currentElement?
       for element, i in gradeSchemeElements
         if element == currentElement
           gradeSchemeElements.splice(i + 1, 0, _newElement())
           return
     else
-      gradeSchemeElements.push(_newElement())
+      gradeSchemeElements.push(_newElement(attributes))
 
   # New empty grade scheme element object
-  _newElement = () ->
-    angular.copy({
+  _newElement = (attributes=null) ->
+    element = angular.copy({
       letter: null
       level: null
       lowest_points: null
     })
+    angular.forEach(attributes, (value, key) ->
+      element[key] = value
+    ) if attributes?
+    element
 
   # Add new element to represent zero threshold
   addZeroThreshold = () ->
@@ -83,8 +87,8 @@
     )
 
   # POST grade scheme element updates
-  postGradeSchemeElements = () ->
-    return if !hasValidPointThresholds()
+  postGradeSchemeElements = (validate=true) ->
+    return if validate && !hasValidPointThresholds()
     data = {
       grade_scheme_elements_attributes: gradeSchemeElements
       deleted_ids: deletedElementIds

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -1,5 +1,5 @@
 # Shared logic for creating, editing, and otherwise interacting with GradeSchemeElements
-@gradecraft.factory 'GradeSchemeElementsService', ['$q', '$http', 'GradeCraftAPI', ($q, $http, GradeCraftAPI) ->
+@gradecraft.factory 'GradeSchemeElementsService', ['$http', 'GradeCraftAPI', ($http, GradeCraftAPI) ->
 
   deletedElementIds = []
   gradeSchemeElements = []
@@ -28,7 +28,7 @@
   # Ensures that the current element does not have a point conflict with another
   validateElement = (currentElement) ->
     currentElement.validationError = undefined
-    
+
     if !currentElement.lowest_points?
       currentElement.validationError = "Point threshold does not have a value"
 
@@ -93,10 +93,10 @@
     )
 
   # POST grade scheme element updates
-  # Returns a promise
-  postGradeSchemeElements = (validate=true) ->
+  # Optionally redirects to a specified url
+  postGradeSchemeElements = (redirectUrl=null, validate=true) ->
     if gradeSchemeElements.length < 1 || (validate && !hasValidPointThresholds())
-      return $q.when(null)  # wrap in a promise for consistent handling by callers
+      return
 
     data = {
       grade_scheme_elements_attributes: gradeSchemeElements
@@ -106,6 +106,7 @@
       (response) ->
         angular.copy(response.grade_scheme_elements, gradeSchemeElements)
         GradeCraftAPI.logResponse(response)
+        window.location.href = redirectUrl if redirectUrl?
       , (error) ->
         alert('An error occurred that prevented saving.')
         GradeCraftAPI.logResponse(error)

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -28,6 +28,10 @@
   # Ensures that the current element does not have a point conflict with another
   validateElement = (currentElement) ->
     currentElement.validationError = undefined
+    
+    if !currentElement.lowest_points?
+      currentElement.validationError = "Point threshold does not have a value"
+
     for element in gradeSchemeElements
       continue if element == currentElement || !element.lowest_points? || isNaN(element.lowest_points)
 

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -93,7 +93,6 @@
       (data) ->
         angular.copy(data.grade_scheme_elements, gradeSchemeElements)
         GradeCraftAPI.logResponse(data)
-        window.location.href = '/grade_scheme_elements/'
     ).error(
       (error) ->
         alert('An error occurred that prevented saving.')

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -111,6 +111,7 @@
     gradeSchemeElements: gradeSchemeElements
     removeElement: removeElement
     addElement: addElement
+    addZeroThreshold: addZeroThreshold
     validateElements: validateElements
     getGradeSchemeElements: getGradeSchemeElements
     postGradeSchemeElements: postGradeSchemeElements

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -9,7 +9,7 @@
     _totalPoints
 
   # Ensure that there are no blank point thresholds
-  hasValidPointThresholds = () ->
+  _hasValidPointThresholds = () ->
     isValid = true
     for element in gradeSchemeElements
       if isNaN(element.lowest_points) || !element.lowest_points?
@@ -21,12 +21,12 @@
   validateElements = () ->
     has_zero_threshold = false
     for element, i in gradeSchemeElements
-      validateElement(element)
+      _validateElement(element)
       has_zero_threshold = true if element.lowest_points == 0
     addZeroThreshold() if not has_zero_threshold
 
   # Ensures that the current element does not have a point conflict with another
-  validateElement = (currentElement) ->
+  _validateElement = (currentElement) ->
     currentElement.validationError = undefined
 
     if !currentElement.lowest_points?
@@ -41,7 +41,7 @@
 
   # Remove the current element from the collection and add to deleted_ids array
   removeElement = (currentElement) ->
-    if currentElement.lowest_points == 0 && isOnlyZeroThreshold(currentElement)
+    if currentElement.lowest_points == 0 && _isOnlyZeroThreshold(currentElement)
       currentElement.validationError = "Lowest level threshold must be 0"
     else
       deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
@@ -77,7 +77,7 @@
     gradeSchemeElements.push(zeroElement)
 
   # Checks if there are more than one zero threshold elements
-  isOnlyZeroThreshold = (currentElement) ->
+  _isOnlyZeroThreshold = (currentElement) ->
     result = _.find(gradeSchemeElements, (element) ->
       currentElement != element && element.lowest_points == 0
     )?
@@ -95,7 +95,7 @@
   # POST grade scheme element updates
   # Optionally redirects to a specified url
   postGradeSchemeElements = (redirectUrl=null, validate=true) ->
-    if gradeSchemeElements.length < 1 || (validate && !hasValidPointThresholds())
+    if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
       return
 
     data = {

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -4,7 +4,7 @@
   standardGradeLetters = ['A', 'B', 'C', 'D', 'E', 'F']
 
   # Add grade scheme elements with the preset parameters
-  addGradeLevels = (includePlusMinusGrades) ->
+  _addGradeLevels = (includePlusMinusGrades) ->
     _.each(standardGradeLetters, (letter) ->
       GradeSchemeElementsService.addElement(null, { letter: letter + "+" }) if includePlusMinusGrades
       GradeSchemeElementsService.addElement(null, { letter: letter })
@@ -12,7 +12,7 @@
     )
 
   # Add additional levels
-  addAdditionalLevels = (numberOfLevels) ->
+  _addAdditionalLevels = (numberOfLevels) ->
     _.times(numberOfLevels-1, () ->
       GradeSchemeElementsService.addElement()
     )
@@ -21,8 +21,8 @@
 
   # Create the grade scheme elements
   postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF, redirectUrl=null) ->
-    addGradeLevels(isUsingPlusMinusGrades) if isUsingGradeLetters
-    addAdditionalLevels(levelsBelowF) if addLevelsBelowF
+    _addGradeLevels(isUsingPlusMinusGrades) if isUsingGradeLetters
+    _addAdditionalLevels(levelsBelowF) if addLevelsBelowF
     GradeSchemeElementsService.postGradeSchemeElements(redirectUrl, false)
 
   {

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -20,9 +20,9 @@
     GradeSchemeElementsService.addZeroThreshold()
 
   # Create the grade scheme elements
-  postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF, redirectUrl=null) ->
+  postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, additionalLevels, redirectUrl=null) ->
     _addGradeLevels(isUsingPlusMinusGrades) if isUsingGradeLetters
-    _addAdditionalLevels(levelsBelowF) if addLevelsBelowF
+    _addAdditionalLevels(additionalLevels) if additionalLevels? && additionalLevels > 0
     GradeSchemeElementsService.postGradeSchemeElements(redirectUrl, false)
 
   {

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -1,0 +1,29 @@
+# Uses the GradeSchemeElementsService to aggregate a list of initialized levels
+# for the initial setup process in a course
+@gradecraft.factory 'GradeSchemeElementsSetupService', ['GradeSchemeElementsService', (GradeSchemeElementsService) ->
+  standardGradeLetters = ['A', 'B', 'C', 'D', 'E', 'F']
+
+  # Add grade scheme elements with the preset parameters
+  addGradeLevels = (includePlusMinusGrades) ->
+    _.each(standardGradeLetters, (letter) ->
+      GradeSchemeElementsService.addElement(null, { letter: letter + "+" }) if includePlusMinusGrades
+      GradeSchemeElementsService.addElement(null, { letter: letter })
+      GradeSchemeElementsService.addElement(null, { letter: letter + "-" }) if includePlusMinusGrades
+    )
+
+  # Add additional levels
+  addAdditionalLevels = (numberOfLevels) ->
+    _.times(numberOfLevels, () ->
+      GradeSchemeElementsService.addElement()
+    )
+
+  # Create the grade scheme elements
+  postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF) ->
+    addGradeLevels(isUsingPlusMinusGrades) if isUsingGradeLetters
+    addAdditionalLevels(levelsBelowF) if addLevelsBelowF
+    GradeSchemeElementsService.postGradeSchemeElements(false)
+
+  {
+    postGradeSchemeElements: postGradeSchemeElements
+  }
+]

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -20,10 +20,10 @@
     GradeSchemeElementsService.addZeroThreshold()
 
   # Create the grade scheme elements
-  postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF) ->
+  postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF, redirectUrl=null) ->
     addGradeLevels(isUsingPlusMinusGrades) if isUsingGradeLetters
     addAdditionalLevels(levelsBelowF) if addLevelsBelowF
-    GradeSchemeElementsService.postGradeSchemeElements(false)
+    GradeSchemeElementsService.postGradeSchemeElements(redirectUrl, false)
 
   {
     postGradeSchemeElements: postGradeSchemeElements

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -13,9 +13,11 @@
 
   # Add additional levels
   addAdditionalLevels = (numberOfLevels) ->
-    _.times(numberOfLevels, () ->
+    _.times(numberOfLevels-1, () ->
       GradeSchemeElementsService.addElement()
     )
+    # Make last element the zero threshold
+    GradeSchemeElementsService.addZeroThreshold()
 
   # Create the grade scheme elements
   postGradeSchemeElements = (isUsingGradeLetters, isUsingPlusMinusGrades, addLevelsBelowF, levelsBelowF) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsSetupService.coffee
@@ -1,14 +1,14 @@
 # Uses the GradeSchemeElementsService to aggregate a list of initialized levels
 # for the initial setup process in a course
 @gradecraft.factory 'GradeSchemeElementsSetupService', ['GradeSchemeElementsService', (GradeSchemeElementsService) ->
-  standardGradeLetters = ['A', 'B', 'C', 'D', 'E', 'F']
+  standardGradeLetters = ['A', 'B', 'C', 'D', 'F']
 
   # Add grade scheme elements with the preset parameters
   _addGradeLevels = (includePlusMinusGrades) ->
     _.each(standardGradeLetters, (letter) ->
-      GradeSchemeElementsService.addElement(null, { letter: letter + "+" }) if includePlusMinusGrades
+      GradeSchemeElementsService.addElement(null, { letter: letter + "+" }) if includePlusMinusGrades and letter != 'F'
       GradeSchemeElementsService.addElement(null, { letter: letter })
-      GradeSchemeElementsService.addElement(null, { letter: letter + "-" }) if includePlusMinusGrades
+      GradeSchemeElementsService.addElement(null, { letter: letter + "-" }) if includePlusMinusGrades and letter not in ['D','F']
     )
 
   # Add additional levels

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -1,4 +1,4 @@
-.grade-scheme-row{'ng-class'=>'{"row-conflict": gradeSchemeElement.validationError != null}'}
+.grade-scheme-row
   .gse-form-container
     %label.gse-label.form_label
       Grade Letter
@@ -11,13 +11,12 @@
     %label.gse-label.form_label
       Point Threshold
       %input.low-range{'type'=>'text',
+        'name'=>'point_threshold_{{index}}',
         'ng-model'=>'gradeSchemeElement.lowest_points',
-        'ng-model-options'=>'{allowInvalid: true}',
         'ng-blur'=>'validateElements()',
         'required'=>'',
         'smart-number'=>'',
-        'allow-negatives'=>'false',
-        'ng-class'=>'{"ng-invalid": gradeSchemeElement.validationError || isNaN(gradeSchemeElement.lowest_points)}'}
+        'allow-negatives'=>'false'}
 
     %span.validation-error{'ng-show'=>'gradeSchemeElement.validationError'}
       %span.error

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -17,7 +17,7 @@
         'required'=>'',
         'smart-number'=>'',
         'allow-negatives'=>'false',
-        'ng-class'=>'{"ng-invalid": gradeSchemeElement.validationError}'}
+        'ng-class'=>'{"ng-invalid": gradeSchemeElement.validationError || isNaN(gradeSchemeElement.lowest_points)}'}
 
     %span.validation-error{'ng-show'=>'gradeSchemeElement.validationError'}
       %span.error

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -2,15 +2,17 @@
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
   %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements',
-                        'set_has_invalid_elements'=>'vm.setHasInvalidElements',
+                        'set_form_is_invalid'=>'vm.setFormIsInvalid',
                         'grade_scheme_element'=>'element'}
 
-  %button.button.right{'ng-click'=>'vm.addElement()',
-                       'ng-hide'=>'vm.gradeSchemeElements.length > 0'} Add Your Highest Grade
+  %button.button.right{'type'=>'button',
+                       'ng-click'=>'vm.addElement()',
+                       'ng-if'=>'vm.gradeSchemeElements.length == 0'} Add Your Highest Grade
 
-.submit-buttons
-  .right
-    %button.button.right{'type'=>'button',
-                         'ng-click'=>'vm.postGradeSchemeElements()',
-                         'ng-class'=>'{"disabled": vm.hasInvalidElements}',
-                         'ng-disabled'=>'vm.hasInvalidElements'} Submit
+  .submit-buttons
+    .right
+      %button.button.right{'type'=>'button',
+                           'ng-click'=>'vm.postGradeSchemeElements()',
+                           'ng-class'=>'{"disabled": vm.formIsInvalid}',
+                           'ng-disabled'=>'vm.formIsInvalid',
+                           'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'} Submit

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -2,7 +2,8 @@
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
   %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements',
-                        'set_form_is_invalid'=>'vm.setFormIsInvalid',
+                        'update_form_validity'=>'vm.updateFormValidity()',
+                        'index'=>'{{$index}}',
                         'grade_scheme_element'=>'element'}
 
   %button.button.right{'type'=>'button',
@@ -13,6 +14,6 @@
     .right
       %button.button.right{'type'=>'button',
                            'ng-click'=>'vm.postGradeSchemeElements()',
-                           'ng-class'=>'{"disabled": vm.formIsInvalid}',
-                           'ng-disabled'=>'vm.formIsInvalid',
+                           'ng-class'=>'{"disabled": gradeSchemeElementsForm.$invalid}',
+                           'ng-disabled'=>'gradeSchemeElementsForm.$invalid',
                            'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'} Submit

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -11,9 +11,14 @@
                        'ng-if'=>'vm.gradeSchemeElements.length == 0'} Add Your Highest Grade
 
   .submit-buttons
-    .right
-      %button.button.right{'type'=>'button',
-                           'ng-click'=>'vm.postGradeSchemeElements()',
-                           'ng-class'=>'{"disabled": gradeSchemeElementsForm.$invalid}',
-                           'ng-disabled'=>'gradeSchemeElementsForm.$invalid',
-                           'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'} Submit
+    %ul
+      %li
+        .button.right{'type'=>'button',
+                      'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0',
+                      'ng-click'=>'vm.deleteGradeSchemeElements()'} Delete All Elements
+      %li
+        .button.right{'type'=>'button',
+                      'ng-click'=>'vm.postGradeSchemeElements()',
+                      'ng-class'=>'{"disabled": gradeSchemeElementsForm.$invalid}',
+                      'ng-disabled'=>'gradeSchemeElementsForm.$invalid',
+                      'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'} Submit

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -1,16 +1,17 @@
-%h2 Add new grading scheme
+.grade_scheme_questions
+  %h2 Add new grading scheme
 
-%dl{"ng-form"=>"", "name"=>"gradeSchemeSetupForm"}
-  %dt Are you using grade letters?
-  %dd
-    %input{"type"=>"radio",
-           "ng-model"=>"vm.isUsingGradeLetters",
-           "ng-value"=>"true",
-           "required"=>""} Yes
-    %input{"type"=>"radio",
-           "ng-model"=>"vm.isUsingGradeLetters",
-           "ng-value"=>"false",
-           "required"=>""} No
+  %dl{"ng-form"=>"", "name"=>"gradeSchemeSetupForm"}
+    %dt Are you using grade letters?
+    %dd
+      %input{"type"=>"radio",
+             "ng-model"=>"vm.isUsingGradeLetters",
+             "ng-value"=>"true",
+             "required"=>""} Yes
+      %input{"type"=>"radio",
+             "ng-model"=>"vm.isUsingGradeLetters",
+             "ng-value"=>"false",
+             "required"=>""} No
 
   %additional-questions{"ng-if"=>"vm.isUsingGradeLetters"}
     %dl
@@ -45,7 +46,9 @@
                "size"=>"8",
                "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}
 
-  %button.button.right{"type"=>"button",
-                       "ng-disabled"=>"gradeSchemeSetupForm.$invalid",
-                       "ng-class"=>'{"disabled": gradeSchemeSetupForm.$invalid}',
-                       "ng-click"=>"vm.postGradeSchemeElements()"} Get me started!
+.clear
+
+%button.button.right{"type"=>"button",
+                     "ng-disabled"=>"gradeSchemeSetupForm.$invalid",
+                     "ng-class"=>'{"disabled": gradeSchemeSetupForm.$invalid}',
+                     "ng-click"=>"vm.postGradeSchemeElements()"} Get me started!

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -1,59 +1,65 @@
 %h2.form-title Add new grading scheme
 
 %form.grading-scheme-setup{"name"=>"gradeSchemeSetupForm"}
-  .form-question
-    %p Are you using grade letters?
-    %ul
-      %li
-        %label
-          %input{"type"=>"radio",
-                 "ng-model"=>"vm.isUsingGradeLetters",
-                 "ng-value"=>"true",
-                 "name"=>"gradeletters",
-                 "required"=>""} Yes
-      %li
-        %label
-          %input{"type"=>"radio",
-                 "ng-model"=>"vm.isUsingGradeLetters",
-                 "ng-value"=>"false",
-                 "name"=>"gradeletters",
-                 "required"=>""} No
+  %fieldset
+    .form-question
+      %legend Are you using grade letters?
+      %ul
+        %li
+          %label
+            %input{"type"=>"radio",
+                   "ng-model"=>"vm.isUsingGradeLetters",
+                   "ng-value"=>"true",
+                   "name"=>"gradeletters",
+                   "tabindex"=>"0",
+                   "required"=>""} Yes
+        %li
+          %label
+            %input{"type"=>"radio",
+                   "ng-model"=>"vm.isUsingGradeLetters",
+                   "ng-value"=>"false",
+                   "name"=>"gradeletters",
+                   "required"=>""} No
 
   %additional-questions.form-section{"ng-if"=>"vm.isUsingGradeLetters"}
-    .form-question
-      %p Are you using +/- grades?
-      %ul
-        %li
-          %label
-            %input{"type"=>"radio",
-                   "ng-model"=>"vm.isUsingPlusMinusGrades",
-                   "ng-value"=>"true",
-                   "name"=>"plusminus",
-                   "ng-required"=>"vm.isUsingGradeLetters"} Yes
-        %li
-          %label
-            %input{"type"=>"radio",
-                   "ng-model"=>"vm.isUsingPlusMinusGrades",
-                   "ng-value"=>"false",
-                   "name"=>"plusminus",
-                   "ng-required"=>"vm.isUsingGradeLetters"} No
+    %fieldset
+      .form-question
+        %legend Are you using +/- grades?
+        %ul{"role"=>"radiogroup"}
+          %li
+            %label
+              %input{"type"=>"radio",
+                     "ng-model"=>"vm.isUsingPlusMinusGrades",
+                     "ng-value"=>"true",
+                     "name"=>"plusminus",
+                     "tabindex"=>"0",
+                     "ng-required"=>"vm.isUsingGradeLetters"} Yes
+          %li
+            %label
+              %input{"type"=>"radio",
+                     "ng-model"=>"vm.isUsingPlusMinusGrades",
+                     "ng-value"=>"false",
+                     "name"=>"plusminus",
+                     "ng-required"=>"vm.isUsingGradeLetters"} No
 
-    .form-question
-      %p Would you like to add levels below 'F'?
-      %ul
-        %li
-          %label
-            %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",
-                   "ng-value"=>"true",
-                    "name"=>"levelsbelow",
-                   "ng-required"=>"vm.isUsingGradeLetters"} Yes
-        %li
-          %label
-            %input{"type"=>"radio",
-                   "ng-model"=>"vm.addLevelsBelowF",
-                   "ng-value"=>"false",
-                  "name"=>"levelsbelow",
-                   "ng-required"=>"vm.isUsingGradeLetters"} No
+    %fieldset
+      .form-question
+        %legend Would you like to add levels below 'F'?
+        %ul{"role"=>"radiogroup"}
+          %li
+            %label
+              %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",
+                     "ng-value"=>"true",
+                     "name"=>"levelsbelow",
+                     "tabindex"=>"0",
+                     "ng-required"=>"vm.isUsingGradeLetters"} Yes
+          %li
+            %label
+              %input{"type"=>"radio",
+                     "ng-model"=>"vm.addLevelsBelowF",
+                     "ng-value"=>"false",
+                     "name"=>"levelsbelow",
+                     "ng-required"=>"vm.isUsingGradeLetters"} No
 
     %additional-questions.form-section{"ng-if"=>"vm.addLevelsBelowF"}
       .form-question

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -1,54 +1,71 @@
-.grade_scheme_questions
-  %h2 Add new grading scheme
+%h2.form-title Add new grading scheme
 
-  %dl{"ng-form"=>"", "name"=>"gradeSchemeSetupForm"}
-    %dt Are you using grade letters?
-    %dd
-      %input{"type"=>"radio",
-             "ng-model"=>"vm.isUsingGradeLetters",
-             "ng-value"=>"true",
-             "required"=>""} Yes
-      %input{"type"=>"radio",
-             "ng-model"=>"vm.isUsingGradeLetters",
-             "ng-value"=>"false",
-             "required"=>""} No
+%form.grading-scheme-setup{"name"=>"gradeSchemeSetupForm"}
+  .form-question
+    %p Are you using grade letters?
+    %ul
+      %li
+        %label
+          %input{"type"=>"radio",
+                 "ng-model"=>"vm.isUsingGradeLetters",
+                 "ng-value"=>"true",
+                 "name"=>"gradeletters",
+                 "required"=>""} Yes
+      %li
+        %label
+          %input{"type"=>"radio",
+                 "ng-model"=>"vm.isUsingGradeLetters",
+                 "ng-value"=>"false",
+                 "name"=>"gradeletters",
+                 "required"=>""} No
 
-  %additional-questions{"ng-if"=>"vm.isUsingGradeLetters"}
-    %dl
-      %dt Are you using +/- grades?
-      %dd
-        %input{"type"=>"radio",
-               "ng-model"=>"vm.isUsingPlusMinusGrades",
-               "ng-value"=>"true",
-               "ng-required"=>"vm.isUsingGradeLetters"} Yes
-        %input{"type"=>"radio",
-               "ng-model"=>"vm.isUsingPlusMinusGrades",
-               "ng-value"=>"false",
-               "ng-required"=>"vm.isUsingGradeLetters"} No
+  %additional-questions.form-section{"ng-if"=>"vm.isUsingGradeLetters"}
+    .form-question
+      %p Are you using +/- grades?
+      %ul
+        %li
+          %label
+            %input{"type"=>"radio",
+                   "ng-model"=>"vm.isUsingPlusMinusGrades",
+                   "ng-value"=>"true",
+                   "name"=>"plusminus",
+                   "ng-required"=>"vm.isUsingGradeLetters"} Yes
+        %li
+          %label
+            %input{"type"=>"radio",
+                   "ng-model"=>"vm.isUsingPlusMinusGrades",
+                   "ng-value"=>"false",
+                   "name"=>"plusminus",
+                   "ng-required"=>"vm.isUsingGradeLetters"} No
 
-    %dl
-      %dt Would you like to add levels below 'F'?
-      %dd
-        %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",
-               "ng-value"=>"true",
-               "ng-required"=>"vm.isUsingGradeLetters"} Yes
-        %input{"type"=>"radio",
-               "ng-model"=>"vm.addLevelsBelowF",
-               "ng-value"=>"false",
-               "ng-required"=>"vm.isUsingGradeLetters"} No
+    .form-question
+      %p Would you like to add levels below 'F'?
+      %ul
+        %li
+          %label
+            %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",
+                   "ng-value"=>"true",
+                    "name"=>"levelsbelow",
+                   "ng-required"=>"vm.isUsingGradeLetters"} Yes
+        %li
+          %label
+            %input{"type"=>"radio",
+                   "ng-model"=>"vm.addLevelsBelowF",
+                   "ng-value"=>"false",
+                  "name"=>"levelsbelow",
+                   "ng-required"=>"vm.isUsingGradeLetters"} No
 
-    %dl{"ng-if"=>"vm.addLevelsBelowF"}
-      %dt How many?
-      %dd
-        %input{"type"=>"number",
-               "ng-model"=>"vm.levelsBelowF",
-               "min"=>"1",
-               "size"=>"8",
-               "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}
-
-.clear
+    %additional-questions.form-section{"ng-if"=>"vm.addLevelsBelowF"}
+      .form-question
+        %p How many?
+        %label
+          %input{"type"=>"number",
+                 "ng-model"=>"vm.levelsBelowF",
+                 "min"=>"1",
+                 "size"=>"8",
+                 "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}
 
 %button.button.right{"type"=>"button",
-                     "ng-disabled"=>"gradeSchemeSetupForm.$invalid",
-                     "ng-class"=>'{"disabled": gradeSchemeSetupForm.$invalid}',
-                     "ng-click"=>"vm.postGradeSchemeElements()"} Get me started!
+                   "ng-disabled"=>"gradeSchemeSetupForm.$invalid",
+                   "ng-class"=>'{"disabled": gradeSchemeSetupForm.$invalid}',
+                   "ng-click"=>"vm.postGradeSchemeElements()"} Get me started!

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -41,7 +41,7 @@
       %dd
         %input{"type"=>"number",
                "ng-model"=>"vm.levelsBelowF",
-               "min"=>"0",
+               "min"=>"1",
                "size"=>"8",
                "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}
 

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -25,7 +25,7 @@
     %fieldset
       .form-question
         %legend Are you using +/- grades?
-        %ul{"role"=>"radiogroup"}
+        %ul
           %li
             %label
               %input{"type"=>"radio",
@@ -45,7 +45,7 @@
     %fieldset
       .form-question
         %legend Would you like to add levels below 'F'?
-        %ul{"role"=>"radiogroup"}
+        %ul
           %li
             %label
               %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -1,0 +1,51 @@
+%h2 Add new grading scheme
+
+%dl{"ng-form"=>"", "name"=>"gradeSchemeSetupForm"}
+  %dt Are you using grade letters?
+  %dd
+    %input{"type"=>"radio",
+           "ng-model"=>"vm.isUsingGradeLetters",
+           "ng-value"=>"true",
+           "required"=>""} Yes
+    %input{"type"=>"radio",
+           "ng-model"=>"vm.isUsingGradeLetters",
+           "ng-value"=>"false",
+           "required"=>""} No
+
+  %additional-questions{"ng-if"=>"vm.isUsingGradeLetters"}
+    %dl
+      %dt Are you using +/- grades?
+      %dd
+        %input{"type"=>"radio",
+               "ng-model"=>"vm.isUsingPlusMinusGrades",
+               "ng-value"=>"true",
+               "ng-required"=>"vm.isUsingGradeLetters"} Yes
+        %input{"type"=>"radio",
+               "ng-model"=>"vm.isUsingPlusMinusGrades",
+               "ng-value"=>"false",
+               "ng-required"=>"vm.isUsingGradeLetters"} No
+
+    %dl
+      %dt Would you like to add levels below 'F'?
+      %dd
+        %input{"type"=>"radio", "ng-model"=>"vm.addLevelsBelowF",
+               "ng-value"=>"true",
+               "ng-required"=>"vm.isUsingGradeLetters"} Yes
+        %input{"type"=>"radio",
+               "ng-model"=>"vm.addLevelsBelowF",
+               "ng-value"=>"false",
+               "ng-required"=>"vm.isUsingGradeLetters"} No
+
+    %dl{"ng-if"=>"vm.addLevelsBelowF"}
+      %dt How many?
+      %dd
+        %input{"type"=>"number",
+               "ng-model"=>"vm.levelsBelowF",
+               "min"=>"0",
+               "size"=>"8",
+               "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}
+
+  %button.button.right{"type"=>"button",
+                       "ng-disabled"=>"gradeSchemeSetupForm.$invalid",
+                       "ng-class"=>'{"disabled": gradeSchemeSetupForm.$invalid}',
+                       "ng-click"=>"vm.postGradeSchemeElements()"} Get me started!

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/setup.html.haml
@@ -21,6 +21,17 @@
                    "name"=>"gradeletters",
                    "required"=>""} No
 
+  %additional-questions.form-section{"ng-if"=>"vm.isUsingGradeLetters === false"}
+    %fieldset
+      .form-question
+        %p How many levels would you like to start with?
+        %label
+          %input{"type"=>"number",
+                 "ng-model"=>"vm.additionalLevels",
+                 "min"=>"1",
+                 "size"=>"8",
+                 "ng-required"=>"!vm.isUsingGradeLetters"}
+
   %additional-questions.form-section{"ng-if"=>"vm.isUsingGradeLetters"}
     %fieldset
       .form-question
@@ -66,7 +77,7 @@
         %p How many?
         %label
           %input{"type"=>"number",
-                 "ng-model"=>"vm.levelsBelowF",
+                 "ng-model"=>"vm.additionalLevels",
                  "min"=>"1",
                  "size"=>"8",
                  "ng-required"=>"vm.isUsingGradeLetters && vm.addLevelsBelowF"}

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -240,9 +240,14 @@ error
   background-color: $color-blue-4
   border: 1px solid $color-grey-5 !important
 
-input[type=text]
+input[type=text],
+input[type=number]
   padding: .5rem
   width: 15rem
+  border: 1px solid rgba(42, 43, 43, 0.2)
+  transition: border-color 0.2s
+  &:focus
+    border: 1px solid rgba(42, 43, 43, 0.8)
 
 .switch-label
   text-transform: capitalize

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -131,19 +131,25 @@ p.predictor-description
   @media (max-width: $media-small-max)
     text-align: right
 
-.grade_scheme_questions
-  width: 40%
-  min-width: 380px
+.form-title
+  margin-bottom: 0.5rem
+  text-transform: capitalize
+  font-style: italic
+  font-size: 1.1rem
 
-  h2
-    font-style: italic
-    font-size: 1rem
-    margin-bottom: 0.5rem
-  dt
-    font-weight: bold
-    float: left
-    clear: both
-    margin: 4px auto
-  dd
-    float: right
-    margin: 4px auto
+.grading-scheme-setup
+  max-width: 450px
+  ul
+    margin: 0
+    padding-left: 0
+    list-style-type: none
+    li
+      display: inline-block
+      margin-right: 0.75rem
+  p
+    margin: 0.5rem 0
+
+  .form-question
+    display: flex
+    justify-content: space-between
+    align-items: center

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -159,3 +159,5 @@ p.predictor-description
     display: flex
     justify-content: space-between
     align-items: center
+    @media (max-width: $media-small-max)
+      display: block

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -149,6 +149,9 @@ p.predictor-description
   p
     margin: 0.5rem 0
 
+  fieldset
+    margin: 1rem 0
+
   .form-question
     display: flex
     justify-content: space-between

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -130,3 +130,20 @@ p.predictor-description
   flex: 0 0 auto
   @media (max-width: $media-small-max)
     text-align: right
+
+.grade_scheme_questions
+  width: 40%
+  min-width: 380px
+
+  h2
+    font-style: italic
+    font-size: 1rem
+    margin-bottom: 0.5rem
+  dt
+    font-weight: bold
+    float: left
+    clear: both
+    margin: 4px auto
+  dd
+    float: right
+    margin: 4px auto

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -152,6 +152,9 @@ p.predictor-description
   fieldset
     margin: 1rem 0
 
+  input
+    margin-right: 0.25rem
+
   .form-question
     display: flex
     justify-content: space-between

--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -1,6 +1,7 @@
 # The Grade Scheme Elements define the point thresholds earned at which students
 # earn course wide levels and grades
 class API::GradeSchemeElementsController < ApplicationController
+  before_action :ensure_staff?, except: :index
 
   # GET /api/grade_scheme_elements
   def index
@@ -15,6 +16,18 @@ class API::GradeSchemeElementsController < ApplicationController
       @total_points = (@grade_scheme_elements.first.lowest_points).to_i
     else
       @total_points = current_course.total_points
+    end
+  end
+
+  # DELETE /api/grade_scheme_elements
+  def destroy
+    current_course.grade_scheme_elements.destroy_all
+    if current_course.grade_scheme_elements.any?
+      render json: { message: "Failed to delete grade scheme elements", success: false },
+        status: 500
+    else
+      render json: { message: "Grade scheme elements successfully deleted", success: true },
+        status: 200
     end
   end
 end

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -4,8 +4,8 @@ class GradeSchemeElementsController < ApplicationController
   before_action :ensure_staff?, except: [:index]
 
   def index
-    @grade_scheme_elements = current_course
-                             .grade_scheme_elements.order_by_points_desc
+    @grade_scheme_elements = current_course.grade_scheme_elements.order_by_points_desc
+    @grade_scheme_elements = @grade_scheme_elements.with_lowest_points if !current_user_is_staff?
   end
 
   def edit

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -21,13 +21,17 @@ class GradeSchemeElement < ActiveRecord::Base
     course.grade_scheme_elements.all? { |gse| !gse.lowest_points.nil? }
   end
 
-  def self.next_highest_element(element)
+  # By default, return only valid elements with lowest_points not equal to nil
+  def self.next_highest_element_for(element, with_lowest_points_only=true)
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
+    ordered_course_elements = ordered_course_elements.with_lowest_points if with_lowest_points_only
     ordered_course_elements[ordered_course_elements.to_a.find_index(element) + 1]
   end
 
-  def self.next_lowest_element(element)
+  # By default, return only valid elements with lowest_points not equal to nil
+  def self.next_lowest_element_for(element, with_lowest_points_only=true)
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
+    ordered_course_elements = ordered_course_elements.with_lowest_points if with_lowest_points_only
     current_index = ordered_course_elements.to_a.find_index(element)
     return nil if current_index == 0
     ordered_course_elements[current_index - 1]
@@ -64,11 +68,11 @@ class GradeSchemeElement < ActiveRecord::Base
   end
 
   def next_highest_element
-    @next_highest_element ||= GradeSchemeElement.next_highest_element self
+    @next_highest_element ||= GradeSchemeElement.next_highest_element_for self
   end
 
   def next_lowest_element
-    @next_lowest_element ||= GradeSchemeElement.next_lowest_element self
+    @next_lowest_element ||= GradeSchemeElement.next_lowest_element_for self
   end
 
   # The highest point value for the element

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -10,8 +10,8 @@ class GradeSchemeElement < ActiveRecord::Base
 
   scope :with_lowest_points, -> { where.not(lowest_points: nil) }
   scope :for_course, -> (course_id) { where(course_id: course_id) }
-  scope :order_by_points_asc, -> { with_lowest_points.order "lowest_points ASC" }
-  scope :order_by_points_desc, -> { with_lowest_points.order "lowest_points DESC" }
+  scope :order_by_points_asc, -> { order lowest_points: :asc }
+  scope :order_by_points_desc, -> { order lowest_points: :desc }
 
   def self.default
     GradeSchemeElement.new(level: "Not yet on board")

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -63,6 +63,10 @@ class GradeSchemeElement < ActiveRecord::Base
     @next_highest_element ||= GradeSchemeElement.next_highest_element self
   end
 
+  def next_lowest_element
+    @next_lowest_element ||= GradeSchemeElement.next_lowest_element self
+  end
+
   # The highest point value for the element
   def highest_points
     return Float::INFINITY if next_highest_element.nil?

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -6,7 +6,7 @@ class GradeSchemeElement < ActiveRecord::Base
   belongs_to :course, touch: true
 
   validates_presence_of :course
-  validates_numericality_of :lowest_points, length: { maximum: 9 }
+  validates :lowest_points, length: { maximum: 9 }, numericality: { only_integer: true }, allow_nil: true
 
   scope :with_lowest_points, -> { where.not(lowest_points: nil) }
   scope :for_course, -> (course_id) { where(course_id: course_id) }

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -17,6 +17,10 @@ class GradeSchemeElement < ActiveRecord::Base
     GradeSchemeElement.new(level: "Not yet on board")
   end
 
+  def self.has_valid_elements_for(course)
+    course.grade_scheme_elements.all? { |gse| !gse.lowest_points.nil? }
+  end
+
   def self.next_highest_element(element)
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
     ordered_course_elements[ordered_course_elements.to_a.find_index(element) + 1]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -235,27 +235,6 @@ class User < ActiveRecord::Base
     @grade_letter_for_course ||= grade_for_course(course).try(:letter)
   end
 
-  def get_element_level(course, direction)
-    course_elements = course.grade_scheme_elements.order_by_points_asc.to_a
-
-    current_element = self.grade_for_course(course)
-    current_element_index = course_elements.index{ |item| item == current_element }
-
-    element = send("#{direction}_element_level", course_elements, current_element_index)
-  end
-
-  def next_element_level(course_elements, current_element_index)
-    next_element = course_elements[current_element_index + 1] unless current_element_index == (course_elements.size - 1)
-  end
-
-  def previous_element_level(course_elements, current_element_index)
-    previous_element = course_elements[current_element_index - 1] unless current_element_index == 0
-  end
-
-  def points_to_next_level(course)
-    get_element_level(course, :next).lowest_points - score_for_course(course)
-  end
-
   ### GRADES
 
   # Checking specifically if there is a released grade for an assignment

--- a/app/presenters/info/dashboard_grading_scheme_presenter.rb
+++ b/app/presenters/info/dashboard_grading_scheme_presenter.rb
@@ -20,12 +20,12 @@ class Info::DashboardGradingSchemePresenter < Showtime::Presenter
   end
 
   def course_elements
-    GradeSchemeElement.for_course(course).order_by_points_asc
+    GradeSchemeElement.for_course(course).with_lowest_points.order_by_points_asc
   end
 
   # showing first element of grading scheme if current score does not reflect a level
   def first_element
-    GradeSchemeElement.for_course(course).order_by_points_asc.first
+    GradeSchemeElement.for_course(course).with_lowest_points.order_by_points_asc.first
   end
 
   def current_element

--- a/app/presenters/info/dashboard_grading_scheme_presenter.rb
+++ b/app/presenters/info/dashboard_grading_scheme_presenter.rb
@@ -33,11 +33,13 @@ class Info::DashboardGradingSchemePresenter < Showtime::Presenter
   end
 
   def next_element
-    student.get_element_level(course, :next)
+    return nil if current_element.nil?
+    current_element.next_highest_element
   end
 
   def previous_element
-    student.get_element_level(course, :previous)
+    return nil if current_element.nil?
+    current_element.next_lowest_element
   end
 
   def points_to_next_level

--- a/app/presenters/students/index_presenter.rb
+++ b/app/presenters/students/index_presenter.rb
@@ -39,7 +39,7 @@ class Students::IndexPresenter < Showtime::Presenter
   end
 
   def grade_scheme_elements
-    @grade_scheme_elements ||= course.grade_scheme_elements.order_by_points_asc
+    @grade_scheme_elements ||= course.grade_scheme_elements.with_lowest_points.order_by_points_asc
   end
 
   def student_ids

--- a/app/views/grade_scheme_elements/_index_staff.haml
+++ b/app/views/grade_scheme_elements/_index_staff.haml
@@ -1,32 +1,14 @@
-- content_for :context_menu do
-  .context_menu
-    %ul
-      %li= link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
+- if @grade_scheme_elements.count > 0
+  - content_for :context_menu do
+    .context_menu
+      %ul
+        %li= link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
 
-  / Grade Scheme Elements Table Display
-  %table
-    %caption.sr-only Grading Scheme Levels
-    %thead
-      %tr
-        %th{scope: "col"} Grade
-        %th{scope: "col"} Level
-        %th{scope: "col"} Point Threshold
-        %th{scope: "col"} Locked?
-        %th{scope: "col"}
-          %span.sr-only Action Buttons
-    %tbody
-      - @grade_scheme_elements.each do |element|
-        %tr
-          %td= element.letter
-          %td= element.level
-          %td{data: { :"sort-value" => "#{element.lowest_points }" }}= points element.lowest_points
-          %td
-            - if element.unlock_conditions.present?
-              - element.unlock_conditions.each do |uc|
-                .condition= glyph(:lock) + uc.requirements_description_sentence
-          %td= link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
-
-  = render partial: "courses/grading_philosophy", locals: { course: current_course }
+  - if @grade_scheme_elements.count == 0
+    = render partial: "grade_scheme_elements/components/grade_scheme_elements_setup"
+  - else
+    = render partial: "grade_scheme_elements/components/grade_scheme_elements_table",
+      locals: { grade_scheme_elements: @grade_scheme_elements }

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_setup.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_setup.haml
@@ -1,0 +1,1 @@
+%grade_scheme_elements_setup{"ng-app"=>"gradecraft"}

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
@@ -1,0 +1,24 @@
+/ Grade Scheme Elements Table Display
+%table
+  %caption.sr-only Grading Scheme Levels
+  %thead
+    %tr
+      %th{scope: "col"} Grade
+      %th{scope: "col"} Level
+      %th{scope: "col"} Point Threshold
+      %th{scope: "col"} Locked?
+      %th{scope: "col"}
+        %span.sr-only Action Buttons
+  %tbody
+    - @grade_scheme_elements.each do |element|
+      %tr
+        %td= element.letter
+        %td= element.level
+        %td{data: { :"sort-value" => "#{element.lowest_points }" }}= points element.lowest_points
+        %td
+          - if element.unlock_conditions.present?
+            - element.unlock_conditions.each do |uc|
+              .condition= glyph(:lock) + uc.requirements_description_sentence
+        %td= link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
+
+= render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/app/views/grade_scheme_elements/mass_edit.html.haml
+++ b/app/views/grade_scheme_elements/mass_edit.html.haml
@@ -1,3 +1,3 @@
 .pageContent
-  #grade_scheme_elements_main_content{'ng-app'=>'gradecraft', 'ng-form'=>'grade_scheme_element_form'}
-    %grade_scheme_elements_mass_edit_form
+  #grade_scheme_elements_main_content{'ng-app'=>'gradecraft'}
+    %grade_scheme_elements_mass_edit_form{'ng-form'=>'', 'name'=>'gradeSchemeElementsForm'}

--- a/app/views/info/dashboard/_instructor_dashboard.haml
+++ b/app/views/info/dashboard/_instructor_dashboard.haml
@@ -7,7 +7,7 @@
     .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_course_events", locals: { presenter: Info::DashboardCourseEventsPresenter.new(course: current_course, student: current_student, assignments: presenter.assignments) }
 
   .flex-column
-    - if current_course.grade_scheme_elements.present?
+    - if current_course.grade_scheme_elements.present? && GradeSchemeElement.has_valid_elements_for(current_course)
       .panel.dashboard-module.grading-scheme-module.flex-row= render partial: "info/dashboard/modules/dashboard_grading_scheme"
 
     .stacked-column

--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -19,7 +19,7 @@
 
 
     .flex-col-30.tablet-col-3
-      - if current_course.grade_scheme_elements.present?
+      - if current_course.grade_scheme_elements.present? && GradeSchemeElement.has_valid_elements_for(current_course)
         .panel.dashboard-module.grading-scheme-module= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
 
       - if AnalyticsProctor.new.viewable? current_student, current_course

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -18,7 +18,7 @@
       .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_badges"
 
   .flex-col-30.tablet-col-3
-    - if current_course.grade_scheme_elements.present?
+    - if current_course.grade_scheme_elements.present? && GradeSchemeElement.has_valid_elements_for(current_course)
       .panel.dashboard-module.grading-scheme-module= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
 
     - if AnalyticsProctor.new.viewable? current_student, current_course

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,7 +354,9 @@ Rails.application.routes.draw do
       end
       resources :attachments, only: [:create, :destroy], module: :grades
     end
-    resources :grade_scheme_elements, only: :index
+    resources :grade_scheme_elements, only: :index do
+      delete :destroy, on: :collection
+    end
     resources :levels, only: :update
 
     # Student Predictor View, Predictor Preview

--- a/spec/controllers/api/grades_scheme_elements_controller_spec.rb
+++ b/spec/controllers/api/grades_scheme_elements_controller_spec.rb
@@ -1,33 +1,72 @@
 describe API::GradeSchemeElementsController do
-  let(:course) { build(:course) }
-  let(:student) { create(:course_membership, :student, course: course).user }
-  let!(:grade_scheme_element_high) { create(:grade_scheme_element, course: course) }
-  
-  before(:each) { login_user(student) }
+  let(:course) { build :course }
 
-  describe "GET index" do
-    context "with Grade Scheme elements" do
-      it "returns grade scheme elements with total points as json" do
-        get :index, format: :json
-        expect(assigns(:grade_scheme_elements)).to eq([grade_scheme_element_high])
-        expect(assigns(:total_points)).to eq(grade_scheme_element_high.lowest_points)
-        expect(response).to render_template(:index)
+  context "as a student" do
+    let(:student) { build_stubbed :user, courses: [course], role: :student }
+    before(:each) { login_user student }
+
+    describe "GET index" do
+      context "with Grade Scheme elements" do
+        let!(:grade_scheme_element_high) { create :grade_scheme_element, course: course }
+
+        it "returns grade scheme elements with total points as json" do
+          get :index, format: :json
+          expect(assigns(:grade_scheme_elements)).to eq([grade_scheme_element_high])
+          expect(assigns(:total_points)).to eq(grade_scheme_element_high.lowest_points)
+          expect(response).to render_template(:index)
+        end
+      end
+
+      context "with no Grade Scheme elements" do
+        it "returns the total points in the course if no grade scheme elements are present" do
+          create :assignment, course: course, full_points: 1000
+          get :index, format: :json
+          expect(assigns(:total_points)).to eq(1000)
+        end
+      end
+
+      context "with no Grade Scheme elements and no assignments" do
+        it "returns the total points in the course if no grade scheme elements are present" do
+          get :index, format: :json
+          expect(assigns(:total_points)).to eq(0)
+        end
       end
     end
 
-    context "with no Grade Scheme elements" do
-      it "returns the total points in the course if no grade scheme elements are present" do
-        GradeSchemeElement.destroy_all
-        assignment = create(:assignment, course: course, full_points: 1000)
-        get :index, format: :json
-        expect(assigns(:total_points)).to eq(1000)
+    describe "DELETE destroy" do
+      it "redirects to root" do
+        expect(delete :destroy).to redirect_to root_path
       end
     end
+  end
 
-    context "with no Grade Scheme elements and no assignments" do
-      it "returns the total points in the course if no grade scheme elements are present" do
-        get :index, format: :json
-        expect(assigns(:total_points)).to eq(0)
+  context "as a professor" do
+    let(:professor) { build_stubbed :user, courses: [course], role: :professor }
+    before(:each) { login_user professor }
+
+    describe "DELETE destroy" do
+      before(:each) { allow(controller).to receive(:current_course).and_return course }
+
+      context "with no grade scheme elements" do
+        it "returns a status OK" do
+          delete :destroy
+          expect(response.status).to eq 200
+        end
+      end
+
+      context "with grade scheme elements" do
+        let!(:grade_scheme_element) { create :grade_scheme_element, course: course }
+
+        it "returns a status OK if the elements were deleted" do
+          delete :destroy
+          expect(response.status).to eq 200
+        end
+
+        it "returns a status Internal Server Error if the elements were not deleted" do
+          allow(course.grade_scheme_elements).to receive(:any?).and_return 1
+          delete :destroy
+          expect(response.status).to eq 500
+        end
       end
     end
   end

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -55,18 +55,6 @@ describe GradeSchemeElementsController do
         expect(course.reload.grade_scheme_elements.count).to eq(2)
         expect(grade_scheme_element.reload.level).to eq("Sea Slug")
       end
-
-      it "does not save the changes if invalid" do
-        grade_scheme_element_2 = create(:grade_scheme_element, course: course)
-        params = { "grade_scheme_elements_attributes" => [{
-          id: grade_scheme_element.id, letter: "C", level: "Sea Slugs Galore", lowest_points: 0,
-          course_id: course.id }, { id: GradeSchemeElement.new.id,
-          letter: "B", level: "Snail", lowest_points: nil,
-          course_id: course.id}], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
-        put :mass_update, params: params, format: :json
-        expect(grade_scheme_element.reload).to eq grade_scheme_element
-        expect(response.status).to eq(500)
-      end
     end
 
     it "recalculates scores for all students in the course" do

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -83,8 +83,10 @@ describe GradeSchemeElementsController do
     end
 
     describe "GET index" do
-      it "assigns all grade scheme elements" do
-        grade_scheme_element = create(:grade_scheme_element, letter: "A", course: course)
+      let(:grade_scheme_element) { create(:grade_scheme_element, letter: "A", course: course, lowest_points: 3000) }
+      let(:empty_grade_scheme_element) { create(:grade_scheme_element, letter: "F", course: course) }
+
+      it "assigns grade scheme elements with point thresholds" do
         get :index
         expect(assigns(:grade_scheme_elements)).to eq([grade_scheme_element])
       end

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -19,36 +19,47 @@ describe GradeSchemeElement do
     end
   end
 
-  describe ".next_highest_element" do
+  describe ".next_highest_element_for" do
     context "when there is a grade scheme element with a higher point threshold" do
-      let!(:next_grade_scheme_element) { create :grade_scheme_element, lowest_points: 5000, course: course }
+      it "returns the next highest element with lowest points by default" do
+        grade_scheme_element = create :grade_scheme_element, lowest_points: 5000, course: course
+        expect(GradeSchemeElement.next_highest_element_for(subject)).to \
+          eq grade_scheme_element
+      end
 
-      it "returns the next highest element" do
-        expect(GradeSchemeElement.next_highest_element(subject)).to \
-          eq next_grade_scheme_element
+      it "returns the next highest element with or without lowest points if requested" do
+        grade_scheme_element = create :grade_scheme_element, lowest_points: nil, course: course
+        expect(GradeSchemeElement.next_highest_element_for(subject, false)).to \
+          eq grade_scheme_element
       end
     end
 
     context "when there is not a grade scheme element with a higher point threshold" do
       it "returns nil" do
-        expect(GradeSchemeElement.next_highest_element(subject)).to be_nil
+        expect(GradeSchemeElement.next_highest_element_for(subject)).to be_nil
       end
     end
   end
 
-  describe ".next_lowest_element" do
+  describe ".next_lowest_element_for" do
     context "when there is a grade scheme element with a lower point threshold" do
-      let!(:next_grade_scheme_element) { create :grade_scheme_element, lowest_points: 500, course: course }
+      it "returns the next lowest element with lowest points by default" do
+        grade_scheme_element = create :grade_scheme_element, lowest_points: 500, course: course
+        expect(GradeSchemeElement.next_lowest_element_for(subject)).to \
+          eq grade_scheme_element
+      end
 
-      it "returns the next lowest element" do
-        expect(GradeSchemeElement.next_lowest_element(subject)).to \
-          eq next_grade_scheme_element
+      it "returns the next lowest element with or without lowest points if requested" do
+        subject.lowest_points = nil
+        grade_scheme_element = create :grade_scheme_element, lowest_points: nil, course: course
+        expect(GradeSchemeElement.next_lowest_element_for(grade_scheme_element, false)).to \
+          eq subject
       end
     end
 
     context "when there is not a grade scheme element with a lower point threshold" do
       it "returns nil" do
-        expect(GradeSchemeElement.next_lowest_element(subject)).to be_nil
+        expect(GradeSchemeElement.next_lowest_element_for(subject)).to be_nil
       end
     end
   end
@@ -172,14 +183,14 @@ describe GradeSchemeElement do
 
   describe "#next_highest_element" do
     it "returns the next highest level relative to itself" do
-      expect(GradeSchemeElement).to receive(:next_highest_element).with(subject)
+      expect(GradeSchemeElement).to receive(:next_highest_element_for).with(subject)
       subject.next_highest_element
     end
   end
 
   describe "#next_lowest_element" do
     it "returns the next highest element relative to itself" do
-      expect(GradeSchemeElement).to receive(:next_lowest_element).with(subject)
+      expect(GradeSchemeElement).to receive(:next_lowest_element_for).with(subject)
       subject.next_lowest_element
     end
   end

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -36,6 +36,23 @@ describe GradeSchemeElement do
     end
   end
 
+  describe ".next_lowest_element" do
+    context "when there is a grade scheme element with a lower point threshold" do
+      let!(:next_grade_scheme_element) { create :grade_scheme_element, lowest_points: 500, course: course }
+
+      it "returns the next lowest element" do
+        expect(GradeSchemeElement.next_lowest_element(subject)).to \
+          eq next_grade_scheme_element
+      end
+    end
+
+    context "when there is not a grade scheme element with a lower point threshold" do
+      it "returns nil" do
+        expect(GradeSchemeElement.next_lowest_element(subject)).to be_nil
+      end
+    end
+  end
+
   describe "#copy" do
     let(:grade_scheme_element) { build :grade_scheme_element }
     subject { grade_scheme_element.copy }

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -8,13 +8,28 @@ describe GradeSchemeElement do
     create :course_membership, :student, user: student, course: course, score: 82, earned_grade_scheme_element_id: subject.id
   end
 
-  context "validations" do
+  describe "validations" do
     it "is valid with a course" do
       expect(subject).to be_valid
     end
 
     it "is invalid without a course" do
       subject.course = nil
+      expect(subject).to be_invalid
+    end
+
+    it "is valid if lowest points is nil" do
+      subject.lowest_points = nil
+      expect(subject).to be_valid
+    end
+
+    it "is invalid if lowest points is not numeric" do
+      subject.lowest_points = "one"
+      expect(subject).to be_invalid
+    end
+
+    it "is invalid if lowest points is greater than a length of nine" do
+      subject.lowest_points = 1234567890
       expect(subject).to be_invalid
     end
   end

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -9,13 +9,8 @@ describe GradeSchemeElement do
   end
 
   context "validations" do
-    it "is valid with a low range, a high range, and a course" do
+    it "is valid with a course" do
       expect(subject).to be_valid
-    end
-
-    it "is invalid without a low range" do
-      subject.lowest_points = nil
-      expect(subject).to be_invalid
     end
 
     it "is invalid without a course" do

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -177,6 +177,13 @@ describe GradeSchemeElement do
     end
   end
 
+  describe "#next_lowest_element" do
+    it "returns the next highest element relative to itself" do
+      expect(GradeSchemeElement).to receive(:next_lowest_element).with(subject)
+      subject.next_lowest_element
+    end
+  end
+
   describe "#range" do
     context "when the current level has the highest points threshold in the course" do
       it "returns infinity" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -183,17 +183,17 @@ describe User do
 
   describe "#is_staff?(course)" do
     let(:user) { create :user }
-    
+
     it "returns true if the user is a professor in the course" do
       create(:course_membership, :professor, course: course, user: user)
       expect(user.is_staff?(course)).to eq(true)
     end
-    
+
     it "returns true if the user is a GSI in the course" do
       create(:course_membership, :staff, course: course, user: user)
       expect(user.is_staff?(course)).to eq(true)
     end
-    
+
     it "returns true if the user is an admin in the course" do
       create(:course_membership, :admin, course: course, user: user)
       expect(user.is_staff?(course)).to eq(true)
@@ -315,23 +315,6 @@ describe User do
     it "returns the grade scheme letter name that matches the student's score for the course" do
       gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
       expect(student.grade_letter_for_course(course)).to eq("Q")
-    end
-  end
-
-  describe "#get_element_level(course, :next)" do
-    it "returns the next level above a student's current score for the course" do
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, letter: "R")
-      gse_2 = create(:grade_scheme_element, course: course, lowest_points: 150001, letter: "S")
-      expect(student.get_element_level(course, :next)).to eq(gse_1)
-    end
-  end
-
-  describe "#points_to_next_level(course)" do
-    it "returns the next level above a student's current score for the course" do
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
-      gse_1 = create(:grade_scheme_element, course: course, lowest_points: 120001, letter: "R")
-      expect(student.points_to_next_level(course)).to eq(20001)
     end
   end
 
@@ -502,7 +485,7 @@ describe User do
 
   describe "#earned_badges_for_course(course)", :unreliable do
     let(:student) { create :user, courses: [course], role: :student }
-    
+
     it "returns the students' earned_badges for a course" do
       earned_badge_1 = create(:earned_badge, student: student, course: course)
       earned_badge_2 = create(:earned_badge, student: student, course: course)

--- a/spec/presenters/info/dashboard_grading_scheme_presenter_spec.rb
+++ b/spec/presenters/info/dashboard_grading_scheme_presenter_spec.rb
@@ -38,11 +38,21 @@ describe Info::DashboardGradingSchemePresenter do
     it "returns the next element the student needs to achieve" do
       expect(subject.next_element).to eq(@grade_scheme_element_3)
     end
+
+    it "returns nil if the current element is nil" do
+      allow(subject).to receive(:current_element).and_return nil
+      expect(subject.next_element).to be_nil
+    end
   end
 
   describe "#previous_element" do
     it "returns the previous_element the student earned" do
       expect(subject.previous_element).to eq(@grade_scheme_element_2)
+    end
+
+    it "returns nil if the current element is nil" do
+      allow(subject).to receive(:current_element).and_return nil
+      expect(subject.previous_element).to be_nil
     end
   end
 


### PR DESCRIPTION
### Status
READY

### Description
The goal of this PR is to allow an instructor to quickly set up grade scheme elements by filling out a few related questions.

This requires us to remove the validation for `lowest_points` on the GradeSchemeElement model so that on submission of the setup questions, "empty" GradeSchemeElements can be created for editing on the `mass_edit` page

Grade scheme elements are not considered "valid" until they have a value for `lowest_points`, meaning they should not be visible or taken into account as a student.

### Migrations
NO

### Steps to Test or Reproduce


### Impacted Areas in Application
Instructors - Setting up new grade scheme elements and mass editing existing
Students - Grade scheme elements index

======================
Closes #2243 
Closes #2244 
Closes #2245