### PR TITLE
Filter out scoreless grades returned from Canvas

### DIFF
--- a/app/helpers/canvas_api_helper.rb
+++ b/app/helpers/canvas_api_helper.rb
@@ -1,0 +1,9 @@
+# Collection of methods for parsing data returned from the Canvas API
+module CanvasAPIHelper
+  def concat_submission_comments(comments, separator="; ")
+    return nil if comments.blank?
+    comments.pluck("comment").each_with_index.map do |comment, i|
+      "Comment #{i+1}: #{comment}"
+    end.join(separator)
+  end
+end

--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -1,6 +1,8 @@
 require "quote_helper"
 
 class CanvasGradeImporter
+  include CanvasAPIHelper
+
   attr_reader :successful, :unsuccessful
   attr_accessor :grades
 
@@ -23,7 +25,7 @@ class CanvasGradeImporter
         end
 
         grade.raw_points = canvas_grade["score"]
-        grade.feedback = canvas_grade["submission_comments"]
+        grade.feedback = concat_submission_comments canvas_grade["submission_comments"]
         grade.status = "Graded" if grade.status.nil?
         grade.instructor_modified = true
 

--- a/app/views/api/grades/importers/show.json.jbuilder
+++ b/app/views/api/grades/importers/show.json.jbuilder
@@ -8,7 +8,7 @@ json.data @grades[:data] do |grade|
     json.id                                   grade["id"].to_s
     json.primary_email                        user["primary_email"]
     json.score                                grade["score"]
-    json.feedback                             grade["submission_comments"]
+    json.feedback                             concat_submission_comments(grade["submission_comments"])
     json.gradecraft_score                     Grade.for_student_email_and_assignment_id(user["primary_email"],
                                                 @assignment.id) || Grade.new
     json.user_exists                          lms_user_match?(user["primary_email"], current_course)

--- a/app/views/grades/importers/grades_import_results.html.haml
+++ b/app/views/grades/importers/grades_import_results.html.haml
@@ -60,6 +60,7 @@
           %th Last Name
           %th Raw Points
           %th Score
+          %th Feedback
       %tbody
         - @result.grades_import_result.successful.each do |grade|
           %tr
@@ -67,3 +68,4 @@
             %td= grade.student.last_name
             %td= points grade.raw_points
             %td= grade.score
+            %td= grade.feedback

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -346,6 +346,7 @@ module ActiveLMS
                  include: ["assignment", "course", "user"],
                  per_page: options.delete(:per_page) || 25 }.merge(options)
       result = client.get_data("/courses/#{course_id}/students/submissions", params, fetch_next) do |data|
+        data.select! { |grade| !grade["score"].blank? }
         if grade_ids.nil?
           grades += data
         else

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -343,7 +343,7 @@ module ActiveLMS
       grades = []
       params = { assignment_ids: assignment_ids,
                  student_ids: "all",
-                 include: ["assignment", "course", "user"],
+                 include: ["assignment", "course", "user", "submission_comments"],
                  per_page: options.delete(:per_page) || 25 }.merge(options)
       result = client.get_data("/courses/#{course_id}/students/submissions", params, fetch_next) do |data|
         data.select! { |grade| !grade["score"].blank? || !grade["submission_comments"].blank? }

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -346,7 +346,7 @@ module ActiveLMS
                  include: ["assignment", "course", "user"],
                  per_page: options.delete(:per_page) || 25 }.merge(options)
       result = client.get_data("/courses/#{course_id}/students/submissions", params, fetch_next) do |data|
-        data.select! { |grade| !grade["score"].blank? }
+        data.select! { |grade| !grade["score"].blank? || !grade["submission_comments"].blank? }
         if grade_ids.nil?
           grades += data
         else

--- a/spec/helpers/canvas_api_helper_spec.rb
+++ b/spec/helpers/canvas_api_helper_spec.rb
@@ -1,0 +1,15 @@
+describe CanvasAPIHelper, focus: true do
+  subject { helper }
+
+  describe "#concat_submission_comments" do
+    it "returns nil if there are no comments" do
+      expect(subject.concat_submission_comments([])).to be_nil
+    end
+
+    it "returns comments parsed and separated by the default separator" do
+      comments = [{ "comment" => "good jorb" }, { "comment" => "excellent" }]
+      expect(subject.concat_submission_comments(comments)).to eq \
+        "Comment 1: good jorb; Comment 2: excellent"
+    end
+  end
+end

--- a/spec/helpers/canvas_api_helper_spec.rb
+++ b/spec/helpers/canvas_api_helper_spec.rb
@@ -1,4 +1,4 @@
-describe CanvasAPIHelper, focus: true do
+describe CanvasAPIHelper do
   subject { helper }
 
   describe "#concat_submission_comments" do

--- a/spec/importers/grade_importers/canvas_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/canvas_grade_importer_spec.rb
@@ -14,7 +14,7 @@ describe CanvasGradeImporter do
           id: canvas_grade_id,
           score: 98.0,
           user_id: "USER_1",
-          submission_comments: "This is great!"
+          submission_comments: [{"comment" => "This is great!"}]
         }.stringify_keys
       end
       let(:canvas_user) do
@@ -34,7 +34,7 @@ describe CanvasGradeImporter do
         expect(grade.assignment).to eq assignment
         expect(grade.student).to eq user
         expect(grade.raw_points).to eq 98
-        expect(grade.feedback).to eq "This is great!"
+        expect(grade.feedback).to eq "Comment 1: This is great!"
         expect(grade.status).to eq "Graded"
         expect(grade).to be_instructor_modified
       end
@@ -80,7 +80,7 @@ describe CanvasGradeImporter do
             expect(grade.assignment).to eq assignment
             expect(grade.student).to eq user
             expect(grade.raw_points).to eq 98
-            expect(grade.feedback).to eq "This is great!"
+            expect(grade.feedback).to eq "Comment 1: This is great!"
           end
         end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -127,6 +127,7 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
 
   describe "#grades" do
     let(:assignment_ids) { [456, 789] }
+    let(:grades) { [{ id: 456, score: 87 }, { id: 789, score: "" }] }
     let!(:stub) do
       stub_request(:get,
           "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
@@ -134,11 +135,11 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
                        "include" => ["assignment", "course", "user"],
                        "per_page" => 25,
                        "access_token" => access_token })
-        .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
+        .to_return(status: 200, body: grades.to_json, headers: {})
     end
     subject { described_class.new access_token }
 
-    it "returns a hash containing the result" do
+    it "returns a hash containing only grades with scores" do
       result = subject.grades(123, assignment_ids)
 
       expect(result[:data].count).to eq 1

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -134,11 +134,11 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
         { id: 777, score: nil, submission_comments: "good jorb!" }
       ]
     end
-    let!(:stub)
+    let!(:stub) do
       stub_request(:get,
           "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
         .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
-                       "include" => ["assignment", "course", "user"],
+                       "include" => ["assignment", "course", "user", "submission_comments"],
                        "per_page" => 25,
                        "access_token" => access_token })
         .to_return(status: 200, body: grades.to_json, headers: {})
@@ -158,7 +158,7 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
       stub_request(:get,
           "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
         .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
-                       "include" => ["assignment", "course", "user"],
+                       "include" => ["assignment", "course", "user", "submission_comments"],
                        "per_page" => 5, "test" => true,
                        "access_token" => access_token })
         .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})


### PR DESCRIPTION
### Status
READY

### Description
When importing grades from Canvas, it is possible to get submissions where the grade is scoreless. This happens in the scenario where a student has been graded on an assignment, but their grade is then cleared out later on. The Canvas API returns these types of submissions anyway since the grade status is considered to be "Graded".

For our case, we should omit these from the import.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Grade a student in Canvas, allowing the grade to persist. Then, clear their grade out and attempt to import grades in Gradecraft for that particular assignment. The scoreless grade should not appear in the selection list.

### Impacted Areas in Application
Canvas grade import

======================
Closes #3239 
