### PR TITLE
Remove touch: true unless there's a cache_key involved

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -9,8 +9,8 @@ class Assignment < ActiveRecord::Base
 
   attr_accessor :current_student_grade
 
-  belongs_to :course, touch: true
-  belongs_to :assignment_type, -> { order("position ASC") }, touch: true
+  belongs_to :course
+  belongs_to :assignment_type, -> { order("position ASC") }
 
   has_one :rubric, dependent: :destroy
 

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -4,7 +4,7 @@ class AssignmentType < ActiveRecord::Base
 
   acts_as_list scope: :course
 
-  belongs_to :course, touch: true
+  belongs_to :course
   has_many :assignments, -> { order("position ASC") }, dependent: :destroy
   has_many :submissions, through: :assignments
   has_many :grades

--- a/app/models/assignment_type_weight.rb
+++ b/app/models/assignment_type_weight.rb
@@ -1,5 +1,5 @@
 class AssignmentTypeWeight < ActiveRecord::Base
-  belongs_to :student, class_name: "User", touch: true
+  belongs_to :student, class_name: "User"
   belongs_to :assignment_type
   belongs_to :course
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -10,7 +10,7 @@ class Badge < ActiveRecord::Base
   has_many :earned_badges, dependent: :destroy
   has_many :predicted_earned_badges, dependent: :destroy
 
-  belongs_to :course, touch: true
+  belongs_to :course
 
   accepts_nested_attributes_for :earned_badges, allow_destroy: true, reject_if: proc { |a| a.points.blank? }
 

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -7,7 +7,7 @@ class Challenge < ActiveRecord::Base
   # grade points available to the predictor from the assignment controller
   attr_accessor :prediction, :grade
 
-  belongs_to :course, touch: true
+  belongs_to :course
   has_many :submissions
   has_many :challenge_grades, dependent: :destroy do
     def find_or_initialize_for_team(team)

--- a/app/models/earned_badge.rb
+++ b/app/models/earned_badge.rb
@@ -2,9 +2,9 @@ class EarnedBadge < ActiveRecord::Base
 
   before_validation :add_associations
 
-  belongs_to :course, touch: true
+  belongs_to :course
   belongs_to :badge
-  belongs_to :student, class_name: "User", touch: true
+  belongs_to :student, class_name: "User"
   belongs_to :submission # Optional
   belongs_to :grade # Optional
   belongs_to :awarded_by, class_name: 'User'

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ActiveRecord::Base
   include UploadsMedia
 
-  belongs_to :course, touch: true
+  belongs_to :course
 
   scope :with_dates, -> { where("events.due_at IS NOT NULL OR events.open_at IS NOT NULL") }
 

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -5,13 +5,13 @@ class Grade < ActiveRecord::Base
   include Sanitizable
 
   belongs_to :course, touch: true
-  belongs_to :assignment, touch: true
-  belongs_to :assignment_type, touch: true
-  belongs_to :student, class_name: "User", touch: true
-  belongs_to :team, touch: true
+  belongs_to :assignment
+  belongs_to :assignment_type
+  belongs_to :student, class_name: "User"
+  belongs_to :team
   belongs_to :submission
-  belongs_to :group, touch: true # Optional
-  belongs_to :graded_by, class_name: "User", touch: true
+  belongs_to :group # Optional
+  belongs_to :graded_by, class_name: "User"
 
   has_one :imported_grade, dependent: :destroy
   has_many :earned_badges, dependent: :destroy

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -3,7 +3,7 @@ class GradeSchemeElement < ActiveRecord::Base
   include Copyable
   include UnlockableCondition
 
-  belongs_to :course, touch: true
+  belongs_to :course
 
   validates_presence_of :lowest_points, :course
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,10 +5,10 @@ class Submission < ActiveRecord::Base
 
   has_paper_trail ignore: [:text_comment_draft]
 
-  belongs_to :assignment, touch: true
-  belongs_to :student, class_name: "User", touch: true
-  belongs_to :creator, class_name: "User", touch: true
-  belongs_to :group, touch: true
+  belongs_to :assignment
+  belongs_to :student, class_name: "User"
+  belongs_to :creator, class_name: "User"
+  belongs_to :group
   belongs_to :course, touch: true
 
   after_save :check_unlockables

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -5,7 +5,7 @@ class Team < ActiveRecord::Base
   validates :name, uniqueness: { case_sensitive: false, scope: :course_id }
 
   # Teams belong to a single course
-  belongs_to :course, touch: true
+  belongs_to :course
 
   has_many :team_memberships
   has_many :students, through: :team_memberships, autosave: true


### PR DESCRIPTION
### Status
**READY**

### Description
This PR removes a series of `touch: true`s that were added two years ago. The examples that are left are the three places (grades -> courses, submissions -> courses, and course_memberships -> courses and users) where we have cache_keys in place that may actually be utilizing this approach. 
