### PR TITLE
3133 update pass fail csv sample

### DIFF
--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -27,7 +27,7 @@ class Grades::ImportersController < ApplicationController
     assignment = current_course.assignments.find(params[:assignment_id])
     respond_to do |format|
       format.csv do
-        send_data GradeExporter.new.export_grades(assignment, current_course.students),
+        send_data GradeExporter.new.export_grades(assignment, current_course.students, true),
           filename: "#{ assignment.name } Import Grades - #{ Date.today}.csv"
       end
     end

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -8,7 +8,7 @@ class GradeExporter
         grade = student.grade_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
                 student.email,
-                score_for_assignment_type(assignment, grade, pass_fail_statuses_as_int) || "",
+                score_for_assignment(assignment, grade, pass_fail_statuses_as_int) || "",
                 grade.feedback || ""]
       end
     end
@@ -22,7 +22,7 @@ class GradeExporter
       groups.each do |group|
         grade = group.grade_for_assignment(assignment)
         csv << [group.name,
-                score_for_assignment_type(assignment, grade, false) || "",
+                score_for_assignment(assignment, grade, false) || "",
                 grade.feedback || ""]
       end
     end
@@ -39,7 +39,7 @@ class GradeExporter
         submission = student.submission_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
                 student.email,
-                score_for_assignment_type(assignment, grade, false) || "",
+                score_for_assignment(assignment, grade, false) || "",
                 grade.feedback || "",
                 grade.raw_points || "",
                 submission.try(:text_comment) || "",
@@ -62,7 +62,7 @@ class GradeExporter
     ["Raw Score", "Statement", "Last Updated"].freeze
   end
 
-  def score_for_assignment_type(assignment, grade, pass_fail_statuses_as_int)
+  def score_for_assignment(assignment, grade, pass_fail_statuses_as_int)
     if assignment.pass_fail?
       return grade.pass_fail_status unless pass_fail_statuses_as_int
       pass_fail_status_as_int(grade.pass_fail_status)

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -4,10 +4,9 @@ class GradeExporter
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
-        score = assignment.pass_fail? ? pass_fail_status_as_int(grade.pass_fail_status) : grade.score
         csv << [student.first_name, student.last_name,
                 student.email,
-                score || "",
+                score_for_assignment_type(assignment, grade) || "",
                 grade.feedback || ""]
       end
     end
@@ -19,7 +18,7 @@ class GradeExporter
       groups.each do |group|
         grade = group.grade_for_assignment(assignment)
         csv << [group.name,
-                grade.score || "",
+                score_for_assignment_type(assignment, grade) || "",
                 grade.feedback || ""]
       end
     end
@@ -55,6 +54,10 @@ class GradeExporter
 
   def detail_headers
     ["Raw Score", "Statement", "Last Updated"].freeze
+  end
+
+  def score_for_assignment_type(assignment, grade)
+    score = assignment.pass_fail? ? pass_fail_status_as_int(grade.pass_fail_status) : grade.score
   end
 
   def pass_fail_status_as_int(status)

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -1,29 +1,35 @@
 class GradeExporter
-  def export_grades(assignment, students, options={})
+  # For exports and csv import sample; return "0" or "1" vs "Fail", "Pass"
+  # if pass_fail_statuses_as_int is true
+  def export_grades(assignment, students, pass_fail_statuses_as_int=false, options={})
     CSV.generate(options) do |csv|
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
                 student.email,
-                score_for_assignment_type(assignment, grade) || "",
+                score_for_assignment_type(assignment, grade, pass_fail_statuses_as_int) || "",
                 grade.feedback || ""]
       end
     end
   end
 
+  # By default, return pass/fail status as score ("Pass" or "Fail")
+  # if assignment is pass/fail type; for exports
   def export_group_grades(assignment, groups, options={})
     CSV.generate(options) do |csv|
       csv << group_headers
       groups.each do |group|
         grade = group.grade_for_assignment(assignment)
         csv << [group.name,
-                score_for_assignment_type(assignment, grade) || "",
+                score_for_assignment_type(assignment, grade, false) || "",
                 grade.feedback || ""]
       end
     end
   end
 
+  # By default, return pass/fail status as score ("Pass" or "Fail")
+  # if assignment is pass/fail type, for exports
   def export_grades_with_detail(assignment, students, options={})
     CSV.generate(options) do |csv|
       csv << headers + detail_headers
@@ -33,7 +39,7 @@ class GradeExporter
         submission = student.submission_for_assignment(assignment)
         csv << [student.first_name, student.last_name,
                 student.email,
-                grade.score || "",
+                score_for_assignment_type(assignment, grade, false) || "",
                 grade.feedback || "",
                 grade.raw_points || "",
                 submission.try(:text_comment) || "",
@@ -56,8 +62,13 @@ class GradeExporter
     ["Raw Score", "Statement", "Last Updated"].freeze
   end
 
-  def score_for_assignment_type(assignment, grade)
-    score = assignment.pass_fail? ? pass_fail_status_as_int(grade.pass_fail_status) : grade.score
+  def score_for_assignment_type(assignment, grade, pass_fail_statuses_as_int)
+    if assignment.pass_fail?
+      return grade.pass_fail_status unless pass_fail_statuses_as_int
+      pass_fail_status_as_int(grade.pass_fail_status)
+    else
+      grade.score
+    end
   end
 
   def pass_fail_status_as_int(status)

--- a/app/exporters/grade_exporter.rb
+++ b/app/exporters/grade_exporter.rb
@@ -1,13 +1,13 @@
 class GradeExporter
-
   def export_grades(assignment, students, options={})
     CSV.generate(options) do |csv|
       csv << headers
       students.each do |student|
         grade = student.grade_for_assignment(assignment)
+        score = assignment.pass_fail? ? pass_fail_status_as_int(grade.pass_fail_status) : grade.score
         csv << [student.first_name, student.last_name,
                 student.email,
-                grade.score || "",
+                score || "",
                 grade.feedback || ""]
       end
     end
@@ -43,7 +43,6 @@ class GradeExporter
     end
   end
 
-
   def group_headers
     ["Group Name", "Score", "Feedback"].freeze
   end
@@ -56,5 +55,12 @@ class GradeExporter
 
   def detail_headers
     ["Raw Score", "Statement", "Last Updated"].freeze
+  end
+
+  def pass_fail_status_as_int(status)
+    case status
+    when "Pass" then 1
+    when "Fail" then 0
+    end
   end
 end

--- a/spec/exporters/grade_exporter_spec.rb
+++ b/spec/exporters/grade_exporter_spec.rb
@@ -57,9 +57,13 @@ describe GradeExporter do
       allow(students[0]).to \
         receive(:grade_for_assignment).with(assignment)
           .and_return double(:grade, score: nil, pass_fail_status: "Pass", feedback: nil)
+      allow(students[1]).to \
+        receive(:grade_for_assignment).with(assignment)
+          .and_return double(:grade, score: nil, pass_fail_status: "Fail", feedback: "Let's talk...")
       csv = CSV.new(subject.export_grades(assignment, students, true)).read
       expect(csv.length).to eq 3
       expect(csv[1][3]).to eq "1"
+      expect(csv[2][3]).to eq "0"
     end
 
     it "includes students that do not have grades for the assignment" do


### PR DESCRIPTION
### Status
READY

### Description
Current grades were not being represented in the sample file download found on the Import Grades page, if the assignment was of a pass/fail type.

This PR addresses this by returning either "0" or a "1" for the Score column, relative to the `pass_fail_status` on the grade.

Also included in this fix are changes to the other grade exporters, which were previously not returning relevant pass/fail grade information when the assignment was pass/fail type.

For a regular grade export on a pass/fail assignment, the value for the "Score" column on the CSV will be replaced with either "Pass" or "Fail", whereas before it was represented with `grade.score`.

### Migrations
NO

### Steps to Test or Reproduce
- Test grade exports for individual and group assignments, ensuring that "Pass" or "Fail" grades are represented in the CSV.
- Ensure that downloading the sample CSV from the Grade Import page returns the current up-to-date grades on a pass/fail assignment, represented by "0" or "1".

### Impacted Areas in Application
All CSV exports

======================
Closes #3133 
