### PR TITLE
2845 redraw grade predictor on resize

### DIFF
--- a/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
@@ -67,15 +67,17 @@
           ay: -40
         }]
 
-      plotAssignmentDistro = ->
-        Plotly.newPlot('assignment-distribution-graph', data, layout, {displayModeBar: false})
+      Plotly.newPlot('assignment-distribution-graph', data, layout, {displayModeBar: false})
 
-      plotAssignmentDistro()
-
-      resizeTimer = undefined
       angular.element($window).on 'resize', ->
+        resizeTimer = undefined
+        assignmentDistributionGraph = document.getElementById('assignment-distribution-graph')
+
         clearTimeout resizeTimer
-        resizeTimer = setTimeout(plotAssignmentDistro, 250)
+        resizeTimer = setTimeout((->
+          Plotly.Plots.resize assignmentDistributionGraph
+          return
+        ), 250)
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
@@ -1,7 +1,7 @@
 # box plot for assignment grade distribution
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentDistributionAnalytics', ['$q', 'AnalyticsService', ($q, AnalyticsService) ->
+@gradecraft.directive 'assignmentDistributionAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
     analyticsDistCtrl = [()->
       vm = this
 
@@ -67,7 +67,15 @@
           ay: -40
         }]
 
-      Plotly.newPlot('assignment-distribution-graph', data, layout, {displayModeBar: false})
+      plotAssignmentDistro = ->
+        Plotly.newPlot('assignment-distribution-graph', data, layout, {displayModeBar: false})
+
+      plotAssignmentDistro()
+
+      resizeTimer = undefined
+      angular.element($window).on 'resize', ->
+        clearTimeout resizeTimer
+        resizeTimer = setTimeout(plotAssignmentDistro, 250)
 
     {
       bindToController: true,
@@ -79,6 +87,5 @@
         }
       templateUrl: 'analytics/assignment_distribution.html'
     }
+
 ]
-
-

--- a/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
@@ -1,7 +1,7 @@
 # box plot for assignment grade distribution
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentDistributionAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
+@gradecraft.directive 'assignmentDistributionAnalytics', ['$q', '$window', 'AnalyticsService', 'DebounceQueue', ($q, $window, AnalyticsService, DebounceQueue) ->
     analyticsDistCtrl = [()->
       vm = this
 
@@ -11,6 +11,11 @@
         vm.assignment_high_score = AnalyticsService.assignmentData.assignment_high_score
         plotGraph(AnalyticsService.assignmentData, vm.studentDistro)
       )
+
+      angular.element($window).on 'resize', ->
+        DebounceQueue.addEvent(
+          "graphs", 'assignmentDistributionAnalytics', refreshGraph, [], 250
+        )
     ]
 
     services = (assignmentId, studentId)->
@@ -69,15 +74,8 @@
 
       Plotly.newPlot('assignment-distribution-graph', data, layout, {displayModeBar: false})
 
-      angular.element($window).on 'resize', ->
-        resizeTimer = undefined
-        assignmentDistributionGraph = document.getElementById('assignment-distribution-graph')
-
-        clearTimeout resizeTimer
-        resizeTimer = setTimeout((->
-          Plotly.Plots.resize assignmentDistributionGraph
-          return
-        ), 250)
+    refreshGraph = ()=>
+      Plotly.Plots.resize document.getElementById('assignment-distribution-graph')
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
@@ -9,7 +9,10 @@
         vm.assignment_average = AnalyticsService.assignmentData.assignment_average
         vm.assignment_low_score = AnalyticsService.assignmentData.assignment_low_score
         vm.assignment_high_score = AnalyticsService.assignmentData.assignment_high_score
-        plotGraph(AnalyticsService.assignmentData, vm.studentDistro)
+        # plot graph when tab is activated for chart usage in jquery ui tabs
+        angular.element('#tabs').on 'tabsactivate', ->
+          if event.currentTarget.classList.contains('class-analytics-tab')
+            plotGraph(AnalyticsService.assignmentData, vm.studentDistro)
       )
 
       angular.element($window).on 'resize', ->

--- a/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_distribution.coffee
@@ -36,6 +36,7 @@
       layout = {
         showlegend: false,
         height: 100,
+        autosize: true,
         hovermode: !1,
         margin: {
           l: 8,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
@@ -1,7 +1,7 @@
 # box plot for assignment grade distribution
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentParticipationAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
+@gradecraft.directive 'assignmentParticipationAnalytics', ['$q', '$window', 'AnalyticsService', 'DebounceQueue', ($q, $window, AnalyticsService, DebounceQueue) ->
     analyticsParticipationCtrl = [()->
       vm = this
 
@@ -11,6 +11,11 @@
         vm.assignment_high_score = AnalyticsService.assignmentData.assignment_high_score
         plotGraph(AnalyticsService.assignmentData)
       )
+
+      angular.element($window).on 'resize', ->
+        DebounceQueue.addEvent(
+          "graphs", 'assignmentParticipationAnalytics', refreshGraph, [], 250
+        )
     ]
 
     services = (assignmentId, studentId)->
@@ -64,15 +69,8 @@
 
       Plotly.newPlot('assignment-participation-graph', participationData, pieLayout, {displayModeBar: false})
 
-      angular.element($window).on 'resize', ->
-        resizeTimer = undefined
-        assignmentParticipationGraph = document.getElementById('assignment-participation-graph')
-
-        clearTimeout resizeTimer
-        resizeTimer = setTimeout((->
-          Plotly.Plots.resize assignmentParticipationGraph
-          return
-        ), 250)
+    refreshGraph = ()=>
+      Plotly.Plots.resize document.getElementById('assignment-participation-graph')
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
@@ -9,7 +9,10 @@
         vm.assignment_average = AnalyticsService.assignmentData.assignment_average
         vm.assignment_low_score = AnalyticsService.assignmentData.assignment_low_score
         vm.assignment_high_score = AnalyticsService.assignmentData.assignment_high_score
-        plotGraph(AnalyticsService.assignmentData)
+        # plot graph when tab is activated for chart usage in jquery ui tabs
+        angular.element('#tabs').on 'tabsactivate', ->
+          if event.currentTarget.classList.contains('class-analytics-tab')
+            plotGraph(AnalyticsService.assignmentData)
       )
 
       angular.element($window).on 'resize', ->

--- a/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
@@ -62,15 +62,17 @@
         }]
       }
 
-      plotAssignmentParticipation = ->
-        Plotly.newPlot('assignment-participation-graph', participationData, pieLayout, {displayModeBar: false})
+      Plotly.newPlot('assignment-participation-graph', participationData, pieLayout, {displayModeBar: false})
 
-      plotAssignmentParticipation()
-
-      resizeTimer = undefined
       angular.element($window).on 'resize', ->
+        resizeTimer = undefined
+        assignmentParticipationGraph = document.getElementById('assignment-participation-graph')
+
         clearTimeout resizeTimer
-        resizeTimer = setTimeout(plotAssignmentParticipation, 250)
+        resizeTimer = setTimeout((->
+          Plotly.Plots.resize assignmentParticipationGraph
+          return
+        ), 250)
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_participation.coffee
@@ -1,7 +1,7 @@
 # box plot for assignment grade distribution
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentParticipationAnalytics', ['$q', 'AnalyticsService', ($q, AnalyticsService) ->
+@gradecraft.directive 'assignmentParticipationAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
     analyticsParticipationCtrl = [()->
       vm = this
 
@@ -40,6 +40,7 @@
 
       pieLayout = {
         showlegend: false,
+        autosize: true,
         height: 220,
         width: 220,
         hovermode: !1,
@@ -61,8 +62,15 @@
         }]
       }
 
-      Plotly.newPlot('assignment-participation-graph', participationData, pieLayout, {displayModeBar: false})
+      plotAssignmentParticipation = ->
+        Plotly.newPlot('assignment-participation-graph', participationData, pieLayout, {displayModeBar: false})
 
+      plotAssignmentParticipation()
+
+      resizeTimer = undefined
+      angular.element($window).on 'resize', ->
+        clearTimeout resizeTimer
+        resizeTimer = setTimeout(plotAssignmentParticipation, 250)
 
     {
       bindToController: true,
@@ -75,5 +83,3 @@
       templateUrl: 'analytics/assignment_participation.html'
     }
 ]
-
-

--- a/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
@@ -64,6 +64,7 @@
 
       layout = {
         showlegend: false,
+        autosize: true,
         hovermode: !1,
         height: 240,
         margin: {

--- a/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
@@ -97,15 +97,17 @@
           ay: -20
         }]
 
-      plotAssignmentScoresGraph = ->
-        Plotly.newPlot('assignment-scores-earned-graph', data, layout, {displayModeBar: false})
+      Plotly.newPlot('assignment-scores-earned-graph', data, layout, {displayModeBar: false})
 
-      plotAssignmentScoresGraph()
-
-      resizeTimer = undefined
       angular.element($window).on 'resize', ->
+        resizeTimer = undefined
+        assignmentScoresGraph = document.getElementById('assignment-scores-earned-graph')
+
         clearTimeout resizeTimer
-        resizeTimer = setTimeout(plotAssignmentScoresGraph, 250)
+        resizeTimer = setTimeout((->
+          Plotly.Plots.resize assignmentScoresGraph
+          return
+        ), 250)
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
@@ -1,12 +1,17 @@
 # bar graph for assignment grades earned
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentScoresEarnedAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
+@gradecraft.directive 'assignmentScoresEarnedAnalytics', ['$q', '$window', 'AnalyticsService', 'DebounceQueue', ($q, $window, AnalyticsService, DebounceQueue) ->
     analyticsScoresEarnedCtrl = [()->
       vm = this
       services(vm.assignmentId, vm.studentId).then(()->
         plotGraph(AnalyticsService.assignmentData)
       )
+      
+      angular.element($window).on 'resize', ->
+        DebounceQueue.addEvent(
+          "graphs", 'assignmentScoresEarnedAnalytics', refreshGraph, [], 250
+        )
     ]
 
     services = (assignmentId, studentId)->
@@ -99,15 +104,8 @@
 
       Plotly.newPlot('assignment-scores-earned-graph', data, layout, {displayModeBar: false})
 
-      angular.element($window).on 'resize', ->
-        resizeTimer = undefined
-        assignmentScoresGraph = document.getElementById('assignment-scores-earned-graph')
-
-        clearTimeout resizeTimer
-        resizeTimer = setTimeout((->
-          Plotly.Plots.resize assignmentScoresGraph
-          return
-        ), 250)
+    refreshGraph = ()=>
+      Plotly.Plots.resize document.getElementById('assignment-scores-earned-graph')
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
@@ -5,7 +5,10 @@
     analyticsScoresEarnedCtrl = [()->
       vm = this
       services(vm.assignmentId, vm.studentId).then(()->
-        plotGraph(AnalyticsService.assignmentData)
+      # plot graph when tab is activated for chart usage in jquery ui tabs
+      angular.element('#tabs').on 'tabsactivate', ->
+        if event.currentTarget.classList.contains('class-analytics-tab')
+          plotGraph(AnalyticsService.assignmentData)
       )
       
       angular.element($window).on 'resize', ->

--- a/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/assignment_scores_earned.coffee
@@ -1,7 +1,7 @@
 # bar graph for assignment grades earned
 # includes an individual's grade if supplied
 
-@gradecraft.directive 'assignmentScoresEarnedAnalytics', ['$q', 'AnalyticsService', ($q, AnalyticsService) ->
+@gradecraft.directive 'assignmentScoresEarnedAnalytics', ['$q', 'AnalyticsService', '$window', ($q, AnalyticsService, $window) ->
     analyticsScoresEarnedCtrl = [()->
       vm = this
       services(vm.assignmentId, vm.studentId).then(()->
@@ -97,7 +97,15 @@
           ay: -20
         }]
 
-      Plotly.newPlot('assignment-scores-earned-graph', data, layout, {displayModeBar: false})
+      plotAssignmentScoresGraph = ->
+        Plotly.newPlot('assignment-scores-earned-graph', data, layout, {displayModeBar: false})
+
+      plotAssignmentScoresGraph()
+
+      resizeTimer = undefined
+      angular.element($window).on 'resize', ->
+        clearTimeout resizeTimer
+        resizeTimer = setTimeout(plotAssignmentScoresGraph, 250)
 
     {
       bindToController: true,

--- a/app/assets/javascripts/angular/directives/analytics/points_breakdown.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/points_breakdown.coffee
@@ -1,13 +1,18 @@
 # graph of student's points, broken down by assignment type
 # Used on student dashboard
 
-@gradecraft.directive 'pointsBreakdownAnalytics', ['$q', 'AnalyticsService', ($q, AnalyticsService) ->
+@gradecraft.directive 'pointsBreakdownAnalytics', ['$q', '$window', 'AnalyticsService', 'DebounceQueue', ($q, $window, AnalyticsService, DebounceQueue) ->
     pointsBreakdownCtrl = [()->
       vm = this
 
       services(vm.assignmentId, vm.studentId).then(()->
         plotGraph(AnalyticsService.studentData)
       )
+
+      angular.element($window).on 'resize', ->
+        DebounceQueue.addEvent(
+          "graphs", 'pointsBreakdownAnalytics', refreshGraph, [], 250
+        )
     ]
 
     services = (assignmentId, studentId)->
@@ -97,6 +102,9 @@
         $('.hovertext path').attr('data-color', barColor)
       )
 
+    refreshGraph = ()=>
+      Plotly.Plots.resize document.getElementById('point-breakdown-chart')
+
     {
       bindToController: true,
       controller: pointsBreakdownCtrl,
@@ -105,5 +113,3 @@
       templateUrl: 'analytics/points_breakdown.html'
     }
 ]
-
-

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -125,7 +125,12 @@
       # Update graph x-axis for redraw
       scope.updateGradeLevelGraph = ()->
         d3.select("#predictor-graph-section svg .grade-point-axis").remove()
+        d3.select('#svg-grade-levels').selectAll('g').remove()
         scope.renderGradeLevelGraph()
+        d3.select("#svg-graph-points-earned").attr("width", scope.svgEarnedBarWidth())
+        d3.select("#svg-graph-points-predicted-locked").attr("width", scope.svgPredictedLockedBarWidth())
+        d3.select("#svg-graph-points-predicted").attr("width", scope.svgPredictedBarWidth())
+
 
       # re-render on window resize end!
       resizeTimer = undefined

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -2,7 +2,7 @@
 # Must not render until Grade Scheme Elements are loaded,
 # to position high and low point ranges.
 
-@gradecraft.directive 'predictorGraph', [ 'PredictorService', '$window', (PredictorService, $window)->
+@gradecraft.directive 'predictorGraph', [ '$window', 'PredictorService', 'DebounceQueue',  ($window, PredictorService, DebounceQueue)->
 
   return {
     templateUrl: 'predictor/graph.html'
@@ -133,10 +133,9 @@
 
 
       # re-render on window resize end!
-      resizeTimer = undefined
       angular.element($window).on 'resize', ->
-        clearTimeout resizeTimer
-        resizeTimer = setTimeout(scope.updateGradeLevelGraph, 250)
-
+        DebounceQueue.addEvent(
+          "graphs", 'predictorGraph', scope.updateGradeLevelGraph, [], 250
+          )
   }
 ]

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -2,7 +2,7 @@
 # Must not render until Grade Scheme Elements are loaded,
 # to position high and low point ranges.
 
-@gradecraft.directive 'predictorGraph', [ 'PredictorService', (PredictorService)->
+@gradecraft.directive 'predictorGraph', [ 'PredictorService', '$window', (PredictorService, $window)->
 
   return {
     templateUrl: 'predictor/graph.html'
@@ -121,6 +121,17 @@
 
       # render!
       scope.renderGradeLevelGraph()
+
+      # Update graph x-axis for redraw
+      scope.updateGradeLevelGraph = ()->
+        d3.select("#predictor-graph-section svg .grade-point-axis").remove()
+        scope.renderGradeLevelGraph()
+
+      # re-render on window resize end!
+      resizeTimer = undefined
+      angular.element($window).on 'resize', ->
+        clearTimeout resizeTimer
+        resizeTimer = setTimeout(scope.updateGradeLevelGraph, 250)
 
   }
 ]

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -126,6 +126,7 @@
       scope.updateGradeLevelGraph = ()->
         d3.select("#predictor-graph-section svg .grade-point-axis").remove()
         d3.select('#svg-grade-levels').selectAll('g').remove()
+        d3.select("#svg-grade-level-text").selectAll('g').remove()
         scope.renderGradeLevelGraph()
         d3.select("#svg-graph-points-earned").attr("width", scope.svgEarnedBarWidth())
         d3.select("#svg-graph-points-predicted-locked").attr("width", scope.svgPredictedLockedBarWidth())

--- a/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
+++ b/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
@@ -7,19 +7,24 @@
 angular.module('helpers').factory('DebounceQueue', ['$timeout', ($timeout)->
 
   queueStore = {}
-  TIME_TO_DELAY = 2500
 
-  addEvent = (type, id, event, args=[], immediate=false)->
+  # Standard delay for making model updates via api
+  API_REQUEST_DELAY = 2500
+
+  # type and id are used to create a unique timout
+  # event will be called with args
+  # add custom delay, or 0 to cancel existing timeout and fire immediately
+  addEvent = (type, id, event, args=[], delay=API_REQUEST_DELAY)->
     return console.warn("Unable to add event:", type, "for:", id) if not type? || not id?
 
-    if immediate is true
+    if delay == 0
       cancelEvent(type, id)
       event.apply(null, args)
     else
       cancelEvent(type, id)
       queueStore[type + id] = $timeout(() ->
         event.apply(null, args)
-      , TIME_TO_DELAY)
+      , delay)
 
   cancelEvent = (type, id)->
     storeId = type + id

--- a/app/assets/javascripts/angular/services/GradeService.coffee
+++ b/app/assets/javascripts/angular/services/GradeService.coffee
@@ -151,9 +151,10 @@
       )
 
   queueUpdateGrade = (immediate=false, returnURL=null) ->
+    delay = if immediate then 0 else null
     calculateGradePoints()
     DebounceQueue.addEvent(
-      "grades", modelGrade.id, _updateGrade, [returnURL], immediate
+      "grades", modelGrade.id, _updateGrade, [returnURL], delay
     )
 
   _confirmMessage = ()->
@@ -261,11 +262,12 @@
     )
 
   queueUpdateCriterionGrade = (criterionId, immediate=false) ->
+    delay = if immediate then 0 else null
     # using criterionId for queue id since we are not assured
     # to have a criterionGrade.id
     DebounceQueue.addEvent(
       "criterion_grades", criterionId, _updateCriterionGrade,
-      [criterionId], immediate
+      [criterionId], delay
     )
 
 #------- Grade File Methods ---------------------------------------------------#

--- a/app/assets/javascripts/angular/services/StudentSubmissionService.coffee
+++ b/app/assets/javascripts/angular/services/StudentSubmissionService.coffee
@@ -4,13 +4,15 @@
   submission = {}
 
   queueSaveDraftSubmission = (assignmentId, immediate=false) ->
+    delay = if immediate then 0 else null
+
     # cancel update if the student has cleared out the text_comment_draft
     unless submission.text_comment_draft
       DebounceQueue.cancelEvent("submissions", assignmentId)
       return
 
     # using assignmentId for queue id since we are not assured to have a submission.id
-    DebounceQueue.addEvent("submissions", assignmentId, saveDraftSubmission, [assignmentId], immediate)
+    DebounceQueue.addEvent("submissions", assignmentId, saveDraftSubmission, [assignmentId], delay)
 
   saveDraftSubmission = (assignmentId) ->
     if submission.id? then updateDraftSubmission(assignmentId) else createDraftSubmission(assignmentId)

--- a/app/assets/javascripts/plotly/grade_distro.js
+++ b/app/assets/javascripts/plotly/grade_distro.js
@@ -53,4 +53,13 @@ if ($gradeDistro.length) {
 
     // eslint-disable-next-line no-undef
     Plotly.newPlot('grade_distro', data, layout, {displayModeBar: false});
+
+    // resize chart on window resize function to remove when chart is angularized
+    $(window).on('resize', function() {
+      var resizeTimer;
+      var gradeDistroDiv = document.getElementById('grade_distro');
+
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(function() {Plotly.Plots.resize(gradeDistroDiv)}, 250);
+   });
 }

--- a/app/assets/javascripts/plotly/team_analytics.js
+++ b/app/assets/javascripts/plotly/team_analytics.js
@@ -98,4 +98,14 @@ if ($('#leaderboardBarChart').length) {
 
   // eslint-disable-next-line no-undef
   Plotly.newPlot('leaderboardBarChart', data, layout, {displayModeBar: false});
+
+  // resize chart on window resize function to remove when chart is angularized
+  $(window).on('resize', function() {
+    var resizeTimer;
+    var leaderboardBarChartDiv = document.getElementById('leaderboardBarChart');
+
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function() {Plotly.Plots.resize(leaderboardBarChartDiv)}, 250);
+ });
+
 }

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -35,13 +35,17 @@
 
 .class-analytics-wrapper
   display: flex
-  flex-wrap: wrap
+  @media (max-width: $media-small-max)
+    display: block
 
 .class-analytics-graph
-  flex: 1
+  width: 50%
   &:not(:last-child)
     margin-right: 1rem
+  &.full-width
+    width: 100%
   @media (max-width: $media-small-max)
+    width: 100%
     margin-right: 0
     margin-bottom: 1rem
 

--- a/app/views/assignments/_show_staff.haml
+++ b/app/views/assignments/_show_staff.haml
@@ -19,7 +19,7 @@
             Rubric
       - if presenter.has_persisted_grades?
         %li
-          %a{"href" => "#tab4"}
+          %a.class-analytics-tab{"href" => "#tab4"}
             %span Class
             Analytics
 

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -9,7 +9,7 @@
           %a{"href" => "#tab"} My Submission
       - if presenter.has_viewable_analytics?(current_student) && presenter.grades_available_for?(current_student)
         %li
-          %a{"href" => "#tab2"} Class Analytics
+          %a.class-analytics-tab{"href" => "#tab2"} Class Analytics
       %li
         %a{"href" => "#tab3"} Description
       - if presenter.show_rubric_preview?(current_student)

--- a/app/views/grades/_analytics.haml
+++ b/app/views/grades/_analytics.haml
@@ -16,5 +16,5 @@
           %assignment-distribution-analytics{ "assignment-id": assignment.id, "student-id": student_id}
         .class-analytics-graph
           %assignment-participation-analytics{ "assignment-id": assignment.id, "student-id": student_id }
-      .class-analytics-graph
+      .class-analytics-graph.full-width
         %assignment-scores-earned-analytics{ "assignment-id": assignment.id, "student-id": student_id}


### PR DESCRIPTION
### Status
**READY**

### Description
This PR intends to redraw the grade predictor on window resize in order to improve responsiveness.

### Related PRs
#3083 

### Todos
- [x] Refresh bar on window resize to reflect new axis scale since 'snap' to scaled width happens when slider is interacted with, not before.
- [x] Redraw tick marks with grades on resize

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. Go to grade predictor and resize window

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grade Predictor

======================
Closes #2845 
