### PR TITLE
compact the ungraded map result

### DIFF
--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -99,7 +99,7 @@ module Gradable
 
   def ungraded_groups(group_to_include=nil)
     included_ids = group_to_include.present? ? group_to_include.students.pluck(:id) : []
-    ungraded_students(included_ids).map { |student| student.group_for_assignment(self) }.uniq
+    ungraded_students(included_ids).map { |student| student.group_for_assignment(self) }.compact.uniq
   end
 
   def ungraded_groups_with_submissions(group_to_include=nil)


### PR DESCRIPTION
### Status
**READY**

### Description

Remove nil values from ungraded students map results array. Fixes a bug that occurred when some students did not have a group.

Note: there is a lot of array manipulation in the next student and group methods. There may be other edge cases where they also break.

======================
Closes #3147 

