### PR TITLE
3096 errant leaderboard ordering

### DIFF
--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -14,7 +14,11 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
         score: 'numeric',
         rank: 'numeric',
         date: 'date',
-        blog: 'alphanum'
+        blog: 'alphanum',
+        scoreWithWeights: 'numeric',
+        finalScore: 'numeric',
+        predictedScore: 'numeric',
+        id: 'numeric'
       }
     }
 });

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -388,6 +388,11 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('#{ term_for :students }', students_path)
   end
 
+  def students_grade_index
+    dashboard
+    breadcrumb('Grades')
+  end
+
   def students_show
     students_index
   end
@@ -426,7 +431,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     teams_index
     breadcrumb('New #{ term_for :team }')
   end
-  
+
   def users_activate
   end
 
@@ -475,7 +480,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
 
   def pages_features
   end
-  
+
   def pages_sign_up
   end
 end

--- a/app/views/assignments/individual/_table_head.html.haml
+++ b/app/views/assignments/individual/_table_head.html.haml
@@ -8,7 +8,7 @@
     %th Raw Score
   // If 'Score' only if the assignment type is not student_weightable
   - if !presenter.assignment_type.student_weightable? && !presenter.assignment.pass_fail?
-    %th{scope: "col", "data-dynatable-sorts" => "numericScore"} Score
+    %th{scope: "col"} Score
   - elsif presenter.assignment_type.student_weightable?
     %th{scope: "col"} Raw Score
     %th{scope: "col"} Multiplied Score

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -2,7 +2,7 @@
   %thead
     %tr
       %th Name
-      %th{"data-dynatable-sorts" => "numericScore"} Max Points
+      %th Max Points
       %th{"data-dynatable-sorts" => "dueDate"} Due
       %th{:style => "display: none"} Due Date
       %th Visible

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -3,7 +3,7 @@
     %thead
       %tr
         %th= current_course.team_term
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
         - if @challenge.has_levels?
           %th Level
         - if @challenge.release_necessary?

--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -12,10 +12,10 @@
   %thead
     %tr
       %th= current_course.team_term
-      %th{ "data-dynatable-sorts" => "numericScore" } Score
+      %th Score
       - if @challenge.has_levels?
         %th Level
-      %th 
+      %th
   %tbody
     - @teams.alpha.each do |team|
       - challenge_grade = @challenge.challenge_grades.find_by team: team
@@ -25,6 +25,6 @@
         - if @challenge.has_levels?
           %td
             = @challenge.grade_level(grade) if challenge_grade
-        %td 
+        %td
           - if team == current_student.team_for_course(current_course) && challenge_grade
             = link_to glyph(:eye) + "See Grade Details", challenge_grade_path(challenge_grade.id), class: 'button'

--- a/app/views/challenges/challenge_grades/edit_status.html.haml
+++ b/app/views/challenges/challenge_grades/edit_status.html.haml
@@ -5,7 +5,7 @@
     %thead
       %tr
         %th= term_for :team
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
         %th Current Status
     %tbody
       - for challenge_grade in @challenge_grades

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -8,7 +8,7 @@
         %th ID | Assignment
         %th Submission
         %th Final Score
-        %th{ "data-dynatable-sorts" => "numericScore" } Score With Weights
+        %th Score With Weights
         %th Predicted Score
         %th Feedback
         %th Status

--- a/app/views/teams/_in_team_rankings.html.haml
+++ b/app/views/teams/_in_team_rankings.html.haml
@@ -13,7 +13,7 @@
           %th Character Profile
         - if current_course.has_team_roles?
           %th Role
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
     %tbody
       - team.students.reverse.each_with_index do |student, index|
         - if student.display_name?

--- a/app/views/teams/_in_team_rankings.html.haml
+++ b/app/views/teams/_in_team_rankings.html.haml
@@ -15,7 +15,7 @@
           %th Role
         %th Score
     %tbody
-      - team.students.reverse.each_with_index do |student, index|
+      - team.students.sort_by { |s| s.score_for_course(current_course) }.reverse.each_with_index do |student, index|
         - if student.display_name?
           %tr{class: ("complete" if student == current_student) }
             %td{"data-title" => "Rank"}= index + 1

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -16,7 +16,7 @@
         %th Email
         - if current_course.has_team_roles?
           %th Role
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
         %th Level
         - if current_course.has_badges?
           %th{scope: "col", "data-dynatable-sorts" => "badgeCount", :width => "20%" }= "#{term_for :badges} Earned"
@@ -51,7 +51,7 @@
     %thead
       %tr
         %th Name
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
         %th{:width => "80px"}
 
     %tbody

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -14,7 +14,7 @@
         %th Role
         %th Courses
         %th #{term_for :team}
-        %th{ "data-dynatable-sorts" => "numericScore" } Score
+        %th Score
         %th Options
     %tbody
       - @users.each do |user|
@@ -48,5 +48,5 @@
                   %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(user) if user_is_student
                 - elsif user_is_staff
                   %li= link_to decorative_glyph(:dashboard) + "Dashboard", staff_path(user) if user_is_staff
-                %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user) 
+                %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user)
                 %li= link_to decorative_glyph(:trash) + "Delete", course_membership, data: { confirm: "This will delete the student from your course - Are you sure?" }, :method => :delete


### PR DESCRIPTION
### Status
READY

### Description
The team leaderboard is not ordering properly by score. By default, the students should also be listed in descending order by their scores.

### Gem dependencies
N/A

### Migrations
NO

### Impacted Areas in Application
- [ ] Team leaderboard sorting
- [ ] Team show
- [ ] Grade audit page for admins (`StudentsController#grade_index`)
- [ ] Users index
- [ ] Challenges view
- [ ] Assignments show

======================
Closes #3096
