### PR TITLE
Modified panel article to correct missing link bug

### DIFF
--- a/app/assets/javascripts/angular/templates/student_panel/panel_article/main.html.haml
+++ b/app/assets/javascripts/angular/templates/student_panel/panel_article/main.html.haml
@@ -25,6 +25,9 @@
     {{article.description}}
   %a.details-link{'ng-href' => "{{article.type}}/{{article.id}}"} Go to {{articleTerm()}} Details Page
 
+%section.student-panel-article-description{'ng-if'=>'!article.has_info && article.type === "badges"'}
+  %a.details-link{'ng-href' => "{{article.type}}/{{article.id}}"} Go to {{articleTerm()}} Details Page
+
 %section.student-panel-article-icons
   %student-panel-article-icon.student-panel-article-icon{'ng-repeat'=>'icon in icons', 'icon-name'=>'icon', 'article'=>'article'}
   .condition-icons{'ng-include'=> true, 'src' => "'student_panel/panel_article/condition_icons.html'"}

--- a/app/assets/javascripts/angular/templates/student_panel/panel_article/main.html.haml
+++ b/app/assets/javascripts/angular/templates/student_panel/panel_article/main.html.haml
@@ -19,13 +19,10 @@
 %section.student-panel-article-image{'ng-if'=>'article.type === "badges"'}
   %img{'ng-src'=>'{{article.icon}}', 'ng-class'=>"(article.earned_badge_count <= 0 ? 'unearned' : 'badge-icon')"}
 
-%section.student-panel-article-description{'ng-if'=>'article.has_info'}
+%section.student-panel-article-description
   %h2 Description
   .student-panel-text-block{ 'ng-bind-html'=> 'article.description | limitTo:700 | html' }
     {{article.description}}
-  %a.details-link{'ng-href' => "{{article.type}}/{{article.id}}"} Go to {{articleTerm()}} Details Page
-
-%section.student-panel-article-description{'ng-if'=>'!article.has_info && article.type === "badges"'}
   %a.details-link{'ng-href' => "{{article.type}}/{{article.id}}"} Go to {{articleTerm()}} Details Page
 
 %section.student-panel-article-icons


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor, I expect that students will be able to award badges to others regardless of whether or not I've created a description for it

### Related PRs
N/A


### Todos
No tests to write because javascript


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, create a badge without a description. As a student, navigate to badges and find the badge with no description. The student should find the "Go to Badge Description" link in the right side panel. The link should take the student to the Badge's show page.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Badges

======================
Closes #3010 
