### PR TITLE
move sort assignment types to api

### DIFF
--- a/app/assets/javascripts/assignment_types.js
+++ b/app/assets/javascripts/assignment_types.js
@@ -57,12 +57,12 @@
       $link.closest('fieldset.proposal').hide();
       return false;
     });
-  
+
     // persistence plugin and accordion behaviour
     $(".assignment_type").collapse({
       show: function() {
         // The context of 'this' is applied to
-        // the collapsed details in a jQuery wrapper 
+        // the collapsed details in a jQuery wrapper
         this.slideDown(100);
       },
       hide: function() {
@@ -75,8 +75,8 @@
     $('.assignments').sortable({
       items: 'div.assignment_type',
       update: function(event){
-        $.ajax({          
-          url: '/assignment_types/sort',
+        $.ajax({
+          url: 'api/assignment_types/sort',
           type: 'post',
           data: $('.assignments').sortable('serialize'),
           dataType: 'script',
@@ -88,7 +88,7 @@
     $('.sort-assignments').sortable({
       update: function(event, ui){
         var element = ui.item[0].parentElement;
-        $.ajax({          
+        $.ajax({
           url: '/assignments/sort',
           type: 'post',
           data: $(element).sortable('serialize'),

--- a/app/controllers/api/assignment_types_controller.rb
+++ b/app/controllers/api/assignment_types_controller.rb
@@ -1,4 +1,7 @@
 class API::AssignmentTypesController < ApplicationController
+  include SortsPosition
+
+  before_action :ensure_staff?, only: [:sort]
 
   # GET api/assignment_types
   def index
@@ -20,5 +23,9 @@ class API::AssignmentTypesController < ApplicationController
         :position,
         :updated_at
       )
+  end
+
+  def sort
+    sort_position_for "assignment-type"
   end
 end

--- a/app/controllers/assignment_types_controller.rb
+++ b/app/controllers/assignment_types_controller.rb
@@ -51,10 +51,6 @@ class AssignmentTypesController < ApplicationController
     end
   end
 
-  def sort
-    sort_position_for "assignment-type"
-  end
-
   def export_scores
     course = current_user.courses.find_by(id: params[:course_id])
     respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,6 @@ Rails.application.routes.draw do
     get :all_grades, on: :member
     get :export_scores, on: :member
     get :export_all_scores, on: :collection
-    post :sort, on: :collection
   end
 
   #5. Assignment Type Weights
@@ -341,6 +340,7 @@ Rails.application.routes.draw do
     resources :challenges, only: :index
     resources :assignment_types, only: :index do
       resources :assignment_type_weights, only: :create
+      post :sort, on: :collection
     end
     resources :badges, only: :index
     resources :courses, only: [:index]

--- a/spec/controllers/api/assignment_types_controller_spec.rb
+++ b/spec/controllers/api/assignment_types_controller_spec.rb
@@ -19,6 +19,20 @@ describe API::AssignmentTypesController do
         expect(response).to render_template(:index)
       end
     end
+
+    describe "GET sort" do
+      it "sorts the assignment types by params" do
+        second_assignment_type = create(:assignment_type, course: course)
+        course.assignment_types << second_assignment_type
+        params = [second_assignment_type.id, assignment_type.id]
+        post :sort, params: { "assignment-type" => params }
+
+        assignment_type.reload
+        second_assignment_type.reload
+        expect(assignment_type.position).to eq(2)
+        expect(second_assignment_type.position).to eq(1)
+      end
+    end
   end
 
   context "as a student" do
@@ -33,6 +47,14 @@ describe API::AssignmentTypesController do
         expect(assigns(:assignment_types)).to eq([assignment_type])
         expect(assigns(:update_weights)).to be_truthy
         expect(response).to render_template(:index)
+      end
+    end
+
+    it "redirects protected routes to root" do
+      [
+        -> { post :sort, params: { "assignment-type" => [assignment_type] }, format: :json}
+      ].each do |protected_route|
+        expect(protected_route.call).to redirect_to(:root)
       end
     end
   end

--- a/spec/controllers/assignment_types_controller_spec.rb
+++ b/spec/controllers/assignment_types_controller_spec.rb
@@ -4,7 +4,7 @@ describe AssignmentTypesController do
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let(:assignment_type) { create(:assignment_type, course: course) }
   let(:assignment) { create(:assignment, assignment_type: assignment_type) }
-  
+
   context "as professor" do
     before(:each) do
       login_user(professor)
@@ -62,20 +62,6 @@ describe AssignmentTypesController do
         params = { name: nil }
         post :update, params: { id: assignment_type.id, assignment_type: params }
         expect(response).to render_template(:edit)
-      end
-    end
-
-    describe "GET sort" do
-      it "sorts the assignment types by params" do
-        second_assignment_type = create(:assignment_type, course: course)
-        course.assignment_types << second_assignment_type
-        params = [second_assignment_type.id, assignment_type.id]
-        post :sort, params: { "assignment-type" => params }
-
-        assignment_type.reload
-        second_assignment_type.reload
-        expect(assignment_type.position).to eq(2)
-        expect(second_assignment_type.position).to eq(1)
       end
     end
 

--- a/spec/controllers/assignment_types_controller_spec.rb
+++ b/spec/controllers/assignment_types_controller_spec.rb
@@ -145,7 +145,6 @@ describe AssignmentTypesController do
         :index,
         :new,
         :create,
-        :sort,
         :export_all_scores
 
       ].each do |route|


### PR DESCRIPTION
### Status
**READY**

### Description

This PR moves the assignment sort route into the api namespace.

### Related

Part of the work towards ticket #3087 
