### PR TITLE
2855 Hide Download Grades Link

### DIFF
--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -27,7 +27,8 @@
   %ul
   - presenter.assignment.assignment_files.each do |af|
     %li= link_to af.filename, af.url
-- if current_user_is_staff?
+
+- if current_user_is_staff? && presenter.assignment.grades.instructor_modified.any?
   %h3.uppercase Downloads
   %p= link_to glyph(:download) + "Download Grades", export_assignment_grades_path(presenter.assignment, format: :csv)
 
@@ -78,7 +79,7 @@
     - presenter.assignment.unlock_conditions.each do |condition|
       - if !condition.unlockable_type == GradeSchemeElement
         %li= link_to condition.requirements_description_sentence, condition.unlockable
-      - else 
+      - else
         %li= condition.requirements_description_sentence
 
 - if presenter.assignment.is_a_condition?
@@ -87,7 +88,7 @@
     - presenter.assignment.unlock_keys.each do |key|
       - if !key.unlockable_type == GradeSchemeElement
         %li= link_to key.key_description_sentence, key.unlockable
-      - else 
+      - else
         %li= key.key_description_sentence
 
 - if presenter.assignment_has_viewable_description?(current_user)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
On the instructor Assignment show page, the grade download link shouldn't display unless there are instructor_modified grades that have been created

### Related PRs
N/A


### Todos
- [ ] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the assignments page. Click on an assignment link that has no grades yet. Click on the "Description & Downloads" tab. If the assignment has no grades, there should be no download link. If there have been grades entered, the instructor should see a download link.


### Impacted Areas in Application
* Assignments Instructor View

======================
Closes #2855 
