### PR TITLE
2896 Manually Activate Account first pass

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -95,6 +95,13 @@ class UsersController < ApplicationController
     redirect_to root_path, alert: "Invalid activation token. Please contact support to request a new one." and return unless @user
   end
 
+  def manually_activate
+    session[:return_to] ||= request.referer
+    @User = User.find(params[:id])
+    @User.activate!
+    redirect_to session.delete(:return_to), notice: "#{@User.first_name} #{@User.last_name} has been activated!" and return
+  end
+
   def activated
     @token = params[:token]
     @user = User.load_from_activation_token(@token)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,9 +97,9 @@ class UsersController < ApplicationController
 
   def manually_activate
     session[:return_to] ||= request.referer
-    @User = User.find(params[:id])
-    @User.activate!
-    redirect_to session.delete(:return_to), notice: "#{@User.first_name} #{@User.last_name} has been activated!" and return
+    @user = User.find(params[:id])
+    @user.activate!
+    redirect_to session.delete(:return_to), notice: "#{@user.first_name} #{@user.last_name} has been activated!" and return
   end
 
   def activated

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   before_action :ensure_staff?,
     except: [:activate, :activated, :edit_profile, :update_profile]
   before_action :ensure_admin?, only: [:all]
+  before_action :save_referer, only: :manually_activate
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]
 
@@ -99,7 +100,7 @@ class UsersController < ApplicationController
     session[:return_to] ||= request.referer
     @user = User.find(params[:id])
     @user.activate!
-    redirect_to session.delete(:return_to), notice: "#{@user.first_name} #{@user.last_name} has been activated!" and return
+    redirect_to session[:return_to] || dashboard_path, notice: "#{@user.first_name} #{@user.last_name} has been activated!" and return
   end
 
   def activated

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,7 +97,6 @@ class UsersController < ApplicationController
   end
 
   def manually_activate
-    session[:return_to] ||= request.referer
     @user = User.find(params[:id])
     @user.activate!
     redirect_to session[:return_to] || dashboard_path, notice: "#{@user.first_name} #{@user.last_name} has been activated!" and return

--- a/app/views/info/dashboard/modules/_dashboard_avatar.haml
+++ b/app/views/info/dashboard/modules/_dashboard_avatar.haml
@@ -25,3 +25,5 @@
         %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
         %li= link_to decorative_glyph(:envelope) + "Email", "mailto:#{current_student.email}", class: "button"
         %li= link_to decorative_glyph(:refresh) + "Update Score", recalculate_student_path(current_student), class: "button"
+        - if !current_student.activated?
+          %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -33,3 +33,5 @@
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
                 %li= link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
                 %li= link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
+                - if !user.activated?
+                  %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -3,6 +3,9 @@
 .pageContent
   = render "layouts/alerts"
 
+  - if !@staff_member.activated?
+    =link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(@staff_member.id), :method => :put, class: "button"
+
   %h4 Courses
   %ul
     - @staff_member.courses.each do |course|

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -55,3 +55,5 @@
               %li= mail_to student.email, glyph(:envelope) + "Email"
               %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(student)
               %li= link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
+              - if !student.activated?
+                %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,7 @@ Rails.application.routes.draw do
   resources :users, except: :show do
     member do
       get :activate
+      put :manually_activate
       post :activate, action: :activated
       post :flag
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -163,6 +163,25 @@ describe UsersController do
         expect(response.body).to include "The team is not cool"
       end
     end
+
+    describe "PUT manually_activate" do
+      let(:unactivated_user) { create(:user)}
+      it "activates the user" do
+        put :manually_activate, params:{id:unactivated_user.id}
+        expect(unactivated_user.activated?).to eq true
+      end
+
+      it "redirects to referer url if present" do
+        request.env["HTTP_REFERER"] = "http://some-referer.com"
+        put :manually_activate, params:{id:unactivated_user.id}
+        expect(response).to redirect_to("http://some-referer.com")
+      end
+
+      it "redirects to dashboard if referer url is not present" do
+        put :manually_activate, params:{id:unactivated_user.id}
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
   end
 
   context "as a student" do
@@ -307,7 +326,8 @@ describe UsersController do
       [
         :edit,
         :update,
-        :destroy
+        :destroy,
+        :manually_activate
       ].each do |route|
         it "#{route} redirects to root" do
           expect(get route, params: { id: "1" }).to redirect_to(:root)


### PR DESCRIPTION
### Status
**READY**

### Description
Enable admins to activate student and faculty accounts manually instead of by email.

### Related PRs
N/A


### Todos


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Students Page
* Staff Page

======================
Closes #[2896]
