### PR TITLE
Options menu bug

### DIFF
--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -114,7 +114,7 @@ $(document).find("[data-behavior~=multi-select]").select2({
 });
 
 //Toggle options menu on some table rows
-$(".button-options").click(function(){
+$("table").on('click', '.button-options', function(){
     $(this).next('.options-menu').toggle();
 });
 

--- a/app/assets/javascripts/utilities.js
+++ b/app/assets/javascripts/utilities.js
@@ -113,8 +113,8 @@ $(document).find("[data-behavior~=multi-select]").select2({
   allowClear: true
 });
 
-//Toggle options menu on some table rows
-$("table").on('click', '.button-options', function(){
+//Toggle options menu in table rows and page headers
+$("table, .context_menu").on('click', '.button-options', function(){
     $(this).next('.options-menu').toggle();
 });
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes an issue with binding a click handler to a dynamic element in Dynatable.

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
* go to course index or any paginated dynatable
* click options drop down button in table row
* search or update `show` select box
* click options menu again!

### Impacted Areas in Application
List general components of the application that this PR will affect:

* paginated dynatables with options menu

======================
Closes #3216 
