### PR TITLE
Patch for rendering Html without ngSanitize

### DIFF
--- a/app/assets/javascripts/angular/directives/user/search/results.coffee
+++ b/app/assets/javascripts/angular/directives/user/search/results.coffee
@@ -1,5 +1,5 @@
 # Renders the search results from the user search form
-@gradecraft.directive 'userSearchResults', ['UserSearchService', (UserSearchService) ->
+@gradecraft.directive 'userSearchResults', ['UserSearchService', '$sce', (UserSearchService, $sce) ->
   {
     restrict: 'EA'
     templateUrl: 'user/search/results.html'
@@ -8,11 +8,11 @@
 
       # Creates link to allow changing of current course
       scope.course_name_with_link = (user) ->
-        _.map(user.course_memberships, (cm) ->
+        $sce.trustAsHtml(_.map(user.course_memberships, (cm) ->
           "<a href='/courses/#{cm.course_id}/change'>#{cm.course_name}</a>"
-        ).join("<br>")
+        ).join("<br>"))
 
       scope.course_membership_attribute_for = (user, attribute) ->
-        _.pluck(user.course_memberships, attribute).join('<br>')
+        $sce.trustAsHtml(_.pluck(user.course_memberships, attribute).join('<br>'))
   }
 ]


### PR DESCRIPTION
### Status
READY

### Description
With the removal of `ngSanitize`, the course memberships, role, and score no longer appear in the results displayed from the user search page.

As a quick fix, the rendered Html has been explicitly marked as trusted using the `$sce` (Strict Contextual Escaping) module.

**Note:** In removing `ngSanitize` for the entire scope of the 'gradecraft' Angular module, it is possible that there are other locations where we are rendering Html that will have issues as well. At a glance, it seems possible to address the issues in #3195 by leaving in the `ngSanitize` module for the rest of our Angular work and removing it only out of Froala.

### Related PRs
#3195 

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Ensure that results are as expected when searching for a user

### Impacted Areas in Application
Search Users

======================
Closes #3212 
