### PR TITLE
Duplicate gradecraft events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,12 @@ class EventsController < ApplicationController
     @event = current_course.events.find(params[:id])
   end
 
+  def copy
+    event = current_course.events.find(params[:id])
+    duplicated = event.copy
+    redirect_to events_path, notice: "Event #{duplicated.name} was successfully created"
+  end
+
   def create
     @event = current_course.events.new(event_params)
     if @event.save

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,6 +10,8 @@ class Event < ActiveRecord::Base
   validates_presence_of :name
 
   def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes)
+    ModelCopier.new(self).copy(attributes: attributes,
+                               options: { prepend: { name: "Copy of "}}
+    )
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
+  include Copyable
   include UploadsMedia
 
   belongs_to :course
@@ -7,4 +8,8 @@ class Event < ActiveRecord::Base
 
   # Check to make sure the event has a name before saving
   validates_presence_of :name
+
+  def copy(attributes={})
+    ModelCopier.new(self).copy(attributes: attributes)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,6 @@ class Event < ActiveRecord::Base
   def copy(attributes={})
     ModelCopier.new(self).copy(attributes: attributes,
                                options: { prepend: { name: "Copy of "}}
-    )
+                              )
   end
 end

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,7 +6,7 @@
 
         %li= link_to decorative_glyph(:edit) + "Edit", edit_event_path(@event), class: "button button-edit"
 
-        %li= link_to decorative_glyph(:copy) + "Duplicate Event ", copy_events_path(id: @event.id), class: "button button-edit", method: :post
+        %li= link_to decorative_glyph(:copy) + "Copy Event ", copy_events_path(id: @event.id), class: "button button-edit", method: :post
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,6 +6,8 @@
 
         %li= link_to decorative_glyph(:edit) + "Edit", edit_event_path(@event), class: "button button-edit"
 
+        %li= link_to decorative_glyph(:copy) + "Duplicate Event ", copy_events_path(id: @event.id), class: "button button-edit", method: :post
+
 .pageContent
   = render partial: "layouts/alerts"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,8 +302,6 @@ Rails.application.routes.draw do
   end
 
   #17. Events
-
-
   resources :events do
     post :copy, on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,7 +302,11 @@ Rails.application.routes.draw do
   end
 
   #17. Events
-  resources :events
+  resources :events do
+    collection do
+      post "copy" => "events#copy"
+    end
+  end
 
   #18. API Calls
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -302,10 +302,10 @@ Rails.application.routes.draw do
   end
 
   #17. Events
+
+
   resources :events do
-    collection do
-      post "copy" => "events#copy"
-    end
+    post :copy, on: :collection
   end
 
   #18. API Calls

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -89,6 +89,16 @@ describe EventsController do
         expect(response).to redirect_to(events_url)
       end
     end
+
+    describe "POST copy" do
+      it "duplicates the requested event" do
+        event
+        post :copy, params: { id: event.id }
+        expect expect(course.events.count).to eq(2)
+      end
+    end
+
+
   end
 
   context "as student" do
@@ -109,7 +119,8 @@ describe EventsController do
       [
         :edit,
         :update,
-        :destroy
+        :destroy,
+        :copy
       ].each do |route|
         it "#{route} redirects to root" do
           expect(get route, params: { id: "1" }).to redirect_to(:root)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -92,9 +92,8 @@ describe EventsController do
 
     describe "POST copy" do
       it "duplicates the requested event" do
-        event
         post :copy, params: { id: event.id }
-        expect expect(course.events.count).to eq(2)
+        expect(course.events.count).to eq(2)
       end
     end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor I expect to be able to duplicate calendar events

### Related PRs
N/A


### Todos
- [x] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the event show page of the event you would like to duplicate. In the top right corner of the page, click the "Duplicate Event" button. View the database to assure that your event has indeed been duplicated.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Events

======================
Closes #3011 
