### PR TITLE
Fix Edit User With Blank Password Bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -59,7 +59,12 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params[:id])
-    @user.assign_attributes user_params
+    up = user_params
+    if up[:password].blank? && up[:password_confirmation].blank?
+      up.delete(:password)
+      up.delete(:password_confirmation)
+    end
+    @user.assign_attributes up
     cancel_course_memberships @user
     if @user.save
       if @user.is_student?(current_course)

--- a/spec/features/editing_a_badge_spec.rb
+++ b/spec/features/editing_a_badge_spec.rb
@@ -7,26 +7,10 @@ feature "editing a badge" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_badge_path(badge.id)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Badges"
-      end
-
-      expect(current_path).to eq badges_path
-
-      within(".pageContent") do
-        click_link "Fancy Badge"
-      end
-
-      expect(current_path).to eq badge_path(badge.id)
-
-      within(".context_menu") do
-        click_link "Edit"
-      end
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Badge Name"
         click_button "Update Badge"

--- a/spec/features/editing_a_challenge_spec.rb
+++ b/spec/features/editing_a_challenge_spec.rb
@@ -7,26 +7,10 @@ feature "editing a challenge" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_challenge_path(challenge)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Section Challenges"
-      end
-
-      expect(current_path).to eq challenges_path
-
-      within(".pageContent") do
-        click_link "Section Challenge Name"
-      end
-
-      expect(current_path).to eq challenge_path(challenge.id)
-
-      within(".context_menu") do
-        click_link "Edit"
-      end
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Section Challenge Name"
         click_button "Update Section Challenge"

--- a/spec/features/editing_a_team_challenge_grade_spec.rb
+++ b/spec/features/editing_a_team_challenge_grade_spec.rb
@@ -9,33 +9,15 @@ feature "editing a team challenge grade" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_challenge_grade_path(challenge_grade)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Section Challenges"
-      end
-
-      expect(current_path).to eq challenges_path
-
-      within(".pageContent") do
-        click_link "Section Challenge Name"
-      end
-
-      expect(current_path).to eq challenge_path(challenge.id)
-
-      within(".pageContent") do
-        click_link "Edit Grade"
-      end
-
-      expect(current_path).to eq edit_challenge_grade_path(challenge_grade)
-
       within(".pageContent") do
         fill_in("challenge_grade_raw_points", with: 101)
         click_button "Update Grade"
       end
-      
+
       expect(current_path).to eq challenge_path(challenge.id)
       expect(page).to have_notification_message("notice", "Section Name's Grade for Section Challenge Name Section Challenge successfully updated")
     end

--- a/spec/features/editing_a_team_spec.rb
+++ b/spec/features/editing_a_team_spec.rb
@@ -7,33 +7,17 @@ feature "editing a team" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_team_path(team.id)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Sections"
-      end
-
-      expect(current_path).to eq teams_path
-
-      within(".pageContent") do
-        click_link "Section Name"
-      end
-
-      expect(current_path).to eq team_path(team.id)
-
-      within(".context_menu") do
-        click_link "Edit"
-      end
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Section Name"
         click_button "Update Section"
       end
-      
+
       expect(current_path).to eq team_path(team)
-      
+
       expect(page).to have_content("Edited Section Name")
     end
   end

--- a/spec/features/editing_a_user_spec.rb
+++ b/spec/features/editing_a_user_spec.rb
@@ -9,17 +9,25 @@ feature "editing a user" do
       visit edit_user_path(student.id)
     end
 
-    context "updating a password for a GradeCraft student" do
-      scenario "successfully" do
-        expect(current_path).to eq edit_user_path(student)
+    context "updating a GradeCraft student" do
+      scenario "setting a new password successfully" do
         fill_in "Password", with: "crookshanks"
         fill_in "Password confirmation", with: "crookshanks"
 
-        #click_button "Update User"
         find('input[name="commit"]').click
 
         expect(current_path).to eq students_path
         expect(page).to have_notification_message "notice", "#{course.student_term} #{student.name} was successfully updated!"
+      end
+
+      scenario "updating a name but not a password" do
+        visit edit_user_path(student.id)
+        fill_in "First name", with: "The Amazing Hermione"
+
+        find('input[name="commit"]').click
+
+        expect(current_path).to eq students_path
+        expect(page).to have_notification_message "notice", "#{course.student_term} The Amazing Hermione Granger was successfully updated!"
       end
     end
   end

--- a/spec/features/editing_a_user_spec.rb
+++ b/spec/features/editing_a_user_spec.rb
@@ -1,0 +1,25 @@
+feature "editing a user", focus: true do
+  context "as an administrator" do
+    let(:course) { build :course }
+    let(:admin) { build :user, role: :admin, courses: [course] }
+    let(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
+
+    before(:each) do
+      login_as admin
+      visit edit_user_path(student)
+    end
+
+    context "for an existing GradeCraft student" do
+      scenario "successfully" do
+        # fill_in 'Password', with: "crookshanks"
+        # fill_in "Password Confirmation", with: "crookshanks"
+        fill_in "First Name", with: "H2"
+
+        click_button "Update User"
+
+        expect(current_path).to eq students_path
+        expect(page).to have_notification_message "notice", "#{course_membership.course.student_term} #{user.name} was successfully updated!"
+      end
+    end
+  end
+end

--- a/spec/features/editing_a_user_spec.rb
+++ b/spec/features/editing_a_user_spec.rb
@@ -1,24 +1,25 @@
-feature "editing a user", focus: true do
+feature "editing a user" do
   context "as an administrator" do
     let(:course) { build :course }
-    let(:admin) { build :user, role: :admin, courses: [course] }
-    let(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
+    let(:admin) { create :user, role: :admin, courses: [course] }
+    let(:student) { create :user, first_name: "Hermione", last_name: "Granger", courses: [course], kerberos_uid: nil, role: :student }
 
     before(:each) do
       login_as admin
-      visit edit_user_path(student)
+      visit edit_user_path(student.id)
     end
 
-    context "for an existing GradeCraft student" do
+    context "updating a password for a GradeCraft student" do
       scenario "successfully" do
-        # fill_in 'Password', with: "crookshanks"
-        # fill_in "Password Confirmation", with: "crookshanks"
-        fill_in "First Name", with: "H2"
+        expect(current_path).to eq edit_user_path(student)
+        fill_in "Password", with: "crookshanks"
+        fill_in "Password confirmation", with: "crookshanks"
 
-        click_button "Update User"
+        #click_button "Update User"
+        find('input[name="commit"]').click
 
         expect(current_path).to eq students_path
-        expect(page).to have_notification_message "notice", "#{course_membership.course.student_term} #{user.name} was successfully updated!"
+        expect(page).to have_notification_message "notice", "#{course.student_term} #{student.name} was successfully updated!"
       end
     end
   end

--- a/spec/features/editing_an_assignment_spec.rb
+++ b/spec/features/editing_an_assignment_spec.rb
@@ -1,4 +1,4 @@
-feature "editing an assignment", focus: true do
+feature "editing an assignment" do
   context "as a professor" do
     let(:course) { build :course, assignment_term: "Assignment"}
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }

--- a/spec/features/editing_an_assignment_spec.rb
+++ b/spec/features/editing_an_assignment_spec.rb
@@ -1,34 +1,16 @@
-feature "editing an assignment" do
+feature "editing an assignment", focus: true do
   context "as a professor" do
     let(:course) { build :course, assignment_term: "Assignment"}
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
-    let!(:assignment_type) { create :assignment_type, name: "Assignment Type Name", course: course }
-    let!(:assignment) { create :assignment, name: "Assignment Name", course: course, assignment_type: assignment_type }
+    let!(:assignment) { create :assignment, name: "Assignment Name", course: course }
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_assignment_path(assignment)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Assignments"
-      end
-
-      expect(current_path).to eq assignments_path
-
-      within(".pageContent") do
-        find(".assignment-type-name").click
-        click_link "Assignment Name"
-      end
-
-      expect(current_path).to eq assignment_path(assignment.id)
-
-      within(".context_menu") do
-        click_link "Edit"
-      end
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Assignment Name"
         click_button "Update Assignment"

--- a/spec/features/editing_an_assignment_type_spec.rb
+++ b/spec/features/editing_an_assignment_type_spec.rb
@@ -1,4 +1,4 @@
-feature "editing an assignment type" do
+feature "editing an assignment type", focus: true do
   context "as a professor" do
     let(:course) { build :course, assignment_term: "Assignment"}
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
@@ -7,16 +7,10 @@ feature "editing an assignment type" do
 
     before(:each) do
       login_as professor
-      visit assignments_path
+      visit edit_assignment_type_path(assignment_type)
     end
 
     scenario "successfully" do
-      within(".assignments") do
-        click_link "[ Edit ]"
-      end
-
-      expect(current_path).to eq edit_assignment_type_path(assignment_type)
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Assignment Type Name"
         click_button "Update Assignment type"

--- a/spec/features/editing_an_assignment_type_spec.rb
+++ b/spec/features/editing_an_assignment_type_spec.rb
@@ -1,4 +1,4 @@
-feature "editing an assignment type", focus: true do
+feature "editing an assignment type" do
   context "as a professor" do
     let(:course) { build :course, assignment_term: "Assignment"}
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }

--- a/spec/features/editing_an_awarded_badge_spec.rb
+++ b/spec/features/editing_an_awarded_badge_spec.rb
@@ -8,31 +8,13 @@ feature "editing an awarded a badge" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
     end
 
     context "with an active course" do
       let(:course) { build :course, has_badges: true, status: true }
 
       scenario "is successful" do
-        within(".sidebar-container") do
-          click_link "Badges"
-        end
-
-        expect(current_path).to eq badges_path
-
-        within(".pageContent") do
-          first(:link, "Fancy Badge").click
-        end
-
-        expect(current_path).to eq badge_path(badge.id)
-
-        within(".pageContent") do
-          click_link "Edit"
-        end
-
-        expect(current_path).to eq \
-          edit_badge_earned_badge_path(badge, earned_badge)
+        visit edit_badge_earned_badge_path(badge, earned_badge)
 
         within(".pageContent") do
           click_button "Update Badge"
@@ -51,17 +33,7 @@ feature "editing an awarded a badge" do
       let(:course) { build :course, has_badges: true, status: false }
 
       scenario "is unsuccessful" do
-        within(".sidebar-container") do
-          click_link "Badges"
-        end
-
-        expect(current_path).to eq badges_path
-
-        within(".pageContent") do
-          first(:link, "Fancy Badge").click
-        end
-
-        expect(current_path).to eq badge_path(badge.id)
+        visit badge_path(badge)
 
         within(".pageContent") do
           expect(page).to_not have_selector(:link_or_button, "Edit")

--- a/spec/features/editing_an_event_spec.rb
+++ b/spec/features/editing_an_event_spec.rb
@@ -7,28 +7,10 @@ feature "editing an event" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_event_path(event.id)
     end
 
     scenario "successfully" do
-      within(".sidebar-container") do
-        click_link "Calendar Events"
-      end
-
-      expect(current_path).to eq events_path
-
-      within(".pageContent") do
-        click_link "Event Name"
-      end
-
-      expect(current_path).to eq event_path(event.id)
-
-      within(".context_menu") do
-        click_link "Edit"
-      end
-
-      expect(current_path).to eq edit_event_path(event.id)
-
       within(".pageContent") do
         fill_in "Name", with: "Edited Event Name"
         click_button "Update Event"

--- a/spec/features/editing_course_options_spec.rb
+++ b/spec/features/editing_course_options_spec.rb
@@ -6,14 +6,10 @@ feature "editing a course's basic settings" do
 
     before(:each) do
       login_as professor
-      visit dashboard_path
+      visit edit_course_path(course.id)
     end
 
     scenario "successfully" do
-      within(".sidebar-container .staff-sidenav") do
-        click_link "Course Settings"
-      end
-
       within(".pageContent") do
         fill_in "Course Title", with: "New Course Name"
         click_button "Save Settings"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
After creating a brand new user, operator should be allowed to edit the user without password confirmation, that is, user does not receive the "Password Confirmation can't be blank" error message when password fields are left blank.

### Related PRs
N/A


### Todos
- [ ] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the staff page. Create a new user. Edit this user by making the user an instructor/student/etc... for the current course while leaving the password and password confirmation fields blank. Should receive message that the user was successfully updated.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Users

======================
Closes #3201 
