### PR TITLE
Fix Predictor Bug

### DIFF
--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -22,8 +22,8 @@ class Grade < ActiveRecord::Base
     reject_if: proc { |a| (a["score"].blank?) }, allow_destroy: true
 
   before_validation :cache_associations
-  before_save :calculate_points
   before_save :zero_points_for_pass_fail
+  before_save :calculate_points
   after_save :check_unlockables
   after_save :update_earned_badges
 

--- a/doc/grades.md
+++ b/doc/grades.md
@@ -64,7 +64,7 @@ Scores and point values are saved in several states on the model. See [[Points]]
   * `raw_points` - raw points for the grade. Unlike `score`, it is never weighted
   * `adjustment_points` - points to add or subtract from the raw points (+ bonus points, - tardiness etc.)
   * `final_points` - The sum of the raw points and the adjustment
-  * `score` - The final points multiplied by the student's weighting for the assignment type.
+  * `score` - The final points multiplied by the student's weighting for the assignment type. Currently set to `0` on a pass/fail type assignment.
 
 #### Future Use
 

--- a/spec/factories/assignment_factory.rb
+++ b/spec/factories/assignment_factory.rb
@@ -44,5 +44,9 @@ FactoryGirl.define do
     factory :assignment_with_due_at do
       due_at Date.today
     end
+
+    trait :pass_fail do
+      pass_fail true
+    end
   end
 end

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -56,6 +56,17 @@ describe Grade do
     end
   end
 
+  describe "callbacks" do
+    context "with a pass/fail type assignment" do
+      let(:pass_fail_assignment) { build_stubbed :assignment, :pass_fail }
+
+      it "sets the grade score to 0" do
+        subject = create :grade, assignment: pass_fail_assignment
+        expect(subject.score).to be_zero
+      end
+    end
+  end
+
   describe "order" do
     it "is sortable by student names" do
       subject.save!


### PR DESCRIPTION
### Status
READY

### Description
This PR reorders the `calculate_points` and the `zero_points_for_pass_fail` callbacks on the Grade model to ensure that a Grade score is always set to `0` for a pass/fail type assignment.

### Migrations
NO

### Steps to Test or Reproduce

1. Upload grades for a Pass/Fail type assignment via CSV
2. As a student, verify that the assignment appears as graded on the predictor page.

======================
Closes #3154 
