### PR TITLE
Bug fix for sort ordering

### DIFF
--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -3,17 +3,17 @@
   .assignment-or-badge
     = f.select :condition_type, [["Assignment Type", "AssignmentType"], "Assignment", "Badge", "Course"], :label => "Type", include_blank: true
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignment_types.ordered.map.sort_by{ |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
+    = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
     = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => "State Achieved"
     = f.input :condition_value, :label => "Amount"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignments.map.sort_by  { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"
+    = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"
     = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => "State Achieved"
     = f.input :condition_value, :label => "Min Points"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #badges-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.badges.map.sort_by { |l| [l.name, l.id] }, :include_blank => true, :label => "#{term_for :badge}"
+    = f.input :condition_id, :collection => current_course.badges.order(:name).map { |l| [l.name, l.id] }, :include_blank => true, :label => "#{term_for :badge}"
     = f.input :condition_state, :collection => ["Earned"], :label => "State Achieved"
     = f.input :condition_value, :label => "Number of Times Earned"
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Bug fix for sort ordering on Unlock fields on Assignment Page

### Related PRs

branch | PR
------ | ------
Sort unlock condition elements | [link](https://github.com/UM-USElab/gradecraft-development/pull/3177)

### Todos
N/A


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
In current or new assignment page, scroll down to unlocks. Select a Requirement and the corresponding input field collections will be in a sorted order.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment

======================
Closes #[ISSUE NUMBER]
