### PR TITLE
Fix submission time

### DIFF
--- a/app/views/announcements/_announcements_dropdown.haml
+++ b/app/views/announcements/_announcements_dropdown.haml
@@ -1,5 +1,7 @@
 %ul.announcements-list.nav-dropdown-card
-  - current_course.announcements.first(3).each do |announcement|
+  - @announcements = Announcement.where(course_id: current_course.id,
+                                        recipient_id: [nil, current_user.id])
+  - @announcements.first(3).each do |announcement|
     %li.announcement-item{class: ("announcement-unread" if !announcement.read?(current_user))}
       = link_to announcement.title, announcement_path(announcement)
       %p.announcement-date= announcement.created_at.strftime("%A, %B %d, %Y, at %l:%M%p")

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -1,5 +1,5 @@
 - presenter.students.each do |student|
-  - student_submission = presenter.submission_for_assignment(student)
+  - student_submission = student.submission_for_assignment(presenter.assignment)
   - grade = presenter.grade_for_student(student)
   %tr
     - if presenter.assignment.is_unlockable?


### PR DESCRIPTION
### Status
**READY**

### Description
This PR is a hotfix for two high priority bugs - the first is that students are able to see earned badge announcement previews for other students in their site currently. The second is that instructors can only see the data for one submission on an assignment page.

### Migrations
NO

### Steps to Test or Reproduce
Award badges to multiple students in a course. Log in as a student, and confirm that if you click the announcements bell at the top of the page you only see preview announcements for your badge awards. 

As an instructor, load up an assignment that accepts submissions but hasn't got any. Submit an this assignment as a student. Confirm that on the instructor side, you don't see submissions for ALL students in the list, usually starting with the one who submitted and going all the way down the list. Instead, you should only see a submission for the student who submitted. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Announcements
* Assignment submissions
