### PR TITLE
Switched grade date check to pay attention to graded_at date

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -270,7 +270,7 @@ class User < ActiveRecord::Base
 
   # Returning all of the grades a student has received this week
   def grades_released_for_course_this_week(course)
-    grades = grades_for_course(course).where("updated_at > ? ", 7.days.ago)
+    grades = grades_for_course(course).where("graded_at > ? ", 7.days.ago)
     viewable_grades = []
     grades.each do |grade|
       viewable_grades << grade if GradeProctor.new(grade).viewable? && !grade.excluded_from_course_score

--- a/app/views/info/dashboard/modules/_dashboard_weekly_stats.haml
+++ b/app/views/info/dashboard/modules/_dashboard_weekly_stats.haml
@@ -12,9 +12,14 @@
         %p Grades received this week:
         %ul
           - presenter.grades_this_week.each do |grade|
-            %li
-              #{link_to grade.assignment.name, grade.assignment}:
-              %span #{number_with_delimiter(grade.final_points)} points earned
+            - if grade.assignment.pass_fail?
+              %li
+                #{link_to grade.assignment.name, grade.assignment}:
+                %span #{term_for (grade.pass_fail_status) }
+            - else
+              %li
+                #{link_to grade.assignment.name, grade.assignment}:
+                %span #{number_with_delimiter(grade.final_points)} points earned
 
     - if !current_student.present? && current_user_is_staff? && presenter.has_submitted_assignment_types_this_week?
       .module-section

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -375,8 +375,8 @@ describe User do
     let(:assignment_2) { create :assignment, course: course }
 
     it "returns the student's earned grades for a course this week" do
-      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", updated_at: Date.today - 10)
-      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released")
+      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
+      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
       expect(student.grades_released_for_course_this_week(course)).to eq([grade_2])
     end
   end
@@ -385,8 +385,8 @@ describe User do
     let(:assignment_2) { create :assignment, course: course }
 
     it "returns the student's earned points for the course this week" do
-      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", updated_at: Date.today - 10)
-      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released")
+      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
+      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
       expect(student.points_earned_for_course_this_week(course)).to eq(300)
     end
   end


### PR DESCRIPTION
### Status
**READY**

### Description
This addresses a bug reported on the dashboard page where grades that have not been updated this week are showing in the Weekly Status module. This PR moves the check for "this week" over to the `graded_at` field, which is harder to be accidentally updated. 

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Student dashboard

======================
Closes #3128 
