### PR TITLE
2946 Provide XLSX error for CSV imports

### DIFF
--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -73,6 +73,7 @@ class Grades::ImportersController < ApplicationController
   end
 
   # POST /assignments/:assignment_id/grades/importers/:importer_provider_id/upload
+  # rubocop:disable AndOr
   def upload
     @assignment = current_course.assignments.find(params[:assignment_id])
 

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -76,6 +76,11 @@ class Grades::ImportersController < ApplicationController
   def upload
     @assignment = current_course.assignments.find(params[:assignment_id])
 
+    if (File.extname params[:file].original_filename) != ".csv"
+      redirect_to assignment_grades_importer_path(@assignment, params[:importer_provider_id]),
+        notice: "Only CSV files accepted for import"
+    end
+
     if params[:file].blank?
       redirect_to assignment_grades_importer_path(@assignment, params[:importer_provider_id]),
         notice: "File is missing"

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -78,7 +78,7 @@ class Grades::ImportersController < ApplicationController
 
     if (File.extname params[:file].original_filename) != ".csv"
       redirect_to assignment_grades_importer_path(@assignment, params[:importer_provider_id]),
-        notice: "Only CSV files accepted for import"
+        notice: "Only CSV files accepted for import" and return
     end
 
     if params[:file].blank?

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -78,7 +78,7 @@ class Grades::ImportersController < ApplicationController
 
     if (File.extname params[:file].original_filename) != ".csv"
       redirect_to assignment_grades_importer_path(@assignment, params[:importer_provider_id]),
-        notice: "Only CSV files accepted for import" and return
+        notice: "We're sorry, the grade import utility only supports .csv files. Please try again using a .csv file." and return
     end
 
     if params[:file].blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,6 +151,10 @@ class UsersController < ApplicationController
 
   # import users for class
   def upload
+    if (File.extname params[:file].original_filename) != ".csv"
+      redirect_to users_path, notice:"Only CSV files accepted for import" and return
+    end
+
     if params[:file].blank?
       flash[:notice] = "File missing"
       redirect_to users_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -152,7 +152,7 @@ class UsersController < ApplicationController
   # import users for class
   def upload
     if (File.extname params[:file].original_filename) != ".csv"
-      redirect_to users_path, notice:"Only CSV files accepted for import" and return
+      redirect_to users_path, notice: "We're sorry, the user import utility only supports .csv files. Please try again using a .csv file." and return
     end
 
     if params[:file].blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -150,8 +150,8 @@ class UsersController < ApplicationController
   end
 
   # import users for class
+  # rubocop:disable AndOr
   def upload
-
     if params[:file].blank?
       flash[:notice] = "File missing"
       redirect_to users_path and return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -151,20 +151,21 @@ class UsersController < ApplicationController
 
   # import users for class
   def upload
+
+    if params[:file].blank?
+      flash[:notice] = "File missing"
+      redirect_to users_path and return
+    end
+
     if (File.extname params[:file].original_filename) != ".csv"
       redirect_to users_path, notice: "We're sorry, the user import utility only supports .csv files. Please try again using a .csv file." and return
     end
 
-    if params[:file].blank?
-      flash[:notice] = "File missing"
-      redirect_to users_path
-    else
-      @result = CSVStudentImporter.new(params[:file].tempfile,
-                                       params[:internal_students] == "1",
-                                       params[:send_welcome] == "1")
-        .import(current_course)
-      render :import_results
-    end
+    @result = CSVStudentImporter.new(params[:file].tempfile,
+                                     params[:internal_students] == "1",
+                                     params[:send_welcome] == "1")
+      .import(current_course)
+    render :import_results
   end
 
   private

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -4,7 +4,7 @@ describe Grades::ImportersController do
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let(:assignment) { create :assignment, course: course }
   let(:grade) { create(:grade, student: student, assignment: assignment, course: course) }
-  
+
   before { allow(controller).to receive(:current_course).and_return course }
 
   context "as a professor" do
@@ -23,6 +23,7 @@ describe Grades::ImportersController do
       render_views
 
       let(:file) { fixture_file "grades.csv", "text/csv" }
+      let(:bad_file) { fixture_file "grades.xlsx"}
 
       it "renders the results from the import" do
         student.reload.update_attribute :email, "robert@example.com"
@@ -58,6 +59,15 @@ describe Grades::ImportersController do
           post :upload, params: { assignment_id: assignment.id, importer_provider_id: :csv }
 
           expect(flash[:notice]).to eq("File is missing")
+          expect(response).to redirect_to(assignment_grades_importer_path(assignment, :csv))
+        end
+      end
+
+      context "with a file that is not csv to import with" do
+        it "renders the file not csv error" do
+          post :upload, params: { assignment_id: assignment.id, importer_provider_id: :csv, file: bad_file }
+
+          expect(flash[:notice]).to eq("We're sorry, the grade import utility only supports .csv files. Please try again using a .csv file.")
           expect(response).to redirect_to(assignment_grades_importer_path(assignment, :csv))
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -139,6 +139,13 @@ describe UsersController do
       let(:file) { fixture_file "users.csv", "text/csv" }
       before { create :team, course: @course, name: "Zeppelin" }
 
+      it "renders any errors that have occured" do
+        file = fixture_file "users.xlsx"
+        post :upload, params: { file: file }
+        expect(flash[:notice]).to eq("We're sorry, the user import utility only supports .csv files. Please try again using a .csv file.")
+        expect(response).to redirect_to(users_path)
+      end
+
       it "renders the results from the import" do
         post :upload, params: { file: file }
 

--- a/spec/fixtures/files/grades.xlsx
+++ b/spec/fixtures/files/grades.xlsx
@@ -1,0 +1,1 @@
+bad excel file

--- a/spec/fixtures/files/users.xlsx
+++ b/spec/fixtures/files/users.xlsx
@@ -1,0 +1,1 @@
+bad users file


### PR DESCRIPTION
### Status
**NEEDS REVIEW**

### Description
As an instructor, when I try to import grades by uploading an .xlsx file, I should get an error saying 'We're sorry, the grade import utility doesn't support .xlsx files. Please try again using a .csv file."

### Related PRs
N/A


### Todos
- [x] Add Tests



### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Navigate to Course Assignments. If there are no assignments, create one. On the assignment page, under options, click "Import Grades". Then "Import Grades from CSV". Click "Choose File" and select a file that does not have a .csv extension. Click import. Expected behavior is to be returned to the Assignment Import page with a notice message that reads, "Only CSV files accepted for import".

Navigate to Learners, click Import Users button. Click "Choose File". Select a non CSV file to upload. Click the "Import" button. Expected behavior is to return to the Users page with the notice message, "Only CSV files accepted for import".

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignments
* Users

======================
Closes #2946 
