### PR TITLE
1949 archived limitations

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -65,10 +65,9 @@
          recipientType: "@",
          recipientId: "=",
          submitPath: "@",
-         gradeNextPath: "@"
+         gradeNextPath: "@",
+         isActiveCourse: "="
         },
       templateUrl: 'grades/edit.html'
     }
 ]
-
-

--- a/app/assets/javascripts/angular/directives/student/submission/save_draft_button.coffee
+++ b/app/assets/javascripts/angular/directives/student/submission/save_draft_button.coffee
@@ -16,6 +16,7 @@
     restrict: 'C'
     scope: {
       assignmentId: '@'
+      isActiveCourse: '='
     }
     templateUrl: 'student/submission/save_draft_button.html'
   }

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -30,7 +30,7 @@
 .right
   %grade-status-select
   .right
-    %grade-submit-buttons(submit-path='{{vm.submitPath}}' grade-next-path='{{vm.gradeNextPath}}')
+    %grade-submit-buttons(ng-if='vm.isActiveCourse' submit-path='{{vm.submitPath}}' grade-next-path='{{vm.gradeNextPath}}')
 
 .clear
 

--- a/app/assets/javascripts/angular/templates/student/submission/save_draft_button.html.haml
+++ b/app/assets/javascripts/angular/templates/student/submission/save_draft_button.html.haml
@@ -1,3 +1,3 @@
-%a.button(ng-click='vm.queueSaveDraftSubmission()')
+%a.button(ng-if='vm.isActiveCourse' ng-click='vm.queueSaveDraftSubmission()')
   %i.fa.fa-save
   Save Draft

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -5,9 +5,9 @@ class API::AssignmentsController < ApplicationController
   def index
     @assignments = current_course.assignments.ordered
 
-    if  current_user_is_student?
+    if current_user_is_student?
       @student = current_student
-      @allow_updates = !impersonating?
+      @allow_updates = !impersonating? && current_course.active?
       @grades = Grade.for_course(current_course).for_student(current_student)
 
       if !impersonating?

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -14,9 +14,9 @@ class API::BadgesController < ApplicationController
       :visible,
       :visible_when_locked)
 
-    if  current_user_is_student?
+    if current_user_is_student?
       @student = current_student
-      @allow_updates = !impersonating?
+      @allow_updates = !impersonating? && current_course.active?
 
       if !impersonating?
         @badges.includes(:predicted_earned_badges)

--- a/app/controllers/api/challenges_controller.rb
+++ b/app/controllers/api/challenges_controller.rb
@@ -8,7 +8,7 @@ class API::ChallengesController < ApplicationController
     if include_student_data?
       @team = current_student.team_for_course(current_course)
       @student = current_student
-      @allow_updates = !impersonating?
+      @allow_updates = !impersonating? && current_course.active?
       @include_in_predictor = true
 
       if !impersonating?

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -3,6 +3,7 @@ class InfoController < ApplicationController
 
   before_action :ensure_not_observer?, except: [:predictor]
   before_action :ensure_staff?, except: [:dashboard, :predictor]
+  before_action :ensure_active_course?, only: :predictor
   before_action :find_team,
     only: [:earned_badges, :multiplier_choices]
   before_action :find_students,
@@ -122,5 +123,9 @@ class InfoController < ApplicationController
     else
       @students = current_course.students_being_graded.order_by_name
     end
+  end
+
+  def ensure_active_course?
+    redirect_to dashboard_path unless current_course.active?
   end
 end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -3,7 +3,6 @@ class InfoController < ApplicationController
 
   before_action :ensure_not_observer?, except: [:predictor]
   before_action :ensure_staff?, except: [:dashboard, :predictor]
-  before_action :ensure_active_course?, only: :predictor
   before_action :find_team,
     only: [:earned_badges, :multiplier_choices]
   before_action :find_students,
@@ -123,9 +122,5 @@ class InfoController < ApplicationController
     else
       @students = current_course.students_being_graded.order_by_name
     end
-  end
-
-  def ensure_active_course?
-    redirect_to dashboard_path unless current_course.active?
   end
 end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -42,11 +42,11 @@ module LinkHelper
   # Conditionally renders a link_to helper based on whether the course is active
   # or not
   def active_course_link_to(name = nil, options = nil, html_options = nil, &block)
-    link_to name, options, html_options, &block if current_course.active?
+    link_to name, options, html_options, &block if current_user_is_admin? || current_course.active?
   end
 
   def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)
-    link_to_unless_current name, options, html_options, &block if current_course.active?
+    link_to_unless_current name, options, html_options, &block if current_user_is_admin? || current_course.active?
   end
 
   class InternalLinkScrubber < Rails::Html::PermitScrubber

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -39,6 +39,12 @@ module LinkHelper
     link_to name, options, html_options, &block
   end
 
+  # Conditionally renders a link_to helper based on whether the course is active
+  # or not
+  def active_course_link_to(name = nil, options = nil, html_options = nil, &block)
+    link_to name, options, html_options, &block if current_course.active?
+  end
+
   class InternalLinkScrubber < Rails::Html::PermitScrubber
     def scrub(node)
       return super unless (node.type == Nokogiri::XML::Node::ELEMENT_NODE) &&

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -45,6 +45,10 @@ module LinkHelper
     link_to name, options, html_options, &block if current_course.active?
   end
 
+  def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)
+    link_to_unless_current name, options, html_options, &block if current_course.active?
+  end
+
   class InternalLinkScrubber < Rails::Html::PermitScrubber
     def scrub(node)
       return super unless (node.type == Nokogiri::XML::Node::ELEMENT_NODE) &&

--- a/app/helpers/submit_tag_helper.rb
+++ b/app/helpers/submit_tag_helper.rb
@@ -1,6 +1,6 @@
 module SubmitTagHelper
   # Conditionally renders submit button based on whether the course is active
   def active_course_submit_tag(value = "Save changes", options={})
-    submit_tag value, options if current_course.active?
+    submit_tag value, options if current_user_is_admin? || current_course.active?
   end
 end

--- a/app/helpers/submit_tag_helper.rb
+++ b/app/helpers/submit_tag_helper.rb
@@ -1,0 +1,6 @@
+module SubmitTagHelper
+  # Conditionally renders submit button based on whether the course is active
+  def active_course_submit_tag(value = "Save changes", options={})
+    submit_tag value, options if current_course.active?
+  end
+end

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= link_to decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -32,9 +32,7 @@
                   = decorative_glyph(:refresh)
                   = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
             %li.hide-for-small
-              %a{:href => assignment_grades_importers_path(presenter.assignment) }
-                = decorative_glyph(:download)
-                Import Grades
+              = active_course_link_to decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
 
               %li.hide-for-small
                 %a{:href => design_assignment_rubrics_path(presenter.assignment) }

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -2,13 +2,13 @@
   .context_menu(ng-app="gradecraft" ng-controller="AssignmentCtrl" ng-init="init(#{presenter.assignment.id}, #{presenter.assignment.use_rubric})")
     %ul
       - if !presenter.new_assignment?
-        %li= link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu
             - if presenter.assignment.grades.present?
               %li= link_to decorative_glyph(:"check-square") + "Review Grades", grades_review_assignment_path(id: presenter.assignment)
-            %li= link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
+            %li= active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
             - if presenter.assignment.has_groups?
               %li= link_to decorative_glyph(:users) + "Create #{term_for :group}", new_group_path
 
@@ -24,11 +24,11 @@
 
             - unless presenter.assignment.imported_assignment.nil?
               %li.hide-for-small
-                = link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+                = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                   = decorative_glyph(:refresh)
                   = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
               %li.hide-for-small
-                = link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+                = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                   = decorative_glyph(:refresh)
                   = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
             %li.hide-for-small

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -14,9 +14,9 @@
 
             - if !presenter.grade_with_rubric?
               - if presenter.for_team?
-                %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
+                %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
               - else
-                %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
+                %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
 
             - if presenter.assignment.accepts_submissions?
               = render partial: "assignments/buttons/submissions_exports",

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -1,8 +1,8 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
-      %li= link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
+      %li= active_course_link_to decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
+      %li= active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -15,8 +15,8 @@
             %i.fa.fa-angle-double-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden{role: "tabpanel"}
-          = link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
-          = link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
+          = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
+          = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr
@@ -51,13 +51,15 @@
                       %ul.button-bar
                         - if !assignment.grade_with_rubric?
                           %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
-                        %li= link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
-                        %li= link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
-                        %li= link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
-          .box{ style: "width: 95%; margin: 1em auto;"}
-            .center
-              = link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment}", new_assignment_path(assignment_type_id: assignment_type.id)
+                        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
+                        %li= active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
+                        %li= active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
+          - if current_course.active? 
+            .box{ style: "width: 95%; margin: 1em auto;"}
+              .center
+                = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment}", new_assignment_path(assignment_type_id: assignment_type.id)
 
-  .box
-    .center
-      = link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment} Type", new_assignment_type_path
+  - if current_course.active? 
+    .box
+      .center
+        = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment} Type", new_assignment_type_path

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -27,7 +27,7 @@
                 %th{:style => "display: none"} Due Date
                 %th{scope: "col", :width => "10%"}  Max Points
                 %th Rubric?
-                %th{ :style => "min-width: 200px" } 
+                %th{ :style => "min-width: 200px" }
                   %span.sr-only Action Buttons
             %tbody.sort-assignments
               - assignments = assignment_type.assignments.ordered.includes(:rubric, :assignment_type)
@@ -49,8 +49,8 @@
                   %td
                     .right
                       %ul.button-bar
-                        - if ! assignment.grade_with_rubric?
-                          %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                        - if !assignment.grade_with_rubric?
+                          %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
                         %li= link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
                         %li= link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
                         %li= link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"

--- a/app/views/assignments/grades/index.html.haml
+++ b/app/views/assignments/grades/index.html.haml
@@ -12,7 +12,7 @@
         %h4.uppercase= student.name
         .left
           %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "
-        .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
+        .right= active_course_link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
         %br
         %br
         .rubric-container= render partial: "grades/components/criterion_grade_results", locals: { presenter: presenter, current_student: student }

--- a/app/views/assignments/group/_group_show.haml
+++ b/app/views/assignments/group/_group_show.haml
@@ -1,5 +1,5 @@
 = form_tag edit_status_assignment_grades_path(presenter.assignment), method: :get do
-  - if ! presenter.groups.present?
+  - if !presenter.groups.present?
     No #{term_for :groups} have been created! You can either have #{term_for :students} self-create their #{term_for :groups}, or you can create them manually #{link_to "here", new_group_path}.
   - else
     %table
@@ -7,4 +7,4 @@
       %tbody= render partial: "assignments/group/table_body", locals: { presenter: presenter }
       .right
         - if presenter.assignment.release_necessary? && presenter.has_grades?
-          = submit_tag "Update Grade Statuses", class: "button"
+          = active_course_submit_tag "Update Grade Statuses", class: "button"

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -7,11 +7,11 @@
         %ul.button-bar
           %li= link_to "Review #{term_for :group}", edit_group_path(id: group_presenter.group), class: "button"
           - if presenter.assignment.accepts_submissions? && !group_presenter.submission
-            %li= link_to "Submit", group_presenter.path_for_new_submission, class: "button"
+            %li= active_course_link_to "Submit", group_presenter.path_for_new_submission, class: "button"
           - if group_presenter.assignment_graded?
-            %li= link_to decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
+            %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
           - else
-            %li= link_to decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
+            %li= active_course_link_to decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
     %td
       %table
         %thead{:style => "background: none !important; color: #000000; margin: 0; padding: 0;"}

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -19,4 +19,5 @@
     'recipient-type'=>"group",
     'recipient-id'=>"#{@group.id}",
     'submit-path'=>"#{assignment_path(@assignment)}",
-    'grade-next-path'=>"#{@grade_next_path}"}
+    'grade-next-path'=>"#{@grade_next_path}",
+    'is-active-course'=>"#{current_course.active?}"}

--- a/app/views/assignments/index_student/components/_submission_buttons.haml
+++ b/app/views/assignments/index_student/components/_submission_buttons.haml
@@ -3,9 +3,9 @@
     %li
       = link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif assignment.open?
-    %li= link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
+    %li= active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
 - elsif assignment.has_groups? && presenter.group_for(assignment)
   - if presenter.group_for(assignment).submission_for_assignment(assignment)
     %li= link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif presenter.group_for(assignment).approved? && assignment.open?
-    %li= link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"
+    %li= active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"

--- a/app/views/assignments/individual/_individual_show.haml
+++ b/app/views/assignments/individual/_individual_show.haml
@@ -5,9 +5,7 @@
     = simple_form_for presenter.assignment, :url => delete_all_assignment_grades_path(assignment_id: presenter.assignment.id), method: :delete do |f|
       = hidden_field_tag :team_id, presenter.team.id unless presenter.team.nil?
       .submit-buttons
-        %button{ :type => "submit", class: "button button-slim", data: { confirm: "Are you sure you want to delete all grades for this assignment?" } }
-          %i.fa.fa-trash
-          Delete All Grades
+        = active_course_submit_tag "Delete All Grades", class: "button button-slim", data: { confirm: "Are you sure you want to delete all grades for this assignment?" }
 
 .progress
 = form_tag edit_status_assignment_grades_path(presenter.assignment), method: :get do
@@ -18,6 +16,6 @@
   - if presenter.assignment.release_necessary? && presenter.has_grades?
     .right
       %br
-      = submit_tag "Update Selected Grade Statuses", class: "button disabled", disabled: true, data: { behavior: "selected-individual-grades-command" }
+      = active_course_submit_tag "Update Selected Grade Statuses", class: "button disabled", disabled: true, data: { behavior: "selected-individual-grades-command" }
 
   .clear

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -59,15 +59,15 @@
           - if grade.instructor_modified?
             %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade), class: "button"
             - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(student_submission)
-              %li= link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
+              %li= active_course_link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
             - else
-              %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
-            %li= link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+            %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
           - else
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
-              %li= link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
+              %li= active_course_link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
-            %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
+            %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -36,6 +36,6 @@
             - presenter.badge.earned_badges.where(student_id: student.id).each do |badge|
               %ul.button-bar
                 %li= link_to decorative_glyph(:star) + "Awarded #{badge.created_at.strftime("%b %d")}", badge_earned_badge_path(presenter.badge, badge.id), class: "button"
-                %li= link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
-                %li= link_to decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
+                %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
+                %li= active_course_link_to decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
               .clear

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -1,5 +1,5 @@
 %ul.button-bar
-  %li= link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
-  %li= link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
+  %li= active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
+  %li= active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
   %li= link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
   %li= link_to decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -1,5 +1,5 @@
 %ul.button-bar
   %li= active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
   %li= active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
-  %li= link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
-  %li= link_to decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }
+  %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
+  %li= active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -2,7 +2,7 @@
   .context_menu
     %ul
       - if actions.include? :new
-        %li= link_to decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
 
       - if actions.include? :see
         %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -8,10 +8,10 @@
         %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
 
       - if actions.include? :edit
-        %li= link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
 
       - if actions.include? :award
-        %li= link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
 
       - if actions.include? :quick_award
-        %li= link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"

--- a/app/views/challenge_grades/_form.html.haml
+++ b/app/views/challenge_grades/_form.html.haml
@@ -34,5 +34,5 @@
     .clear
   .submit-buttons
     %ul
-      %li= active_course_submit_tag "#{ @challenge_grade.persisted? ? 'Update Grade' : 'Submit Grade'}"
+      %li= active_course_submit_tag "#{ @challenge_grade.persisted? ? 'Update Grade' : 'Submit Grade'}", class: "button"
       %li= link_to glyph("times-circle") + "Cancel", challenges_path, class: "button"

--- a/app/views/challenge_grades/_form.html.haml
+++ b/app/views/challenge_grades/_form.html.haml
@@ -22,7 +22,7 @@
     %h4 Feedback
     .textarea
       = f.text_area :feedback, class: "froala"
-      
+
   %section
     .right
       %h4.text-right Points Adjustment
@@ -30,9 +30,9 @@
       %p
       %h4.text-right Points Adjustment Feedback
       = f.text_area :adjustment_points_feedback
-      
+
     .clear
   .submit-buttons
     %ul
-      %li= f.button :submit, "#{ @challenge_grade.persisted? ? 'Update Grade' : 'Submit Grade'}"
+      %li= active_course_submit_tag "#{ @challenge_grade.persisted? ? 'Update Grade' : 'Submit Grade'}"
       %li= link_to glyph("times-circle") + "Cancel", challenges_path, class: "button"

--- a/app/views/challenge_grades/components/_edit_button.haml
+++ b/app/views/challenge_grades/components/_edit_button.haml
@@ -1,1 +1,1 @@
-= link_to glyph(:edit) + "Edit #{ term_for :challenge } Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
+= active_course_link_to glyph(:edit) + "Edit #{ term_for :challenge } Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -24,6 +24,6 @@
         %td
           .right
             %ul.button-bar
-              %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
-              %li= link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
-              %li= link_to decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }
+              %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
+              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
+              %li= active_course_link_to decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -36,11 +36,11 @@
               - if challenge_grade
                 %ul.button-bar
                   %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id), class: 'button'
-                  %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
-                  %li= link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
+                  %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
+                  %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
               - else
                 %ul.button-bar
-                  %li= link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
           - if @challenge.release_necessary?
             %td
               - if challenge_grade && !challenge_grade.is_released?
@@ -49,4 +49,4 @@
   %br
   .right
     - if @challenge.release_necessary? && @challenge.challenge_grades.present?
-      = submit_tag "Update Grade Statuses", class: "button"
+      = active_course_submit_tag "Update Grade Statuses", class: "button"

--- a/app/views/challenges/index.html.haml
+++ b/app/views/challenges/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -2,9 +2,9 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
-        %li= link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
 
         %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
 

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -6,7 +6,7 @@
 
         %li= link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
 
-        %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/earned_badges/_form.html.haml
+++ b/app/views/earned_badges/_form.html.haml
@@ -16,5 +16,5 @@
 
   .submit-buttons
     %ul
-      %li= active_course_link_to "#{@earned_badge.persisted? ? 'Update' : 'Award'} #{term_for :badge}"
+      %li= active_course_submit_tag "#{@earned_badge.persisted? ? 'Update' : 'Award'} #{term_for :badge}", class: "button"
       %li= link_to glyph("times-circle") + "Cancel", badge_path(@badge), class: "button"

--- a/app/views/earned_badges/_form.html.haml
+++ b/app/views/earned_badges/_form.html.haml
@@ -16,5 +16,5 @@
 
   .submit-buttons
     %ul
-      %li= f.button :submit, "#{@earned_badge.persisted? ? 'Update' : 'Award'} #{term_for :badge}"
+      %li= active_course_link_to "#{@earned_badge.persisted? ? 'Update' : 'Award'} #{term_for :badge}"
       %li= link_to glyph("times-circle") + "Cancel", badge_path(@badge), class: "button"

--- a/app/views/earned_badges/mass_edit.html.haml
+++ b/app/views/earned_badges/mass_edit.html.haml
@@ -30,5 +30,5 @@
 
       .submit-buttons
         %ul
-          %li= active_course_link_to "Award Badge", class: "button"
+          %li= active_course_submit_tag "Award Badge", class: "button"
           %li= link_to glyph("times-circle") + "Cancel", badges_path, class: "button"

--- a/app/views/earned_badges/mass_edit.html.haml
+++ b/app/views/earned_badges/mass_edit.html.haml
@@ -30,5 +30,5 @@
 
       .submit-buttons
         %ul
-          %li= f.button :submit, "Award Badge", class: "button"
+          %li= active_course_link_to "Award Badge", class: "button"
           %li= link_to glyph("times-circle") + "Cancel", badges_path, class: "button"

--- a/app/views/earned_badges/show.html.haml
+++ b/app/views/earned_badges/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
+      %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -9,7 +9,7 @@
   %img{:src => @earned_badge.badge.try(:icon), :alt => @earned_badge.badge.try(:name), :width => "25", :height => "25"}
   %p
     %b= link_to @earned_badge.name, badge_path(@earned_badge.badge)
-    - if @earned_badge.points?
+    - if @earned_badge.badge.full_points?
       = "(#{@earned_badge.points} points)"
 
   %p

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,7 +1,7 @@
 - if current_user_is_staff?
   - content_for :context_menu do
     .context_menu
-      %ul=link_to decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
+      %ul= active_course_link_to decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -26,5 +26,5 @@
             - if current_user_is_staff?
               .right
                 %ul.button-bar
-                  %li= link_to decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
-                  %li= link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"
+                  %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
+                  %li= active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"

--- a/app/views/grade_scheme_elements/_index_staff.haml
+++ b/app/views/grade_scheme_elements/_index_staff.haml
@@ -1,14 +1,34 @@
-- if @grade_scheme_elements.count > 0
-  - content_for :context_menu do
-    .context_menu
-      %ul
-        %li= link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
+- if @grade_scheme_elements.count == 0
+  = render partial: "grade_scheme_elements/components/grade_scheme_elements_setup"
+- else
+  = render partial: "grade_scheme_elements/components/grade_scheme_elements_table",
+    locals: { grade_scheme_elements: @grade_scheme_elements }
 
 .pageContent
   = render partial: "layouts/alerts"
 
-  - if @grade_scheme_elements.count == 0
-    = render partial: "grade_scheme_elements/components/grade_scheme_elements_setup"
-  - else
-    = render partial: "grade_scheme_elements/components/grade_scheme_elements_table",
-      locals: { grade_scheme_elements: @grade_scheme_elements }
+  / Grade Scheme Elements Table Display
+  %table
+    %caption.sr-only Grading Scheme Levels
+    %thead
+      %tr
+        %th{scope: "col"} Grade
+        %th{scope: "col"} Level
+        %th{scope: "col"} Point Threshold
+        %th{scope: "col"} Locked?
+        %th{scope: "col"}
+          %span.sr-only Action Buttons
+    %tbody
+      - @grade_scheme_elements.each do |element|
+        %tr
+          %td= element.letter
+          %td= element.level
+          %td{data: { :"sort-value" => "#{element.lowest_points }" }}= points element.lowest_points
+          %td
+            - if element.unlock_conditions.present?
+              - element.unlock_conditions.each do |uc|
+                .condition= glyph(:lock) + uc.requirements_description_sentence
+          %td= active_course_link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
+
+  = render partial: "courses/grading_philosophy", locals: { course: current_course }
+>>>>>>> Deactivate all sorts of buttons in an archive state

--- a/app/views/grade_scheme_elements/_index_staff.haml
+++ b/app/views/grade_scheme_elements/_index_staff.haml
@@ -1,34 +1,14 @@
-- if @grade_scheme_elements.count == 0
-  = render partial: "grade_scheme_elements/components/grade_scheme_elements_setup"
-- else
-  = render partial: "grade_scheme_elements/components/grade_scheme_elements_table",
-    locals: { grade_scheme_elements: @grade_scheme_elements }
+- if @grade_scheme_elements.count > 0
+  - content_for :context_menu do
+    .context_menu
+      %ul
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
 
-  / Grade Scheme Elements Table Display
-  %table
-    %caption.sr-only Grading Scheme Levels
-    %thead
-      %tr
-        %th{scope: "col"} Grade
-        %th{scope: "col"} Level
-        %th{scope: "col"} Point Threshold
-        %th{scope: "col"} Locked?
-        %th{scope: "col"}
-          %span.sr-only Action Buttons
-    %tbody
-      - @grade_scheme_elements.each do |element|
-        %tr
-          %td= element.letter
-          %td= element.level
-          %td{data: { :"sort-value" => "#{element.lowest_points }" }}= points element.lowest_points
-          %td
-            - if element.unlock_conditions.present?
-              - element.unlock_conditions.each do |uc|
-                .condition= glyph(:lock) + uc.requirements_description_sentence
-          %td= active_course_link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
-
-  = render partial: "courses/grading_philosophy", locals: { course: current_course }
->>>>>>> Deactivate all sorts of buttons in an archive state
+  - if @grade_scheme_elements.count == 0
+    = render partial: "grade_scheme_elements/components/grade_scheme_elements_setup"
+  - else
+    = render partial: "grade_scheme_elements/components/grade_scheme_elements_table",
+      locals: { grade_scheme_elements: @grade_scheme_elements }

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
@@ -19,6 +19,6 @@
           - if element.unlock_conditions.present?
             - element.unlock_conditions.each do |uc|
               .condition= glyph(:lock) + uc.requirements_description_sentence
-        %td= link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
+        %td= active_course_link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
 
 = render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/app/views/grades/components/_edit_button.html.haml
+++ b/app/views/grades/components/_edit_button.html.haml
@@ -3,4 +3,4 @@
 - else
   - path = grade_assignment_group_path(grade.assignment, grade.group)
 
-= link_to "Edit Grade", path, class: "button"
+= active_course_link_to "Edit Grade", path, class: "button"

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -17,4 +17,5 @@
     'recipient-type'=>"student",
     'recipient-id'=>"#{@grade.student.id}",
     'submit-path'=>"#{@submit_path}",
-    'grade-next-path'=>"#{@grade_next_path}"}
+    'grade-next-path'=>"#{@grade_next_path}",
+    'is-active-course'=>"#{current_course.active?}"}

--- a/app/views/groups/_buttons.haml
+++ b/app/views/groups/_buttons.haml
@@ -1,4 +1,4 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"
+      %li= active_course_link_to decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"

--- a/app/views/groups/_groups_table.haml
+++ b/app/views/groups/_groups_table.haml
@@ -23,7 +23,7 @@
           .right
             %ul.button-bar
               - if group.pending?
-                %li= link_to decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
+                %li= active_course_link_to decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
               - else
-                %li= link_to decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
-              %li= link_to decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete
+                %li= active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
+              %li= active_course_link_to decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -54,6 +54,6 @@
 
       .submit-buttons
         .right
-          = submit_tag "Update Selected Grade Statuses", class: "button disabled", disabled: true, data: { behavior: "selected-#{grade_type}-#{assignment.name}-grades-command" }
+          = active_course_submit_tag "Update Selected Grade Statuses", class: "button disabled", disabled: true, data: { behavior: "selected-#{grade_type}-#{assignment.name}-grades-command" }
 
   %hr.dotted

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -43,9 +43,9 @@
                 .right
                   %ul.button-bar
                     - if assignment.is_individual?
-                      %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                      %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
                     - elsif assignment.has_groups?
-                      %li= link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
+                      %li= active_course_link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
               %td
                 .center
                   %label

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -19,9 +19,10 @@
             %th{scope: "col"} Feedback
             %th{scope: "col", "data-dynatable-no-sort" => "true", :width => "20%" }
               %span.sr-only Actions
-            %th{"data-dynatable-no-sort" => "true", :width => "120px" }
-              %button.button.table-select-all{role: "button", type: "button"}= "Check"
-              %button.button.table-select-none{role: "button", type: "button"}= "Uncheck"
+            - if current_course.active? 
+              %th{"data-dynatable-no-sort" => "true", :width => "120px" }
+                %button.button.table-select-all{role: "button", type: "button"}= "Check"
+                %button.button.table-select-none{role: "button", type: "button"}= "Uncheck"
         %tbody
           - grades.each do |grade|
             - student = grade.student
@@ -46,11 +47,12 @@
                       %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
                     - elsif assignment.has_groups?
                       %li= active_course_link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
-              %td
-                .center
-                  %label
-                    %span.sr-only Select grade to update status
-                    = check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-#{grade_type}-#{assignment.name}-grades-command']" }, id: "grade_id_#{assignment.id}-#{grade.id}"
+              - if current_course.active?
+                %td
+                  .center
+                    %label
+                      %span.sr-only Select grade to update status
+                      = check_box_tag "grade_ids[]", grade.id, false, data: { behavior: "toggle-disable-list-command", commands: "[data-behavior='selected-#{grade_type}-#{assignment.name}-grades-command']" }, id: "grade_id_#{assignment.id}-#{grade.id}"
 
       .submit-buttons
         .right

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -34,7 +34,7 @@
             .right
               %ul.button-bar
                 - if assignment.is_individual?
-                  %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
                 - elsif assignment.has_groups?
-                  %li= link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
   %hr.dotted

--- a/app/views/info/dashboard/modules/_dashboard_avatar.haml
+++ b/app/views/info/dashboard/modules/_dashboard_avatar.haml
@@ -22,8 +22,8 @@
 
     .module-section
       %ul.button-bar
-        %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
         %li= link_to decorative_glyph(:envelope) + "Email", "mailto:#{current_student.email}", class: "button"
         %li= link_to decorative_glyph(:refresh) + "Update Score", recalculate_student_path(current_student), class: "button"
         - if !current_student.activated?
-          %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"
+          %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"

--- a/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
+++ b/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
@@ -9,7 +9,7 @@
         .small.uppercase= "#{assignment.assignment_type.name}"
       - else
         - if assignment.name_visible_for_student?(current_student)
-          %span.bold.assignment-name= link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
+          %span.bold.assignment-name= active_course_link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
         - else
           %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
           %span.italic= "You must unlock this #{(term_for :assignment).downcase} to learn more about it"

--- a/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
+++ b/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
@@ -29,6 +29,6 @@
         - else
           This class has flexible #{(term_for :assignment).downcase} due dates. Check your course rules to learn when to turn in certain #{(term_for :assignment).downcase.pluralize}.
       - elsif list_class == "my-planner-list"
-        You have not predicted any #{(term_for :assignment).downcase.pluralize}! Check out the 
-        = link_to "grade predictor", predictor_path
+        You have not predicted any #{(term_for :assignment).downcase.pluralize}! Check out the
+        = active_course_link_to "grade predictor", predictor_path
         to add #{(term_for :assignment).downcase.pluralize} to this planner.

--- a/app/views/info/gradebook.html.haml
+++ b/app/views/info/gradebook.html.haml
@@ -25,7 +25,7 @@
             - current_course.assignments.each do |assignment|
               - assignment.grade_for_student(student).tap do |grade|
                 - if grade
-                  %td= link_to "#{grade.score}", edit_grade_path(grade)
+                  %td= active_course_link_to "#{grade.score}", edit_grade_path(grade)
                 - else
                   %td
             - if current_course.valuable_badges?

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -46,5 +46,5 @@
                 %th= points assignment.grade_count
                 %th
                   %ul.button-bar.right
-                    %li= link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                    %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
                     %li= link_to decorative_glyph("cloud-download") + "Download Grades", export_assignment_grades_path(assignment, format: :csv), class: "button"

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -44,7 +44,7 @@
                 .right
                   %ul.button-bar
                     %li= link_to decorative_glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    %li= link_to decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
+                    %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td
@@ -55,4 +55,4 @@
                   %ul.button-bar
                     %li= link_to re.group.name, group_path(re.group)
                     %li= link_to decorative_glyph(:eye) + "See Submission", assignment_submission_path(re.assignment.id, id: re.id), class: "button"
-              %td= link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(re.assignment, re.group), class: "button"
+              %td= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(re.assignment, re.group), class: "button"

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -41,7 +41,7 @@
               %ul.button-bar
                 - if submission.assignment.is_individual?
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
                 - else
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  %li= link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"

--- a/app/views/layouts/navigation/_observer_profile_tabs.haml
+++ b/app/views/layouts/navigation/_observer_profile_tabs.haml
@@ -6,7 +6,7 @@
     %li{class: ("active" if current_page?(grade_scheme_elements_path)) }
       = link_to_unless_current "Grading Scheme", grade_scheme_elements_path
   %li{class: ("active" if current_page?(predictor_path)) }
-    = link_to_unless_current "Grade Predictor", predictor_path
+    = active_course_link_to_unless_current "Grade Predictor", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -49,12 +49,13 @@
 %li= link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
 %li= link_to_unless_current decorative_glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
 
-.hide-for-small
-  %hr
+- if current_course.active? 
+  .hide-for-small
+    %hr
 
-  %h5{ class: "make-lizards" } Admin
-  %li= link_to_unless_current decorative_glyph(:plus) + "New Course", new_course_path
-  - if current_user_is_admin?
-    %li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
-    %li= link_to_unless_current decorative_glyph("user-times") + "All Users", users_path
-    %li= link_to_unless_current decorative_glyph(:search) + "Search Users", search_users_path
+    %h5{ class: "make-lizards" } Admin
+    %li= active_course_link_to_unless_current decorative_glyph(:plus) + "New Course", new_course_path
+    - if current_user_is_admin?
+      %li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
+      %li= link_to_unless_current decorative_glyph("user-times") + "All Users", users_path
+      %li= link_to_unless_current decorative_glyph(:search) + "Search Users", search_users_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -46,7 +46,7 @@
 
 %h5 Course Setup
 %li= link_to_unless_current decorative_glyph(:cog) + "Course Settings", edit_course_path(current_course)
-%li= active_course_link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
+%li= link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
 %li= link_to_unless_current decorative_glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
 
 .hide-for-small

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -46,7 +46,7 @@
 
 %h5 Course Setup
 %li= link_to_unless_current decorative_glyph(:cog) + "Course Settings", edit_course_path(current_course)
-%li= link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
+%li= active_course_link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
 %li= link_to_unless_current decorative_glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
 
 .hide-for-small

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -8,7 +8,7 @@
     %li{class: ("active" if current_page?(grade_scheme_elements_path)) }
       = link_to_unless_current "Grading Scheme", grade_scheme_elements_path
   %li{class: ("active" if current_page?(predictor_path)) }
-    = active_course_link_to_unless_current "Grade Predictor", predictor_path
+    = link_to_unless_current "Grade Predictor", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -8,7 +8,7 @@
     %li{class: ("active" if current_page?(grade_scheme_elements_path)) }
       = link_to_unless_current "Grading Scheme", grade_scheme_elements_path
   %li{class: ("active" if current_page?(predictor_path)) }
-    = link_to_unless_current "Grade Predictor", predictor_path
+    = active_course_link_to_unless_current "Grade Predictor", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/observers/_buttons.html.haml
+++ b/app/views/observers/_buttons.html.haml
@@ -2,4 +2,4 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"

--- a/app/views/observers/index.html.haml
+++ b/app/views/observers/index.html.haml
@@ -23,5 +23,5 @@
           %td
             .right
               %ul.button-bar
-                %li= link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
-                %li= link_to decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+                %li= active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
+                %li= active_course_link_to decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/staff/_buttons.haml
+++ b/app/views/staff/_buttons.haml
@@ -2,6 +2,6 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= link_to_unless_current decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
       - if @staff_member.present?
-        %li= link_to_unless_current glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"
+        %li= active_course_link_to glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -31,8 +31,8 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
-                %li= link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                %li= link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
+                %li= active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
+                %li= active_course_link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
                 - if !user.activated?
-                  %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
-                  %li= link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)
+                  %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
+                  %li= active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -33,5 +33,5 @@
           %td= grade.graded_at
           %td
             %ul.button-bar
-              %li= link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
-              %li= link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
+              %li= active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }

--- a/app/views/students/_group_submissions.html.haml
+++ b/app/views/students/_group_submissions.html.haml
@@ -2,4 +2,4 @@
   = link_to glyph("file-o") + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
 - else
   - if group && group.approved?
-    = link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: group), class: "button"
+    = active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: group), class: "button"

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -53,8 +53,8 @@
             %ul.options-menu
               %li= link_to decorative_glyph(:eye) + "Preview as this student", student_preview_path(student)
               %li= mail_to student.email, glyph(:envelope) + "Email"
-              %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(student)
-              %li= link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
+              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student)
+              %li= active_course_link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
               - if !student.activated?
-                %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
-                %li= link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)
+                %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
+                %li= active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)

--- a/app/views/students/_submissions.html.haml
+++ b/app/views/students/_submissions.html.haml
@@ -8,16 +8,16 @@
   - elsif assignment.open?
     - if student_submission.present? && student_submission.text_comment_draft.present?
       -# new submission with preexisting autosaved draft
-      = link_to glyph(:pencil) + "Edit Draft", edit_assignment_submission_path(assignment, id: student_submission.id), class: "button"
+      = active_course_link_to glyph(:pencil) + "Edit Draft", edit_assignment_submission_path(assignment, id: student_submission.id), class: "button"
     - else
       -# new submission with no prior autosaved draft
-      = link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: current_student), class: "button"
+      = active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: current_student), class: "button"
 - elsif assignment.has_groups?
   - group = current_student.group_for_assignment(assignment)
   - if group.present?
     - submission = group.submission_for_assignment(assignment)
   - if group.present?
     - if submission.present?
-      = link_to glyph(:edit) + "Edit Our Submission", edit_assignment_submission_path(assignment, id: submission), class: "button"
+      = active_course_link_to glyph(:edit) + "Edit Our Submission", edit_assignment_submission_path(assignment, id: submission), class: "button"
     - elsif group.approved?
-      = link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: group), class: "button"
+      = active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: group), class: "button"

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -26,6 +26,6 @@
           %td= g.predicted_points
           %td= g.feedback
           %td= g.status
-          %td= link_to "Edit Grade", edit_grade_path(g), class: "button"
+          %td= active_course_link_to "Edit Grade", edit_grade_path(g), class: "button"
           %td= link_to "See Grade", grade_path(g), class: "button"
-          %td= link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+          %td= active_course_link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -39,6 +39,6 @@
     .submit-buttons
       %ul
         %li.save-draft-button.button{"assignment_id"=>"#{presenter.assignment.id}", "is_active_course"=>"#{current_course.active?}"}
-        %li= active_course_link_to "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
-        data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }, class: "ng-cloak"
+        %li= active_course_submit_tag "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
+        data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }, class: "ng-cloak button"
         %li= link_to glyph("times-circle") + "Cancel", assignment_path(presenter.assignment), class: "button ng-cloak"

--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -38,8 +38,7 @@
 
     .submit-buttons
       %ul
-        %li.save-draft-button.button{"assignment_id"=>"#{presenter.assignment.id}"}
-        %li= f.button :submit,
-          "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
-          data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }, class: "ng-cloak"
+        %li.save-draft-button.button{"assignment_id"=>"#{presenter.assignment.id}", "is_active_course"=>"#{current_course.active?}"}
+        %li= active_course_link_to "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
+        data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }, class: "ng-cloak"
         %li= link_to glyph("times-circle") + "Cancel", assignment_path(presenter.assignment), class: "button ng-cloak"

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -2,23 +2,23 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li
-          %a.button.button-edit{:href => "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?student_id=#{presenter.student.id}" }
-            = decorative_glyph(:edit)
-            Edit Submission
-            %span.sr-only #{presenter.student.try(:first_name)}'s Submission
-        %li= link_to decorative_glyph(:trash) + "Delete Submission", assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit", data: { confirm: "Are you sure?",  method: :delete }
-
-        %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit Submission",
+          "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?student_id=#{presenter.student.id}",
+          class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:trash) + "Delete Submission",
+          assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit",
+          data: { confirm: "Are you sure?", method: :delete }
+        %li= active_course_link_to decorative_glyph(:check) + "Grade",
+          assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
 - elsif presenter.assignment.has_groups?
   - content_for :context_menu do
     .context_menu
       %ul
-        %li
-          %a.button.button-edit{:href => "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?group_id=#{presenter.group.id}" }
-            = decorative_glyph(:edit)
-            Edit Submission
-            %span.sr-only #{presenter.group.name}'s Submission
-        %li
-          = link_to decorative_glyph(:trash) + "Delete Submission", assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), data: { confirm: "Are you sure?",  method: :delete }, class: "button button-edit"
-        %li= link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(presenter.assignment,  presenter.group), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit Submission",
+          "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?group_id=#{presenter.group.id}",
+          class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:trash) + "Delete Submission",
+          assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ),
+          data: { confirm: "Are you sure?",  method: :delete }, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:check) + "Grade",
+          grade_assignment_group_path(presenter.assignment,  presenter.group), class: "button button-edit"

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -35,7 +35,8 @@
 
   .submit-buttons
     %ul
-      %li= f.button :submit,
-        "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
-        data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }
+      - if current_course.active?
+        %li= f.button :submit,
+          "#{presenter.submission.persisted? ? (presenter.submission.will_be_resubmitted? ? "Resubmit" : "Update Submission") : "Submit #{term_for :assignment}"}",
+          data: { confirm: ("This submission will be late. Continue?" if !presenter.submission.will_be_resubmitted? && presenter.submission_will_be_late?) }
       %li= link_to glyph("times-circle") + "Cancel", assignment_path(presenter.assignment), class: "button"

--- a/app/views/submissions/components/_edit.haml
+++ b/app/views/submissions/components/_edit.haml
@@ -1,1 +1,1 @@
-= link_to glyph(:pencil) + "#{presenter.term_for_edit(current_user)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"
+= active_course_link_to glyph(:pencil) + "#{presenter.term_for_edit(current_user)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"

--- a/app/views/teams/_buttons.haml
+++ b/app/views/teams/_buttons.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= link_to_unless_current decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
+      %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
 
       - if @team.present? && @team.persisted?
-        %li= link_to decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -30,6 +30,5 @@
         %td
           .right
             %ul.button-bar
-              %li= link_to decorative_glyph(:dashboard) + "See #{term_for :team}", team, class: "button"
-              %li= link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
-              %li= link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+              %li= active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
+              %li= active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -67,7 +67,7 @@
             .right
               %ul.button-bar
                 - if challenge.challenge_grade_for_team(@team).present?
-                  %li= link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
-                  %li= link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
+                  %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
+                  %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
                 - else
                   %li= link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -43,7 +43,7 @@
             .right
               %ul.button-bar
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(student), class: "button"
-                %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
+                %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
 
   %h2.subtitle #{term_for :challenge } Grades
 
@@ -70,4 +70,4 @@
                   %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
                   %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
                 - else
-                  %li= link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"
+                  %li= active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"

--- a/app/views/users/_buttons.haml
+++ b/app/views/users/_buttons.haml
@@ -2,10 +2,10 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
-        %li= link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
       - if @user.present? && @user.persisted?
-        %li= link_to decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
+        %li= active_course_link_to decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
         - if @user.is_staff?(current_course)
           %li= link_to decorative_glyph(:list) + "Show Staff Member", staff_path(@user), class: "button button-edit"
         - else

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -91,12 +91,13 @@ User.create! do |u|
 end.activate!
 puts "Children must be taught how to think, not what to think. ― Margaret Mead"
 
-# Itereate through course names and create courses
+# Iterate through course names and create courses
 @courses.each do |course_name, config|
   course = Course.create! do |c|
     @course_default_config[:attributes].keys.each do |attr|
       c[attr] =
-        config[:attributes][attr] || @course_default_config[:attributes][attr]
+        config[:attributes].key?(attr) ? config[:attributes][attr] :
+          @course_default_config[:attributes][attr]
     end
 
     # Add weight attributes if course has weights

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -307,7 +307,7 @@ end
     course_config[:course].tap do |course|
       badge = Badge.create! do |b|
         @badge_default_config[:attributes].keys.each do |attr|
-          b[attr] = config[:attributes][attr] ||
+          b[attr] = config[:attributes].key?(attr) ? config[:attributes][attr] :
             @badge_default_config[:attributes][attr]
         end
         b.course = course
@@ -354,7 +354,7 @@ end
     course_config[:course].tap do |course|
       assignment_type = AssignmentType.create! do |at|
         @assignment_type_default_config[:attributes].keys.each do |attr|
-          at[attr] = config[:attributes][attr] ||
+          at[attr] = config[:attributes].key?(attr) ? config[:attributes][attr] :
             @assignment_type_default_config[:attributes][attr]
         end
         at.course = course
@@ -594,7 +594,7 @@ end
               elsif attr == :score
                 cg[attr] = rand(assignment_full_points)
               else
-                cg[attr] = grade_attributes[attr] ||
+                cg[attr] = grade_attributes.key?(attr) ? grade_attributes[attr] :
                   @challenge_default_config[:grade_attributes][attr]
               end
             end

--- a/db/samples/courses.rb
+++ b/db/samples/courses.rb
@@ -64,6 +64,7 @@
     twitter_hashtag: nil,
     student_term: "Student",
     year: Date.today.year,
+    status: true
   }
 }
 
@@ -320,6 +321,23 @@ Dracula",
     to the assignments. Show us you've completed the necessary competencies in any \
     way you like.",
     name: "Course with No Dates",
+    semester: "Fall",
+    has_teams: true,
+  }
+}
+
+@courses[:inactive_course] = {
+  quotes: {
+    course_created: "“Stay hungry, stay foolish” ― Steve Jobs",
+    grade_sceme_elements_created: "“Stay thirsty my friends” - The most interesting man in the world",
+    teams_created: "“Don't cry because it's over, smile because it happened.” - Dr. Seuss",
+  },
+  attributes: {
+    status: false,
+    accepts_submissions: true,
+    course_number: "GC106",
+    gameful_philosophy: "This course is inactive. None shall pass.",
+    name: "Inactive course",
     semester: "Fall",
     has_teams: true,
   }

--- a/spec/controllers/api/assignments_controller_spec.rb
+++ b/spec/controllers/api/assignments_controller_spec.rb
@@ -1,7 +1,7 @@
 include SessionHelper
 
 describe API::AssignmentsController do
-  let(:course) { build_stubbed :course}
+  let(:course) { build_stubbed :course, status: true }
   let(:student)  { create(:course_membership, :student, course: course).user }
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let!(:assignment) { create(:assignment, course: course) }
@@ -43,14 +43,28 @@ describe API::AssignmentsController do
     end
 
     describe "GET index" do
-      it "assigns the assignments with predictions and grades and a call to update" do
-        get :index, format: :json
-        expect(assigns(:assignments).first.id).to eq(assignment.id)
-        expect(assigns :student).to eq(student)
-        expect(assigns :predicted_earned_grades).to eq([predicted_earned_grade])
-        expect(assigns :grades).to eq([grade])
-        expect(assigns(:allow_updates)).to be_truthy
-        expect(response).to render_template(:index)
+      context "when the course is active" do
+        it "assigns the assignments with predictions and grades and a call to update" do
+          get :index, format: :json
+          expect(assigns(:assignments).first.id).to eq(assignment.id)
+          expect(assigns :student).to eq(student)
+          expect(assigns :predicted_earned_grades).to eq([predicted_earned_grade])
+          expect(assigns :grades).to eq([grade])
+          expect(assigns(:allow_updates)).to be_truthy
+          expect(response).to render_template(:index)
+        end
+      end
+
+      context "when the course is not active" do
+        it "assigns the assignments with predictions and grades and a call to update" do
+          course.status = false
+          get :index, format: :json
+          expect(assigns :student).to eq(student)
+          expect(assigns :predicted_earned_grades).to eq([predicted_earned_grade])
+          expect(assigns :grades).to eq([grade])
+          expect(assigns(:allow_updates)).to be_falsey
+          expect(response).to render_template(:index)
+        end
       end
     end
   end

--- a/spec/features/awarding_a_badge_spec.rb
+++ b/spec/features/awarding_a_badge_spec.rb
@@ -1,35 +1,49 @@
 feature "awarding a badge" do
   context "as a professor" do
-    let(:course) { build :course, has_badges: true }
-    let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
-    let(:professor) { create :user }
+    let(:professor) { create :user, courses: [course], role: :professor }
     let!(:badge) { create :badge, name: "Fancy Badge", course: course}
-    let(:student) { build :user, first_name: "Hermione", last_name: "Granger" }
-    let!(:course_membership_2) { create :course_membership, :student, user: student, course: course }
+    let!(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
 
     before(:each) do
       login_as professor
       visit dashboard_path
     end
 
-    scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Badges"
+    context "with an active course" do
+      let(:course) { build :course, has_badges: true, status: true }
+
+      scenario "is successful" do
+        within(".sidebar-container") do
+          click_link "Badges"
+        end
+
+        expect(current_path).to eq badges_path
+
+        within(".pageContent") do
+          click_link "Award"
+        end
+
+        expect(current_path).to eq new_badge_earned_badge_path(badge)
+
+        within(".pageContent") do
+          select "Hermione Granger", from: "earned_badge_student_id"
+          click_button "Award Badge"
+        end
+        expect(page).to have_notification_message("notice", "The Fancy Badge Badge was successfully awarded to Hermione Granger")
       end
+    end
 
-      expect(current_path).to eq badges_path
+    context "with an active course" do
+      let(:course) { build :course, has_badges: true, status: false }
 
-      within(".pageContent") do
-        click_link "Award"
+      scenario "is unsuccessful" do
+        within(".sidebar-container") do
+          click_link "Badges"
+        end
+
+        expect(current_path).to eq badges_path
+        expect(page).to_not have_selector(:link_or_button, "/^Award$/")
       end
-
-      expect(current_path).to eq new_badge_earned_badge_path(badge)
-
-      within(".pageContent") do
-        select "Hermione Granger", from: "earned_badge_student_id"
-        click_button "Award Badge"
-      end
-      expect(page).to have_notification_message("notice", "The Fancy Badge Badge was successfully awarded to Hermione Granger")
     end
   end
 end

--- a/spec/features/editing_an_awarded_badge_spec.rb
+++ b/spec/features/editing_an_awarded_badge_spec.rb
@@ -64,13 +64,8 @@ feature "editing an awarded a badge" do
         expect(current_path).to eq badge_path(badge.id)
 
         within(".pageContent") do
-          click_link "Edit"
+          expect(page).to_not have_selector(:link_or_button, "Edit")
         end
-
-        expect(current_path).to eq \
-          edit_badge_earned_badge_path(badge, earned_badge)
-
-        expect(page).to_not have_selector(:link_or_button, "Update Badge")
       end
     end
   end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -145,6 +145,23 @@ describe LinkHelper do
     end
   end
 
+  describe "#active_course_link_to" do
+    let(:course) { build_stubbed :course }
+    before(:each) { allow(helper).to receive(:current_course).and_return course }
+
+    it "renders the link if the current course is active" do
+      course.status = true
+      link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+      expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+    end
+
+    it "does not render the link if the current course is not active" do
+      course.status = false
+      link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+      expect(link).to be_nil
+    end
+  end
+
   describe "#sanitize_external_links" do
     let(:content) { "<p>This is some content for <a href='http://example.org'>External</a>" }
 

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -149,16 +149,29 @@ describe LinkHelper do
     let(:course) { build_stubbed :course }
     before(:each) { allow(helper).to receive(:current_course).and_return course }
 
-    it "renders the link if the current course is active" do
-      course.status = true
-      link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
-      expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+    context "when the current user is not an admin" do
+      before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return false }
+
+      it "renders the link if the current course is active" do
+        course.status = true
+        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+        expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+      end
+
+      it "does not render the link if the current course is not active" do
+        course.status = false
+        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+        expect(link).to be_nil
+      end
     end
 
-    it "does not render the link if the current course is not active" do
-      course.status = false
-      link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
-      expect(link).to be_nil
+    context "when the current user is an admin" do
+      before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return true }
+
+      it "renders the link" do
+        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+        expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+      end
     end
   end
 

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -162,6 +162,23 @@ describe LinkHelper do
     end
   end
 
+  describe "#active_course_link_to_unless_current" do
+    let(:course) { build_stubbed :course }
+    before(:each) { allow(helper).to receive(:current_course).and_return course }
+
+    it "renders the link if the current course is active" do
+      course.status = true
+      link = helper.active_course_link_to_unless_current("Delicious cured ham", "http://prosciutto.com")
+      expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+    end
+
+    it "does not render the link if the current course is not active" do
+      course.status = false
+      link = helper.active_course_link_to_unless_current("Delicious cured ham", "http://prosciutto.com")
+      expect(link).to be_nil
+    end
+  end
+
   describe "#sanitize_external_links" do
     let(:content) { "<p>This is some content for <a href='http://example.org'>External</a>" }
 

--- a/spec/helpers/submit_tag_helper_spec.rb
+++ b/spec/helpers/submit_tag_helper_spec.rb
@@ -5,16 +5,29 @@ describe SubmitTagHelper do
     let(:course) { build_stubbed :course }
     before(:each) { allow(helper).to receive(:current_course).and_return course }
 
-    it "renders the submit button if the current course is active" do
-      course.status = true
-      submit_button = helper.active_course_submit_tag("Click to claim your prize!")
-      expect(submit_button).to have_tag("input", type: :submit, value: "Click to claim your prize!")
+    context "when the current user is not an admin" do
+      before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return false }
+
+      it "renders the submit button if the current course is active" do
+        course.status = true
+        submit_button = helper.active_course_submit_tag("Click to claim your prize!")
+        expect(submit_button).to have_tag("input", type: :submit, value: "Click to claim your prize!")
+      end
+
+      it "does not render the submit button if the current course is not active" do
+        course.status = false
+        submit_button = helper.active_course_submit_tag("Click to claim your prize!")
+        expect(submit_button).to be_nil
+      end
     end
 
-    it "does not render the submit button if the current course is not active" do
-      course.status = false
-      submit_button = helper.active_course_submit_tag("Click to claim your prize!")
-      expect(submit_button).to be_nil
+    context "when the current user is an admin" do
+      before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return true }
+
+      it "renders the submit button" do
+        submit_button = helper.active_course_submit_tag("Click to claim your prize!")
+        expect(submit_button).to have_tag("input", type: :submit, value: "Click to claim your prize!")
+      end
     end
   end
 end

--- a/spec/helpers/submit_tag_helper_spec.rb
+++ b/spec/helpers/submit_tag_helper_spec.rb
@@ -1,0 +1,21 @@
+describe SubmitTagHelper do
+  include RSpecHtmlMatchers
+
+  describe "#active_course_submit_tag" do
+    let(:course) { build_stubbed :course }
+    before(:each) { allow(helper).to receive(:current_course).and_return course }
+
+    it "renders the submit button if the current course is active" do
+      course.status = true
+      submit_button = helper.active_course_submit_tag("Click to claim your prize!")
+      binding.pry
+      expect(submit_button).to have_tag("input", type: :submit, value: "Click to claim your prize!")
+    end
+
+    it "does not render the submit button if the current course is not active" do
+      course.status = false
+      submit_button = helper.active_course_submit_tag("Click to claim your prize!")
+      expect(submit_button).to be_nil
+    end
+  end
+end

--- a/spec/helpers/submit_tag_helper_spec.rb
+++ b/spec/helpers/submit_tag_helper_spec.rb
@@ -8,7 +8,6 @@ describe SubmitTagHelper do
     it "renders the submit button if the current course is active" do
       course.status = true
       submit_button = helper.active_course_submit_tag("Click to claim your prize!")
-      binding.pry
       expect(submit_button).to have_tag("input", type: :submit, value: "Click to claim your prize!")
     end
 

--- a/spec/javascripts/angular/directives/grades/edit_spec.coffee
+++ b/spec/javascripts/angular/directives/grades/edit_spec.coffee
@@ -10,12 +10,12 @@ describe 'gradeEdit directive', ()->
       @http.whenGET("/api/assignments/1").respond(apiTestDoubles.assignment.standard)
       @http.whenGET("/api/assignments/1/students/99/grade/").respond(apiTestDoubles.grade.standard)
       @http.whenGET("/api/students/99/badges").respond(apiTestDoubles.badges)
-      @element = @compile("<grade-edit assignment-id=1 recipient-type=student recipient-id=99 ></grade-edit>")(@rootScope)
+      @element = @compile("<grade-edit assignment-id=1 recipient-type=student recipient-id=99 is-active-course='true'></grade-edit>")(@rootScope)
       @rootScope.$digest()
 
     it 'loads the edit template', ()->
       expect($(@element).children("loading-message").length).toEqual(1)
-      expect($(@element).children("article.grade-form-fields").length).toEqual(1)
+      expect($(@element).children("article.grade-form-fields").length).toEqual(2)
       expect($(@element).find("grade-status-select").length).toEqual(1)
       expect($(@element).find("grade-submit-buttons").length).toEqual(1)
       expect($(@element).find("grade-last-updated").length).toEqual(1)
@@ -38,7 +38,7 @@ describe 'gradeEdit directive', ()->
     beforeEach ()->
       @http.whenGET("/api/assignments/2").respond(apiTestDoubles.assignment.standard)
       @http.whenGET("/api/assignments/2/groups/101/grades/").respond(apiTestDoubles.grade.group)
-      @element = @compile("<grade-edit assignment-id=2 recipient-type=group recipient-id=101 ></grade-edit>")(@rootScope)
+      @element = @compile("<grade-edit assignment-id=2 recipient-type=group recipient-id=101 is-active-course='true'></grade-edit>")(@rootScope)
       @rootScope.$digest()
 
     it "does not include a file uploader", ()->

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -186,9 +186,10 @@ describe Submission do
 
   describe "#graded_at" do
     it "returns when the grade was graded if it was graded" do
-      graded_at = DateTime.now
-      grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded", graded_at: graded_at)
-      expect(submission.graded_at.strftime("%A, %B %d")).to eq graded_at.strftime("%A, %B %d")
+      grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded")
+      grade.graded_at = grade.created_at
+      grade.save
+      expect(submission.graded_at).to be_present
     end
 
     it "returns nil if there is no grade" do


### PR DESCRIPTION
### Status
READY

### Description
Per the issue description, an inactive course should not allow you to:

- Create/Edit grades
- Predict grades
- Submit assignments
- Award badges

To achieve this without adding additional logic and bloat to the views, view helpers were added to `link_helper.rb` and `submit_tag_helper.rb` to conditionally render the appropriate element only when the course is active.

Use the latter vs the former when we need the element to display based on course status:
- `link_to` => `active_course_link_to`
- `submit_tag` => `active_course_submit_tag`
- `link_to_unless_current` => `active_course_link_to_unless_current`

Usage of these custom helpers is the same as their standard Rails counterparts.

### Migrations
NO

### Impacted Areas in Application
Pretty much any page that allows you to grade, submit, or award badges 😢 

======================
Closes #1949
