### PR TITLE
Allow Toggling of Canvas-Related UI Elements

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -114,7 +114,7 @@ class CoursesController < ApplicationController
 
   def course_params
     params.require(:course).permit :course_number, :name,
-      :semester, :year, :has_badges, :has_teams, 
+      :semester, :year, :has_badges, :has_teams,
       :team_term, :student_term, :section_leader_term, :group_term, :lti_uid,
       :user_id, :course_id, :course_rules, :syllabus,
       :has_character_names, :has_team_roles, :has_character_profiles, :show_analytics,
@@ -128,7 +128,7 @@ class CoursesController < ApplicationController
       :team_score_average, :has_team_challenges, :team_leader_term,
       :max_assignment_types_weighted, :full_points, :has_in_team_leaderboards,
       :grade_scheme_elements_attributes, :add_team_score_to_student, :status,
-      :assignments_attributes, :start_date, :end_date,
+      :assignments_attributes, :start_date, :end_date, :allows_canvas,
       unlock_conditions_attributes: [:id, :unlockable_id, :unlockable_type, :condition_id,
         :condition_type, :condition_state, :condition_value, :condition_date, :_destroy],
       instructors_of_record_ids: [], course_memberships_attributes: [:id, :course_id, :user_id, :instructor_of_record]

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -2,7 +2,8 @@
   .context_menu
     %ul
       %li= active_course_link_to decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
-      %li= active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
+      - if current_course.allows_canvas?
+        %li= active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -54,12 +55,12 @@
                         %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
                         %li= active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
                         %li= active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
-          - if current_course.active? 
+          - if current_course.active?
             .box{ style: "width: 95%; margin: 1em auto;"}
               .center
                 = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment}", new_assignment_path(assignment_type_id: assignment_type.id)
 
-  - if current_course.active? 
+  - if current_course.active?
     .box
       .center
         = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment} Type", new_assignment_type_path

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -39,7 +39,11 @@
     .form-item
       = f.label :has_paid, "Has Paid?"
       = f.check_box :has_paid
-      .form_label If this course is not at Michigan, has it been paid for? This affects whether or not instructors can add users. 
+      .form_label If this course is not at Michigan, has it been paid for? This affects whether or not instructors can add users.
+    .form-item
+      = f.label :allows_canvas, "Allows Canvas?"
+      = f.check_box :allows_canvas
+      .form_label Does this course allow integration with Canvas?
 
 %section
   %h2 Enable Features
@@ -101,7 +105,7 @@
         = f.label :has_team_challenges, "Section Assignments"
         = f.check_box :has_team_challenges, {class: "feature-checkbox dependent-on-section has-settings-menu"}
       .form-card-body
-        .feature-description{id: "txtSectionAssignments"}  These are larger assignments to be completed by discussion section groups. 
+        .feature-description{id: "txtSectionAssignments"}  These are larger assignments to be completed by discussion section groups.
       .form-card-advanced-settings
         %button.button-advanced-settings= glyph(:cog) + "Settings"
       .advanced-settings-card

--- a/app/views/grades/importers/index.html.haml
+++ b/app/views/grades/importers/index.html.haml
@@ -13,19 +13,20 @@
 
         = link_to "Import Grades from CSV", assignment_grades_importer_path(@assignment, :csv), class: "card-link button"
 
-    .card{style: "height: 400px;"}
-      .card-cap
-        %img{src: "/images/canvas-logo.png"}
-      .card-block
-        %h4.card-title Canvas LMS
-        .card-text
-        %p.card-text
-          An open-source LMS from Instructure. Import any grade for the courses you are enrolled as a teacher.
-
-        - if !@assignment.course.linked?(:canvas)
+    - if current_course.allows_canvas?
+      .card{style: "height: 400px;"}
+        .card-cap
+          %img{src: "/images/canvas-logo.png"}
+        .card-block
+          %h4.card-title Canvas LMS
+          .card-text
           %p.card-text
-            You must add the Canvas integration and link the course first in order to import any Canvas assignments.
+            An open-source LMS from Instructure. Import any grade for the courses you are enrolled as a teacher.
 
-          = link_to "Add a Canvas Integration", integrations_path, class: "card-link button"
-        -else
-          = link_to "Import Canvas Grades", assignment_grades_importer_assignments_path(@assignment, :canvas, @assignment.course.linked_for(:canvas).provider_resource_id), class: "card-link button"
+          - if !@assignment.course.linked?(:canvas)
+            %p.card-text
+              You must add the Canvas integration and link the course first in order to import any Canvas assignments.
+
+            = link_to "Add a Canvas Integration", integrations_path, class: "card-link button"
+          -else
+            = link_to "Import Canvas Grades", assignment_grades_importer_assignments_path(@assignment, :canvas, @assignment.course.linked_for(:canvas).provider_resource_id), class: "card-link button"

--- a/app/views/integrations/index.html.haml
+++ b/app/views/integrations/index.html.haml
@@ -1,6 +1,7 @@
-.card.left{style: "height: 350px;"}
-  .card-cap
-    %img{src: "/images/canvas-logo.png"}
-  .card-block= integration_card_for(:canvas, @course)
+- if current_course.allows_canvas?
+  .card.left{style: "height: 350px;"}
+    .card-cap
+      %img{src: "/images/canvas-logo.png"}
+    .card-block= integration_card_for(:canvas, @course)
 
 .clear

--- a/db/migrate/20170403145349_add_allows_canvas_to_course.rb
+++ b/db/migrate/20170403145349_add_allows_canvas_to_course.rb
@@ -1,0 +1,5 @@
+class AddAllowsCanvasToCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :allows_canvas, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170309154739) do
+ActiveRecord::Schema.define(version: 20170403145349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,6 +305,7 @@ ActiveRecord::Schema.define(version: 20170309154739) do
     t.string   "time_zone",                                               default: "Eastern Time (US & Canada)"
     t.boolean  "has_multipliers",                                         default: false,                        null: false
     t.boolean  "has_paid",                                                default: true,                         null: false
+    t.boolean  "allows_canvas",                                           default: true,                         null: false
   end
 
   create_table "criteria", force: :cascade do |t|

--- a/doc/courses.md
+++ b/doc/courses.md
@@ -1,0 +1,4 @@
+# Courses
+
+### Attributes
+  * `allows_canvas` - boolean switch controlling whether Canvas-related UI elements should be visible


### PR DESCRIPTION
### Status
READY

### Description
This PR adds an additional column called, `allows_canvas`, to the Course table. The intention is to allow an admin only to conditionally set whether Canvas-related elements should render for a specific course.

### Todos
- [x] Update Documentation

### Gem dependencies
N/A

### Migrations
YES, to add an additional non-nullable field `allows_canvas` to the Course table that defaults to true

### Steps to Test or Reproduce
- Ensure that the option to Import Grades from Canvas is not visible when `allows_canvas` is false
- Ensure that the option to Import Assignments from Canvas is not visible when ""
- Ensure that no Canvas references exist from the Integrations tab while editing a course

======================
Closes #2973 
