### PR TITLE
Show submission pane if student has draft

### DIFF
--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -78,7 +78,7 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def has_viewable_submission?(student, user)
-    submission = student.submission_for_assignment(assignment)
+    submission = student.submission_for_assignment(assignment, submitted_only=false)
     assignment.accepts_submissions? &&
       submission.present? &&
       SubmissionProctor.new(submission).viewable?(user)


### PR DESCRIPTION
### Status
**READY**

### Description
This fix addresses a place where students save drafts, and then can't get back to them. 
