### PR TITLE
3219 grading form style

### DIFF
--- a/app/assets/javascripts/angular/directives/common/collapse_toggler.coffee
+++ b/app/assets/javascripts/angular/directives/common/collapse_toggler.coffee
@@ -9,6 +9,7 @@
   link: (scope, elm, attrs) ->
     elm.bind('click', (event)->
       unless angular.element(event.target).is('.coins, .coin-slot, .coin-stack, .coin-remove-icon, .coin-add-icon')
+        event.preventDefault()
         elm.siblings().toggleClass('collapsed')
         elm.toggleClass('collapsed')
     )

--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -46,6 +46,9 @@
         _rawPointsType() == "PASS_FAIL"
       vm.isScoreLevelGraded = ()->
         _rawPointsType() == "SCORE_LEVELS"
+        
+      vm.hasAwardableBadges = ()->
+        GradeService.hasAwardableBadges
 
     ]
 

--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -24,7 +24,7 @@
           GradeService.setGradeToPass()
       )
 
-      _rawPointsType = ()->
+      rawPointsType = ()->
         assignment = AssignmentService.assignment()
         return "" if !assignment
 
@@ -39,13 +39,13 @@
 
       vm.isGroupGrade = vm.recipientType == "group"
       vm.isStandardGraded = ()->
-        _rawPointsType() == "DEFAULT"
+        rawPointsType() == "DEFAULT"
       vm.isRubricGraded = ()->
-        _rawPointsType() == "RUBRIC"
+        rawPointsType() == "RUBRIC"
       vm.isPassFailGraded = ()->
-        _rawPointsType() == "PASS_FAIL"
+        rawPointsType() == "PASS_FAIL"
       vm.isScoreLevelGraded = ()->
-        _rawPointsType() == "SCORE_LEVELS"
+        rawPointsType() == "SCORE_LEVELS"
 
     ]
 

--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -46,9 +46,6 @@
         _rawPointsType() == "PASS_FAIL"
       vm.isScoreLevelGraded = ()->
         _rawPointsType() == "SCORE_LEVELS"
-        
-      vm.hasAwardableBadges = ()->
-        GradeService.hasAwardableBadges
 
     ]
 
@@ -69,7 +66,8 @@
          recipientId: "=",
          submitPath: "@",
          gradeNextPath: "@",
-         isActiveCourse: "="
+         isActiveCourse: "=",
+         hasAwardableBadges: "="
         },
       templateUrl: 'grades/edit.html'
     }

--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -24,7 +24,7 @@
           GradeService.setGradeToPass()
       )
 
-      rawPointsType = ()->
+      _rawPointsType = ()->
         assignment = AssignmentService.assignment()
         return "" if !assignment
 
@@ -39,13 +39,13 @@
 
       vm.isGroupGrade = vm.recipientType == "group"
       vm.isStandardGraded = ()->
-        rawPointsType() == "DEFAULT"
+        _rawPointsType() == "DEFAULT"
       vm.isRubricGraded = ()->
-        rawPointsType() == "RUBRIC"
+        _rawPointsType() == "RUBRIC"
       vm.isPassFailGraded = ()->
-        rawPointsType() == "PASS_FAIL"
+        _rawPointsType() == "PASS_FAIL"
       vm.isScoreLevelGraded = ()->
-        rawPointsType() == "SCORE_LEVELS"
+        _rawPointsType() == "SCORE_LEVELS"
 
     ]
 

--- a/app/assets/javascripts/angular/directives/grades/points_overview.coffee
+++ b/app/assets/javascripts/angular/directives/grades/points_overview.coffee
@@ -5,6 +5,10 @@
 
   return {
     templateUrl: 'grades/points_overview.html'
+    scope: {
+      rawPointsType: "=",
+      gradeType: "@"
+    }
     link: (scope, el, attr)->
 
       scope.assignment = ()->
@@ -49,4 +53,3 @@
 
   }
 ]
-

--- a/app/assets/javascripts/angular/directives/grades/points_overview.coffee
+++ b/app/assets/javascripts/angular/directives/grades/points_overview.coffee
@@ -6,7 +6,6 @@
   return {
     templateUrl: 'grades/points_overview.html'
     scope: {
-      rawPointsType: "=",
       gradeType: "@"
     }
     link: (scope, el, attr)->
@@ -45,11 +44,11 @@
 
       scope.isBelowThreshold = ()->
         return false if !(scope.assignment() && scope.grade)
-        scope.assignment().has_threshold && (scope.grade.final_points < scope.assignment().threshold_points)
+        scope.assignment().has_threshold && (scope.finalPoints() < scope.assignment().threshold_points)
 
       scope.pointsBelowThreshold = ()->
         return 0 if !(scope.assignment() && scope.grade)
-        scope.assignment().threshold_points - scope.grade.raw_points + scope.grade.adjustment_points
+        scope.assignment().threshold_points - scope.grade.raw_points + scope.adjustmentPoints()
 
   }
 ]

--- a/app/assets/javascripts/angular/services/GradeService.coffee
+++ b/app/assets/javascripts/angular/services/GradeService.coffee
@@ -15,6 +15,7 @@
   gradeStatusOptions = []
 
   isRubricGraded = false
+  hasAwardableBadges = false
   thresholdPoints = 0
 
   # used to distinguish group and individual grades:
@@ -80,6 +81,7 @@
     modelGrade.pending_status =  modelGrade.status
     thresholdPoints = response.data.meta.threshold_points
     isRubricGraded = response.data.meta.is_rubric_graded
+    hasAwardableBadges = response.data.meta.has_awardable_badges
 
   getGrade = (assignmentId, recipientType, recipientId)->
     _recipientType = recipientType
@@ -312,6 +314,8 @@
     fileUploads: fileUploads
     criterionGrades: criterionGrades
     gradeStatusOptions: gradeStatusOptions
+
+    hasAwardableBadges: hasAwardableBadges
 
     calculateGradePoints: calculateGradePoints
 

--- a/app/assets/javascripts/angular/services/GradeService.coffee
+++ b/app/assets/javascripts/angular/services/GradeService.coffee
@@ -15,7 +15,6 @@
   gradeStatusOptions = []
 
   isRubricGraded = false
-  hasAwardableBadges = false
   thresholdPoints = 0
 
   # used to distinguish group and individual grades:
@@ -81,7 +80,6 @@
     modelGrade.pending_status =  modelGrade.status
     thresholdPoints = response.data.meta.threshold_points
     isRubricGraded = response.data.meta.is_rubric_graded
-    hasAwardableBadges = response.data.meta.has_awardable_badges
 
   getGrade = (assignmentId, recipientType, recipientId)->
     _recipientType = recipientType
@@ -314,8 +312,6 @@
     fileUploads: fileUploads
     criterionGrades: criterionGrades
     gradeStatusOptions: gradeStatusOptions
-
-    hasAwardableBadges: hasAwardableBadges
 
     calculateGradePoints: calculateGradePoints
 

--- a/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
@@ -5,7 +5,7 @@
     .assignment-type-bar.assignment-settings.collapse-toggler{role: "tab"}
       %a(href="#")
         %h2.assignment-type-name
-          %i.fa.fa-fw.fa-angle-double-right
+          %i.fa.fa-fw.fa-chevron-circle-right
           {{assignmentType.name}}
         .points-summary(ng-if="!vm.loading")
 

--- a/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
@@ -5,7 +5,7 @@
   %span(ng-if="!groupGrade")
     Would you like to adjust the grade's final points?
 
-%section.grade-adjustments-section.collapse.collapsed
+%section.grade-adjustments-section.collapse.collapsed(ng-class='{"flex-wrapper": groupGrade}')
   %div.grade-adjustments(ng-repeat="grade in grades")
 
     %article.grade-form-fields(ng-class='{"sectional": groupGrade}')

--- a/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
@@ -1,9 +1,10 @@
-%h3.collapse-toggler.collapsed
-  %i.fa.fa-angle-double-right.fa-fw
-  %span(ng-if="groupGrade")
-    Would you like to adjust a specific student’s grade or share individualized feedback?
-  %span(ng-if="!groupGrade")
-    Would you like to adjust the grade's final points?
+%a.grade-form-collapsible.collapse-toggler.collapsed(href="#")
+  %h3
+    %i.fa.fa-angle-double-right.fa-fw
+    %span(ng-if="groupGrade")
+      Would you like to adjust a specific student’s grade or share individualized feedback?
+    %span(ng-if="!groupGrade")
+      Would you like to adjust the grade's final points?
 
 %section.grade-adjustments-section.collapse.collapsed(ng-class='{"flex-wrapper": groupGrade}')
   %div.grade-adjustments(ng-repeat="grade in grades")

--- a/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/adjustment_points_input.html.haml
@@ -1,10 +1,10 @@
 %a.grade-form-collapsible.collapse-toggler.collapsed(href="#")
   %h3
-    %i.fa.fa-angle-double-right.fa-fw
+    %i.fa.fa-chevron-circle-right.fa-fw
     %span(ng-if="groupGrade")
-      Would you like to adjust a specific student’s grade or share individualized feedback?
+      Adjust a specific student’s grade
     %span(ng-if="!groupGrade")
-      Would you like to adjust the grade's final points?
+      Adjust final points
 
 %section.grade-adjustments-section.collapse.collapsed(ng-class='{"flex-wrapper": groupGrade}')
   %div.grade-adjustments(ng-repeat="grade in grades")

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,9 +1,9 @@
-%a.grade-form-collapsible.collapse-toggler.collapsed(ng-if="vm.BadgeService.badges.length > 0")
+%a.grade-form-collapsible.collapse-toggler.collapsed(href="#")
   %h3
     %i.fa.fa-chevron-circle-right.fa-fw
     %span Award {{vm.BadgeService.termFor("badges")}}
 
-%section.badge-index-section.collapse.collapsed(ng-if="vm.BadgeService.badges.length > 0")
+%section.badge-index-section.collapse.collapsed
   %label.badge-award-container(for="{{vm.inputId(badge)}}"
   ng-repeat="badge in vm.BadgeService.badges"
   ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,5 +1,5 @@
-%a.grade-form-collapsible.collapse-toggler.collapsed(href="#")
-  %h3 
+%a.grade-form-collapsible.collapse-toggler.collapsed(ng-if="vm.BadgeService.badges.length > 0")
+  %h3
     %i.fa.fa-chevron-circle-right.fa-fw
     %span Award {{vm.BadgeService.termFor("badges")}}
 

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -1,6 +1,9 @@
-%section.badge-index-section(ng-if="vm.BadgeService.badges.length > 0")
-  .grade-section-label Award {{vm.BadgeService.termFor("badges")}} for this {{vm.BadgeService.termFor("assignment")}}
+%a.grade-form-collapsible.collapse-toggler.collapsed(href="#")
+  %h3 
+    %i.fa.fa-chevron-circle-right.fa-fw
+    %span Award {{vm.BadgeService.termFor("badges")}}
 
+%section.badge-index-section.collapse.collapsed(ng-if="vm.BadgeService.badges.length > 0")
   %label.badge-award-container(for="{{vm.inputId(badge)}}"
   ng-repeat="badge in vm.BadgeService.badges"
   ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -13,7 +13,7 @@
       ng-click="vm.awardBadge(badge)"
     )
     .badge-award-image
-      %img(ng-src="{{badge.icon}}")
+      %img(ng-src="{{badge.icon}}" alt="")
 
     .badge-award-name {{badge.name}}
 .clear

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -18,8 +18,9 @@
   %grade-file-uploader(ng-if='!vm.isGroupGrade')
   %grade-feedback-text-input
 
-%article.grade-form-fields(ng-if='!vm.isPassFailGraded()' group-grade='vm.isGroupGrade')
-  %grade-adjustment-points-input
+
+%article.grade-form-fields(ng-if='!vm.isPassFailGraded()')
+  %grade-adjustment-points-input(group-grade='vm.isGroupGrade')
 
 %article.grade-form-fields(ng-if='!vm.isGroupGrade')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -18,10 +18,8 @@
   %grade-file-uploader(ng-if='!vm.isGroupGrade')
   %grade-feedback-text-input
 
-
-%grade-adjustment-points-input(ng-if='!vm.isPassFailGraded()' group-grade='vm.isGroupGrade')
-
-.clear
+%article.grade-form-fields(ng-if='!vm.isPassFailGraded()' group-grade='vm.isGroupGrade')
+  %grade-adjustment-points-input
 
 %article.grade-form-fields(ng-if='!vm.isGroupGrade')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -20,7 +20,7 @@
 %article.grade-form-fields(ng-if='!vm.isPassFailGraded()')
   %grade-adjustment-points-input(group-grade='vm.isGroupGrade')
 
-%article.grade-form-fields(ng-if='!vm.isGroupGrade && vm.hasAwardableBadges()')
+%article.grade-form-fields(ng-if='!vm.isGroupGrade && vm.hasAwardableBadges')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')
 
 .grading-summary

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -20,7 +20,7 @@
 %article.grade-form-fields(ng-if='!vm.isPassFailGraded()')
   %grade-adjustment-points-input(group-grade='vm.isGroupGrade')
 
-%article.grade-form-fields(ng-if='!vm.isGroupGrade')
+%article.grade-form-fields(ng-if='!vm.isGroupGrade && vm.hasAwardableBadges()')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')
 
 .grading-summary

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -25,7 +25,6 @@
 
 %article.grade-form-fields(ng-if='!vm.isGroupGrade')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')
-  %hr.grading-divider
 
 .right
   %grade-status-select

--- a/app/assets/javascripts/angular/templates/grades/edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/edit.html.haml
@@ -1,8 +1,6 @@
 -# This is the main template for the grading form,
 -# all partials are loaded below.
 
-%grade-points-overview(ng-if='!vm.loading && !vm.isPassFailGraded() && !vm.isGroupGrade')
-
 %loading-message(loading='vm.loading' message="Loading Grade...")
 
 %grade-rubric-edit(ng-if='vm.isRubricGraded()')
@@ -25,7 +23,8 @@
 %article.grade-form-fields(ng-if='!vm.isGroupGrade')
   %grade-earned-badges-select(student-id='{{vm.recipientId}}')
 
-.right
+.grading-summary
+  %grade-points-overview(ng-if='!vm.loading && !vm.isPassFailGraded() && !vm.isGroupGrade' grade-type='{{vm.isRubricGraded() ? "RUBRIC" : "STANDARD_ASSIGNMENT"}}')
   %grade-status-select
   .right
     %grade-submit-buttons(ng-if='vm.isActiveCourse' submit-path='{{vm.submitPath}}' grade-next-path='{{vm.gradeNextPath}}')

--- a/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
@@ -1,4 +1,4 @@
-.points-overview-container
+.points-overview-container(ng-if="gradeType == 'RUBRIC'")
   #points-overview-floating
     %h4#points-legend
       %span.points-assigned(ng-class="{'points-missing': pointsAreLessThanFull(), 'points-satisfied': pointsAreSatisfied(), 'points-overage': pointsAreOver()}") {{ finalPoints() | number:0 }} Points
@@ -11,3 +11,12 @@
     %h4.notice(ng-show="isBelowThreshold()") {{ pointsBelowThreshold() | number:0 }} points below the threshold
 
     %h4.notice.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}" ng-show="adjustmentPoints() != 0") You have adjusted the total by {{adjustmentPoints()}} points
+
+.lower-points-summary(ng-if="gradeType == 'STANDARD_ASSIGNMENT'")
+  %h2.grade-form-header Points Summary
+  %p(ng-show="pointsArePresent()") Awarded Points: {{ grade.raw_points | number:0 }} / {{ assignment().full_points | number:0 }}
+  %p(ng-show="isBelowThreshold()") {{ pointsBelowThreshold() | number:0 }} points below the threshold
+  %p.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}" ng-show="adjustmentPoints() != 0") Adjusted Points: {{adjustmentPoints()}}
+  %hr.grading-divider
+  %p.total-points-score(ng-show="pointsArePresent()") Total Points: {{ grade.raw_points + adjustmentPoints() | number:0 }} / {{ assignment().full_points | number:0 }}
+    

--- a/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
@@ -15,8 +15,8 @@
 .lower-points-summary(ng-if="gradeType == 'STANDARD_ASSIGNMENT'")
   %h2.grade-form-header Points Summary
   %p(ng-show="pointsArePresent()") Awarded Points: {{ grade.raw_points | number:0 }} / {{ assignment().full_points | number:0 }}
-  %p(ng-show="isBelowThreshold()") {{ pointsBelowThreshold() | number:0 }} points below the threshold
-  %p.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}" ng-show="adjustmentPoints() != 0") Adjusted Points: {{adjustmentPoints()}}
+  %p.adjustment(ng-class="{'positive-adjustment' : adjustmentPoints() > 0}") Adjusted Points: {{adjustmentPoints()}}
+  %p(ng-show="isBelowThreshold()") Points below the threshold: {{ pointsBelowThreshold() | number:0 }}
   %hr.grading-divider
-  %p.total-points-score(ng-show="pointsArePresent()") Total Points: {{ grade.raw_points + adjustmentPoints() | number:0 }} / {{ assignment().full_points | number:0 }}
+  %p.total-points-score(ng-show="pointsArePresent()") Total Points: {{ finalPoints() | number:0 }} / {{ assignment().full_points | number:0 }}
     

--- a/app/assets/javascripts/angular/templates/grades/submit_buttons.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/submit_buttons.html.haml
@@ -1,3 +1,3 @@
 %section.grade-submit-buttons
   %button#submit-grade(ng-click="submitGrade(submitPath)" ng-class='{"disabled" : !grade.pending_status}') Submit Grade
-  %button#submit-grade(ng-if="gradeNextPath" ng-click="submitGrade(gradeNextPath)" ng-class='{"disabled" : !grade.pending_status}') Submit and Grade Next
+  %button#submit-grade-next(ng-if="gradeNextPath" ng-click="submitGrade(gradeNextPath)" ng-class='{"disabled" : !grade.pending_status}') Submit and Grade Next

--- a/app/assets/stylesheets/components/_collapse.sass
+++ b/app/assets/stylesheets/components/_collapse.sass
@@ -4,5 +4,11 @@
 .collapse
   margin: 0
 
-.collapse.open a i.fa.fa-angle-double-right.fa-fw
+.collapse-toggler .fa
+  padding-right: 0
+  transition: all 0.25s
   transform: rotate(90deg)
+
+.collapse-toggler.collapsed .fa,
+.collapse-toggler.open .fa
+  transform: rotate(0deg)

--- a/app/assets/stylesheets/components/_collapse.sass
+++ b/app/assets/stylesheets/components/_collapse.sass
@@ -9,6 +9,13 @@
   transition: all 0.25s
   transform: rotate(90deg)
 
-.collapse-toggler.collapsed .fa,
-.collapse-toggler.open .fa
+.collapse-toggler.collapsed .fa
   transform: rotate(0deg)
+
+.collapse .fa
+  padding-right: 0
+  transition: all 0.25s
+  transform: rotate(0deg)
+
+.collapse.open .fa
+  transform: rotate(90deg)

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -80,13 +80,13 @@ hr.light-grey
 .page-header
   padding: 0.5rem 1rem
 
-.collapse-toggler
-  i.fa.fa-angle-double-right.fa-fw
-    transform: rotate(90deg)
+.collapse-toggler .fa
+  padding-right: 0
+  transition: all 0.25s
+  transform: rotate(90deg)
 
-.collapse-toggler.collapsed
-  i.fa.fa-angle-double-right.fa-fw
-    transform: rotate(0deg)
+.collapse-toggler.collapsed .fa
+  transform: rotate(0deg)
 
 @media (min-width: $media-medium-max)
   .panel .row

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -80,14 +80,6 @@ hr.light-grey
 .page-header
   padding: 0.5rem 1rem
 
-.collapse-toggler .fa
-  padding-right: 0
-  transition: all 0.25s
-  transform: rotate(90deg)
-
-.collapse-toggler.collapsed .fa
-  transform: rotate(0deg)
-
 @media (min-width: $media-medium-max)
   .panel .row
     margin-bottom: 1rem

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -53,7 +53,7 @@ ul.nav-pill
     position: relative
 
   .search-input
-    padding: 0.4rem
+    margin: 0
     width: 190px
     border-radius: 0
     border-top-left-radius: $global-radius
@@ -69,10 +69,11 @@ ul.nav-pill
 
   .dropdown-menu
     position: absolute
+    left: 0
     padding: 0
     display: none
     background-color: $color-white
-    margin: 2px 0 0
+    margin-top: 5px
     font-size: 14px
     list-style: none
     border: 1px solid $color-grey-6

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -83,11 +83,12 @@
 .assignment-type-bar
   margin: 0 0 -1px 0
   border: 1px solid $color-grey-6
-  border-bottom: 3px solid $color-blue-2
   &:hover
       background-color: $color-grey-7
   &.collapsed
     border-bottom: 1px solid $color-grey-6
+  &.open
+    border-bottom: 3px solid $color-blue-2
 
   a
     padding: 0.75rem
@@ -124,7 +125,7 @@
   @media (max-width: $media-medium-max)
     float: right
 
-.assignment-type-container.collapsable
+.assignment-type-container
   padding: 1rem
   border: 1px solid $color-grey-6
   margin-bottom: -1px

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -157,10 +157,14 @@ ul.earned-badge-list
 // Award Earned Badges on Grading Page
 .badge-award-container
   float: left
-  margin: 1rem
-  width: 29%
+  width: 30%
   vertical-align: top
   cursor: pointer
+  display: flex
+  align-items: center
+  margin: 0.25rem 0
+  padding: 0 0.25rem
+
   img
     width: 40px
   &.unavailable
@@ -168,23 +172,21 @@ ul.earned-badge-list
     img
       cursor: default
     opacity: .5
+  @media (max-width: $media-small-max)
+    width: 48%
+    padding: 0
 
 .badge-award-checkmark
   input
     cursor: pointer
-  margin: 0.55rem
+  margin-right: 0.5rem
   width: 1rem
-  float: left
 
 .badge-award-image
-  width: 50px
-  height: 50px
-  float: left
-  font-size: 1.5rem
+  display: inline-block
+  vertical-align: middle
+  margin-right: 0.5rem
 
 .badge-award-name
   font-size: .7rem
-  margin: 0.55rem 0 0 0.55rem
   display: inline-block
-
-

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -67,7 +67,7 @@ section.grade-feedback-upload
   margin: 0.5rem 0
 
 section.grade-status
-  margin-bottom: 2rem
+  margin: 2rem 0
   p
     font-style: italic
     margin: 0

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -17,22 +17,12 @@
 .grade-form-subsection
   margin-bottom: 1rem
 
-.simple_form section label.grade-section-label,
-.grade-section-label
-  display: block
-  text-align: left
-
 article.grade-form-fields
   background-color: $color-grey-6
   margin: 1rem auto
   padding: 1rem
-  section
+  section:not(:last-child)
     margin-bottom: 0.5rem
-
-article.grade-form-fields.sectional
-  width: 28%
-  margin: 1rem
-  float: left
 
 section.grade-pass-fail
   .binary-switch-socket
@@ -48,20 +38,30 @@ section.grade-score-levels
   #grade-score-level-selector
     margin-bottom: 9px
 
+section.grade-adjustments-section.flex-wrapper
+  display: flex
+  flex-wrap: wrap
+  input[type="text"]
+   width: 100%
+  textarea
+   width: 100%
+   min-height: 100px
+  .grade-adjustments
+    width: 250px
+    margin: 0.5rem
+    background-color: $color-grey-6
+    @media (max-width: $media-small-max)
+      width: 100%
+
+
 section.grade-adjustments-section.collapse.collapsed
   overflow: hidden
   height: 0
 
-section.grade-adjustment-points-feedback
- width: 100%
- textarea
-   width: 100%
-   min-height: 100px
-
 section.grade-final-points
-  margin-top: 1rem
-  font-size: 1.25rem
-  padding: .25rem
+  margin-top: 0.5rem
+  font-size: 1rem
+  font-weight: 600
 
 section.grade-feedback-upload
   margin: 0.5rem 0

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -53,6 +53,10 @@ section.grade-adjustments-section.flex-wrapper
     @media (max-width: $media-small-max)
       width: 100%
 
+.grade-form-collapsible
+  color: $color-blue-2
+  &:hover
+    text-decoration: none
 
 section.grade-adjustments-section.collapse.collapsed
   overflow: hidden

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -50,6 +50,7 @@ section.grade-adjustments-section.flex-wrapper
     width: 250px
     margin: 0.5rem
     background-color: $color-grey-7
+    border: 1px solid $color-grey-6
     @media (max-width: $media-small-max)
       width: 100%
 

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -80,6 +80,18 @@ hr.grading-divider
   border: 1px solid $color-grey-6
   margin: 1rem auto
 
+.grading-summary
+  float: right
+
+.lower-points-summary
+  margin: 1rem 0
+  .grading-divider
+    margin: 0.5rem 0
+  p
+    margin: 0
+    font-weight: 300
+    &.total-points-score
+      font-weight: 400
 
 #rubric-grade-edit
   @include transition(all, .5s, ease-out)

--- a/app/assets/stylesheets/pages/_edit_grades.sass
+++ b/app/assets/stylesheets/pages/_edit_grades.sass
@@ -18,8 +18,8 @@
   margin-bottom: 1rem
 
 article.grade-form-fields
-  background-color: $color-grey-6
-  margin: 1rem auto
+  background-color: $color-grey-7
+  // margin: 1rem auto
   padding: 1rem
   section:not(:last-child)
     margin-bottom: 0.5rem
@@ -49,7 +49,7 @@ section.grade-adjustments-section.flex-wrapper
   .grade-adjustments
     width: 250px
     margin: 0.5rem
-    background-color: $color-grey-6
+    background-color: $color-grey-7
     @media (max-width: $media-small-max)
       width: 100%
 
@@ -58,7 +58,7 @@ section.grade-adjustments-section.flex-wrapper
   &:hover
     text-decoration: none
 
-section.grade-adjustments-section.collapse.collapsed
+.grade-form-fields section.collapse.collapsed
   overflow: hidden
   height: 0
 

--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -458,6 +458,7 @@ button.meets-expectations-status.no-expectation
     .points-overage
       color: $color-red-1
 
+
 //notices used on rubric design and rubric grading views
 h4.notice
   font-size: 14px

--- a/app/views/api/grades/show.json.jbuilder
+++ b/app/views/api/grades/show.json.jbuilder
@@ -39,5 +39,4 @@ json.meta do
   json.grade_status_options @grade_status_options if @grade_status_options
   json.threshold_points     @grade.assignment.threshold_points
   json.is_rubric_graded     @grade.assignment.grade_with_rubric?
-  json.has_awardable_badges @grade.course.has_badges?
 end

--- a/app/views/api/grades/show.json.jbuilder
+++ b/app/views/api/grades/show.json.jbuilder
@@ -39,5 +39,5 @@ json.meta do
   json.grade_status_options @grade_status_options if @grade_status_options
   json.threshold_points     @grade.assignment.threshold_points
   json.is_rubric_graded     @grade.assignment.grade_with_rubric?
+  json.has_awardable_badges @grade.course.has_badges?
 end
-

--- a/app/views/assignments/_index_observer.haml
+++ b/app/views/assignments/_index_observer.haml
@@ -4,7 +4,7 @@
   .assignments{role: "tablist"}
     - @assignment_types.each do |assignment_type|
       .assignment_type{id: "assignment-type-#{assignment_type.id}" }
-        .collapse.collapse-toggler{role: "tab"}
+        .collapse.collapse-toggle{role: "tab"}
           %h2.assignment-type-name
             %i.fa.fa-chevron-circle-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points

--- a/app/views/assignments/_index_observer.haml
+++ b/app/views/assignments/_index_observer.haml
@@ -4,9 +4,9 @@
   .assignments{role: "tablist"}
     - @assignment_types.each do |assignment_type|
       .assignment_type{id: "assignment-type-#{assignment_type.id}" }
-        .collapse{role: "tab"}
+        .collapse.collapse-toggler{role: "tab"}
           %h2.assignment-type-name
-            %i.fa.fa-angle-double-right.fa-fw
+            %i.fa.fa-chevron-circle-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden{role: "tabpanel"}
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -10,7 +10,7 @@
   .assignments{role: "tablist"}
     - @assignment_types.each do |assignment_type|
       .assignment_type{id: "assignment-type-#{assignment_type.id}" }
-        .collapse.collapse-toggler{role: "tab"}
+        .collapse{role: "tab"}
           %h2.assignment-type-name
             %i.fa.fa-chevron-circle-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -10,9 +10,9 @@
   .assignments{role: "tablist"}
     - @assignment_types.each do |assignment_type|
       .assignment_type{id: "assignment-type-#{assignment_type.id}" }
-        .collapse{role: "tab"}
+        .collapse.collapse-toggler{role: "tab"}
           %h2.assignment-type-name
-            %i.fa.fa-angle-double-right.fa-fw
+            %i.fa.fa-chevron-circle-right.fa-fw
             #{assignment_type.name} – #{points assignment_type.total_points} points
         .collapse-hidden{role: "tabpanel"}
           %ul.assignment-action-buttons

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -3,8 +3,6 @@
 
   = render partial: "submissions/assignment_guidelines", locals: { assignment: @assignment }
 
-  %hr.grading-divider
-
   - if @assignment.accepts_submissions? && @submission.present? && SubmissionProctor.new(@submission).viewable?(current_user)
     %hr.grading-divider
 

--- a/app/views/assignments/index_student/_assignments.haml
+++ b/app/views/assignments/index_student/_assignments.haml
@@ -3,7 +3,7 @@
 .assignment-index-container{role: "tablist"}
   - presenter.assignment_types.each do |assignment_type|
     .assignment_type.student{id: "assignment-type-#{assignment_type.id}" }
-      .assignment-type-bar.collapse.collapse-toggler{role: "tab"}
+      .assignment-type-bar.collapse{role: "tab"}
         %h2.assignment-type-name= glyph('chevron-circle-right') + "#{assignment_type.try(:name)}" 
         .points-summary
           // Display the student's points out of assignment total, if there is an assignment max value. Else

--- a/app/views/assignments/index_student/_assignments.haml
+++ b/app/views/assignments/index_student/_assignments.haml
@@ -3,8 +3,8 @@
 .assignment-index-container{role: "tablist"}
   - presenter.assignment_types.each do |assignment_type|
     .assignment_type.student{id: "assignment-type-#{assignment_type.id}" }
-      .assignment-type-bar.collapse{role: "tab"}
-        %h2.assignment-type-name= glyph('angle-double-right') + "#{assignment_type.try(:name)}" 
+      .assignment-type-bar.collapse.collapse-toggler{role: "tab"}
+        %h2.assignment-type-name= glyph('chevron-circle-right') + "#{assignment_type.try(:name)}" 
         .points-summary
           // Display the student's points out of assignment total, if there is an assignment max value. Else
           // display the student's points out of the the current point total for assignment.

--- a/app/views/assignments/index_student/_challenges.haml
+++ b/app/views/assignments/index_student/_challenges.haml
@@ -1,7 +1,7 @@
 - if current_course.has_team_challenges? && current_course.add_team_score_to_student? && current_student.team_for_course(current_course).present?
   .assignment_type.team-challenge.student{role: "tablist"}
 
-    .collapse.collapse-toggler{role: "tab"}
+    .collapse{role: "tab"}
       %h3= glyph('chevron-circle-right') + "#{term_for :challenges}" 
       .points-summary
         .points-bar-graph

--- a/app/views/assignments/index_student/_challenges.haml
+++ b/app/views/assignments/index_student/_challenges.haml
@@ -1,8 +1,8 @@
 - if current_course.has_team_challenges? && current_course.add_team_score_to_student? && current_student.team_for_course(current_course).present?
   .assignment_type.team-challenge.student{role: "tablist"}
 
-    .collapse{role: "tab"}
-      %h3= glyph('angle-double-right') + "#{term_for :challenges}" 
+    .collapse.collapse-toggler{role: "tab"}
+      %h3= glyph('chevron-circle-right') + "#{term_for :challenges}" 
       .points-summary
         .points-bar-graph
           .points-bar-graph-fill{:style => "width: #{(current_student.team_for_course(current_course).challenge_grade_score).to_f / (current_course.point_total_for_challenges).to_f * 100}%;"}

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -18,4 +18,5 @@
     'recipient-id'=>"#{@grade.student.id}",
     'submit-path'=>"#{@submit_path}",
     'grade-next-path'=>"#{@grade_next_path}",
-    'is-active-course'=>"#{current_course.active?}"}
+    'is-active-course'=>"#{current_course.active?}",
+    'has-awardable-badges'=>"#{current_course.has_badges?}"}

--- a/app/views/info/grading_status.html.haml
+++ b/app/views/info/grading_status.html.haml
@@ -24,7 +24,7 @@
 
   - if @ungraded_submissions_by_assignment.present?
     .collapseSection{id: "ungraded", role: "tablist"}
-      .collapse.collapse-toggler{role: "tab"}
+      .collapse{role: "tab"}
         %h3
           %i.fa.fa-chevron-circle-right.fa-fw
           Ungraded Submissions
@@ -33,7 +33,7 @@
 
   - if @unreleased_grades_by_assignment.present?
     .collapseSection{id: "unreleased", role: "tablist"}
-      .collapse.collapse-toggler{role: "tab"}
+      .collapse{role: "tab"}
         %h3
           %i.fa.fa-chevron-circle-right.fa-fw
           Unreleased Grades
@@ -42,7 +42,7 @@
 
   - if @in_progress_grades_by_assignment.present?
     .collapseSection{id: "in_progress", role: "tablist"}
-      .collapse.collapse-toggler{role: "tab"}
+      .collapse{role: "tab"}
         %h3
           %i.fa.fa-chevron-circle-right.fa-fw
           In Progress Grades
@@ -51,7 +51,7 @@
 
   - if @resubmissions_by_assignment.present?
     .collapseSection{id: "resubmissions", role: "tablist"}
-      .collapse.collapse-toggler{role: "tab"}
+      .collapse{role: "tab"}
         %h3
           %i.fa.fa-chevron-circle-right.fa-fw
           Resubmissions

--- a/app/views/info/grading_status.html.haml
+++ b/app/views/info/grading_status.html.haml
@@ -24,36 +24,36 @@
 
   - if @ungraded_submissions_by_assignment.present?
     .collapseSection{id: "ungraded", role: "tablist"}
-      .collapse{role: "tab"}
+      .collapse.collapse-toggler{role: "tab"}
         %h3
-          %i.fa.fa-angle-double-right.fa-fw
+          %i.fa.fa-chevron-circle-right.fa-fw
           Ungraded Submissions
       .collapse-hidden{role: "tabpanel"}
         = render partial: "submissions_table", locals: { submission_type: "ungraded", submissions_by_assignment: @ungraded_submissions_by_assignment, course: current_course }
 
   - if @unreleased_grades_by_assignment.present?
     .collapseSection{id: "unreleased", role: "tablist"}
-      .collapse{role: "tab"}
+      .collapse.collapse-toggler{role: "tab"}
         %h3
-          %i.fa.fa-angle-double-right.fa-fw
+          %i.fa.fa-chevron-circle-right.fa-fw
           Unreleased Grades
       .collapse-hidden{role: "tabpanel"}
         = render partial: "grades_table", locals: { grade_type: "unreleased", grades_by_assignment: @unreleased_grades_by_assignment, course: current_course }
 
   - if @in_progress_grades_by_assignment.present?
     .collapseSection{id: "in_progress", role: "tablist"}
-      .collapse{role: "tab"}
+      .collapse.collapse-toggler{role: "tab"}
         %h3
-          %i.fa.fa-angle-double-right.fa-fw
+          %i.fa.fa-chevron-circle-right.fa-fw
           In Progress Grades
       .collapse-hidden{role: "tabpanel"}
         = render partial: "grades_table", locals: { grade_type: "in_progress", grades_by_assignment: @in_progress_grades_by_assignment, course: current_course }
 
   - if @resubmissions_by_assignment.present?
     .collapseSection{id: "resubmissions", role: "tablist"}
-      .collapse{role: "tab"}
+      .collapse.collapse-toggler{role: "tab"}
         %h3
-          %i.fa.fa-angle-double-right.fa-fw
+          %i.fa.fa-chevron-circle-right.fa-fw
           Resubmissions
       .collapse-hidden{role: "tabpanel"}
         = render partial: "submissions_table", locals: { submission_type: "resubmissions", submissions_by_assignment: @resubmissions_by_assignment, course: current_course }

--- a/app/views/submissions/_assignment_guidelines.haml
+++ b/app/views/submissions/_assignment_guidelines.haml
@@ -32,7 +32,7 @@
     %p.minimize= raw assignment.assignment_type.description
     %hr.grading-divider
 
-- if current_user_is_staff? && @grade.present?
+- if current_user_is_staff? 
   %section.grade-form-section
     - if assignment.has_groups?
       %h2.grade-form-header= "Grade for #{@group.name}:" 

--- a/app/views/submissions/components/_edit.haml
+++ b/app/views/submissions/components/_edit.haml
@@ -1,1 +1,2 @@
-= active_course_link_to glyph(:pencil) + "#{presenter.term_for_edit(current_user)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"
+- if current_user_is_admin? || current_course.active?
+  = link_to glyph(:pencil) + "#{presenter.term_for_edit(current_user)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -41,6 +41,9 @@ en:
     grades:
       mass_edit:
         title: "Quick Grade #{ @assignment.name }"
+    groups:
+      grade:
+        title: "Editing #{ @group.name }'s Grade for #{ @assignment.name }"
   importers:
     importers:
       index:


### PR DESCRIPTION
### Status
**READY**

### Description
This PR tweaks the styling and cleans up the grading form for instructors.

### Todos
- [x] Lighten grey background color
- [x] convert badges section to be collapsible, shorten title of this and adjustment section
- [x] include collapsible section as part of grey background rather than separated sections
- [x] swap out icons for collapsible form sections
- [x] create new points allocated template and include right before submit buttons rather than floating
- [x] make icons for collapsible sections same everywhere
- [x] fix styling for assignment index

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Grading form
* Assignment index for students
* All collapsible sections (assignment, challenge indexes, assignment settings, grading forms, grading status)
* search course/students on Safari mostly - fixed padding and placement of dropdown menu

======================
Closes #3219 
