### PR TITLE
Team student bug

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -58,6 +58,7 @@ class TeamsController < ApplicationController
     params.require(:team).permit :name, :course, :course_id, :average_score,
       :banner, :rank, :challenge_grade_score,
       team_memberships_attributes: [:id, :student_id, :team_id, :_destroy],
-      team_leaderships_attributes: [:id, :leader_id, :team_id, :_destroy]
+      team_leaderships_attributes: [:id, :leader_id, :team_id, :_destroy],
+      leader_ids: [], student_ids: []
   end
 end

--- a/app/views/challenges/_index_student.haml
+++ b/app/views/challenges/_index_student.haml
@@ -8,7 +8,7 @@
 
   %tbody
     - current_course.challenges.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
-      - if challenge.visible? || (ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable? user: current_student)
+      - if challenge.visible? || (@team.present? &&  (ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable? user: current_student))
         %tr
           %td= link_to challenge.name, challenge
           %td

--- a/app/views/teams/_index_student.haml
+++ b/app/views/teams/_index_student.haml
@@ -5,6 +5,8 @@
     %h2.subtitle Your #{term_for :team} (#{@team.name}) has earned #{points @team.challenge_grade_score } points
     - if @team.banner.present?
       %img.clear{:src => @team.banner, :height => 200 }
+  - else
+    %i You haven't been assigned to a #{ (term_for :team).downcase } yet. You might want to talk to your instructor!
 
   = render partial: "teams/leaderboard" if current_course.teams_visible?
 

--- a/app/views/teams/_leaderboard.html.haml
+++ b/app/views/teams/_leaderboard.html.haml
@@ -1,6 +1,6 @@
 %h2.subtitle= "#{term_for :team} Leaderboard"
 - if @teams.present?
   .leaderboard-chart-container
-    #leaderboardBarChart{"data-scores" => @team_names_and_scores.to_json, "data-team" => (@team.name if current_student.present?) }
+    #leaderboardBarChart{"data-scores" => @team_names_and_scores.to_json, "data-team" => (@team.name if current_student.present? && @team.present?) }
 - else
   %p There are no #{term_for :teams} in this course yet!


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where users couldn't add students to a team that had already been created. 

### Migrations
NO
