### PR TITLE
2895 Resend Course Invitation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   respond_to :html, :json
 
   before_action :ensure_staff?,
-    except: [:activate, :activated, :edit_profile, :update_profile]
+    except: [:activate, :activated, :edit_profile, :update_profile] 
   before_action :save_referer, only: [:manually_activate, :resend_invite_email]
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   respond_to :html, :json
 
   before_action :ensure_staff?,
-    except: [:activate, :activated, :edit_profile, :update_profile] 
+    except: [:activate, :activated, :edit_profile, :update_profile]
   before_action :save_referer, only: [:manually_activate, :resend_invite_email]
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -167,8 +167,7 @@ class UsersController < ApplicationController
   def resend_invite_email
     @user = User.find(params[:id])
     UserMailer.welcome_email(@user).deliver
-    flash[:notice] = "Welcome email resent"
-    redirect_to session[:return_to] || dashboard_path, notice: "An Invite Email has been sent to #{@user.name}!" and return
+    redirect_to session[:return_to] || dashboard_path, notice: "An Invite Email has been sent to #{@user.name}!"
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   before_action :ensure_staff?,
     except: [:activate, :activated, :edit_profile, :update_profile]
-  before_action :save_referer, only: :manually_activate
+  before_action :save_referer, only: [:manually_activate, :resend_invite_email]
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]
 
@@ -161,6 +161,14 @@ class UsersController < ApplicationController
         .import(current_course)
       render :import_results
     end
+  end
+
+  # resend invite email
+  def resend_invite_email
+    @user = User.find(params[:id])
+    UserMailer.welcome_email(@user).deliver
+    flash[:notice] = "Welcome email resent"
+    redirect_to session[:return_to] || dashboard_path, notice: "An Invite Email has been sent to #{@user.name}!" and return
   end
 
   private

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -35,3 +35,4 @@
                 %li= link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
                 - if !user.activated?
                   %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
+                  %li= link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -57,3 +57,4 @@
               %li= link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
               - if !student.activated?
                 %li= link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
+                %li= link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,6 +250,7 @@ Rails.application.routes.draw do
   resources :users, except: :show do
     member do
       get :activate
+      get :resend_invite_email
       put :manually_activate
       post :activate, action: :activated
       post :flag

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -185,6 +185,26 @@ describe UsersController do
         expect(response).to redirect_to(dashboard_path)
       end
     end
+
+    describe "GET resend_invite_email" do
+      let(:unactivated_user) { create(:user)}
+      it "resend invitation to user" do
+        expect {
+            get :resend_invite_email, params:{id:unactivated_user.id}
+        }.to change  { ActionMailer::Base.deliveries.count }.by 1
+      end
+
+      it "redirects to referer url if present" do
+        request.env["HTTP_REFERER"] = "http://some-referer.com"
+        get :resend_invite_email, params:{id:unactivated_user.id}
+        expect(response).to redirect_to("http://some-referer.com")
+      end
+
+      it "redirects to dashboard if referer url is not present" do
+        get :resend_invite_email, params:{id:unactivated_user.id}
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
   end
 
   context "as a student" do


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
If a user doesn't receive the initial welcome email for any reason, we need a way to resend it

This option should appear on the Students table page under the options cog
OR
In the staff table under the Users cog AND ONLY be there if their account is not active.

### Related PRs
N/A


### Todos
- [x] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce


### Impacted Areas in Application

* Students Table view
* Staff Index view

======================
Closes #[2895]
