### PR TITLE
move predictor graph pins over 3 px

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -75,7 +75,8 @@
         g.append("path")
           .attr("d", "M3,2.492c0,1.392-1.5,4.48-1.5,4.48S0,3.884,0,2.492c0-1.392,0.671-2.52,1.5-2.52S3,1.101,3,2.492z")
           .attr("class",(gse)-> "grade_scheme-pointer-" + gse.lowest_points)
-          .attr("transform","scale(2)")
+          # move the pins over so the point is on the right value
+          .attr("transform","scale(2) translate(-1.5,0)")
         txt = d3.select("#svg-grade-level-text").selectAll('g').data(PredictorService.gradeSchemeElements).enter()
                 .append('g')
                 .attr("class", (gse)->


### PR DESCRIPTION
The pins on the predictor are positions by their top-left corner, which causes the pointer end to be off by 3 px. This PR translates the graphic to the left by 3px to compensate.


<img width="75" alt="screen shot 2017-04-13 at 1 22 50 pm" src="https://cloud.githubusercontent.com/assets/1138350/25016545/7a149bd8-204e-11e7-88c9-59ccd844be99.png">

After Correction:

<img width="97" alt="screen shot 2017-04-13 at 1 32 31 pm" src="https://cloud.githubusercontent.com/assets/1138350/25016538/6ca75cd8-204e-11e7-8b46-06b7ef618194.png">


closes  #3209