### PR TITLE
Fix a bug where deleting a staff membership would delete the user rather than the course membership

### DIFF
--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -32,7 +32,7 @@
               %ul.options-menu
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
                 = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                = active_course_link_to decorative_glyph(:trash) + "Delete",  user, data: { confirm: "Are you sure?"}, :method => :delete
+                = active_course_link_to decorative_glyph(:trash) + "Delete",  user.course_memberships.where(course: current_course).first, data: { confirm: "Are you sure?"}, :method => :delete
                 - if !user.activated?
                   = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
                   = active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where deleting the staff member would delete the User not the CourseMembership for this particular course. This then resulted in an error for various associations. 

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the staff page. Confirm that deleting the staff member produces a successful alert describing their removal from the course site.  

### Impacted Areas in Application
List general components of the application that this PR will affect:

* User management (staff page)

======================
Closes #3194 
