### PR TITLE
3087 api sort badge

### DIFF
--- a/app/assets/javascripts/earned_badges.js
+++ b/app/assets/javascripts/earned_badges.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
   	},
 	update: function (){
 	  $.ajax({
-        url: '/badges/sort',
+        url: 'api/badges/sort',
 	    type: 'post',
 	    data: $('.sort-badges').sortable('serialize'),
 	    dataType: 'script',

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -1,4 +1,7 @@
 class API::BadgesController < ApplicationController
+  include SortsPosition
+
+  before_action :ensure_staff?, only: [:sort]
 
   # GET api/badges
   def index
@@ -24,5 +27,9 @@ class API::BadgesController < ApplicationController
           PredictedEarnedBadge.for_course(current_course).for_student(current_student)
       end
     end
+  end
+
+  def sort
+    sort_position_for :badge
   end
 end

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,5 +1,4 @@
 class BadgesController < ApplicationController
-  include SortsPosition
 
   before_action :ensure_not_observer?, except: [:index, :show]
   before_action :ensure_staff?, except: [:index, :show]
@@ -50,10 +49,6 @@ class BadgesController < ApplicationController
     else
       render action: "edit"
     end
-  end
-
-  def sort
-    sort_position_for :badge
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,7 +158,6 @@ Rails.application.routes.draw do
 
   #6. Badges
   resources :badges do
-    post :sort, on: :collection
     get "export_structure", on: :collection
     resources :earned_badges do
       get :mass_edit, on: :collection
@@ -337,26 +336,32 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :challenges, only: :index
     resources :assignment_types, only: :index do
       resources :assignment_type_weights, only: :create
       post :sort, on: :collection
     end
-    resources :badges, only: :index
+
+    resources :badges, only: :index do
+      post :sort, on: :collection
+    end
+
+    resources :challenges, only: :index
     resources :courses, only: [:index]
 
     get "timeline_events", to: "courses#timeline_events"
-
     put "course_memberships/confirm_onboarding", to: "course_memberships#confirm_onboarding"
+
     resources :earned_badges, only: [:create, :destroy]
     get "courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned", to: "earned_badges#confirm_earned",
       as: :earned_badge_confirm
+
     resources :grades, only: :update do
       resources :earned_badges, only: :create, module: :grades do
         delete :delete_all, on: :collection
       end
       resources :attachments, only: [:create, :destroy], module: :grades
     end
+
     resources :grade_scheme_elements, only: :index do
       delete :destroy, on: :collection
     end

--- a/spec/controllers/api/badges_controller_spec.rb
+++ b/spec/controllers/api/badges_controller_spec.rb
@@ -25,6 +25,18 @@ describe API::BadgesController do
         expect(assigns(:allow_updates)).to be_falsey
       end
     end
+
+    describe "GET sort" do
+      it "sorts the badges by params" do
+        second_badge = create(:badge)
+        course.badges << second_badge
+        params = [second_badge.id, badge.id]
+        post :sort, params: { badge: params }
+
+        expect(badge.reload.position).to eq(2)
+        expect(second_badge.reload.position).to eq(1)
+      end
+    end
   end
 
   context "as student" do
@@ -66,6 +78,14 @@ describe API::BadgesController do
         prediction = create(:predicted_earned_badge, badge: badge, student: student)
         get :index, params: { id: student.id }, format: :json
         expect(assigns(:predicted_earned_badges)[0]).to eq(prediction)
+      end
+    end
+
+    it "redirects protected routes to root" do
+      [
+        -> { post :sort, params: { "badge" => [badge] }, format: :json}
+      ].each do |protected_route|
+        expect(protected_route.call).to redirect_to(:root)
       end
     end
   end

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -135,8 +135,7 @@ describe BadgesController do
     describe "protected routes not requiring id in params" do
       routes = [
         { action: :new, request_method: :get },
-        { action: :create, request_method: :post },
-        { action: :sort, request_method: :post }
+        { action: :create, request_method: :post }
       ]
       routes.each do |route|
         it "#{route[:request_method]} :#{route[:action]} redirects to assignments index" do

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -81,18 +81,6 @@ describe BadgesController do
       end
     end
 
-    describe "GET sort" do
-      it "sorts the badges by params" do
-        second_badge = create(:badge)
-        course.badges << second_badge
-        params = [second_badge.id, badge.id]
-        post :sort, params: { badge: params }
-
-        expect(badge.reload.position).to eq(2)
-        expect(second_badge.reload.position).to eq(1)
-      end
-    end
-
     describe "GET destroy" do
       it "destroys the badge" do
         another_badge = create :badge, course: course
@@ -114,8 +102,7 @@ describe BadgesController do
     describe "protected routes" do
       [
         :new,
-        :create,
-        :sort
+        :create
       ].each do |route|
           it "#{route} redirects to root" do
             expect(get route).to redirect_to(:root)


### PR DESCRIPTION
### Status
**READY**

### Description
Moves the badges sort route to the api namespace

### Related PRs

see #3087  

### Migrations
NO

### Steps to Test or Reproduce

Verify sorting badges on the badges index page still persists.
