### PR TITLE
2941 resubmission after grading

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -48,8 +48,11 @@ class SubmissionsController < ApplicationController
   def update
     assignment = current_course.assignments.find(params[:assignment_id])
     submission = assignment.submissions.find(params[:id])
-    submission_was_draft = submission.unsubmitted?
+    redirect_to assignment_path(assignment, anchor: "tab3"),
+      flash: { error: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released." } \
+      and return if !SubmissionProctor.new(submission).open_for_editing? assignment
 
+    submission_was_draft = submission.unsubmitted?
     respond_to do |format|
       if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) &&
         Services::DeletesSubmissionDraftContent.for(submission).success?

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -61,6 +61,7 @@ module GradeStatus
   end
 
   def graded_and_visible_by_student?
-    is_released? || (is_graded? && !assignment.release_necessary?)
+    return false unless (is_released? || (is_graded? && !assignment.release_necessary?))
+    return true
   end
 end

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -60,7 +60,7 @@ module GradeStatus
     is_graded? || is_released?
   end
 
-  def graded_and_visible_by_student?
+  def student_visible?
     if is_released? || (is_graded? && !assignment.release_necessary?) 
       return true
     else

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -61,7 +61,7 @@ module GradeStatus
   end
 
   def graded_and_visible_by_student?
-    return false unless (is_released? || (is_graded? && !assignment.release_necessary?))
+    return false unless is_released? || (is_graded? && !assignment.release_necessary?)
     return true
   end
 end

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -59,4 +59,8 @@ module GradeStatus
   def graded_or_released?
     is_graded? || is_released?
   end
+
+  def graded_and_visible_by_student?
+    is_released? || (is_graded? && !assignment.release_necessary?)
+  end
 end

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -61,7 +61,10 @@ module GradeStatus
   end
 
   def graded_and_visible_by_student?
-    return false unless is_released? || (is_graded? && !assignment.release_necessary?)
-    return true
+    if is_released? || (is_graded? && !assignment.release_necessary?) 
+      return true
+    else
+      return false
+    end
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -82,10 +82,11 @@ class Submission < ActiveRecord::Base
     !submission_grade || submission_grade.status.nil?
   end
 
-  # Used to report to the user that a change will be a resubmission because this
-  # submission is already graded.
+  # Reports to the user that a change will be a resubmission because this
+  # submission is already graded and visible to them.
   def will_be_resubmitted?
-    submission_grade.graded_and_visible_by_student? if submission_grade.present?
+    return false unless submission_grade.present? && submission_grade.graded_and_visible_by_student?
+    return true
   end
 
   # this is transitive so that once it is graded again, then

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -85,7 +85,7 @@ class Submission < ActiveRecord::Base
   # Reports to the user that a change will be a resubmission because this
   # submission is already graded and visible to them.
   def will_be_resubmitted?
-    return false unless submission_grade.present? && submission_grade.graded_and_visible_by_student?
+    return false unless submission_grade.present? && submission_grade.student_visible?
     return true
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -36,9 +36,10 @@ class Submission < ActiveRecord::Base
   end
 
   scope :resubmitted, -> {
-    includes(:grade)
-    .where(grades: { status: ["Graded", "Released"] })
+    includes(:grade, :assignment)
+    .where("grades.status = 'Released' OR (grades.status = 'Graded' AND NOT assignments.release_necessary)")
     .where("grades.graded_at < submitted_at")
+    .references(:grade, :assignment)
   }
   scope :order_by_submitted, -> { order("submitted_at ASC") }
   scope :for_course, ->(course) { where(course_id: course.id) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -66,7 +66,7 @@ class Submission < ActiveRecord::Base
   end
 
   def graded_at
-    grade.graded_at if graded?
+    submission_grade.graded_at if graded?
   end
 
   def graded?
@@ -85,7 +85,7 @@ class Submission < ActiveRecord::Base
   # Used to report to the user that a change will be a resubmission because this
   # submission is already graded.
   def will_be_resubmitted?
-    grade.graded_and_visible_by_student? if grade.present?
+    submission_grade.graded_and_visible_by_student? if submission_grade.present?
   end
 
   # this is transitive so that once it is graded again, then

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -83,14 +83,13 @@ class Submission < ActiveRecord::Base
   # Used to report to the user that a change will be a resubmission because this
   # submission is already graded.
   def will_be_resubmitted?
-    grade.present? && grade.graded_and_visible_by_student?
+    grade.present?
   end
 
   # this is transitive so that once it is graded again, then
   # it will no longer be resubmitted
   def resubmitted?
-    grade.present? && grade.graded_and_visible_by_student? &&
-      !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
+    graded? && !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
   end
 
   # Getting the name of the student who submitted the work

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -83,13 +83,14 @@ class Submission < ActiveRecord::Base
   # Used to report to the user that a change will be a resubmission because this
   # submission is already graded.
   def will_be_resubmitted?
-    graded?
+    grade.present? && grade.graded_and_visible_by_student?
   end
 
   # this is transitive so that once it is graded again, then
   # it will no longer be resubmitted
   def resubmitted?
-    graded? && !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
+    grade.present? && grade.graded_and_visible_by_student? &&
+      !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
   end
 
   # Getting the name of the student who submitted the work

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,7 +32,7 @@ class Submission < ActiveRecord::Base
 
   scope :ungraded, -> do
     includes(:assignment, :group, :student)
-    .where.not(id: with_grade.where(grades: { status: ["Graded", "Released"] }))
+    .where.not(id: with_grade.where(grades: { status: ["In Progress", "Graded", "Released"] }))
   end
 
   scope :resubmitted, -> {
@@ -83,7 +83,7 @@ class Submission < ActiveRecord::Base
   # Used to report to the user that a change will be a resubmission because this
   # submission is already graded.
   def will_be_resubmitted?
-    grade.present?
+    grade.graded_and_visible_by_student? if grade.present?
   end
 
   # this is transitive so that once it is graded again, then

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -72,12 +72,14 @@ class Submission < ActiveRecord::Base
   def graded?
     !ungraded?
   end
+  
+  def submission_grade
+    student.grades.where(assignment_id: self.assignment_id).first
+  end
 
-  # Grabbing any submission that has NO instructor-defined grade (if the
-  # student has predicted the grade, it'll exist, but we still don't want to
-  # catch those here)
+  # Grabbing any submission that has NO instructor-defined grade
   def ungraded?
-    !grade || grade.status.nil?
+    !submission_grade || submission_grade.status.nil?
   end
 
   # Used to report to the user that a change will be a resubmission because this

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -15,8 +15,8 @@ class Assignments::Presenter < Showtime::Presenter
     assignment.assignment_type
   end
 
-  def submission_for_assignment(user)
-    @submission ||= user.submission_for_assignment(assignment, false)
+  def submission_for_assignment(student)
+    @submission ||= student.submission_for_assignment(assignment, false)
   end
 
   def completion_rate
@@ -189,10 +189,6 @@ class Assignments::Presenter < Showtime::Presenter
 
   def student_logged?(user)
     assignment.student_logged? && assignment.open? && user.is_student?(course)
-  end
-
-  def submission_for_assignment(student)
-    student.submission_for_assignment(assignment, false)
   end
 
   # Tallying the percentage of participation from the entire class

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -15,6 +15,10 @@ class Assignments::Presenter < Showtime::Presenter
     assignment.assignment_type
   end
 
+  def submission_for_assignment(user)
+    @submission ||= user.submission_for_assignment(assignment, false)
+  end
+
   def completion_rate
     assignment.completion_rate(course)
   end
@@ -77,15 +81,16 @@ class Assignments::Presenter < Showtime::Presenter
     grades.instructor_modified.present?
   end
 
-  def has_viewable_submission?(submission, current_user)
+  def has_viewable_submission?(user)
+    submission = submission_for_assignment(user)
     assignment.accepts_submissions? &&
       submission.present? &&
-      SubmissionProctor.new(submission).viewable?(current_user)
+      SubmissionProctor.new(submission).viewable?(user)
   end
 
   def has_viewable_submission_for?(user)
-    submission = Submission.for_assignment_and_student(assignment.id, user.id).first
-    has_viewable_submission?(submission, user)
+    submission = submission_for_assignment(user)
+    has_viewable_submission?(user)
   end
 
   def has_viewable_analytics?(user)

--- a/app/presenters/submissions/show_presenter.rb
+++ b/app/presenters/submissions/show_presenter.rb
@@ -55,8 +55,7 @@ module Submissions
     end
 
     def open_for_editing?
-      assignment.open? &&
-        (!grade.present? || assignment.resubmissions_allowed?)
+      assignment.open? && resubmissions_allowed?
     end
 
     def term_for_edit(current_user)
@@ -64,6 +63,18 @@ module Submissions
         "Edit Draft"
       else
         "Edit Submission"
+      end
+    end
+
+    private
+
+    # If graded, the grade must be released and the assignment must allow resubmissions
+    # otherwise, the assignment must allow resubmissions
+    def resubmissions_allowed?
+      if grade.present?
+        grade.graded_and_visible_by_student? && assignment.resubmissions_allowed?
+      else
+        assignment.resubmissions_allowed?
       end
     end
   end

--- a/app/presenters/submissions/show_presenter.rb
+++ b/app/presenters/submissions/show_presenter.rb
@@ -54,27 +54,11 @@ module Submissions
       submission.submitted_at
     end
 
-    def open_for_editing?
-      assignment.open? && resubmissions_allowed?
-    end
-
     def term_for_edit(current_user)
       if !current_user.is_staff?(assignment.course) && submission.text_comment_draft.present?
         "Edit Draft"
       else
         "Edit Submission"
-      end
-    end
-
-    private
-
-    # If graded, the grade must be released and the assignment must allow resubmissions
-    # otherwise, the assignment must allow resubmissions
-    def resubmissions_allowed?
-      if grade.present?
-        grade.graded_and_visible_by_student? && assignment.resubmissions_allowed?
-      else
-        assignment.resubmissions_allowed?
       end
     end
   end

--- a/app/presenters/submissions/show_presenter.rb
+++ b/app/presenters/submissions/show_presenter.rb
@@ -57,6 +57,8 @@ module Submissions
     def term_for_edit(current_user)
       if !current_user.is_staff?(assignment.course) && submission.text_comment_draft.present?
         "Edit Draft"
+      elsif submission.will_be_resubmitted?
+        "Resubmit"
       else
         "Edit Submission"
       end

--- a/app/proctors/grade_proctor/viewable.rb
+++ b/app/proctors/grade_proctor/viewable.rb
@@ -17,7 +17,7 @@ class GradeProctor
       course = options[:course] || grade.course
 
       grade_for_course?(course) &&
-        (user.is_staff?(course) || (grade_for_user?(user) && grade.graded_and_visible_by_student?))
+        (user.is_staff?(course) || (grade_for_user?(user) && grade.student_visible?))
     end
   end
 end

--- a/app/proctors/grade_proctor/viewable.rb
+++ b/app/proctors/grade_proctor/viewable.rb
@@ -17,14 +17,7 @@ class GradeProctor
       course = options[:course] || grade.course
 
       grade_for_course?(course) &&
-        (user.is_staff?(course) || (grade_for_user?(user) && grade_visible_by_student?))
-    end
-
-    private
-
-    def grade_visible_by_student?
-      grade.is_released? ||
-        (grade.is_graded? && !grade.assignment.release_necessary?)
+        (user.is_staff?(course) || (grade_for_user?(user) && grade.graded_and_visible_by_student?))
     end
   end
 end

--- a/app/proctors/submission_proctor.rb
+++ b/app/proctors/submission_proctor.rb
@@ -16,7 +16,7 @@ class SubmissionProctor
   end
 
   def open_for_editing?(assignment)
-    return false if @submission.graded?
+    return false if @submission.graded? && !@submission.grade.is_released?
     if @submission.will_be_resubmitted?
       assignment.open? && assignment.resubmissions_allowed?
     else

--- a/app/proctors/submission_proctor.rb
+++ b/app/proctors/submission_proctor.rb
@@ -6,12 +6,28 @@ class SubmissionProctor
   # If the user is not considered staff, the submission should be viewable
   # Otherwise, it should only be visible if it is not a draft
   def viewable?(user)
-    return @submission.belongs_to?(user) if user.is_student?(@submission.course)
+    return @submission.belongs_to? user if user.is_student? @submission.course
     !@submission.unsubmitted?
   end
 
   def viewable_submission(user)
-    return nil unless viewable?(user)
+    return nil unless viewable? user
     @submission
+  end
+
+  def open_for_editing?(assignment)
+    assignment.open? && resubmissions_allowed?(assignment)
+  end
+
+  private
+
+  # If graded, the grade must be released and the assignment must allow resubmissions
+  # otherwise, the assignment must allow resubmissions
+  def resubmissions_allowed?(assignment)
+    if @submission.grade.present?
+      @submission.grade.graded_and_visible_by_student? && assignment.resubmissions_allowed?
+    else
+      assignment.resubmissions_allowed?
+    end
   end
 end

--- a/app/proctors/submission_proctor.rb
+++ b/app/proctors/submission_proctor.rb
@@ -16,7 +16,7 @@ class SubmissionProctor
   end
 
   def open_for_editing?(assignment)
-    return false if @submission.graded? && !@submission.grade.is_released?
+    return false if @submission.graded? && !@submission.submission_grade.is_released?
     if @submission.will_be_resubmitted?
       assignment.open? && assignment.resubmissions_allowed?
     else

--- a/app/proctors/submission_proctor.rb
+++ b/app/proctors/submission_proctor.rb
@@ -16,18 +16,11 @@ class SubmissionProctor
   end
 
   def open_for_editing?(assignment)
-    assignment.open? && resubmissions_allowed?(assignment)
-  end
-
-  private
-
-  # If graded, the grade must be released and the assignment must allow resubmissions
-  # otherwise, the assignment must allow resubmissions
-  def resubmissions_allowed?(assignment)
-    if @submission.grade.present?
-      @submission.grade.graded_and_visible_by_student? && assignment.resubmissions_allowed?
+    return false if @submission.graded?
+    if @submission.will_be_resubmitted?
+      assignment.open? && assignment.resubmissions_allowed?
     else
-      assignment.resubmissions_allowed?
+      assignment.open?
     end
   end
 end

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -17,6 +17,7 @@
           %a{"href" => "#tab4"} Rubric
 
 
+<<<<<<< HEAD
     #tabt1.ui-tabs-panel
       - if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)
         .ui-tabs-panel#tab{class: ("active" if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
@@ -25,6 +26,17 @@
               %h2 My Grade
               = render partial: "grades/grade_content", locals: { grade: presenter.grade_for_student(current_student) }
               %hr.dotted
+=======
+    - submission = presenter.submission_for_assignment(current_student)
+    - if presenter.has_viewable_submission_for?(current_student) && submission.ungraded?
+      %section
+        %h2 My Submission
+        = render partial: "submissions/submission_content",
+            locals: { presenter: Submissions::ShowPresenter.new(id: submission.id,
+              assignment_id: presenter.assignment.id, course: current_course) }
+        = history_timeline presenter.submission_grade_history(current_student)
+        %hr.dotted
+>>>>>>> Hide edit submission button if graded
 
           - if presenter.has_viewable_submission_for?(current_student)
             %section.assignment-details-container

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -17,7 +17,6 @@
           %a{"href" => "#tab4"} Rubric
 
 
-<<<<<<< HEAD
     #tabt1.ui-tabs-panel
       - if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)
         .ui-tabs-panel#tab{class: ("active" if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
@@ -26,17 +25,6 @@
               %h2 My Grade
               = render partial: "grades/grade_content", locals: { grade: presenter.grade_for_student(current_student) }
               %hr.dotted
-=======
-    - submission = presenter.submission_for_assignment(current_student)
-    - if presenter.has_viewable_submission_for?(current_student) && submission.ungraded?
-      %section
-        %h2 My Submission
-        = render partial: "submissions/submission_content",
-            locals: { presenter: Submissions::ShowPresenter.new(id: submission.id,
-              assignment_id: presenter.assignment.id, course: current_course) }
-        = history_timeline presenter.submission_grade_history(current_student)
-        %hr.dotted
->>>>>>> Hide edit submission button if graded
 
           - if presenter.has_viewable_submission_for?(current_student)
             %section.assignment-details-container

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -1,5 +1,5 @@
 - presenter.students.each do |student|
-  - student_submission = Submission.for_assignment_and_student(presenter.assignment.id, student.id).first
+  - student_submission = presenter.submission_for_assignment(student)
   - grade = presenter.grade_for_student(student)
   %tr
     - if presenter.assignment.is_unlockable?
@@ -52,7 +52,7 @@
       .right
         %ul.button-bar
           - if presenter.assignment.accepts_submissions?
-            - if presenter.has_viewable_submission?(student_submission, current_user)
+            - if presenter.has_viewable_submission?(current_user)
               /* Submission present - allow instructor to see it, and identify if it's a new submission or a resubmission. Icon represents if there are files attached. */
               %li= link_to decorative_glyph(:paperclip) + "See Submission", assignment_submission_path(presenter.assignment, student_submission.id), class: "button"
 
@@ -67,7 +67,7 @@
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               %li= link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
-            %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(student_submission, current_user) ? "danger" : ""}"
+            %li= link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/submissions/_submission_content.haml
+++ b/app/views/submissions/_submission_content.haml
@@ -1,5 +1,6 @@
 // Allow students to edit the submission if that's still possible
-= render partial: "submissions/components/edit", locals: { presenter: presenter } if presenter.open_for_editing?
+- if SubmissionProctor.new(presenter.submission).open_for_editing? presenter.assignment
+  = render partial: "submissions/components/edit", locals: { presenter: presenter }
 
 // Displaying when the assignment was submitted and if it was late/resubmitted
 = render partial: "submissions/components/dates_and_state", locals: { presenter: presenter }

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -98,32 +98,38 @@ describe SubmissionsController do
     end
 
     describe "POST update" do
+      let(:submission_params) { attributes_for(:submission) }
+
       it "updates the submission successfully"  do
-        params = attributes_for(:submission)
-        params[:assignment_id] = assignment.id
-        params[:text_comment] = "Ausgezeichnet"
-        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
+        submission_params.merge!(assignment_id: assignment.id, text_comment: "Ausgezeichnet")
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }
         expect(response).to redirect_to(assignment_submission_path(assignment, submission, student_id: student.id))
         expect(submission.reload.text_comment).to eq("Ausgezeichnet")
       end
 
       it "deletes the text comment draft content" do
-        params = attributes_for(:submission)
         expect(Services::DeletesSubmissionDraftContent).to receive(:for).and_call_original
-        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }, format: :json
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }, format: :json
       end
 
-      it "checks if the submission is late if it is not a resubmission" do
-        params = attributes_for(:submission)
+      it "redirects to the assignments page if the submission is not open for editing" do
+        allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }
+        expect(response).to redirect_to(assignment_path(assignment,
+          anchor: "tab3",
+          notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released.")
+        )
+      end
+
+      it "checks if the submission is late if the submission is not a resubmission" do
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
-        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }
       end
 
-      it "does not check if the submission is late if it is a resubmission" do
-        params = attributes_for(:submission)
+      it "does not check if the submission is late if the submission is a resubmission" do
         allow_any_instance_of(Submission).to receive(:will_be_resubmitted?).and_return true
         expect_any_instance_of(Submission).to_not receive(:check_and_set_late_status!)
-        post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }
       end
     end
 
@@ -203,13 +209,22 @@ describe SubmissionsController do
         expect(submission.reload.submitted_at).to be > current_time
       end
 
-      it "checks if the submission is late if it is not a resubmission" do
+      it "redirects to the assignments page if the submission is not open for editing" do
+        allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
+        post :update, params: { assignment_id: assignment.id, id: submission, submission: attributes_for(:submission) }
+        expect(response).to redirect_to(assignment_path(assignment,
+          anchor: "tab3",
+          notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released.")
+        )
+      end
+
+      it "checks if the submission is late if the submission is not a resubmission" do
         params = attributes_for(:submission).merge({ assignment_id: assignment.id })
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
         post :update, params: { assignment_id: assignment.id, id: submission, submission: params }
       end
 
-      it "does not check if the submission is late if it is a resubmission" do
+      it "does not check if the submission is late if the submission is a resubmission" do
         params = attributes_for(:submission)
         allow_any_instance_of(Submission).to receive(:will_be_resubmitted?).and_return true
         expect_any_instance_of(Submission).to_not receive(:check_and_set_late_status!)

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -64,6 +64,12 @@ describe SubmissionsController do
         get :edit, params: { id: submission.id, assignment_id: assignment.id }
         expect(response).to render_template(:edit)
       end
+
+      it "redirects to the assignment path if the submission is not open for editing" do
+        allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
+        get :edit, params: { id: submission.id, assignment_id: assignment.id }
+        expect(response).to redirect_to(assignment_path(assignment, anchor: "tab3"))
+      end
     end
 
     describe "POST create" do
@@ -115,10 +121,7 @@ describe SubmissionsController do
       it "redirects to the assignments page if the submission is not open for editing" do
         allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
         post :update, params: { assignment_id: assignment.id, id: submission, submission: submission_params }
-        expect(response).to redirect_to(assignment_path(assignment,
-          anchor: "tab3",
-          notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released.")
-        )
+        expect(response).to redirect_to(assignment_path(assignment, anchor: "tab3"))
       end
 
       it "checks if the submission is late if the submission is not a resubmission" do
@@ -154,6 +157,12 @@ describe SubmissionsController do
       it "shows the edit submission form" do
         get :edit, params: { id: submission.id, assignment_id: assignment.id }
         expect(response).to render_template(:edit)
+      end
+
+      it "redirects to the assignment path if the submission is not open for editing" do
+        allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
+        get :edit, params: { id: submission.id, assignment_id: assignment.id }
+        expect(response).to redirect_to(assignment_path(assignment, anchor: "tab3"))
       end
     end
 
@@ -212,10 +221,7 @@ describe SubmissionsController do
       it "redirects to the assignments page if the submission is not open for editing" do
         allow_any_instance_of(SubmissionProctor).to receive(:open_for_editing?).and_return false
         post :update, params: { assignment_id: assignment.id, id: submission, submission: attributes_for(:submission) }
-        expect(response).to redirect_to(assignment_path(assignment,
-          anchor: "tab3",
-          notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released.")
-        )
+        expect(response).to redirect_to(assignment_path(assignment, anchor: "tab3"))
       end
 
       it "checks if the submission is late if the submission is not a resubmission" do

--- a/spec/factories/group_factory.rb
+++ b/spec/factories/group_factory.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :group do
     association :course, factory: :course
+    text_proposal "how important is it to get this right?"
     before(:create) do |group|
       (0..3).each { group.students << create(:course_membership, :student, course: group.course).user }
       group.assignments << create(:assignment, grade_scope: "Group", course: group.course)

--- a/spec/features/editing_submissions_spec.rb
+++ b/spec/features/editing_submissions_spec.rb
@@ -4,7 +4,7 @@ feature "editing submissions" do
       create :submission, course: membership.course, assignment: assignment, student: student
     end
 
-    let(:assignment) { build :assignment, accepts_submissions: true, course: membership.course }
+    let(:assignment) { build :assignment, accepts_submissions: true, resubmissions_allowed: true, course: membership.course }
     let(:membership) { create :course_membership, :student, user: student }
     let(:student) { create :user }
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -2,7 +2,7 @@ describe Assignment do
   subject { build(:assignment) }
 
   context "with a persisted assignment" do 
-    it_behaves_like "a model that needs sanitization", :description
+    it_behaves_like "a model that needs sanitization", :assignment, :description
   end
 
   context "validations" do

--- a/spec/models/concerns/grade_status_spec.rb
+++ b/spec/models/concerns/grade_status_spec.rb
@@ -4,35 +4,35 @@ describe GradeStatus do
   let(:assignment) { create(:assignment, course: course) }
   let(:grade) { create(:grade, assignment: assignment, student: student) }
   
-  describe "graded_and_visible_by_student?" do
+  describe "student_visible?" do
     it "returns true if the grade is released" do
       grade.status = "Released"
       assignment.release_necessary = true
-      expect(grade.graded_and_visible_by_student?).to eq true
+      expect(grade.student_visible?).to eq true
     end
     
     it "returns true if the grade is graded and the assignment does not need release" do 
       grade.status = "Graded"
       assignment.release_necessary = false
-      expect(grade.graded_and_visible_by_student?).to eq true
+      expect(grade.student_visible?).to eq true
     end
     
     it "returns false if the grade is not released" do
       grade.status = "Graded"
       assignment.release_necessary = true
-      expect(grade.graded_and_visible_by_student?).to eq false
+      expect(grade.student_visible?).to eq false
     end
     
     it "returns false if the grade is not marked as graded" do
       grade.status = nil
       assignment.release_necessary = true
-      expect(grade.graded_and_visible_by_student?).to eq false
+      expect(grade.student_visible?).to eq false
     end
     
     it "returns false if the grade is marked as in progress" do
       grade.status = "In Progress"
       assignment.release_necessary = true
-      expect(grade.graded_and_visible_by_student?).to eq false
+      expect(grade.student_visible?).to eq false
     end
   end
 end

--- a/spec/models/concerns/grade_status_spec.rb
+++ b/spec/models/concerns/grade_status_spec.rb
@@ -1,0 +1,38 @@
+describe GradeStatus do 
+  let(:course) { create(:course) }
+  let(:student)  { create(:course_membership, :student, course: course).user }
+  let(:assignment) { create(:assignment, course: course) }
+  let(:grade) { create(:grade, assignment: assignment, student: student) }
+  
+  describe "graded_and_visible_by_student?" do
+    it "returns true if the grade is released" do
+      grade.status = "Released"
+      assignment.release_necessary = true
+      expect(grade.graded_and_visible_by_student?).to eq true
+    end
+    
+    it "returns true if the grade is graded and the assignment does not need release" do 
+      grade.status = "Graded"
+      assignment.release_necessary = false
+      expect(grade.graded_and_visible_by_student?).to eq true
+    end
+    
+    it "returns false if the grade is not released" do
+      grade.status = "Graded"
+      assignment.release_necessary = true
+      expect(grade.graded_and_visible_by_student?).to eq false
+    end
+    
+    it "returns false if the grade is not marked as graded" do
+      grade.status = nil
+      assignment.release_necessary = true
+      expect(grade.graded_and_visible_by_student?).to eq false
+    end
+    
+    it "returns false if the grade is marked as in progress" do
+      grade.status = "In Progress"
+      assignment.release_necessary = true
+      expect(grade.graded_and_visible_by_student?).to eq false
+    end
+  end
+end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -76,8 +76,10 @@ describe Grade do
     end
   end
 
-  it_behaves_like "a historical model", :grade, raw_points: 1234
-  it_behaves_like "a model that needs sanitization", :feedback
+  context "with a persisted assignment" do 
+    it_behaves_like "a historical model", :grade, raw_points: 1234
+    it_behaves_like "a model that needs sanitization", :grade, :feedback
+  end
 
   describe "#squish_history!", versioning: true do
     it "squishes two previous changes into one" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,7 +1,9 @@
 describe Group do
   subject { create(:group) }
 
-  it_behaves_like "a model that needs sanitization", :text_proposal
+  context "with a persisted assignment" do 
+    it_behaves_like "a model that needs sanitization", :group, :text_proposal
+  end
 
   describe "validations" do
     it "is valid with a name and an approval state" do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,8 +1,16 @@
 describe Group do
-  
+
   let(:group) { create(:group, name: "Steven's Wondersauce") }
 
   it_behaves_like "a model that needs sanitization", :group, :text_proposal
+
+  describe "sanitization" do
+    it "has html save text text_proposal" do
+      group.text_proposal = "Fine & Dandy"
+      group.save
+      expect(group.text_proposal).to eq("Fine &amp; Dandy")
+    end
+  end
 
   describe "validations" do
     it "is valid with a name and an approval state" do
@@ -68,39 +76,39 @@ describe Group do
       expect(group).to be_invalid
     end
   end
-  
+
   describe "#approved?" do
     it "returns true if approved" do
       group.approved = "Approved"
       expect(group.approved?).to eq true
     end
-  
+
     it "returns false if any other state" do
       group.approved = "Rejected"
       expect(group.approved?).to eq false
     end
   end
-  
+
   describe "#assignment_ids" do
     let(:assignment1) { create :assignment }
     let(:assignment2) { create :assignment }
     let(:student) { create :user }
-  
+
     it "creates assignment groups for each assignment id" do
       group.assignment_ids = [assignment1, assignment2].map(&:id)
       group.save
-  
+
       expect(group.assignment_groups.count).to eq 2
     end
   end
-  
-  describe "submitter directory names" do  
+
+  describe "submitter directory names" do
     describe "#submitter_directory_name" do
       it "formats the submitter name into a directory name" do
         expect(group.submitter_directory_name).to eq("Stevens Wondersauce")
       end
     end
-  
+
     describe "#submitter_directory_name_with_suffix" do
       it "formats the submitter name into a directory name with unique id" do
         expect(group.submitter_directory_name_with_suffix)
@@ -108,95 +116,95 @@ describe Group do
       end
     end
   end
-  
+
   describe "#grade_for_assignment" do
     context "group grade exists" do
       it "returns the grade" do
         assignment = create :assignment
         group = create :group
         grade = create :grade, group: group, assignment: assignment
-  
+
         expect(group.grade_for_assignment(assignment)).to eq grade
       end
     end
-  
+
     context "no group grade exists" do
       it "builds a new grade" do
         assignment = create :assignment
         group = create :group
-  
+
         grade = group.grade_for_assignment(assignment)
-  
+
         expect(grade.new_record?).to eq true
         expect(grade.group).to eq group
         expect(grade.assignment).to eq assignment
       end
     end
   end
-  
+
   describe "#pending?" do
     it "returns true if pending" do
       group.approved = "Pending"
       expect(group.pending?).to eq true
     end
-  
+
     it "returns false if any other state" do
       group.approved = "Rejected"
       expect(group.pending?).to eq false
     end
   end
-  
+
   describe "#rejected?" do
     it "returns true if rejected" do
       group.approved = "Rejected"
       expect(group.rejected?).to eq true
     end
-  
+
     it "returns false if any other state" do
       group.approved = "Approved"
       expect(group.rejected?).to eq false
     end
   end
-  
+
   describe "#submission_for_assignment(assignment)" do
     let(:assignment) { create(:assignment, grade_scope: "Group") }
-  
+
     context "when there is not a draft submission" do
       it "returns the group's submission for an assignment" do
         submission = create(:group_submission, group: group, assignment: assignment)
         expect(group.submission_for_assignment(assignment)).to eq(submission)
       end
-  
+
       it "returns nil if the group doesn't have an assignment submission" do
         # assignment = create(:assignment, grade_scope: "Group")
         expect(group.submission_for_assignment(assignment)).to eq nil
       end
     end
-  
+
     context "when there is a draft submission" do
       let!(:draft_submission) { create(:group_submission, assignment: assignment, group: group, submitted_at: nil) }
-  
+
       it "returns nil if submitted only is true" do
         expect(group.submission_for_assignment(assignment)).to eq nil
       end
-  
+
       it "returns the draft submission" do
         expect(group.submission_for_assignment(assignment, false)).to eq draft_submission
       end
     end
   end
-  
+
   describe "#same_name_as?" do
     let(:hound_dogz1) { create(:group, name: "Hound Dogz") }
     let(:hound_dogz2) { create(:group, name: "Hound Dogz") }
     let(:roger_daltry) { create(:group, name: "Roger Daltry") }
-  
+
     context "has the same name as the group given" do
       it "returns true" do
         expect(hound_dogz1.same_name_as?(hound_dogz2)).to eq true
       end
     end
-  
+
     context "has a different name than the group given" do
       it "returns false" do
         expect(hound_dogz1.same_name_as?(roger_daltry)).to eq false

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -2,7 +2,7 @@ describe Group do
 
   let(:group) { create(:group, name: "Steven's Wondersauce") }
 
-  describe "sanitization" do
+  describe "proposal sanitization" do
     it "has html save text text_proposal" do
       group.text_proposal = "Fine & Dandy"
       group.save

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,23 +1,22 @@
 describe Group do
-  subject { create(:group) }
+  
+  let(:group) { create(:group, name: "Steven's Wondersauce") }
 
-  context "with a persisted assignment" do 
-    it_behaves_like "a model that needs sanitization", :group, :text_proposal
-  end
+  it_behaves_like "a model that needs sanitization", :group, :text_proposal
 
   describe "validations" do
     it "is valid with a name and an approval state" do
-      expect(subject).to be_valid
+      expect(group).to be_valid
     end
 
     it "is invalid without a name" do
-      subject.name = nil
-      expect(subject).to be_invalid
+      group.name = nil
+      expect(group).to be_invalid
     end
 
     it "is invalid without an approval state" do
-      subject.approved = nil
-      expect(subject).to be_invalid
+      group.approved = nil
+      expect(group).to be_invalid
     end
 
     it "does not allow more group members than the assignment max" do
@@ -28,10 +27,10 @@ describe Group do
       student5 = create :user
       assignment1 = create :assignment, max_group_size: 4
 
-      subject.assignments << assignment1
-      subject.students << [student1, student2, student3, student4, student5]
+      group.assignments << assignment1
+      group.students << [student1, student2, student3, student4, student5]
 
-      expect(subject).to be_invalid
+      expect(group).to be_invalid
     end
 
     it "does not allow fewer group members than the assignment min" do
@@ -39,10 +38,10 @@ describe Group do
       student2 = create :user
       assignment1 = create :assignment, max_group_size: 4
 
-      subject.assignments << assignment1
-      subject.students << [student1, student2]
+      group.assignments << assignment1
+      group.students << [student1, student2]
 
-      expect(subject).to be_invalid
+      expect(group).to be_invalid
     end
 
     it "does not allow students to belong to more than one group per assignment" do
@@ -53,10 +52,10 @@ describe Group do
       group_dup = create :group
       group_dup.assignments << assignment1
       group_dup.students << [student1, student3]
-      subject.assignments << assignment1
-      subject.students << [student1, student2]
+      group.assignments << assignment1
+      group.students << [student1, student2]
 
-      expect(subject).to be_invalid
+      expect(group).to be_invalid
     end
 
     it "requires the group to work on at least one assignment" do
@@ -64,144 +63,140 @@ describe Group do
       student2 = create :user
       assignment1 = create :assignment, max_group_size: 4
 
-      subject.students << [student1, student2]
+      group.students << [student1, student2]
 
-      expect(subject).to be_invalid
+      expect(group).to be_invalid
     end
   end
-
+  
   describe "#approved?" do
     it "returns true if approved" do
-      subject.approved = "Approved"
-      expect(subject.approved?).to eq true
+      group.approved = "Approved"
+      expect(group.approved?).to eq true
     end
-
+  
     it "returns false if any other state" do
-      subject.approved = "Rejected"
-      expect(subject.approved?).to eq false
+      group.approved = "Rejected"
+      expect(group.approved?).to eq false
     end
   end
-
-  describe "#assignment_ids=" do
+  
+  describe "#assignment_ids" do
     let(:assignment1) { create :assignment }
     let(:assignment2) { create :assignment }
     let(:student) { create :user }
-
-    subject { build :group, student_ids: [student.id] }
-
+  
     it "creates assignment groups for each assignment id" do
-      subject.assignment_ids = [assignment1, assignment2].map(&:id)
-      subject.save
-
-      expect(subject.assignment_groups.count).to eq 2
+      group.assignment_ids = [assignment1, assignment2].map(&:id)
+      group.save
+  
+      expect(group.assignment_groups.count).to eq 2
     end
   end
-
-  describe "submitter directory names" do
-    subject { create :group, name: "Steven's Wondersauce" }
-
+  
+  describe "submitter directory names" do  
     describe "#submitter_directory_name" do
       it "formats the submitter name into a directory name" do
-        expect(subject.submitter_directory_name).to eq("Stevens Wondersauce")
+        expect(group.submitter_directory_name).to eq("Stevens Wondersauce")
       end
     end
-
+  
     describe "#submitter_directory_name_with_suffix" do
       it "formats the submitter name into a directory name with unique id" do
-        expect(subject.submitter_directory_name_with_suffix)
-          .to eq("Stevens Wondersauce - #{subject.id}")
+        expect(group.submitter_directory_name_with_suffix)
+          .to eq("Stevens Wondersauce - #{group.id}")
       end
     end
   end
-
+  
   describe "#grade_for_assignment" do
     context "group grade exists" do
       it "returns the grade" do
         assignment = create :assignment
         group = create :group
         grade = create :grade, group: group, assignment: assignment
-
+  
         expect(group.grade_for_assignment(assignment)).to eq grade
       end
     end
-
+  
     context "no group grade exists" do
       it "builds a new grade" do
         assignment = create :assignment
         group = create :group
-
+  
         grade = group.grade_for_assignment(assignment)
-
+  
         expect(grade.new_record?).to eq true
         expect(grade.group).to eq group
         expect(grade.assignment).to eq assignment
       end
     end
   end
-
+  
   describe "#pending?" do
     it "returns true if pending" do
-      subject.approved = "Pending"
-      expect(subject.pending?).to eq true
+      group.approved = "Pending"
+      expect(group.pending?).to eq true
     end
-
+  
     it "returns false if any other state" do
-      subject.approved = "Rejected"
-      expect(subject.pending?).to eq false
+      group.approved = "Rejected"
+      expect(group.pending?).to eq false
     end
   end
-
+  
   describe "#rejected?" do
     it "returns true if rejected" do
-      subject.approved = "Rejected"
-      expect(subject.rejected?).to eq true
+      group.approved = "Rejected"
+      expect(group.rejected?).to eq true
     end
-
+  
     it "returns false if any other state" do
-      subject.approved = "Approved"
-      expect(subject.rejected?).to eq false
+      group.approved = "Approved"
+      expect(group.rejected?).to eq false
     end
   end
-
+  
   describe "#submission_for_assignment(assignment)" do
     let(:assignment) { create(:assignment, grade_scope: "Group") }
-
+  
     context "when there is not a draft submission" do
       it "returns the group's submission for an assignment" do
-        submission = create(:group_submission, group: subject, assignment: assignment)
-        expect(subject.submission_for_assignment(assignment)).to eq(submission)
+        submission = create(:group_submission, group: group, assignment: assignment)
+        expect(group.submission_for_assignment(assignment)).to eq(submission)
       end
-
+  
       it "returns nil if the group doesn't have an assignment submission" do
         # assignment = create(:assignment, grade_scope: "Group")
-        expect(subject.submission_for_assignment(assignment)).to eq nil
+        expect(group.submission_for_assignment(assignment)).to eq nil
       end
     end
-
+  
     context "when there is a draft submission" do
-      let!(:draft_submission) { create(:group_submission, assignment: assignment, group: subject, submitted_at: nil) }
-
+      let!(:draft_submission) { create(:group_submission, assignment: assignment, group: group, submitted_at: nil) }
+  
       it "returns nil if submitted only is true" do
-        expect(subject.submission_for_assignment(assignment)).to eq nil
+        expect(group.submission_for_assignment(assignment)).to eq nil
       end
-
+  
       it "returns the draft submission" do
-        expect(subject.submission_for_assignment(assignment, false)).to eq draft_submission
+        expect(group.submission_for_assignment(assignment, false)).to eq draft_submission
       end
     end
   end
-
+  
   describe "#same_name_as?" do
     let(:hound_dogz1) { create(:group, name: "Hound Dogz") }
     let(:hound_dogz2) { create(:group, name: "Hound Dogz") }
     let(:roger_daltry) { create(:group, name: "Roger Daltry") }
-
+  
     context "has the same name as the group given" do
       it "returns true" do
         expect(hound_dogz1.same_name_as?(hound_dogz2)).to eq true
       end
     end
-
+  
     context "has a different name than the group given" do
       it "returns false" do
         expect(hound_dogz1.same_name_as?(roger_daltry)).to eq false

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -2,8 +2,6 @@ describe Group do
 
   let(:group) { create(:group, name: "Steven's Wondersauce") }
 
-  it_behaves_like "a model that needs sanitization", :group, :text_proposal
-
   describe "sanitization" do
     it "has html save text text_proposal" do
       group.text_proposal = "Fine & Dandy"

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -7,7 +7,7 @@ describe Submission do
   let(:ungraded_submission) { create(:submission, course: course) }
 
   describe "validations" do
-    it "is valid" do 
+    it "is valid" do
       expect(submission).to be_valid
     end
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -235,6 +235,8 @@ describe Submission do
   end
 
   describe ".ungraded" do
+    before { Submission.destroy_all }
+      
     let(:in_progress_submission) { create(:submission, course: course) }
     
     it "returns the submissions that do not have any grades" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,26 +1,28 @@
 describe Submission do
-  include UniMock::StubRails
-
-  before { stub_env "development" }
+  
   let(:course) { build(:course) }
-  subject { build(:submission, course: course) }
+  let(:assignment) { create(:assignment) }
+  let(:student) { create(:user) }
+  let(:submission) { create(:submission, course: course, assignment: assignment, student: student) }
   let(:ungraded_submission) { create(:submission, course: course) }
 
   describe "validations" do
-    it { is_expected.to be_valid }
+    it "is valid" do 
+      expect(submission).to be_valid
+    end
 
     it "requires a valid url" do
-      subject.link = "not a url"
-      expect(subject).to_not be_valid
-      expect(subject.errors[:link]).to include "is invalid"
+      submission.link = "not a url"
+      expect(submission).to_not be_valid
+      expect(submission.errors[:link]).to include "is invalid"
     end
 
     it "requires something to have been submitted" do
-      subject.link = nil
-      subject.text_comment = nil
-      subject.submission_files.clear
-      expect(subject).to_not be_valid
-      expect(subject.errors[:base]).to include "Submission cannot be empty"
+      submission.link = nil
+      submission.text_comment = nil
+      submission.submission_files.clear
+      expect(submission).to_not be_valid
+      expect(submission.errors[:base]).to include "Submission cannot be empty"
     end
 
     it "restricts duplicate submissions for a given student on an assignment" do
@@ -50,20 +52,22 @@ describe Submission do
       expect(build_stubbed(:submission)).to be_valid
       expect(build_stubbed(:group_submission)).to be_valid
       expect(build_stubbed(:submission, student: nil, group: nil)).not_to be_valid
-      expect(build_stubbed(:submission, student: build_stubbed(:user), group: build_stubbed(:group))).not_to be_valid
+      expect(build_stubbed(:submission, student: student, group: build_stubbed(:group))).not_to be_valid
     end
   end
 
-  it_behaves_like "a historical model", :submission, link: "http://example.org"
-  it_behaves_like "a model that needs sanitization", :text_comment
+  context "with a persisted assignment" do 
+    it_behaves_like "a historical model", :submission, link: "http://example.org"
+    it_behaves_like "a model that needs sanitization", :submission, :text_comment
+  end
 
   describe "versioning", versioning: true do
-    before { subject.save }
+    before { submission.save }
 
     it "creates a version when the link is updated" do
-      previous_link = subject.link
-      subject.update_attributes link: "http://example.com"
-      expect(subject).to have_a_version_with link: previous_link
+      previous_link = submission.link
+      submission.update_attributes link: "http://example.com"
+      expect(submission).to have_a_version_with link: previous_link
     end
 
     it "creates a version when the attachment is updated" do
@@ -72,41 +76,41 @@ describe Submission do
       # submission_id requires a create, then an update, which creates two
       # versions instead of one.
       #
-      subject.submission_files.create attributes_for(:submission_file)
-      expect(subject.submission_files.first.versions.count).to eq 1
+      submission.submission_files.create attributes_for(:submission_file)
+      expect(submission.submission_files.first.versions.count).to eq 1
     end
 
     it "creates a version when the comment is updated" do
-      previous_comment = subject.text_comment
-      subject.update_attributes text_comment: "This was updated"
-      expect(subject).to have_a_version_with text_comment: previous_comment
+      previous_comment = submission.text_comment
+      submission.update_attributes text_comment: "This was updated"
+      expect(submission).to have_a_version_with text_comment: previous_comment
     end
   end
 
   it "can be saved with only a text comment" do
-    subject.text_comment = "I volunteer! I volunteer! I volunteer as tribute!"
-    subject.save!
-    expect(subject.errors.size).to eq(0)
+    submission.text_comment = "I volunteer! I volunteer! I volunteer as tribute!"
+    submission.save!
+    expect(submission.errors.size).to eq(0)
   end
 
   it "can be saved with only a link" do
-    subject.link = "http://www.amazon.com/dp/0439023521"
-    subject.save!
-    expect expect(subject.errors.size).to eq(0)
+    submission.link = "http://www.amazon.com/dp/0439023521"
+    submission.save!
+    expect expect(submission.errors.size).to eq(0)
   end
 
   it "can be saved with only an attached file" do
-    subject.submission_files << build(:submission_file)
-    subject.save!
-    expect expect(subject.errors.size).to eq(0)
+    submission.submission_files << build(:submission_file)
+    submission.save!
+    expect expect(submission.errors.size).to eq(0)
   end
 
   it "can have an an attached file, comment, and link" do
-    subject.text_comment = "I volunteer! I volunteer! I volunteer as tribute!"
-    subject.link = "http://www.amazon.com/dp/0439023521"
-    subject.submission_files << build(:submission_file)
-    subject.save!
-    expect expect(subject.errors.size).to eq(0)
+    submission.text_comment = "I volunteer! I volunteer! I volunteer as tribute!"
+    submission.link = "http://www.amazon.com/dp/0439023521"
+    submission.submission_files << build(:submission_file)
+    submission.save!
+    expect expect(submission.errors.size).to eq(0)
   end
 
   describe ".for_course" do
@@ -121,36 +125,27 @@ describe Submission do
 
   describe ".for_student" do
     it "returns all submissions for a specific student" do
-      student = create(:user)
-      student_submission = create(:submission, student: student)
       another_submission = create(:submission)
       results = Submission.for_student(student)
-      expect(results).to eq [student_submission]
+      expect(results).to eq [submission]
     end
   end
 
   describe ".for_assignment_and_student" do
-    let(:assignment) { create(:assignment) }
-    let(:student)  { create(:course_membership, :student, course: assignment.course).user }
-    let!(:submission) { create(:submission, assignment: assignment, student: student) }
-
     it "returns the submission for the student and assignment" do
-      result = Submission.for_assignment_and_student(assignment.id, student.id).first
-      expect(result).to eq submission
+      expect(Submission.for_assignment_and_student(assignment.id, student.id)).to eq [submission]
     end
   end
 
   describe ".for_assignment_and_group" do
-    let(:assignment) { create(:group_assignment) }
-    let(:student) { create(:user) }
-    let!(:course_membership) { create(:course_membership, :student, user: student, course: assignment.course) }
-    let!(:assignment_group) { create(:assignment_group, assignment: assignment) }
+    let(:group_assignment) { create(:group_assignment) }
+    let!(:assignment_group) { create(:assignment_group, assignment: group_assignment) }
     let!(:group_membership) { create(:group_membership, student: student, group: assignment_group.group) }
-    let!(:submission) { create(:group_submission, assignment: assignment, group: assignment_group.group) }
+    let!(:group_submission) { create(:group_submission, assignment: group_assignment, group: assignment_group.group) }
 
     it "returns the submission for the group and assignment" do
-      result = Submission.for_assignment_and_group(assignment.id, assignment_group.group_id).first
-      expect(result).to eq submission
+      result = Submission.for_assignment_and_group(group_assignment.id, assignment_group.group_id).first
+      expect(result).to eq group_submission
     end
   end
 
@@ -168,10 +163,10 @@ describe Submission do
     it "supports multiple file uploads" do
       file_attribute_1 = fixture_file "test_file.txt", "txt"
       file_attribute_2 = fixture_file "test_image.jpg", "image/jpg"
-      subject.submission_files_attributes = { "0" => { "file" => [file_attribute_1, file_attribute_2] }}
-      expect(subject.submission_files.length).to eq 2
-      expect(subject.submission_files[0].filename).to eq "test_file.txt"
-      expect(subject.submission_files[1].filename).to eq "test_image.jpg"
+      submission.submission_files_attributes = { "0" => { "file" => [file_attribute_1, file_attribute_2] }}
+      expect(submission.submission_files.length).to eq 2
+      expect(submission.submission_files[0].filename).to eq "test_file.txt"
+      expect(submission.submission_files[1].filename).to eq "test_image.jpg"
     end
   end
 
@@ -191,59 +186,51 @@ describe Submission do
 
   describe "#graded_at" do
     it "returns when the grade was graded if it was graded" do
-      subject.save
       graded_at = DateTime.now
-      grade = create(:grade, submission: subject, status: "Graded", graded_at: graded_at)
-      expect(subject.graded_at).to eq graded_at
+      grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded", graded_at: graded_at)
+      expect(submission.graded_at).to eq graded_at
     end
 
     it "returns nil if there is no grade" do
-      subject.save
-      expect(subject.graded_at).to be_nil
+      expect(submission.graded_at).to be_nil
     end
 
     it "returns nil if the grade is not released" do
-      subject.save
-      grade = create(:grade, submission: subject)
-      expect(subject.graded_at).to be_nil
+      grade = create(:grade, submission: submission)
+      expect(submission.graded_at).to be_nil
     end
   end
 
   describe "#graded?" do
     it "returns false for a submission that has no grade" do
-      subject.save
-      expect(subject).to_not be_graded
+      expect(submission).to_not be_graded
     end
 
     it "returns false for a submission that has grade that is not student visible" do
-      subject.save
-      grade = create(:grade, submission: subject)
-      expect(subject).to_not be_graded
+      grade = create(:grade, submission: submission)
+      expect(submission).to_not be_graded
     end
 
     it "returns true for a submission that has grade that is student visible" do
-      subject.save
-      grade = create(:grade, submission: subject, status: "Graded")
-      expect(subject).to be_graded
+      # because of the way that the submission_grades query is written, we need to create both the assignment and the student for the test to pass 
+      grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded")
+      expect(submission).to be_graded
     end
   end
 
   describe "#ungraded?" do
-    it "returns true for a submission that has no grade" do
-      subject.save
-      expect(subject).to be_ungraded
+    it "returns false for a submission that has a grade" do
+      expect(submission).to be_ungraded
     end
 
     it "returns true for a submission that has grade but no status" do
-      subject.save
-      grade = create(:grade, submission: subject)
-      expect(subject).to be_ungraded
+      grade = create(:grade, submission: submission)
+      expect(submission).to be_ungraded
     end
 
     it "returns false for a submission that has grade that is student visible" do
-      subject.save
-      grade = create(:grade, submission: subject, status: "Graded")
-      expect(subject).to_not be_ungraded
+      grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded")
+      expect(submission).to_not be_ungraded
     end
   end
 
@@ -256,70 +243,70 @@ describe Submission do
 
     it "does not return the submissions that have in progress grades" do
       create :grade, course: course, assignment: in_progress_submission.assignment,
-        student: subject.student, submission: in_progress_submission, status: "In Progress"
+        student: submission.student, submission: in_progress_submission, status: "In Progress"
       expect(Submission.ungraded).to_not include [in_progress_submission]
     end
 
     it "does not return submissions that have been graded or released" do
-      create :grade, course: course, assignment: subject.assignment,
-        student: subject.student, submission: subject, status: "Graded"
+      create :grade, course: course, assignment: submission.assignment,
+        student: submission.student, submission: submission, status: "Graded"
       expect(Submission.ungraded).to be_empty
     end
 
     it "returns the group submissions that do not have a grade" do
       group = create :group
-      create :grade, course: course, group: group, submission: subject,
+      create :grade, course: course, group: group, submission: submission,
         status: "Graded"
-      subject.update_attributes group_id: group.id, student_id: nil
-      expect(Submission.ungraded).to eq [subject]
+      submission.update_attributes group_id: group.id, student_id: nil
+      expect(Submission.ungraded).to eq [submission]
     end
   end
 
   describe ".resubmitted" do
     it "returns the submissions that have been submitted after they were graded" do
-      grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)
-      subject.submitted_at = DateTime.now
-      subject.save
-      expect(Submission.resubmitted).to eq [subject]
+      grade = create(:grade, submission: submission, status: "Graded", graded_at: 1.day.ago)
+      submission.submitted_at = DateTime.now
+      submission.save
+      expect(Submission.resubmitted).to eq [submission]
     end
 
     it "does not return ungraded submissions" do
-      create(:grade, submission: subject, graded_at: 1.day.ago)
-      subject.submitted_at = DateTime.now
-      subject.save
+      create(:grade, submission: submission, graded_at: 1.day.ago)
+      submission.submitted_at = DateTime.now
+      submission.save
       expect(Submission.resubmitted).to be_empty
     end
 
     it "does not return submissions that have unreleased grades" do
       assignment = build(:assignment, release_necessary: true)
-      subject = build(:submission, assignment: assignment)
-      create(:unreleased_grade, submission: subject, graded_at: 1.day.ago)
-      subject.submitted_at = DateTime.now
-      subject.save
+      submission = build(:submission, assignment: assignment)
+      create(:unreleased_grade, submission: submission, graded_at: 1.day.ago)
+      submission.submitted_at = DateTime.now
+      submission.save
       expect(Submission.resubmitted).to be_empty
     end
 
     it "does not return resubmissions that have been graded" do
-      grade = create(:grade, submission: subject, status: "Graded", graded_at: 1.day.ago)
-      subject.submitted_at = 2.days.ago
-      subject.save
+      grade = create(:grade, submission: submission, status: "Graded", graded_at: 1.day.ago)
+      submission.submitted_at = 2.days.ago
+      submission.save
       expect(Submission.resubmitted).to be_empty
     end
 
     it "returns one submission for a group resubmissions" do
-      subject = build(:group_submission)
+      submission = build(:group_submission)
       student1 = create(:user)
       student2 = create(:user)
-      group = create(:group, assignments: [subject.assignment])
+      group = create(:group, assignments: [submission.assignment])
       group.students << [student1, student2]
-      grade1 = create(:grade, submission: subject, student: student1,
+      grade1 = create(:grade, submission: submission, student: student1,
                       status: "Graded", graded_at: 1.day.ago)
-      grade2 = create(:grade, submission: subject, student: student2,
+      grade2 = create(:grade, submission: submission, student: student2,
                       status: "Graded", graded_at: 1.day.ago)
-      subject.submitted_at = DateTime.now
-      subject.group_id = group.id
-      subject.save
-      expect(Submission.resubmitted).to eq [subject]
+      submission.submitted_at = DateTime.now
+      submission.group_id = group.id
+      submission.save
+      expect(Submission.resubmitted).to eq [submission]
     end
   end
 
@@ -337,46 +324,42 @@ describe Submission do
   end
 
   describe "#will_be_resubmitted?", versioning: true do
-    before { subject.save }
+    before { submission.save }
 
     it "returns false if there is no grade" do
-      expect(subject).to_not be_will_be_resubmitted
+      expect(submission).to_not be_will_be_resubmitted
     end
 
-    it "returns true if there is a grade" do
-      create :grade, status: "Graded", submission: subject, assignment: subject.assignment
-
-      expect(subject).to be_will_be_resubmitted
+    it "returns true if there is a grade that is visible to the student" do
+      create :grade, student: student, status: "Released", submission: submission, assignment: assignment
+      expect(submission).to be_will_be_resubmitted
     end
   end
 
   describe "#resubmitted?" do
     it "returns false if it has no grade" do
-      subject.save
-      expect(subject).to_not be_resubmitted
+      expect(submission).to_not be_resubmitted
     end
 
     it "returns true if grade was graded before it was submitted" do
-      subject.save
-      create :grade, status: "Graded", submission: subject,
-        assignment: subject.assignment, graded_at: DateTime.now
-      subject.update_attributes submitted_at: DateTime.now
-      expect(subject).to be_resubmitted
+      create :grade, status: "Graded", student: student, submission: submission,
+        assignment: assignment, graded_at: DateTime.now
+      submission.update_attributes submitted_at: DateTime.now
+      expect(submission).to be_resubmitted
     end
 
     it "returns false if the grade was graded after it was submitted" do
-      subject.submitted_at = DateTime.now
-      subject.save
-      create :grade, status: "Graded", submission: subject,
-        assignment: subject.assignment, graded_at: DateTime.now
-      expect(subject).to_not be_resubmitted
+      submission.submitted_at = DateTime.now
+      submission.save
+      create :grade, status: "Graded", submission: submission,
+        assignment: submission.assignment, graded_at: DateTime.now
+      expect(submission).to_not be_resubmitted
     end
 
     it "returns false if it was not graded" do
-      subject.save
-      create :grade, status: "Graded", submission: subject,
-        assignment: subject.assignment
-      expect(subject).to_not be_resubmitted
+      create :grade, status: "Graded", submission: submission,
+        assignment: submission.assignment
+      expect(submission).to_not be_resubmitted
     end
   end
 
@@ -453,8 +436,6 @@ describe Submission do
 
     context "when the assignment does not have a due_at date" do
       it "returns false" do
-        assignment = create(:assignment)
-        submission = create(:submission, assignment: assignment)
         expect(submission.check_and_set_late_status!).to eq false
       end
     end
@@ -505,30 +486,30 @@ describe Submission do
 
   describe "#base_filename" do
     before do
-      allow(subject).to receive_message_chain(:student, :name) { "Dan Ho" }
-      allow(subject).to receive_message_chain(:assignment, :name) { "Great" }
+      allow(submission).to receive_message_chain(:student, :name) { "Dan Ho" }
+      allow(submission).to receive_message_chain(:assignment, :name) { "Great" }
     end
 
     it "titleizes the student's full name and assignment name" do
       expect(Formatter::Filename).to receive(:titleize).with "Dan Ho"
       expect(Formatter::Filename).to receive(:titleize).with "Great"
-      subject.base_filename
+      submission.base_filename
     end
 
     it "returns the combination of the titleized student and assignment names" do
-      expect(subject.base_filename).to eq "Dan Ho - Great"
+      expect(submission.base_filename).to eq "Dan Ho - Great"
     end
   end
 
   describe "#unsubmitted?" do
     it "returns true if the submitted at date is nil" do
-      subject.submitted_at = nil
-      expect(subject.unsubmitted?).to eq true
+      submission.submitted_at = nil
+      expect(submission.unsubmitted?).to eq true
     end
 
     it "returns false if the submitted at date is not nil" do
-      subject.submitted_at = DateTime.now
-      expect(subject.unsubmitted?).to eq false
+      submission.submitted_at = DateTime.now
+      expect(submission.unsubmitted?).to eq false
     end
   end
 
@@ -537,19 +518,19 @@ describe Submission do
 
     context "when the assignment is individual" do
       it "returns true if the student_id equals the user id" do
-        subject.student_id = student.id
-        expect(subject.belongs_to?(student)).to eq true
+        submission.student_id = student.id
+        expect(submission.belongs_to?(student)).to eq true
       end
     end
 
     context "when the assignment is for groups" do
-      before(:each) { allow(subject).to receive(:assignment).and_return build_stubbed(:group_assignment) }
+      before(:each) { allow(submission).to receive(:assignment).and_return build_stubbed(:group_assignment) }
 
       let!(:group_membership) { create(:group_membership, student: student) }
 
       it "returns true if the student's group memberships include the group id" do
-        subject.group_id = group_membership.group_id
-        expect(subject.belongs_to?(student)).to eq true
+        submission.group_id = group_membership.group_id
+        expect(submission.belongs_to?(student)).to eq true
       end
     end
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -4,6 +4,7 @@ describe Submission do
   before { stub_env "development" }
   let(:course) { build(:course) }
   subject { build(:submission, course: course) }
+  let(:ungraded_submission) { create(:submission, course: course) }
 
   describe "validations" do
     it { is_expected.to be_valid }
@@ -246,15 +247,17 @@ describe Submission do
     end
   end
 
-  describe ".ungraded", focus: true do
+  describe ".ungraded" do
+    let(:in_progress_submission) { create(:submission, course: course) }
+    
     it "returns the submissions that do not have any grades" do
-      expect(Submission.ungraded).to eq [submission_2]
+      expect(Submission.ungraded).to eq [ungraded_submission]
     end
 
     it "does not return the submissions that have in progress grades" do
-      create :grade, course: course, assignment: subject.assignment,
-        student: subject.student, submission: subject, status: "In Progress"
-      expect(Submission.ungraded).to not_include [ungraded_submission]
+      create :grade, course: course, assignment: in_progress_submission.assignment,
+        student: subject.student, submission: in_progress_submission, status: "In Progress"
+      expect(Submission.ungraded).to_not include [in_progress_submission]
     end
 
     it "does not return submissions that have been graded or released" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -188,7 +188,7 @@ describe Submission do
     it "returns when the grade was graded if it was graded" do
       graded_at = DateTime.now
       grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded", graded_at: graded_at)
-      expect(submission.graded_at).to eq graded_at
+      expect(submission.graded_at.strftime("%A, %B %d, %l:%M%p")).to eq graded_at.strftime("%A, %B %d, %l:%M%p")
     end
 
     it "returns nil if there is no grade" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -188,7 +188,7 @@ describe Submission do
     it "returns when the grade was graded if it was graded" do
       graded_at = DateTime.now
       grade = create(:grade, assignment: assignment, student: student, submission: submission, status: "Graded", graded_at: graded_at)
-      expect(submission.graded_at.strftime("%A, %B %d, %l:%M%p")).to eq graded_at.strftime("%A, %B %d, %l:%M%p")
+      expect(submission.graded_at.strftime("%A, %B %d")).to eq graded_at.strftime("%A, %B %d")
     end
 
     it "returns nil if there is no grade" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -289,8 +289,17 @@ describe Submission do
       expect(Submission.resubmitted).to eq [subject]
     end
 
-    it "does not return non-graded or released grades" do
-      grade = create(:grade, submission: subject, graded_at: 1.day.ago)
+    it "does not return ungraded submissions" do
+      create(:grade, submission: subject, graded_at: 1.day.ago)
+      subject.submitted_at = DateTime.now
+      subject.save
+      expect(Submission.resubmitted).to be_empty
+    end
+
+    it "does not return submissions that have unreleased grades" do
+      assignment = build(:assignment, release_necessary: true)
+      subject = build(:submission, assignment: assignment)
+      create(:unreleased_grade, submission: subject, graded_at: 1.day.ago)
       subject.submitted_at = DateTime.now
       subject.save
       expect(Submission.resubmitted).to be_empty

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -163,9 +163,10 @@ describe Assignments::Presenter do
     let(:submission) { double(:submission) }
 
     it "checks if there is a viewable submission" do
-      allow(Submission).to receive(:for_assignment_and_student).and_return [submission]
-      expect(subject).to receive(:has_viewable_submission?).with(submission, user)
-      subject.has_viewable_submission_for?(user)
+      allow(user).to receive(:submission_for_assignment).and_return submission
+      allow(subject).to receive(:has_viewable_submission?).with(submission, user)
+        .and_return true
+      expect(subject.has_viewable_submission_for?(user)).to eq true
     end
   end
 

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -164,7 +164,7 @@ describe Assignments::Presenter do
 
     it "checks if there is a viewable submission" do
       allow(user).to receive(:submission_for_assignment).and_return submission
-      allow(subject).to receive(:has_viewable_submission?).with(submission, user)
+      allow(subject).to receive(:has_viewable_submission?).with(user)
         .and_return true
       expect(subject.has_viewable_submission_for?(user)).to eq true
     end

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -1,8 +1,9 @@
 describe Assignments::Presenter do
-  let(:assignment) { double(:assignment, id: 1, name: "Crazy Wizardry", pass_fail?: false, full_points: 5000)}
-  let(:course) { double(:course) }
+  let(:course) { build(:course) }
+  let(:assignment) { create(:assignment, id: 1, name: "Crazy Wizardry", pass_fail: false, full_points: 5000)}
   let(:view_context) { double(:view_context) }
   let(:team) { double(:team) }
+  let(:student) { create(:user) }
   subject { Assignments::Presenter.new({ assignment: assignment, course: course, view_context: view_context }) }
 
   describe "#assignment" do
@@ -132,20 +133,17 @@ describe Assignments::Presenter do
   end
 
   describe "#has_viewable_submission?" do
-    let(:user) { double(:user, id: 1) }
-    let(:submission) { double(:submission) }
-
     context "when the assignment accepts submissions" do
       before(:each) { allow(assignment).to receive(:accepts_submissions?).and_return true }
 
       it "is false if the submission is nil" do
-        expect(subject.has_viewable_submission?(nil, user)).to eq false
+        expect(subject.has_viewable_submission?(student)).to eq false
       end
 
-      it "is true when the submission is not nil and
-        all viewable conditions are met in the submission proctor" do
-        allow_any_instance_of(SubmissionProctor).to receive(:viewable?).and_return true
-        expect(subject.has_viewable_submission?(submission, user)).to eq true
+      it "is true when the submission is not nil and all viewable conditions are met in the submission proctor" do
+        allow(SubmissionProctor).to receive(:viewable?).and_return true
+        create(:submission, assignment: assignment, student: student)
+        expect(subject.has_viewable_submission?(student)).to eq true
       end
     end
 
@@ -153,7 +151,7 @@ describe Assignments::Presenter do
       before(:each) { allow(assignment).to receive(:accepts_submissions?).and_return false }
 
       it "is false" do
-        expect(subject.has_viewable_submission?(submission, user)).to eq false
+        expect(subject.has_viewable_submission?(student)).to eq false
       end
     end
   end

--- a/spec/presenters/submissions/show_presenter_spec.rb
+++ b/spec/presenters/submissions/show_presenter_spec.rb
@@ -169,33 +169,6 @@ describe Submissions::ShowPresenter do
     end
   end
 
-  describe "#open_for_editing?" do
-    let(:result) { subject.open_for_editing? }
-
-    before do
-      allow(subject).to receive(:grade) { grade }
-    end
-
-    context "assignment is not open" do
-      it "returns false" do
-        allow(assignment).to receive(:open?) { false }
-        expect(result).to eq false
-      end
-    end
-
-    context "assignment is open" do
-      it "returns true if resubmissions are allowed" do
-        allow(subject).to receive(:resubmissions_allowed?).and_return true
-        expect(result).to eq true
-      end
-
-      it "returns true if resubmissions are not allowed" do
-        allow(subject).to receive(:resubmissions_allowed?).and_return false
-        expect(result).to eq false
-      end
-    end
-  end
-
   describe "#present_submission_files" do
     # @present_submission_files ||= submission.submission_files.present
     let(:result) { subject.present_submission_files }

--- a/spec/presenters/submissions/show_presenter_spec.rb
+++ b/spec/presenters/submissions/show_presenter_spec.rb
@@ -7,12 +7,12 @@ describe Submissions::ShowPresenter do
     { course: course }
   end
 
-  let(:submission) { double(:submission, student: student, group: group, assignment: assignment, id: 200, submitted_at: Time.now) }
-  let(:assignment) { double(:assignment, course: course, threshold_points: 13200, grade_scope: "Group", id: 300).as_null_object }
-  let(:course) { double(:course, name: "Some Course").as_null_object }
-  let(:student) { double(:user, first_name: "Jimmy", id: 500)}
-  let(:group) { double(:group, name: "My group", course: course, id: 400) }
-  let(:grade) { double(:grade).as_null_object }
+  let(:submission) { create(:submission, student: student, assignment: assignment, id: 200, submitted_at: Time.now) }
+  let(:assignment) { create(:assignment, course: course, threshold_points: 13200, grade_scope: "Group", id: 300) }
+  let(:course) { build(:course, name: "Some Course") }
+  let(:student) { create(:user, first_name: "Jimmy", id: 500)}
+  let(:group) { create(:group, name: "My group", course: course, id: 400) }
+  let(:grade) { create(:grade) }
 
   before(:each) do
     allow(subject).to receive_messages(

--- a/spec/presenters/submissions/show_presenter_spec.rb
+++ b/spec/presenters/submissions/show_presenter_spec.rb
@@ -184,27 +184,14 @@ describe Submissions::ShowPresenter do
     end
 
     context "assignment is open" do
-      context "grade is not present" do
-        it "returns true" do
-          allow(grade).to receive(:present?) { false }
-          expect(result).to eq true
-        end
+      it "returns true if resubmissions are allowed" do
+        allow(subject).to receive(:resubmissions_allowed?).and_return true
+        expect(result).to eq true
       end
 
-      context "grade is present and re-submissions are allowed" do
-        it "returns true" do
-          allow(grade).to receive(:present?) { true }
-          allow(assignment).to receive(:resubmissions_allowed?) { true }
-          expect(result).to eq true
-        end
-      end
-
-      context "grades is present but re-submissions are not allowed" do
-        it "returns false" do
-          allow(grade).to receive(:present?) { true }
-          allow(assignment).to receive(:resubmissions_allowed?) { false }
-          expect(result).to eq false
-        end
+      it "returns true if resubmissions are not allowed" do
+        allow(subject).to receive(:resubmissions_allowed?).and_return false
+        expect(result).to eq false
       end
     end
   end

--- a/spec/proctors/grade_proctor/viewable_spec.rb
+++ b/spec/proctors/grade_proctor/viewable_spec.rb
@@ -2,7 +2,7 @@ describe GradeProctor::Viewable do
   let(:assignment) { double(:assignment, release_necessary?: true) }
   let(:course) { double(:course, id: 456) }
   let(:grade) { double(:grade, assignment: assignment, course_id: course.id,
-                       student_id: 123, is_graded?: true, is_released?: false) }
+                       student_id: 123) }
   let(:user) { double(:user, id: 123, is_staff?: false) }
 
   describe "#viewable?" do
@@ -20,22 +20,17 @@ describe GradeProctor::Viewable do
       end
 
       it "cannot view the grade if it's not part of the course" do
-        allow(grade).to receive(:is_released?).and_return true
         allow(grade).to receive(:course_id).and_return 789
         expect(subject).to_not be_viewable user: user, course: course
       end
 
-      it "can view the grade if it's been released" do
-        allow(grade).to receive(:is_released?).and_return true
-        expect(subject).to be_viewable user: user, course: course
-      end
-
-      it "can view the grade if it's been graded and a release is not necessary" do
-        allow(assignment).to receive(:release_necessary?).and_return false
+      it "can view the grade if it's graded and viewable to a student" do
+        allow(grade).to receive(:graded_and_visible_by_student?).and_return true
         expect(subject).to be_viewable user: user, course: course
       end
 
       it "cannot view the grade if it's been graded and a release is necessary" do
+        allow(grade).to receive(:graded_and_visible_by_student?).and_return false
         expect(subject).to_not be_viewable user: user, course: course
       end
     end

--- a/spec/proctors/grade_proctor/viewable_spec.rb
+++ b/spec/proctors/grade_proctor/viewable_spec.rb
@@ -25,12 +25,12 @@ describe GradeProctor::Viewable do
       end
 
       it "can view the grade if it's graded and viewable to a student" do
-        allow(grade).to receive(:graded_and_visible_by_student?).and_return true
+        allow(grade).to receive(:student_visible?).and_return true
         expect(subject).to be_viewable user: user, course: course
       end
 
       it "cannot view the grade if it's been graded and a release is necessary" do
-        allow(grade).to receive(:graded_and_visible_by_student?).and_return false
+        allow(grade).to receive(:student_visible?).and_return false
         expect(subject).to_not be_viewable user: user, course: course
       end
     end

--- a/spec/proctors/submission_proctor_spec.rb
+++ b/spec/proctors/submission_proctor_spec.rb
@@ -1,8 +1,8 @@
 describe SubmissionProctor do
   subject { described_class.new submission }
-  let(:user) { double(:user) }
-  let(:course) { double(:course) }
-  let(:submission) { double(:submission, course: course) }
+  let(:user) { build(:user) }
+  let(:course) { build(:course) }
+  let(:submission) { build(:submission, course: course) }
 
   describe "#viewable" do
     before(:each) { allow(user).to receive(:is_student?).with(course).and_return false }
@@ -42,10 +42,10 @@ describe SubmissionProctor do
   end
 
   describe "#open_for_editing?" do
-    let(:grade) { double(:grade) }
-    let(:assignment) { double(:assignment) }
+    let(:grade) { build(:grade) }
+    let(:assignment) { build(:assignment) }
 
-    before(:each) { allow(submission).to receive(:grade).and_return grade }
+    before(:each) { allow(submission).to receive(:submission_grade).and_return grade }
 
     it "returns false if the submission is graded but not yet released" do
       allow(submission).to receive(:graded?).and_return true

--- a/spec/proctors/submission_proctor_spec.rb
+++ b/spec/proctors/submission_proctor_spec.rb
@@ -42,14 +42,15 @@ describe SubmissionProctor do
   end
 
   describe "#open_for_editing?" do
+    let(:grade) { double(:grade) }
     let(:assignment) { double(:assignment) }
 
-    context "when the submission is graded" do
-      before(:each) { allow(submission).to receive(:graded?).and_return true }
+    before(:each) { allow(submission).to receive(:grade).and_return grade }
 
-      it "returns false" do
-        expect(subject.open_for_editing?(assignment)).to be_falsey
-      end
+    it "returns false if the submission is graded but not yet released" do
+      allow(submission).to receive(:graded?).and_return true
+      allow(grade).to receive(:is_released?).and_return false
+      expect(subject.open_for_editing?(assignment)).to be_falsey
     end
   end
 end

--- a/spec/proctors/submission_proctor_spec.rb
+++ b/spec/proctors/submission_proctor_spec.rb
@@ -40,4 +40,29 @@ describe SubmissionProctor do
       expect(subject.viewable_submission(user)).to eq(submission)
     end
   end
+
+  describe "#open_for_editing?" do
+    let(:assignment) { double(:assignment) }
+    before(:each) { allow(assignment).to receive(:open?).and_return false }
+
+    context "when the assignment is not open" do
+      it "returns false" do
+        expect(subject.open_for_editing? assignment).to be_falsey
+      end
+    end
+
+    context "when the assignment is open" do
+      before(:each) { allow(assignment).to receive(:open?).and_return true }
+
+      it "returns false if resubmissions are not allowed" do
+        allow(subject).to receive(:resubmissions_allowed?).and_return false
+        expect(subject.open_for_editing? assignment).to be_falsey
+      end
+
+      it "returns true if resubmissions are allowed" do
+        allow(subject).to receive(:resubmissions_allowed?).and_return true
+        expect(subject.open_for_editing? assignment).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/proctors/submission_proctor_spec.rb
+++ b/spec/proctors/submission_proctor_spec.rb
@@ -43,25 +43,12 @@ describe SubmissionProctor do
 
   describe "#open_for_editing?" do
     let(:assignment) { double(:assignment) }
-    before(:each) { allow(assignment).to receive(:open?).and_return false }
 
-    context "when the assignment is not open" do
+    context "when the submission is graded" do
+      before(:each) { allow(submission).to receive(:graded?).and_return true }
+
       it "returns false" do
-        expect(subject.open_for_editing? assignment).to be_falsey
-      end
-    end
-
-    context "when the assignment is open" do
-      before(:each) { allow(assignment).to receive(:open?).and_return true }
-
-      it "returns false if resubmissions are not allowed" do
-        allow(subject).to receive(:resubmissions_allowed?).and_return false
-        expect(subject.open_for_editing? assignment).to be_falsey
-      end
-
-      it "returns true if resubmissions are allowed" do
-        allow(subject).to receive(:resubmissions_allowed?).and_return true
-        expect(subject.open_for_editing? assignment).to be_truthy
+        expect(subject.open_for_editing?(assignment)).to be_falsey
       end
     end
   end

--- a/spec/toolkits/sanitization_toolkit.rb
+++ b/spec/toolkits/sanitization_toolkit.rb
@@ -1,17 +1,19 @@
-RSpec.shared_examples "a model that needs sanitization" do |attribute|
+RSpec.shared_examples "a model that needs sanitization" do |fixture, attribute|
+  let(:model) { build fixture }
+  
   describe "relaxed html sanitization" do
     describe "##{attribute}" do
       def get(attribute)
-        subject.send attribute
+        model.send attribute
       end
 
       def set(attribute, value)
-        subject.send "#{attribute}=", value
+        model.send "#{attribute}=", value
       end
 
       it "html-escapes entities" do
         set attribute, "Hello & Goodbye"
-        subject.save
+        model.save
         expect(get attribute).to eq "Hello &amp; Goodbye"
       end
     end

--- a/spec/toolkits/sanitization_toolkit.rb
+++ b/spec/toolkits/sanitization_toolkit.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples "a model that needs sanitization" do |fixture, attribute|
   let(:model) { build fixture }
-  
+
   describe "relaxed html sanitization" do
     describe "##{attribute}" do
       def get(attribute)
@@ -13,6 +13,11 @@ RSpec.shared_examples "a model that needs sanitization" do |fixture, attribute|
 
       it "html-escapes entities" do
         set attribute, "Hello & Goodbye"
+
+        # don't test an invalid factory
+        # you'll end up pulling your hair out!
+        expect(model).to be_valid
+
         model.save
         expect(get attribute).to eq "Hello &amp; Goodbye"
       end

--- a/spec/views/assignments/individual/_table_body_spec.rb
+++ b/spec/views/assignments/individual/_table_body_spec.rb
@@ -10,8 +10,8 @@ describe "assignments/individual/_table_body" do
     student = create(:user, courses: [@course], role: :student)
     @grade = create(:grade, course: @course, assignment: @assignment,
                     student: student)
-    allow(view).to receive(:current_course).and_return(@course)
-    allow(view).to receive(:presenter).and_return presenter
+    allow(view).to receive_messages(current_course: @course, presenter: presenter,
+      current_user: student)
   end
 
   it "renders successfully" do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where submissions that had grades that were marked as `in_progress` were still identified as `ungraded` on the grading status page. It also moves the `open_for_editing?(assignment)` method over to a proctor. It also blocks students from submitting a resubmission unless their grade has actually been returned to them by the instructor. 


### Todos
- [x] Tests
- [ ] Documentation


### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grading Status
* Resubmissions

### To Test
_In Progress Grades_
* Add a grade for an ungraded Submission, mark it as "In Progress"
* In master branch, you should still see it appear in the Ungraded Section (but also under In Progress)
• In this branch, it should only appear under In Progress

_Resubmitting Assignment Conditions_
• Confirm that on the student side, they cannot update/resubmit the assignment before they've actually gotten a grade back. 

======================
Closes #3131 
