### PR TITLE
move assignment sort route

### DIFF
--- a/app/assets/javascripts/assignment_types.js
+++ b/app/assets/javascripts/assignment_types.js
@@ -89,7 +89,7 @@
       update: function(event, ui){
         var element = ui.item[0].parentElement;
         $.ajax({
-          url: '/assignments/sort',
+          url: 'api/assignments/sort',
           type: 'post',
           data: $(element).sortable('serialize'),
           dataType: 'script',

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -1,5 +1,7 @@
 class API::AssignmentsController < ApplicationController
-  before_action :ensure_staff?, only: [:show, :update]
+  include SortsPosition
+
+  before_action :ensure_staff?, only: [:show, :update, :sort]
 
   # GET api/assignments
   def index
@@ -33,6 +35,10 @@ class API::AssignmentsController < ApplicationController
         message: "failed to save assignment", success: false
         }, status: 400
     end
+  end
+
+  def sort
+    sort_position_for :assignment
   end
 
   # optional student for graph point:

--- a/app/controllers/assignment_types_controller.rb
+++ b/app/controllers/assignment_types_controller.rb
@@ -1,5 +1,4 @@
 class AssignmentTypesController < ApplicationController
-  include SortsPosition
 
   before_action :ensure_staff?
   before_action :find_assignment_type,

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -3,7 +3,6 @@ require "canvas"
 
 class AssignmentsController < ApplicationController
   include AssignmentsHelper
-  include SortsPosition
 
   before_action :ensure_staff?, except: [:show, :index]
   before_action :sanitize_params, only: [:create, :update]
@@ -102,10 +101,6 @@ class AssignmentsController < ApplicationController
       end
       format.json { render json: { errors: assignment.errors }, status: 400 }
     end
-  end
-
-  def sort
-    sort_position_for :assignment
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,6 @@ Rails.application.routes.draw do
 
   resources :assignments do
     collection do
-      post :sort
       get :feed
       get :settings
       post "copy" => "assignments#copy"
@@ -312,6 +311,7 @@ Rails.application.routes.draw do
 
     resources :assignments, only: [:index, :show, :update] do
       get "analytics"
+      post :sort, on: :collection
       resources :criteria, only: :index
       resources :students, only: [] do
         resources :criteria, only: [] do

--- a/spec/controllers/api/assignments_controller_spec.rb
+++ b/spec/controllers/api/assignments_controller_spec.rb
@@ -43,6 +43,18 @@ describe API::AssignmentsController do
         expect(assignment.visible).to be_falsey
       end
     end
+
+    describe "POST sort" do
+      it "sorts the assignments by params" do
+        second_assignment = create(:assignment, assignment_type: assignment.assignment_type)
+        course.assignments << second_assignment
+
+        post :sort, params: { assignment: [second_assignment.id, assignment.id] }
+
+        expect(assignment.reload.position).to eq(2)
+        expect(second_assignment.reload.position).to eq(1)
+      end
+    end
   end
 
   context "as student" do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -120,18 +120,6 @@ describe AssignmentsController do
       end
     end
 
-    describe "POST sort" do
-      it "sorts the assignments by params" do
-        second_assignment = create(:assignment, assignment_type: assignment_type)
-        course.assignments << second_assignment
-
-        post :sort, params: { assignment: [second_assignment.id, assignment.id] }
-
-        expect(assignment.reload.position).to eq(2)
-        expect(second_assignment.reload.position).to eq(1)
-      end
-    end
-
     describe "GET export_structure" do
       it "retrieves the export_structure download" do
         get :export_structure, params: { id: course.id }, format: :csv
@@ -177,9 +165,7 @@ describe AssignmentsController do
       [
         :new,
         :copy,
-        :create,
-        :sort
-
+        :create
       ].each do |route|
         it "#{route} redirects to root" do
           expect(get route).to redirect_to(:root)
@@ -221,7 +207,6 @@ describe AssignmentsController do
       routes = [
         { action: :new, request_method: :get },
         { action: :create, request_method: :post },
-        { action: :sort, request_method: :post },
         { action: :settings, request_method: :get }
       ]
       routes.each do |route|


### PR DESCRIPTION
### Status
**READY**

### Description

This PR moves the assignment sort route into the api namespace.

`api/assignments/sort`

### Related

Part of the work towards ticket #3087 

Follows #3181 (api assignment_types sort)
