### PR TITLE
Sort unlock condition elements

### DIFF
--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -3,17 +3,17 @@
   .assignment-or-badge
     = f.select :condition_type, [["Assignment Type", "AssignmentType"], "Assignment", "Badge", "Course"], :label => "Type", include_blank: true
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignment_types.ordered.map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
+    = f.input :condition_id, :collection => current_course.assignment_types.ordered.map.sort_by{ |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
     = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => "State Achieved"
     = f.input :condition_value, :label => "Amount"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignments.map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"
+    = f.input :condition_id, :collection => current_course.assignments.map.sort_by  { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"
     = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => "State Achieved"
     = f.input :condition_value, :label => "Min Points"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #badges-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.badges.map { |l| [l.name, l.id] }, :include_blank => true, :label => "#{term_for :badge}"
+    = f.input :condition_id, :collection => current_course.badges.map.sort_by { |l| [l.name, l.id] }, :include_blank => true, :label => "#{term_for :badge}"
     = f.input :condition_state, :collection => ["Earned"], :label => "State Achieved"
     = f.input :condition_value, :label => "Number of Times Earned"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
When I go to set an unlock condition, the elements are in no particular sort order. We should order them by their alphabetically by name.

### Related PRs
N/A


### Todos
- [ ] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, create a new assignment with unlocks, the user should notice that the Requirement elements are in alphabetical order. Regardless whether the user chooses "Assignment Type", "Assignment", "Badge", or "Course", the following field "Assignment Type", "Assignment", "Badge", or "Course" will have corresponding elements in the drop down menu in alphabetical order.

### Impacted Areas in Application
* Assignments

======================
Closes #2865 
