### PR TITLE
2498 add dir to upload

### DIFF
--- a/app/controllers/api/grades/attachments_controller.rb
+++ b/app/controllers/api/grades/attachments_controller.rb
@@ -8,7 +8,12 @@ class API::Grades::AttachmentsController < ApplicationController
 
     @file_uploads = []
     params[:file_uploads].each do |f|
-      file = FileUpload.create(file: f, filename: f.original_filename[0..49], grade_id: grade.id)
+      file = FileUpload.create(
+        file: f, filename: f.original_filename[0..49],
+        grade_id: grade.id,
+        course_id: grade.course.id,
+        assignment_id: grade.assignment.id
+      )
       Attachment.create(file_upload_id: file.id, grade_id: grade.id)
       @file_uploads << file
     end

--- a/app/models/file_upload.rb
+++ b/app/models/file_upload.rb
@@ -13,10 +13,12 @@ class FileUpload < ActiveRecord::Base
   mount_uploader :file, AttachmentUploader
   process_in_background :file
 
+  # remove once attachments rake task is run
   def course
     grade.course
   end
 
+  # remove once attachments rake task is run
   def assignment
     grade.assignment
   end

--- a/db/migrate/20170310181729_add_course_assignment_to_file_upload.rb
+++ b/db/migrate/20170310181729_add_course_assignment_to_file_upload.rb
@@ -1,0 +1,6 @@
+class AddCourseAssignmentToFileUpload < ActiveRecord::Migration[5.0]
+  def change
+    add_column :file_uploads, :course_id, :integer
+    add_column :file_uploads, :assignment_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+
 ActiveRecord::Schema.define(version: 20170403145349) do
 
   # These are extensions that must be enabled in order to support this database
@@ -372,6 +373,8 @@ ActiveRecord::Schema.define(version: 20170403145349) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "store_dir"
+    t.integer  "course_id"
+    t.integer  "assignment_id"
   end
 
   create_table "flagged_users", force: :cascade do |t|

--- a/lib/tasks/attachments.rake
+++ b/lib/tasks/attachments.rake
@@ -2,10 +2,11 @@ namespace :attachments do
 
   desc "Add grade file association for many to many relationship"
   task add_associations: :environment do
-    FileUpload.find_each(batch_size: 500) do |gf|
-      if Attachment.where(file_upload_id: gf.id, grade_id: gf.grade_id).empty?
-        Attachment.create(file_upload_id: gf.id, grade_id: gf.grade_id)
+    FileUpload.find_each(batch_size: 500) do |fu|
+      if Attachment.where(file_upload_id: fu.id, grade_id: fu.grade_id).empty?
+        Attachment.create(file_upload_id: fu.id, grade_id: fu.grade_id)
       end
+      fu.update_attributes course_id: fu.grade.course_id, assignment_id: fu.grade.assignment_id
     end
   end
 end


### PR DESCRIPTION
### Status
Ready, **DO NOT MERGE** until ready to run rake task and merge <branch: 2498-group-files-step-2>

### Description

This PR prepares existing files for the PR which implements group grade file uploads.
  * It adds course and assignment fields to `FileUpload` to maintain current directory structure.
  * It manually fills these fields in at the controller level for new uploads.

### Related PRs

branch | PR | status
------ | ------ | -----------
original ticket | #2498 | step 1 of 3
2498-group-grade-files | #2682 | merged
2498-group-files-step-2 | #3116 | pending

### Deploy Notes

When we are ready to merge <branch: 2498-group-files-step-2>:

  * merge and deploy this branch
  * run migration
  * run rake task: `rails attachments:add_associations`

### Migrations
YES

```
add_column :file_uploads, :course_id, :integer
add_column :file_uploads, :assignment_id, :integer
```

### Steps to Test

  * Ideally, run on staging and verify that this will work
  * After merge and rake task, verify that existing file uploads are still available

### Impacted Areas in Application

* Grade File uploads

