### PR TITLE
allow student access to api/courses

### DIFF
--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -1,5 +1,4 @@
 class API::CoursesController < ApplicationController
-  before_action :ensure_staff?, except: [:timeline_events]
 
   # accessed by the dashboard
   # GET api/courses


### PR DESCRIPTION
fixes permissions for students on the api/courses controller to allow course index for switching courses.