### PR TITLE
3135 grade importer bug

### DIFF
--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -29,4 +29,12 @@ module GradesHelper
     # This cache key is busted when a grade is updated
     "#{course.cache_key}/unreleased_grades_count"
   end
+
+  # Returns the corresponding pass/fail status for a score
+  # If the score is not a 0 or 1, the status will be nil
+  def pass_fail_status_for(score)
+    return status = "Pass" if score == 1
+    return status = "Fail" if score == 0
+    nil
+  end
 end

--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -95,8 +95,9 @@ class CSVGradeImporter
     end
   end
 
+  # Precondition: row.grade has been validated by is_valid_grade?
   def set_grade_score(row, grade)
-    score = Integer(row.grade || "")
+    score = Integer(row.grade)
     if grade.assignment.pass_fail?
       grade.pass_fail_status = pass_fail_status_for score
     else
@@ -104,10 +105,12 @@ class CSVGradeImporter
     end
   end
 
+  # Ensures that the input is valid and integer-like
   def is_valid_grade?(assignment, grade)
     begin
-      score = Integer(grade || "")
-      return PASS_FAIL_GRADE_VALUES.include?(score) if assignment.pass_fail?
+      return false if grade.nil?
+      # Integer() vs to_i to prevent unwanted coercion
+      return PASS_FAIL_GRADE_VALUES.include?(Integer(grade)) if assignment.pass_fail?
       true
     rescue ArgumentError
       false
@@ -116,8 +119,9 @@ class CSVGradeImporter
 
   # If the assignment is pass/fail type, update the grade if the status or feedback changes
   # Else, update if the raw points or feedback changes
+  # Precondition: row.grade has been validated by is_valid_grade?
   def update_grade?(row, grade, assignment)
-    score = Integer(row.grade || "")
+    score = Integer(row.grade)
     if assignment.pass_fail?
       grade.present? && (grade.pass_fail_status != pass_fail_status_for(score) || grade.feedback != row.feedback)
     else

--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -5,8 +5,8 @@ class CSVGradeImporter
   include GradesHelper
   attr_reader :successful, :unsuccessful, :unchanged
   attr_accessor :file
-  
-  PASS_FAIL_GRADE_VALUES = [0,1].freeze
+
+  PASS_FAIL_GRADE_VALUES ||= [0,1].freeze
 
   def initialize(file)
     @file = file

--- a/spec/fixtures/files/pass_fail_grades.csv
+++ b/spec/fixtures/files/pass_fail_grades.csv
@@ -1,5 +1,6 @@
 First Name,Last Name,Email,Score,Feedback
 Robert,Plant,robert@example.com,1,"Rock on!"
+Eric,Clapton,eric.clapton@guitarlegends.com,0,
 Lindsey,Buckingham,lindsey,0,
 John,Frusciante,john.frusciante@rhcp.com, ,
 Don,Henley,don.henley@eagles.com,2

--- a/spec/helpers/grades_helper_spec.rb
+++ b/spec/helpers/grades_helper_spec.rb
@@ -49,4 +49,18 @@ describe GradesHelper do
       expect(helper.grading_status_count_for(course)).to eq 62
     end
   end
+
+  describe "#pass_fail_status_for" do
+    it "returns pass if the score is 1" do
+      expect(helper.pass_fail_status_for(1)).to eq "Pass"
+    end
+
+    it "returns fail if the score is 0" do
+      expect(helper.pass_fail_status_for(0)).to eq "Fail"
+    end
+
+    it "returns nil if the score is neither 1 nor 0" do
+      expect(helper.pass_fail_status_for(123)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Status
READY

### Description
If a grade already exists for a student on a pass/fail type assignment and an instructor attempts to set their status to `Fail` via CSV grade upload, no change will be made.

This is the result of a check that was previously put in place to prevent unnecessary grade updates.

This PR also addresses #3109, which pertains to warnings being generated due to already initialized constants.

### Migrations
NO

### Steps to Test or Reproduce
Upload a CSV and set a student's score to 1 to signify passing. Ensure that it is possible to update their grade to 0 afterwards to signify failing, and vice versa.

### Impacted Areas in Application
CSV Grade Upload

======================
Closes #3135 
Closes #3109 
