### PR TITLE
refactor assignment presenter submission viewable method

### DIFF
--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -77,16 +77,11 @@ class Assignments::Presenter < Showtime::Presenter
     grades.instructor_modified.present?
   end
 
-  def has_viewable_submission?(user)
-    submission = submission_for_assignment(user)
+  def has_viewable_submission?(student, user)
+    submission = student.submission_for_assignment(assignment)
     assignment.accepts_submissions? &&
       submission.present? &&
       SubmissionProctor.new(submission).viewable?(user)
-  end
-
-  def has_viewable_submission_for?(user)
-    submission = submission_for_assignment(user)
-    has_viewable_submission?(user)
   end
 
   def has_viewable_analytics?(user)

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -15,7 +15,7 @@
 %p.assignment-description.italic= "Opens: #{presenter.assignment.open_at}" if presenter.assignment.open_at?
 %p.assignment-description.italic= "Due: #{presenter.assignment.due_at}" if presenter.assignment.due_at?
 
-- if presenter.assignment_accepting_submissions?(current_student) && !presenter.has_viewable_submission_for?(current_student)
+- if presenter.assignment_accepting_submissions?(current_student) && !presenter.has_viewable_submission?(current_student, current_user)
   = render partial: "students/submissions", locals: { assignment: presenter.assignment }
 
 - if presenter.student_logged?(current_user)

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -4,7 +4,7 @@
   // Note that things added here also need to be added to the grade/show view for instructors
   #tabs.ui-tabs.ui-widget
     %ul.ui-tabs-nav{role: "tablist"}
-      - if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)
+      - if presenter.has_viewable_submission?(current_student, current_user) || presenter.grades_available_for?(current_student)
         %li
           %a{"href" => "#tab"} My Submission
       - if presenter.has_viewable_analytics?(current_student) && presenter.grades_available_for?(current_student)
@@ -18,15 +18,15 @@
 
 
     #tabt1.ui-tabs-panel
-      - if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)
-        .ui-tabs-panel#tab{class: ("active" if presenter.has_viewable_submission_for?(current_student) || presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
+      - if presenter.has_viewable_submission?(current_student, current_user) || presenter.grades_available_for?(current_student)
+        .ui-tabs-panel#tab{class: ("active" if presenter.has_viewable_submission?(current_student, current_user) || presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
           - if presenter.grades_available_for?(current_student)
             %section.assignment-details-container
               %h2 My Grade
               = render partial: "grades/grade_content", locals: { grade: presenter.grade_for_student(current_student) }
               %hr.dotted
 
-          - if presenter.has_viewable_submission_for?(current_student)
+          - if presenter.has_viewable_submission?(current_student, current_user)
             %section.assignment-details-container
               %h2 My Submission
               = render partial: "submissions/submission_content",
@@ -40,7 +40,7 @@
               %h2 Class Analytics
               = render partial: "grades/analytics", locals: { presenter: presenter }
 
-      .ui-tabs-panel#tab3{class: ("active" if !presenter.has_viewable_submission_for?(current_student) && !presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
+      .ui-tabs-panel#tab3{class: ("active" if !presenter.has_viewable_submission?(current_student, current_user) && !presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
         %section.assignment-details-container
           %h2 Description
           = render partial: "assignments/description", locals: { presenter: presenter }

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -52,7 +52,7 @@
       .right
         %ul.button-bar
           - if presenter.assignment.accepts_submissions?
-            - if presenter.has_viewable_submission?(current_user)
+            - if presenter.has_viewable_submission?(student, current_user)
               /* Submission present - allow instructor to see it, and identify if it's a new submission or a resubmission. Icon represents if there are files attached. */
               %li= link_to decorative_glyph(:paperclip) + "See Submission", assignment_submission_path(presenter.assignment, student_submission.id), class: "button"
 
@@ -67,7 +67,7 @@
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               = active_course_link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
             - team_param = presenter.for_team? ? {team_id: presenter.team.id} : nil
-            = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(current_user) ? "danger" : ""}"
+            = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(presenter.assignment, student, team_param), method: :post, class: "button #{presenter.has_viewable_submission?(student, current_user) ? "danger" : ""}"
 
     - if presenter.assignment.release_necessary?
       %td

--- a/app/views/grades/show.html.haml
+++ b/app/views/grades/show.html.haml
@@ -12,7 +12,7 @@
       = render partial: "grades/analytics", locals: { presenter: presenter, current_student: @grade.student }
       %hr.dotted
 
-    - if presenter.has_viewable_submission_for?(@grade.student)
+    - if presenter.has_viewable_submission?(@grade.student, current_user)
       %section
         %h2 The Submission
         = render partial: "submissions/submission_content",
@@ -30,4 +30,3 @@
       %section
         %h2 Grading Rubric
         = render partial: "rubrics/components/rubric_table", locals: { rubric: presenter.rubric, presenter: presenter, student: @grade.student, include_grade_info: false }
-


### PR DESCRIPTION
### Status
**READY**

### Description
This PR refactors a method on the assignments presenter that makes sense of whether or not the submission is viewable to the current user.

### Todos
- [x] Add Tests

### Migrations
NO

### Steps to Test or Reproduce
Submit an assignment as a student - confirm that you and the instructor can both see it. Save another submission as a draft. Confirm that the student can see it but not the instructor. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment show pages, submission pages. 