### PR TITLE
Check for nil student when creating a new submission

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -72,8 +72,9 @@ class Submission < ActiveRecord::Base
   def graded?
     !ungraded?
   end
-  
+
   def submission_grade
+    return nil if student.nil?
     student.grades.where(assignment_id: self.assignment_id).first
   end
 


### PR DESCRIPTION
### Status
READY

### Description
It appears that there is a missing check to ensure that the student association on a submission is not `nil`, prior to returning the `submission_grade` as defined on the Submission model. This is preventing a user from creating a new submission for an assignment.

### Migrations
NO

### Steps to Test or Reproduce
Create a new submission for an assignment

======================
Closes #3170 
