### PR TITLE
Update inactive course link helper

### DIFF
--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -23,6 +23,13 @@
   .button
     margin: 0.5rem 0
 
+.assignment-action-buttons
+  margin: 0
+  padding-left: 0
+  list-style-type: none
+  li
+    display: inline-block
+
 .add-unlock-condition
   margin-bottom: 1rem
 

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -40,9 +40,14 @@ module LinkHelper
   end
 
   # Conditionally renders a link_to helper based on whether the course is active
-  # or not
-  def active_course_link_to(name = nil, options = nil, html_options = nil, &block)
-    link_to name, options, html_options, &block if current_user_is_admin? || current_course.active?
+  # or not - tag allows you to optionally wrap value in html tag
+  def active_course_link_to(tag = nil, tag_class = nil, name = nil, options = nil, html_options = nil, &block)
+    return unless current_user_is_admin? || current_course.active?
+    if !tag.nil?
+      content_tag(tag, class: tag_class) do
+        link_to name, options, html_options, &block
+      end
+    end
   end
 
   def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -41,9 +41,9 @@ module LinkHelper
 
   # Conditionally renders a link_to helper based on whether the course is active
   # or not - tag allows you to optionally wrap value in html tag
-  def active_course_link_to(name = nil, options = nil, html_options = nil, &block)
+  def active_course_link_to(name = nil, options = nil, html_options = nil, tag_class = nil, &block)
     return unless current_user_is_admin? || current_course.active?
-    content_tag(:li) do
+    content_tag(:li, class: tag_class) do
       link_to name, options, html_options, &block
     end
   end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -41,12 +41,10 @@ module LinkHelper
 
   # Conditionally renders a link_to helper based on whether the course is active
   # or not - tag allows you to optionally wrap value in html tag
-  def active_course_link_to(tag = nil, tag_class = nil, name = nil, options = nil, html_options = nil, &block)
+  def active_course_link_to(name = nil, options = nil, html_options = nil, &block)
     return unless current_user_is_admin? || current_course.active?
-    if !tag.nil?
-      content_tag(tag, class: tag_class) do
-        link_to name, options, html_options, &block
-      end
+    content_tag(:li) do
+      link_to name, options, html_options, &block
     end
   end
 

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/announcements/index.html.haml
+++ b/app/views/announcements/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New Announcement", new_announcement_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -2,36 +2,36 @@
   .context_menu(ng-app="gradecraft" ng-controller="AssignmentCtrl" ng-init="init(#{presenter.assignment.id}, #{presenter.assignment.use_rubric})")
     %ul
       - if !presenter.new_assignment?
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu
             - if presenter.assignment.grades.present?
               %li= link_to decorative_glyph(:"check-square") + "Review Grades", grades_review_assignment_path(id: presenter.assignment)
-            = active_course_link_to :li, decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
+            = active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
             - if presenter.assignment.has_groups?
               %li= link_to decorative_glyph(:users) + "Create #{term_for :group}", new_group_path
 
             - if !presenter.grade_with_rubric?
               - if presenter.for_team?
-                = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
+                = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
               - else
-                = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
+                = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
 
             - if presenter.assignment.accepts_submissions?
               = render partial: "assignments/buttons/submissions_exports",
                 locals: { assignment: presenter.assignment, team: presenter.team }
 
             - unless presenter.assignment.imported_assignment.nil?
-              = active_course_link_to :li, 'hide-for-small', assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to 'hide-for-small', assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                 = decorative_glyph(:refresh)
                 = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
 
-              = active_course_link_to :li, 'hide-for-small', assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to 'hide-for-small', assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                 = decorative_glyph(:refresh)
                 = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
 
-            = active_course_link_to :li, 'hide-for-small', decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
+            = active_course_link_to 'hide-for-small', decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
 
             %li.hide-for-small
               %a{:href => design_assignment_rubrics_path(presenter.assignment) }

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -23,15 +23,15 @@
                 locals: { assignment: presenter.assignment, team: presenter.team }
 
             - unless presenter.assignment.imported_assignment.nil?
-              = active_course_link_to 'hide-for-small', assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                 = decorative_glyph(:refresh)
                 = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
 
-              = active_course_link_to 'hide-for-small', assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
                 = decorative_glyph(:refresh)
                 = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
 
-            = active_course_link_to 'hide-for-small', decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
+            = active_course_link_to(decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment))
 
             %li.hide-for-small
               %a{:href => design_assignment_rubrics_path(presenter.assignment) }

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -23,15 +23,15 @@
                 locals: { assignment: presenter.assignment, team: presenter.team }
 
             - unless presenter.assignment.imported_assignment.nil?
-              = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), nil, "hide-for-small", method: :post do
                 = decorative_glyph(:refresh)
                 = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
 
-              = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+              = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), nil, "hide-for-small", method: :post do
                 = decorative_glyph(:refresh)
                 = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
 
-            = active_course_link_to(decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment))
+            = active_course_link_to decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment), nil, "hide-for-small"
 
             %li.hide-for-small
               %a{:href => design_assignment_rubrics_path(presenter.assignment) }

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -2,42 +2,41 @@
   .context_menu(ng-app="gradecraft" ng-controller="AssignmentCtrl" ng-init="init(#{presenter.assignment.id}, #{presenter.assignment.use_rubric})")
     %ul
       - if !presenter.new_assignment?
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu
             - if presenter.assignment.grades.present?
               %li= link_to decorative_glyph(:"check-square") + "Review Grades", grades_review_assignment_path(id: presenter.assignment)
-            %li= active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
+            = active_course_link_to :li, decorative_glyph(:copy) + "Copy", copy_assignments_path(id: presenter.assignment), method: :copy
             - if presenter.assignment.has_groups?
               %li= link_to decorative_glyph(:users) + "Create #{term_for :group}", new_group_path
 
             - if !presenter.grade_with_rubric?
               - if presenter.for_team?
-                %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
+                = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
               - else
-                %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
+                = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment)
 
             - if presenter.assignment.accepts_submissions?
               = render partial: "assignments/buttons/submissions_exports",
                 locals: { assignment: presenter.assignment, team: presenter.team }
 
             - unless presenter.assignment.imported_assignment.nil?
-              %li.hide-for-small
-                = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
-                  = decorative_glyph(:refresh)
-                  = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
-              %li.hide-for-small
-                = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
-                  = decorative_glyph(:refresh)
-                  = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
-            %li.hide-for-small
-              = active_course_link_to decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
+              = active_course_link_to :li, 'hide-for-small', assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+                = decorative_glyph(:refresh)
+                = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
 
-              %li.hide-for-small
-                %a{:href => design_assignment_rubrics_path(presenter.assignment) }
-                  = decorative_glyph(:sliders)
-                  - if presenter.grade_with_rubric?
-                    Edit Rubric
-                  - else
-                    Create Rubric
+              = active_course_link_to :li, 'hide-for-small', assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), method: :post do
+                = decorative_glyph(:refresh)
+                = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
+
+            = active_course_link_to :li, 'hide-for-small', decorative_glyph(:download) + "Import Grades", assignment_grades_importers_path(presenter.assignment)
+
+            %li.hide-for-small
+              %a{:href => design_assignment_rubrics_path(presenter.assignment) }
+                = decorative_glyph(:sliders)
+                - if presenter.grade_with_rubric?
+                  Edit Rubric
+                - else
+                  Create Rubric

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -1,8 +1,8 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      = active_course_link_to :li, decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
-      = active_course_link_to :li, decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
+      = active_course_link_to decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
+      = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -50,10 +50,10 @@
                     .right
                       %ul.button-bar
                         - if !assignment.grade_with_rubric?
-                          = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
-                        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
-                        = active_course_link_to :li, decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
-                        = active_course_link_to :li, decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
+                          = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                        = active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
+                        = active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
+                        = active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
           - if current_course.active? 
             .box{ style: "width: 95%; margin: 1em auto;"}
               .center

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -1,8 +1,8 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= active_course_link_to decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
-      %li= active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
+      = active_course_link_to :li, decorative_glyph(:plus) + "New #{term_for :assignment}", new_assignment_path, class: "button button-edit"
+      = active_course_link_to :li, decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -50,10 +50,10 @@
                     .right
                       %ul.button-bar
                         - if !assignment.grade_with_rubric?
-                          %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
-                        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
-                        %li= active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
-                        %li= active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
+                          = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment), class: "button"
+                        = active_course_link_to :li, decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), class: "button", :method => :copy
+                        = active_course_link_to :li, decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }, class: "button"
           - if current_course.active? 
             .box{ style: "width: 95%; margin: 1em auto;"}
               .center

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -15,8 +15,9 @@
             %i.fa.fa-angle-double-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden{role: "tabpanel"}
-          = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
-          = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
+          %ul.assignment-action-buttons
+            = active_course_link_to "[Edit ]", edit_assignment_type_path(assignment_type)
+            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr
@@ -57,9 +58,11 @@
           - if current_course.active? 
             .box{ style: "width: 95%; margin: 1em auto;"}
               .center
-                = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment}", new_assignment_path(assignment_type_id: assignment_type.id)
+                - if current_user_is_admin? || current_course.active?
+                  = link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment}", new_assignment_path(assignment_type_id: assignment_type.id)
 
   - if current_course.active? 
     .box
       .center
-        = active_course_link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment} Type", new_assignment_type_path
+        - if current_user_is_admin? || current_course.active?
+          = link_to decorative_glyph(:plus) + "Add a New #{term_for :assignment} Type", new_assignment_type_path

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -16,7 +16,7 @@
             #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden{role: "tabpanel"}
           %ul.assignment-action-buttons
-            = active_course_link_to "[Edit ]", edit_assignment_type_path(assignment_type)
+            = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
             = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead

--- a/app/views/assignments/grades/index.html.haml
+++ b/app/views/assignments/grades/index.html.haml
@@ -12,7 +12,8 @@
         %h4.uppercase= student.name
         .left
           %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "
-        .right= active_course_link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
+        - if current_user_is_admin? || current_course.active?
+          .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
         %br
         %br
         .rubric-container= render partial: "grades/components/criterion_grade_results", locals: { presenter: presenter, current_student: student }

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -7,11 +7,11 @@
         %ul.button-bar
           %li= link_to "Review #{term_for :group}", edit_group_path(id: group_presenter.group), class: "button"
           - if presenter.assignment.accepts_submissions? && !group_presenter.submission
-            %li= active_course_link_to "Submit", group_presenter.path_for_new_submission, class: "button"
+            = active_course_link_to :li, "Submit", group_presenter.path_for_new_submission, class: "button"
           - if group_presenter.assignment_graded?
-            %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
+            = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
           - else
-            %li= active_course_link_to decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
+            = active_course_link_to :li, decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
     %td
       %table
         %thead{:style => "background: none !important; color: #000000; margin: 0; padding: 0;"}

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -7,11 +7,11 @@
         %ul.button-bar
           %li= link_to "Review #{term_for :group}", edit_group_path(id: group_presenter.group), class: "button"
           - if presenter.assignment.accepts_submissions? && !group_presenter.submission
-            = active_course_link_to :li, "Submit", group_presenter.path_for_new_submission, class: "button"
+            = active_course_link_to "Submit", group_presenter.path_for_new_submission, class: "button"
           - if group_presenter.assignment_graded?
-            = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
+            = active_course_link_to decorative_glyph(:edit) + "Edit Grade", group_presenter.path_for_grading_assignment, class: "button"
           - else
-            = active_course_link_to :li, decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
+            = active_course_link_to decorative_glyph(:edit) + "Grade", group_presenter.path_for_grading_assignment, class: "button"
     %td
       %table
         %thead{:style => "background: none !important; color: #000000; margin: 0; padding: 0;"}

--- a/app/views/assignments/index_student/components/_submission_buttons.haml
+++ b/app/views/assignments/index_student/components/_submission_buttons.haml
@@ -3,9 +3,9 @@
     %li
       = link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif assignment.open?
-    %li= active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
+    = active_course_link_to :li, glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
 - elsif assignment.has_groups? && presenter.group_for(assignment)
   - if presenter.group_for(assignment).submission_for_assignment(assignment)
     %li= link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif presenter.group_for(assignment).approved? && assignment.open?
-    %li= active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"
+    = active_course_link_to :li, glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"

--- a/app/views/assignments/index_student/components/_submission_buttons.haml
+++ b/app/views/assignments/index_student/components/_submission_buttons.haml
@@ -3,9 +3,9 @@
     %li
       = link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif assignment.open?
-    = active_course_link_to :li, glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
+    = active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, student_id: presenter.student.id), class: "button"
 - elsif assignment.has_groups? && presenter.group_for(assignment)
   - if presenter.group_for(assignment).submission_for_assignment(assignment)
     %li= link_to glyph(:paperclip) + "See Submission", assignment_path(assignment, anchor: "tab3"), class: "button"
   - elsif presenter.group_for(assignment).approved? && assignment.open?
-    = active_course_link_to :li, glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"
+    = active_course_link_to glyph(:upload) + "Submit", new_assignment_submission_path(assignment, group_id: presenter.group_for(assignment)), class: "button"

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -59,15 +59,15 @@
           - if grade.instructor_modified?
             %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade), class: "button"
             - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(student_submission)
-              %li= active_course_link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
+              = active_course_link_to :li, decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
             - else
-              %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
-            %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+            = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
           - else
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
-              %li= active_course_link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
+              = active_course_link_to :li, decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
-            %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
+            = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -59,15 +59,15 @@
           - if grade.instructor_modified?
             %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade), class: "button"
             - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(student_submission)
-              = active_course_link_to :li, decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
+              = active_course_link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
             - else
-              = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
-            = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+            = active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
           - else
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
-              = active_course_link_to :li, decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
+              = active_course_link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
-            = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
+            = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -36,6 +36,6 @@
             - presenter.badge.earned_badges.where(student_id: student.id).each do |badge|
               %ul.button-bar
                 %li= link_to decorative_glyph(:star) + "Awarded #{badge.created_at.strftime("%b %d")}", badge_earned_badge_path(presenter.badge, badge.id), class: "button"
-                %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
-                %li= active_course_link_to decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
+                = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
+                = active_course_link_to :li, decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
               .clear

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -36,6 +36,6 @@
             - presenter.badge.earned_badges.where(student_id: student.id).each do |badge|
               %ul.button-bar
                 %li= link_to decorative_glyph(:star) + "Awarded #{badge.created_at.strftime("%b %d")}", badge_earned_badge_path(presenter.badge, badge.id), class: "button"
-                = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
-                = active_course_link_to :li, decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
+                = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(presenter.badge, badge), class: "button"
+                = active_course_link_to decorative_glyph(:trash) + "Delete", badge_earned_badge_path(presenter.badge, badge), class: "button", :method => :delete, data: { confirm: "Are you sure you want to delete this award?" }
               .clear

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -1,5 +1,5 @@
 %ul.button-bar
-  %li= active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
-  %li= active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
-  %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
-  %li= active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }
+  = active_course_link_to :li, decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
+  = active_course_link_to :li, decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
+  = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
+  = active_course_link_to :li, decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -1,5 +1,5 @@
 %ul.button-bar
-  = active_course_link_to :li, decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
-  = active_course_link_to :li, decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
-  = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
-  = active_course_link_to :li, decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }
+  = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button"
+  = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge), class: "button"
+  = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button"
+  = active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), class: "button", data: { confirm: "Are you sure?",  method: :delete }

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -2,16 +2,16 @@
   .context_menu
     %ul
       - if actions.include? :new
-        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
 
       - if actions.include? :see
         %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
 
       - if actions.include? :edit
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
 
       - if actions.include? :award
-        = active_course_link_to :li, decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
 
       - if actions.include? :quick_award
-        = active_course_link_to :li, decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -2,16 +2,16 @@
   .context_menu
     %ul
       - if actions.include? :new
-        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
 
       - if actions.include? :see
         %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
 
       - if actions.include? :edit
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
 
       - if actions.include? :award
-        %li= active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge), class: "button button-edit"
 
       - if actions.include? :quick_award
-        %li= active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge), class: "button button-edit"

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -24,6 +24,6 @@
         %td
           .right
             %ul.button-bar
-              = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
-              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
-              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }
+              = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
+              = active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
+              = active_course_link_to decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -24,6 +24,6 @@
         %td
           .right
             %ul.button-bar
-              %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
-              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
-              %li= active_course_link_to decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }
+              = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge), class: "button"
+              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge), class: "button"
+              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", challenge, class: "button", :method => :delete, data: { confirm: "Are you sure?" }

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -36,11 +36,11 @@
               - if challenge_grade
                 %ul.button-bar
                   %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id), class: 'button'
-                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
-                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
+                  = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
+                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
               - else
                 %ul.button-bar
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
+                  = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
           - if @challenge.release_necessary?
             %td
               - if challenge_grade && !challenge_grade.is_released?

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -36,11 +36,11 @@
               - if challenge_grade
                 %ul.button-bar
                   %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id), class: 'button'
-                  %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
-                  %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
+                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id), class: 'button'
+                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), class: 'button', data: { confirm: 'Are you sure?', method: :delete }
               - else
                 %ul.button-bar
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: 'button'
           - if @challenge.release_necessary?
             %td
               - if challenge_grade && !challenge_grade.is_released?

--- a/app/views/challenges/index.html.haml
+++ b/app/views/challenges/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/challenges/index.html.haml
+++ b/app/views/challenges/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -2,11 +2,11 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
 
-        %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/challenges/show.html.haml
+++ b/app/views/challenges/show.html.haml
@@ -2,11 +2,11 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New #{(term_for :challenge).titleize}", new_challenge_path, class: "button button-edit"
 
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(@challenge), class: "button button-edit"
 
-        = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(@challenge), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/earned_badges/show.html.haml
+++ b/app/views/earned_badges/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
+      = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/earned_badges/show.html.haml
+++ b/app/views/earned_badges/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
+      = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_badge_earned_badge_path(id: @earned_badge.id), class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,7 +1,8 @@
 - if current_user_is_staff?
   - content_for :context_menu do
     .context_menu
-      %ul= active_course_link_to decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
+      %ul
+        = active_course_link_to :li, decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -26,5 +27,5 @@
             - if current_user_is_staff?
               .right
                 %ul.button-bar
-                  %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
-                  %li= active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"
+                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
+                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New Event", new_event_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"
@@ -27,5 +27,5 @@
             - if current_user_is_staff?
               .right
                 %ul.button-bar
-                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
-                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"
+                  = active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event), class: "button"
+                  = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }, class: "button"

--- a/app/views/grade_scheme_elements/_index_staff.haml
+++ b/app/views/grade_scheme_elements/_index_staff.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/grade_scheme_elements/_index_staff.haml
+++ b/app/views/grade_scheme_elements/_index_staff.haml
@@ -2,7 +2,7 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit", mass_edit_grade_scheme_elements_path, class: "button button-edit"
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
@@ -19,6 +19,8 @@
           - if element.unlock_conditions.present?
             - element.unlock_conditions.each do |uc|
               .condition= glyph(:lock) + uc.requirements_description_sentence
-        %td= active_course_link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
+        %td
+          - if current_user_is_admin? || current_course.active?
+            = link_to "Set Lock Conditions", edit_grade_scheme_element_path(element), class: "button"
 
 = render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/app/views/groups/_buttons.haml
+++ b/app/views/groups/_buttons.haml
@@ -1,4 +1,4 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      = active_course_link_to :li, decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"
+      = active_course_link_to decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"

--- a/app/views/groups/_buttons.haml
+++ b/app/views/groups/_buttons.haml
@@ -1,4 +1,4 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= active_course_link_to decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"
+      = active_course_link_to :li, decorative_glyph(:plus) + "New #{term_for :group}", new_group_path, class: "button button-edit"

--- a/app/views/groups/_groups_table.haml
+++ b/app/views/groups/_groups_table.haml
@@ -23,7 +23,7 @@
           .right
             %ul.button-bar
               - if group.pending?
-                = active_course_link_to :li, decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
+                = active_course_link_to decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
               - else
-                = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
-              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete
+                = active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
+              = active_course_link_to decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete

--- a/app/views/groups/_groups_table.haml
+++ b/app/views/groups/_groups_table.haml
@@ -23,7 +23,7 @@
           .right
             %ul.button-bar
               - if group.pending?
-                %li= active_course_link_to decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
+                = active_course_link_to :li, decorative_glyph(:eye) + "Review #{term_for :group}", edit_group_path(id: group), class: "button"
               - else
-                %li= active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
-              %li= active_course_link_to decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete
+                = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{term_for :group}", edit_group_path(id: group), class: "button"
+              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", group_path(group), class: "button", data: { confirm: "This will delete the #{group.name} #{term_for :group} - are you sure?" }, :method => :delete

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -44,9 +44,9 @@
                 .right
                   %ul.button-bar
                     - if assignment.is_individual?
-                      %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                      = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
                     - elsif assignment.has_groups?
-                      %li= active_course_link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
+                      = active_course_link_to :li, decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
               - if current_course.active?
                 %td
                   .center

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -44,9 +44,9 @@
                 .right
                   %ul.button-bar
                     - if assignment.is_individual?
-                      = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                      = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
                     - elsif assignment.has_groups?
-                      = active_course_link_to :li, decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
+                      = active_course_link_to decorative_glyph(:check) + "Edit Grade", grade_assignment_group_path(assignment, group), class: "button"
               - if current_course.active?
                 %td
                   .center

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -34,7 +34,7 @@
             .right
               %ul.button-bar
                 - if assignment.is_individual?
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
+                  = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
                 - elsif assignment.has_groups?
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
+                  = active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
   %hr.dotted

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -34,7 +34,7 @@
             .right
               %ul.button-bar
                 - if assignment.is_individual?
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
                 - elsif assignment.has_groups?
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"
   %hr.dotted

--- a/app/views/info/dashboard/_instructor_dashboard.haml
+++ b/app/views/info/dashboard/_instructor_dashboard.haml
@@ -8,9 +8,9 @@
 
   .flex-column
     - if current_course.grade_scheme_elements.present? && GradeSchemeElement.has_valid_elements_for(current_course)
-      .panel.dashboard-module.grading-scheme-module.flex-row= render partial: "info/dashboard/modules/dashboard_grading_scheme"
+      .panel.dashboard-module.grading-scheme-module.flex-row.col-50= render partial: "info/dashboard/modules/dashboard_grading_scheme"
 
-    .stacked-column
+    .stacked-column.col-50
       .panel.dashboard-module.stacked-module= render partial: "info/dashboard/modules/dashboard_grade_distribution"
 
       .panel.dashboard-module.stacked-module= render partial: "info/dashboard/modules/dashboard_weekly_stats", locals:  { presenter: Info::DashboardWeeklyStatsPresenter.new(course: current_course, student: current_student) }

--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -17,9 +17,9 @@
 
       .flex-column
         - if current_course.grade_scheme_elements.present? && GradeSchemeElement.has_valid_elements_for(current_course)
-          .flex-row.panel.dashboard-module.grading-scheme-module= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
+          .flex-row.panel.dashboard-module.grading-scheme-module.col-50= render partial: "info/dashboard/modules/dashboard_grading_scheme", locals: { presenter: Info::DashboardGradingSchemePresenter.new(course: current_course, student: current_student) }
 
-        .stacked-column
+        .stacked-column.col-50
           .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_weekly_stats", locals:  { presenter: Info::DashboardWeeklyStatsPresenter.new(course: current_course, student: current_student) }
 
           - if AnalyticsProctor.new.viewable? current_student, current_course

--- a/app/views/info/dashboard/modules/_dashboard_avatar.haml
+++ b/app/views/info/dashboard/modules/_dashboard_avatar.haml
@@ -22,8 +22,8 @@
 
     .module-section
       %ul.button-bar
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
+        = active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
         %li= link_to decorative_glyph(:envelope) + "Email", "mailto:#{current_student.email}", class: "button"
         %li= link_to decorative_glyph(:refresh) + "Update Score", recalculate_student_path(current_student), class: "button"
         - if !current_student.activated?
-          = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"
+          = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"

--- a/app/views/info/dashboard/modules/_dashboard_avatar.haml
+++ b/app/views/info/dashboard/modules/_dashboard_avatar.haml
@@ -22,8 +22,8 @@
 
     .module-section
       %ul.button-bar
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(current_student), class: "button"
         %li= link_to decorative_glyph(:envelope) + "Email", "mailto:#{current_student.email}", class: "button"
         %li= link_to decorative_glyph(:refresh) + "Update Score", recalculate_student_path(current_student), class: "button"
         - if !current_student.activated?
-          %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"
+          = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(current_student.id), :method => :put, class: "button"

--- a/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
+++ b/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
@@ -9,7 +9,9 @@
         .small.uppercase= "#{assignment.assignment_type.name}"
       - else
         - if assignment.name_visible_for_student?(current_student)
-          %span.bold.assignment-name= active_course_link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
+          %span.bold.assignment-name
+            - if current_user_is_admin? || current_course.active?
+              = link_to assignment.name, grade_path(Grade.find_or_create(assignment.id, current_student.id))
         - else
           %span.bold.assignment-name= "Locked #{(term_for :assignment ).titleize}"
           %span.italic= "You must unlock this #{(term_for :assignment).downcase} to learn more about it"

--- a/app/views/info/gradebook.html.haml
+++ b/app/views/info/gradebook.html.haml
@@ -25,7 +25,9 @@
             - current_course.assignments.each do |assignment|
               - assignment.grade_for_student(student).tap do |grade|
                 - if grade
-                  %td= active_course_link_to "#{grade.score}", edit_grade_path(grade)
+                  %td
+                    - if current_user_is_admin? || current_course.active?
+                      = link_to "#{grade.score}", edit_grade_path(grade)
                 - else
                   %td
             - if current_course.valuable_badges?

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -46,5 +46,5 @@
                 %th= points assignment.grade_count
                 %th
                   %ul.button-bar.right
-                    = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                    = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
                     %li= link_to decorative_glyph("cloud-download") + "Download Grades", export_assignment_grades_path(assignment, format: :csv), class: "button"

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -46,5 +46,5 @@
                 %th= points assignment.grade_count
                 %th
                   %ul.button-bar.right
-                    %li= active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
+                    = active_course_link_to :li, decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment), class: "button"
                     %li= link_to decorative_glyph("cloud-download") + "Download Grades", export_assignment_grades_path(assignment, format: :csv), class: "button"

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -55,4 +55,6 @@
                   %ul.button-bar
                     %li= link_to re.group.name, group_path(re.group)
                     %li= link_to decorative_glyph(:eye) + "See Submission", assignment_submission_path(re.assignment.id, id: re.id), class: "button"
-              %td= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(re.assignment, re.group), class: "button"
+              %td
+                - if current_user_is_admin? || current_course.active?
+                  = link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(re.assignment, re.group), class: "button"

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -44,7 +44,7 @@
                 .right
                   %ul.button-bar
                     %li= link_to decorative_glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
+                    = active_course_link_to decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td

--- a/app/views/info/resubmissions.html.haml
+++ b/app/views/info/resubmissions.html.haml
@@ -44,7 +44,7 @@
                 .right
                   %ul.button-bar
                     %li= link_to decorative_glyph(:eye) + "See Submission", assignment_submission_path(re.assignment, id: re.id), class: "button"
-                    %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
+                    = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", assignment_student_grade_path(re.assignment, re.student), method: :post, class: "button"
             - elsif re.assignment.has_groups?
               %td= link_to re.group.name, group_path(id: re.group.id)
               %td

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -41,7 +41,7 @@
               %ul.button-bar
                 - if submission.assignment.is_individual?
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
+                  = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
                 - else
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"
+                  = active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"

--- a/app/views/info/ungraded_submissions.html.haml
+++ b/app/views/info/ungraded_submissions.html.haml
@@ -41,7 +41,7 @@
               %ul.button-bar
                 - if submission.assignment.is_individual?
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", assignment_student_grade_path(submission.assignment, submission.student), method: :post, class: "button"
                 - else
                   %li= link_to decorative_glyph(:eye) + "See Submission",assignment_submission_path(submission.assignment, id: submission.id), class: "button"
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", grade_assignment_group_path(submission.assignment, submission.group), class: "button"

--- a/app/views/layouts/navigation/_observer_profile_tabs.haml
+++ b/app/views/layouts/navigation/_observer_profile_tabs.haml
@@ -6,7 +6,8 @@
     %li{class: ("active" if current_page?(grade_scheme_elements_path)) }
       = link_to_unless_current "Grading Scheme", grade_scheme_elements_path
   %li{class: ("active" if current_page?(predictor_path)) }
-    = active_course_link_to_unless_current "Grade Predictor", predictor_path
+    - if current_user_is_admin? || current_course.active?
+      = link_to_unless_current "Grade Predictor", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -54,7 +54,7 @@
     %hr
 
     %h5{ class: "make-lizards" } Admin
-    %li= active_course_link_to_unless_current decorative_glyph(:plus) + "New Course", new_course_path
+    = active_course_link_to_unless_current decorative_glyph(:plus) + "New Course", new_course_path
     - if current_user_is_admin?
       %li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
       %li= link_to_unless_current decorative_glyph("user-times") + "All Users", users_path

--- a/app/views/observers/_buttons.html.haml
+++ b/app/views/observers/_buttons.html.haml
@@ -2,4 +2,4 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"

--- a/app/views/observers/_buttons.html.haml
+++ b/app/views/observers/_buttons.html.haml
@@ -2,4 +2,4 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"

--- a/app/views/observers/index.html.haml
+++ b/app/views/observers/index.html.haml
@@ -23,5 +23,5 @@
           %td
             .right
               %ul.button-bar
-                = active_course_link_to :li, decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
-                = active_course_link_to :li, decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+                = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
+                = active_course_link_to decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/observers/index.html.haml
+++ b/app/views/observers/index.html.haml
@@ -23,5 +23,5 @@
           %td
             .right
               %ul.button-bar
-                %li= active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
-                %li= active_course_link_to decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+                = active_course_link_to :li, decorative_glyph(:edit) + "Edit",  edit_user_path(user), { class: "button" }
+                = active_course_link_to :li, decorative_glyph(:trash) + "Delete",  user, class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/staff/_buttons.haml
+++ b/app/views/staff/_buttons.haml
@@ -2,6 +2,6 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
       - if @staff_member.present?
-        = active_course_link_to :li, glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"
+        = active_course_link_to glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"

--- a/app/views/staff/_buttons.haml
+++ b/app/views/staff/_buttons.haml
@@ -2,6 +2,6 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
       - if @staff_member.present?
-        %li= active_course_link_to glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"
+        = active_course_link_to :li, glyph(:edit) + "Edit Staff Member", edit_user_path(@staff_member), class: "button button-edit"

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -31,8 +31,8 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
-                = active_course_link_to :li, decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                = active_course_link_to :li, decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
+                = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
+                = active_course_link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
                 - if !user.activated?
-                  = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
-                  = active_course_link_to :li, glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)
+                  = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
+                  = active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -31,8 +31,8 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
-                %li= active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                %li= active_course_link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
+                = active_course_link_to :li, decorative_glyph(:edit) + "Edit",  edit_user_path(user)
+                = active_course_link_to :li, decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
                 - if !user.activated?
-                  %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
-                  %li= active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)
+                  = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
+                  = active_course_link_to :li, glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -33,5 +33,5 @@
           %td= grade.graded_at
           %td
             %ul.button-bar
-              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
-              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              = active_course_link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
+              = active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -33,5 +33,5 @@
           %td= grade.graded_at
           %td
             %ul.button-bar
-              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
-              %li= active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
+              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -53,8 +53,8 @@
             %ul.options-menu
               %li= link_to decorative_glyph(:eye) + "Preview as this student", student_preview_path(student)
               %li= mail_to student.email, glyph(:envelope) + "Email"
-              %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student)
-              %li= active_course_link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
+              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(student)
+              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
               - if !student.activated?
-                %li= active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
-                %li= active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)
+                = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
+                = active_course_link_to :li, glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)

--- a/app/views/students/_students_table.haml
+++ b/app/views/students/_students_table.haml
@@ -53,8 +53,8 @@
             %ul.options-menu
               %li= link_to decorative_glyph(:eye) + "Preview as this student", student_preview_path(student)
               %li= mail_to student.email, glyph(:envelope) + "Email"
-              = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(student)
-              = active_course_link_to :li, decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
+              = active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student)
+              = active_course_link_to decorative_glyph(:trash) + "Delete", student.course_membership, data: { confirm: "This will delete #{student.name} from your course - are you sure?" }, :method => :delete
               - if !student.activated?
-                = active_course_link_to :li, decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
-                = active_course_link_to :li, glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)
+                = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(student.id), :method => :put
+                = active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(student.id)

--- a/app/views/students/grade_index.html.haml
+++ b/app/views/students/grade_index.html.haml
@@ -26,6 +26,10 @@
           %td= g.predicted_points
           %td= g.feedback
           %td= g.status
-          %td= active_course_link_to "Edit Grade", edit_grade_path(g), class: "button"
+          %td
+            - if current_user_is_admin? || current_course.active?
+              = link_to "Edit Grade", edit_grade_path(g), class: "button"
           %td= link_to "See Grade", grade_path(g), class: "button"
-          %td= active_course_link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+          %td
+            - if current_user_is_admin? || current_course.active?
+              = link_to "Delete Grade", grade_path(g), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -2,23 +2,23 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit Submission",
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit Submission",
           "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?student_id=#{presenter.student.id}",
           class: "button button-edit"
-        %li= active_course_link_to decorative_glyph(:trash) + "Delete Submission",
+        = active_course_link_to :li, decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit",
           data: { confirm: "Are you sure?", method: :delete }
-        %li= active_course_link_to decorative_glyph(:check) + "Grade",
+        = active_course_link_to :li, decorative_glyph(:check) + "Grade",
           assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
 - elsif presenter.assignment.has_groups?
   - content_for :context_menu do
     .context_menu
       %ul
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit Submission",
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit Submission",
           "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?group_id=#{presenter.group.id}",
           class: "button button-edit"
-        %li= active_course_link_to decorative_glyph(:trash) + "Delete Submission",
+        = active_course_link_to :li, decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ),
           data: { confirm: "Are you sure?",  method: :delete }, class: "button button-edit"
-        %li= active_course_link_to decorative_glyph(:check) + "Grade",
+        = active_course_link_to :li, decorative_glyph(:check) + "Grade",
           grade_assignment_group_path(presenter.assignment,  presenter.group), class: "button button-edit"

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -2,23 +2,23 @@
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit Submission",
+        = active_course_link_to decorative_glyph(:edit) + "Edit Submission",
           "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?student_id=#{presenter.student.id}",
           class: "button button-edit"
-        = active_course_link_to :li, decorative_glyph(:trash) + "Delete Submission",
+        = active_course_link_to decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit",
           data: { confirm: "Are you sure?", method: :delete }
-        = active_course_link_to :li, decorative_glyph(:check) + "Grade",
+        = active_course_link_to decorative_glyph(:check) + "Grade",
           assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
 - elsif presenter.assignment.has_groups?
   - content_for :context_menu do
     .context_menu
       %ul
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit Submission",
+        = active_course_link_to decorative_glyph(:edit) + "Edit Submission",
           "#{edit_assignment_submission_path(presenter.assignment, presenter.submission)}?group_id=#{presenter.group.id}",
           class: "button button-edit"
-        = active_course_link_to :li, decorative_glyph(:trash) + "Delete Submission",
+        = active_course_link_to decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ),
           data: { confirm: "Are you sure?",  method: :delete }, class: "button button-edit"
-        = active_course_link_to :li, decorative_glyph(:check) + "Grade",
+        = active_course_link_to decorative_glyph(:check) + "Grade",
           grade_assignment_group_path(presenter.assignment,  presenter.group), class: "button button-edit"

--- a/app/views/teams/_buttons.haml
+++ b/app/views/teams/_buttons.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
+      = active_course_link_to decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
 
       - if @team.present? && @team.persisted?
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"

--- a/app/views/teams/_buttons.haml
+++ b/app/views/teams/_buttons.haml
@@ -1,7 +1,7 @@
 - content_for :context_menu do
   .context_menu
     %ul
-      %li= active_course_link_to decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
+      = active_course_link_to :li, decorative_glyph(:plus) + "New #{(term_for :team).titleize}", new_team_path, class: "button button-edit"
 
       - if @team.present? && @team.persisted?
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{(term_for :team).titleize}", edit_team_path(@team), class: "button button-edit"

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -30,5 +30,5 @@
         %td
           .right
             %ul.button-bar
-              %li= active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
-              %li= active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+              = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
+              = active_course_link_to :li, decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -30,5 +30,5 @@
         %td
           .right
             %ul.button-bar
-              = active_course_link_to :li, decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
-              = active_course_link_to :li, decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete
+              = active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team), class: "button"
+              = active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), class: "button", data: { confirm: "Are you sure?" }, :method => :delete

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -43,7 +43,7 @@
             .right
               %ul.button-bar
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(student), class: "button"
-                = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
+                = active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
 
   %h2.subtitle #{term_for :challenge } Grades
 
@@ -67,7 +67,7 @@
             .right
               %ul.button-bar
                 - if challenge.challenge_grade_for_team(@team).present?
-                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
-                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
+                  = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
+                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
                 - else
-                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"
+                  = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -43,7 +43,7 @@
             .right
               %ul.button-bar
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(student), class: "button"
-                %li= active_course_link_to decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
+                = active_course_link_to :li, decorative_glyph(:edit) + "Edit", edit_user_path(student), class: "button"
 
   %h2.subtitle #{term_for :challenge } Grades
 
@@ -67,7 +67,7 @@
             .right
               %ul.button-bar
                 - if challenge.challenge_grade_for_team(@team).present?
-                  %li= active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
-                  %li= active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
+                  = active_course_link_to :li, decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
+                  = active_course_link_to :li, decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), class: "button", data: { confirm: "Are you sure?", method: :delete }
                 - else
-                  %li= active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"
+                  = active_course_link_to :li, decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id), class: "button"

--- a/app/views/users/_buttons.haml
+++ b/app/views/users/_buttons.haml
@@ -2,10 +2,10 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        %li= active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
-        %li= active_course_link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
       - if @user.present? && @user.persisted?
-        %li= active_course_link_to decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
+        = active_course_link_to :li, decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
         - if @user.is_staff?(current_course)
           %li= link_to decorative_glyph(:list) + "Show Staff Member", staff_path(@user), class: "button button-edit"
         - else

--- a/app/views/users/_buttons.haml
+++ b/app/views/users/_buttons.haml
@@ -2,10 +2,10 @@
   .context_menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        = active_course_link_to :li, decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
-        = active_course_link_to :li, decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:download) + "Import Users", import_users_path, class: "button button-edit"
       - if @user.present? && @user.persisted?
-        = active_course_link_to :li, decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
+        = active_course_link_to decorative_glyph(:edit) + "Edit User", edit_user_path(@user), class: "button button-edit"
         - if @user.is_staff?(current_course)
           %li= link_to decorative_glyph(:list) + "Show Staff Member", staff_path(@user), class: "button button-edit"
         - else

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -150,13 +150,12 @@ describe LinkHelper do
     before(:each) { allow(helper).to receive(:current_course).and_return course }
 
     context "when the current user is not an admin" do
-      let(:tag) {:li}
       let(:tag_class) {'hide-for-small'}
       before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return false }
 
       it "renders the link if the current course is active" do
         course.status = true
-        link = helper.active_course_link_to(tag, tag_class, "Delicious cured ham", "http://prosciutto.com")
+        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com", nil, tag_class)
         expect(link).to have_tag("li", with: {class: "hide-for-small"}) do
           with_tag("a", with: { href: "http://prosciutto.com" })
         end
@@ -170,13 +169,13 @@ describe LinkHelper do
     end
 
     context "when the current user is an admin" do
-      let(:tag) {:li}
-      let(:tag_class) {'some-class'}
       before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return true }
 
       it "renders the link" do
-        link = helper.active_course_link_to(tag, tag_class, "Delicious cured ham", "http://prosciutto.com")
-        expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+        expect(link).to have_tag("li") do
+          with_tag("a", with: { href: "http://prosciutto.com" })
+        end
       end
     end
   end

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -150,12 +150,16 @@ describe LinkHelper do
     before(:each) { allow(helper).to receive(:current_course).and_return course }
 
     context "when the current user is not an admin" do
+      let(:tag) {:li}
+      let(:tag_class) {'hide-for-small'}
       before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return false }
 
       it "renders the link if the current course is active" do
         course.status = true
-        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
-        expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
+        link = helper.active_course_link_to(tag, tag_class, "Delicious cured ham", "http://prosciutto.com")
+        expect(link).to have_tag("li", with: {class: "hide-for-small"}) do
+          with_tag("a", with: { href: "http://prosciutto.com" })
+        end
       end
 
       it "does not render the link if the current course is not active" do
@@ -166,10 +170,12 @@ describe LinkHelper do
     end
 
     context "when the current user is an admin" do
+      let(:tag) {:li}
+      let(:tag_class) {'some-class'}
       before(:each) { allow(helper).to receive(:current_user_is_admin?).and_return true }
 
       it "renders the link" do
-        link = helper.active_course_link_to("Delicious cured ham", "http://prosciutto.com")
+        link = helper.active_course_link_to(tag, tag_class, "Delicious cured ham", "http://prosciutto.com")
         expect(link).to have_tag("a", with: { href: "http://prosciutto.com" })
       end
     end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updates the `active_course_link_to` method  to wrap the link in a `li` tag. This prevents empty list items from showing up in the views and causing unexpected styling or behavior.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Everywhere that `active_course_link_to` was being used and the content was empty. Mostly able to be seen in `button-bar` in inactive courses.

======================
Closes #3167 
