### PR TITLE
add z-index to datepicker

### DIFF
--- a/app/assets/stylesheets/components/_datepicker.sass
+++ b/app/assets/stylesheets/components/_datepicker.sass
@@ -1,5 +1,8 @@
 @import "../utilities/variables"
 
+#ui-datepicker-div.ui-datepicker
+ z-index: 100 !important
+
 .ui-datepicker.ui-widget-content
 	margin-top: .15rem !important
 	background: $color-blue-4
@@ -33,7 +36,7 @@
 	table tr:nth-child(even)
 		background-color: inherit
 
-	table tr 
+	table tr
 		border-bottom: none
 
 .ui-timepicker-div


### PR DESCRIPTION
### Status
**READY**

### Description

See issue #3223 

@chcholman  I had a similar issue as I was working on the dates on the assignments settings page.  Let me know if this solution works for you or looks funky. The datepicker is now above the menu bar, but it will still scroll offscreen. 

The solution in this PR:

![screen shot 2017-04-20 at 3 30 41 pm](https://cloud.githubusercontent.com/assets/1138350/25249134/d664d016-25de-11e7-8b07-e977cd376cc8.png)

If the issue you have is the actual location of the datepicker widget (ex. "too far up") we may need to document additional details (browser window size, device screen width etc.) to find the correct solution. The position is determined by the browser window size, so it may be showing up above where you would expect it to be:

Normal Datepicker location when the browser window is large enough to accommodate it (below the input field):

![screen shot 2017-04-20 at 3 30 57 pm](https://cloud.githubusercontent.com/assets/1138350/25249150/e9782cc0-25de-11e7-802b-c1dc08aff4a7.png)

=====================
Closes #3223
