### PR TITLE
Reroute Delete Staff Member to Staff Page

### DIFF
--- a/app/controllers/course_memberships_controller.rb
+++ b/app/controllers/course_memberships_controller.rb
@@ -3,6 +3,7 @@ require_relative "../services/cancels_course_membership"
 class CourseMembershipsController < ApplicationController
 
   before_action :ensure_staff?
+  before_action :save_referer, only: [:destroy]
 
   def create
     @course_membership =
@@ -16,8 +17,7 @@ class CourseMembershipsController < ApplicationController
   def destroy
     course_membership = current_course.course_memberships.find(params[:id])
     Services::CancelsCourseMembership.for_student course_membership
-
-    redirect_to students_path,
+    redirect_to session[:return_to],
       notice: "#{course_membership.user.name} was successfully removed from course."
   end
 

--- a/app/controllers/staff_controller.rb
+++ b/app/controllers/staff_controller.rb
@@ -13,7 +13,7 @@ class StaffController < ApplicationController
 
   def show
     @staff_member = current_course.users.find(params[:id])
-    @grades = current_course.grades.where(graded_by: @staff)
+    @grades = current_course.grades.where(graded_by: @staff_member)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   before_action :ensure_staff?,
     except: [:activate, :activated, :edit_profile, :update_profile]
-  before_action :save_referer, only: [:manually_activate, :resend_invite_email]
+  before_action :save_referer, only: [:manually_activate, :resend_invite_email, :destroy]
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]
 
@@ -83,7 +83,7 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       format.html do
-        redirect_to users_url,
+        redirect_to session[:return_to] || users_url,
         notice: "#{@name} was successfully deleted"
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   before_action :ensure_staff?,
     except: [:activate, :activated, :edit_profile, :update_profile]
-  before_action :save_referer, only: [:manually_activate, :resend_invite_email, :destroy]
+  before_action :save_referer, only: [:manually_activate, :resend_invite_email]
   skip_before_action :require_login, only: [:activate, :activated]
   skip_before_action :require_course_membership, only: [:activate, :activated]
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -83,7 +83,7 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       format.html do
-        redirect_to session[:return_to] || users_url,
+        redirect_to users_url,
         notice: "#{@name} was successfully deleted"
       end
     end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor, if I have deleted a staff member from my list, I expect to stay on the Staff Index page.

### Related PRs
N/A


### Todos


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an Admin, navigate to the staff page and delete a staff member using the options cog. Deleting said staff member should remove the staff member from the staff roster as well as navigate the user back to the staff page.

### Impacted Areas in Application
* Staff page

======================
Closes #2806 
