### PR TITLE
Fix a missing plural in the display of rubrics

### DIFF
--- a/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
@@ -6,7 +6,7 @@
     %h4.notice(ng-show="!pointsArePresent()") You have not yet allocated any points
     %h4.notice(ng-show="pointsArePresent()") {{ grade.raw_points | number:0 }} / {{ assignment().full_points | number:0 }} Points Allocated
 
-    %h4.notice(ng-show="pointsAreLessThanFull()") {{ pointsBelowFull() | number:0 }} point{{ pointsRemaining() > 1 ? "s" : "" }} have not been assigned
+    %h4.notice(ng-show="pointsAreLessThanFull()") {{ pointsBelowFull() | number:0 }} points {{ pointsRemaining() > 1 ? "s" : "" }} have not been assigned
     %h4.notice(ng-show="pointsAreSatisfied() || pointsAreOver()") You have allocated all possible points
     %h4.notice(ng-show="isBelowThreshold()") {{ pointsBelowThreshold() | number:0 }} points below the threshold
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR adds a missing "s" to the points overview display. 
