### PR TITLE
3099 Prevent footer from hiding last options dropdown in students table

### DIFF
--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -12,16 +12,15 @@ body
   margin: 2.75rem auto 0
   max-width: 1500px
   width: 100%
-  flex: 1 0 auto
   background-color: $color-white
-  display: flex
 
-.outer-wrap
-  padding: 0.1rem 0
+.staff-layout-wrapper
+  display: flex
 
 .mainContainer
   flex: 1
-  overflow: hidden
+  &.staff
+    min-width: 0
 
 .pageContent
   padding: 0rem 1rem 1rem

--- a/app/assets/stylesheets/pages/_dashboard.sass
+++ b/app/assets/stylesheets/pages/_dashboard.sass
@@ -19,6 +19,7 @@
     display: flex
     flex-direction: column
     margin-right: 1rem
+    min-width: 0
     @media (max-width: $media-medium-max)
       width: 50%
     @media (max-width: $media-small-max)

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -1,18 +1,19 @@
-.sidebar-container.hide-for-small.hide-for-medium
-  / Staff-only sidebar navigation
-  = render partial: "layouts/navigation/staff_subnav"
+.staff-layout-wrapper
+  .sidebar-container.hide-for-small.hide-for-medium
+    / Staff-only sidebar navigation
+    = render partial: "layouts/navigation/staff_subnav"
 
-%main.mainContainer#main-content{role: "main", class: "staff"}
+  %main.mainContainer#main-content{role: "main", class: "staff"}
 
-  / Page content
-  .mainContent
-    - if current_student.present?
-      .page-header
-        = breadcrumbs
-        %h1.pagetitle= current_student.name
-    - else
-      .page-header
-        = breadcrumbs
-        %h1.pagetitle= title
-        = yield(:context_menu)
-    = render partial: "layouts/content"
+    / Page content
+    .mainContent
+      - if current_student.present?
+        .page-header
+          = breadcrumbs
+          %h1.pagetitle= current_student.name
+      - else
+        .page-header
+          = breadcrumbs
+          %h1.pagetitle= title
+          = yield(:context_menu)
+      = render partial: "layouts/content"


### PR DESCRIPTION
### Status
**READY**

### Description
This PR reduces flexbox complexity in the page layout and replaces `overflow: hidden` (that was hiding the options dropdown in the student table) with `min-width: 0`to prevent slick-slider from acting unexpectedly in flexbox context.

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. View student's table on instructor's side and view last options dropdown

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Student, Instructor Dashboard, Student's table

======================
Closes #3099 
