### PR TITLE
3240 Add individual assignments to google calendar

### DIFF
--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -21,7 +21,7 @@ class GoogleCalendarsController < ApplicationController
     google_authorization = get_google_authorization(current_user)
     item = get_event_or_assignment(current_course, params[:class], params[:id])
     if item.due_at.nil?
-      redirect_to get_path(params[:class]), alert: "Google Calendar requires " + params[:class] + " have at least END time!" and return
+      redirect_to item, alert: "Google Calendar requires " + params[:class] + " have at least END time!" and return
     end
     begin
       google_event = create_google_event(item)

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -31,9 +31,9 @@ class GoogleCalendarsController < ApplicationController
       calendar.authorization = secrets.to_authorization
       calendar.authorization.refresh!
       result = calendar.insert_event('primary', google_event)
-      redirect_to get_path(params[:class]), notice: params[:class].capitalize + " " + item.name + " successfully added to your Google Calendar"
+      redirect_to item, notice: params[:class].capitalize + " " + item.name + " successfully added to your Google Calendar"
     rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
-      redirect_to get_path(params[:class]), alert: "Google Calendar encountered an Error. Your " + params[:class] + " was NOT copied to your Google calendar."
+      redirect_to item, alert: "Google Calendar encountered an Error. Your " + params[:class] + " was NOT copied to your Google calendar."
     end
   end
 

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -45,17 +45,21 @@ class GoogleCalendarsController < ApplicationController
     end
     google_authorization = get_google_authorization(current_user)
     assignment = current_course.assignments.find(params[:id])
-    begin
-      google_event = create_google_event_from_assignment(assignment)
-      calendar = Calendar::CalendarService.new
-      client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
-      secrets = create_google_secrets(google_authorization)
-      calendar.authorization = secrets.to_authorization
-      calendar.authorization.refresh!
-      result = calendar.insert_event('primary', google_event)
-      redirect_to assignments_path, notice: "Assignment " + assignment.name + " successfully added to your Google Calendar"
-    rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
-      redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
+    if assignment.due_at.nil?
+      redirect_to assignments_path, alert: "Google Calendar requires assignment have at least END time!"
+    else
+      begin
+        google_event = create_google_event_from_assignment(assignment)
+        calendar = Calendar::CalendarService.new
+        client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
+        secrets = create_google_secrets(google_authorization)
+        calendar.authorization = secrets.to_authorization
+        calendar.authorization.refresh!
+        result = calendar.insert_event('primary', google_event)
+        redirect_to assignments_path, notice: "Assignment " + assignment.name + " successfully added to your Google Calendar"
+      rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
+        redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
+      end
     end
   end
 

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -19,7 +19,7 @@ class GoogleCalendarsController < ApplicationController
       redirect_to "/auth/google_oauth2" and return
     end
     google_authorization = get_google_authorization(current_user)
-    item = get_event_or_assignment(params[:class], params[:id])
+    item = get_event_or_assignment(current_course, params[:class], params[:id])
     if item.due_at.nil?
       redirect_to get_path(params[:class]), alert: "Google Calendar requires " + params[:class] + " have at least END time!" and return
     end

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -21,7 +21,7 @@ class GoogleCalendarsController < ApplicationController
     google_authorization = get_google_authorization(current_user)
     item = get_event_or_assignment(params[:class], params[:id])
     if item.due_at.nil?
-      redirect_to assignments_path, alert: "Google Calendar requires " + params[:class] + " assignment have at least END time!" and return
+      redirect_to get_path(params[:class]), alert: "Google Calendar requires " + params[:class] + " have at least END time!" and return
     end
     begin
       google_event = create_google_event(item)
@@ -34,12 +34,6 @@ class GoogleCalendarsController < ApplicationController
       redirect_to get_path(params[:class]), notice: params[:class].capitalize + " " + item.name + " successfully added to your Google Calendar"
     rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
       redirect_to get_path(params[:class]), alert: "Google Calendar encountered an Error. Your " + params[:class] + " was NOT copied to your Google calendar."
-      # if item.is_a?(Assignment)
-      #   redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
-      # end
-      # if item.is_a?(Event)
-      #   redirect_to events_path, alert: "Google Calendar encountered an Error. Your event was NOT copied to your Google calendar."
-      # end
     end
   end
 

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -8,58 +8,38 @@ class GoogleCalendarsController < ApplicationController
   require 'googleauth'
 
   before_action do |controller|
-    controller.redirect_path events_path
+    controller.redirect_path request.referer
   end
 
   Calendar = Google::Apis::CalendarV3
 
-  def add_event_to_google_calendar
+  def add_to_google_calendar
     if !google_auth_present?(current_user)
       # rubocop:disable AndOr
       redirect_to "/auth/google_oauth2" and return
     end
     google_authorization = get_google_authorization(current_user)
-    event = current_course.events.find(params[:id])
-    if event.open_at.nil? || event.due_at.nil?
-      redirect_to events_path, alert: "Google Calendar requires event have both START and END time!"
-    else
-      begin
-        google_event = create_google_event(event)
-        calendar = Calendar::CalendarService.new
-        client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
-        secrets = create_google_secrets(google_authorization)
-        calendar.authorization = secrets.to_authorization
-        calendar.authorization.refresh!
-        result = calendar.insert_event('primary', google_event)
-        redirect_to events_path, notice: "Event " + event.name + " successfully added to your Google Calendar"
-      rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
-        redirect_to events_path, alert: "Google Calendar encountered an Error. Your event was NOT copied to your Google calendar."
-      end
+    item = get_event_or_assignment(params[:class], params[:id])
+    if item.due_at.nil?
+      redirect_to assignments_path, alert: "Google Calendar requires " + params[:class] + " assignment have at least END time!" and return
     end
-  end
-
-  def add_assignment_to_google_calendar
-    if !google_auth_present?(current_user)
-      # rubocop:disable AndOr
-      redirect_to "/auth/google_oauth2" and return
-    end
-    google_authorization = get_google_authorization(current_user)
-    assignment = current_course.assignments.find(params[:id])
-    if assignment.due_at.nil?
-      redirect_to assignments_path, alert: "Google Calendar requires assignment have at least END time!"
-    else
-      begin
-        google_event = create_google_event_from_assignment(assignment)
-        calendar = Calendar::CalendarService.new
-        client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
-        secrets = create_google_secrets(google_authorization)
-        calendar.authorization = secrets.to_authorization
-        calendar.authorization.refresh!
-        result = calendar.insert_event('primary', google_event)
-        redirect_to assignments_path, notice: "Assignment " + assignment.name + " successfully added to your Google Calendar"
-      rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
-        redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
-      end
+    begin
+      google_event = create_google_event(item)
+      calendar = Calendar::CalendarService.new
+      client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
+      secrets = create_google_secrets(google_authorization)
+      calendar.authorization = secrets.to_authorization
+      calendar.authorization.refresh!
+      result = calendar.insert_event('primary', google_event)
+      redirect_to get_path(params[:class]), notice: params[:class].capitalize + " " + item.name + " successfully added to your Google Calendar"
+    rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
+      redirect_to get_path(params[:class]), alert: "Google Calendar encountered an Error. Your " + params[:class] + " was NOT copied to your Google calendar."
+      # if item.is_a?(Assignment)
+      #   redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
+      # end
+      # if item.is_a?(Event)
+      #   redirect_to events_path, alert: "Google Calendar encountered an Error. Your event was NOT copied to your Google calendar."
+      # end
     end
   end
 

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -38,4 +38,25 @@ class GoogleCalendarsController < ApplicationController
     end
   end
 
+  def add_assignment_to_google_calendar
+    if !google_auth_present?(current_user)
+      # rubocop:disable AndOr
+      redirect_to "/auth/google_oauth2" and return
+    end
+    google_authorization = get_google_authorization(current_user)
+    assignment = current_course.assignments.find(params[:id])
+    begin
+      google_event = create_google_event_from_assignment(assignment)
+      calendar = Calendar::CalendarService.new
+      client_id = Google::Auth::ClientId.new(ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_SECRET'])
+      secrets = create_google_secrets(google_authorization)
+      calendar.authorization = secrets.to_authorization
+      calendar.authorization.refresh!
+      result = calendar.insert_event('primary', google_event)
+      redirect_to assignments_path, notice: "Assignment " + assignment.name + " successfully added to your Google Calendar"
+    rescue Google::Apis::ServerError, Google::Apis::ClientError, Google::Apis::AuthorizationError, Signet::AuthorizationError
+      redirect_to assignments_path, alert: "Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar."
+    end
+  end
+
 end

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -11,6 +11,24 @@ module GoogleCalendarsHelper
     google_authorization
   end
 
+  def get_event_or_assignment(class_name, id)
+    if class_name == "event"
+      return current_course.events.find(id)
+    end
+    if class_name == "assignment"
+      return current_course.assignments.find(id)
+    end
+  end
+
+  def get_path(class_name)
+    if class_name == "assignment"
+      return assignments_path
+    end
+    if class_name == "event"
+      return events_path
+    end
+  end
+
   def refresh_if_google_authorization_is_expired(google_authorization)
     return unless google_authorization.expired?
     google_authorization.refresh!({ client_id: ENV["GOOGLE_CLIENT_ID"], client_secret: ENV["GOOGLE_SECRET"] })

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -12,21 +12,13 @@ module GoogleCalendarsHelper
   end
 
   def get_event_or_assignment(class_name, id)
-    if class_name == "event"
-      return current_course.events.find(id)
-    end
-    if class_name == "assignment"
-      return current_course.assignments.find(id)
-    end
+    return current_course.events.find(id) if class_name == "event"
+    return current_course.assignments.find(id) if class_name == "assignment"
   end
 
   def get_path(class_name)
-    if class_name == "assignment"
-      return assignments_path
-    end
-    if class_name == "event"
-      return events_path
-    end
+    return assignments_path if class_name == "assignment"
+    return events_path if class_name == "event"
   end
 
   def refresh_if_google_authorization_is_expired(google_authorization)
@@ -38,38 +30,25 @@ module GoogleCalendarsHelper
     current_user.authorizations.find_by(provider: "google_oauth2").present?
   end
 
-  def create_google_event(event)
+  def create_google_event(item)
     google_event = Calendar::Event.new({
-      summary: event.name,
+      summary: item.name,
+      description: item.description,
       start: {
-        date_time: event.open_at.to_datetime.rfc3339
+        date_time: (generate_open_date_if_one_does_not_exist(item)).to_datetime.rfc3339
       },
       end: {
-        date_time: event.due_at.to_datetime.rfc3339
+        date_time: item.due_at.to_datetime.rfc3339
       }
     })
     google_event
   end
 
-  def create_google_event_from_assignment(assignment)
-    google_event = Calendar::Event.new({
-      summary: assignment.name,
-      description: assignment.description,
-      start: {
-        date_time: (generate_open_date_if_one_does_not_exist(assignment)).to_datetime.rfc3339
-      },
-      end: {
-        date_time: assignment.due_at.to_datetime.rfc3339
-      }
-    })
-    google_event
-  end
-
-  def generate_open_date_if_one_does_not_exist(assignment)
-    if assignment.open_at.nil?
-      assignment.due_at - 30.minutes
+  def generate_open_date_if_one_does_not_exist(item)
+    if item.open_at.nil?
+      item.due_at - 30.minutes
     else
-      assignment.open_at
+      item.open_at
     end
   end
 

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -38,13 +38,21 @@ module GoogleCalendarsHelper
       summary: assignment.name,
       description: assignment.description,
       start: {
-        date_time: (assignment.due_at - 30.minutes).to_datetime.rfc3339
+        date_time: (generate_open_date_if_one_does_not_exist(assignment)).to_datetime.rfc3339
       },
       end: {
         date_time: assignment.due_at.to_datetime.rfc3339
       }
     })
     google_event
+  end
+
+  def generate_open_date_if_one_does_not_exist(assignment)
+    if assignment.open_at.nil?
+      assignment.due_at - 30.minutes
+    else
+      assignment.open_at
+    end
   end
 
   def create_google_secrets(google_authorization)

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -11,7 +11,7 @@ module GoogleCalendarsHelper
     google_authorization
   end
 
-  def get_event_or_assignment(class_name, id)
+  def get_event_or_assignment(current_course, class_name, id)
     return current_course.events.find(id) if class_name == "event"
     return current_course.assignments.find(id) if class_name == "assignment"
   end

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -16,11 +16,6 @@ module GoogleCalendarsHelper
     return current_course.assignments.find(id) if class_name == "assignment"
   end
 
-  def get_path(class_name)
-    return assignments_path if class_name == "assignment"
-    return events_path if class_name == "event"
-  end
-
   def refresh_if_google_authorization_is_expired(google_authorization)
     return unless google_authorization.expired?
     google_authorization.refresh!({ client_id: ENV["GOOGLE_CLIENT_ID"], client_secret: ENV["GOOGLE_SECRET"] })

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -33,6 +33,20 @@ module GoogleCalendarsHelper
     google_event
   end
 
+  def create_google_event_from_assignment(assignment)
+    google_event = Calendar::Event.new({
+      summary: assignment.name,
+      description: assignment.description,
+      start: {
+        date_time: (assignment.due_at - 30.minutes).to_datetime.rfc3339
+      },
+      end: {
+        date_time: assignment.due_at.to_datetime.rfc3339
+      }
+    })
+    google_event
+  end
+
   def create_google_secrets(google_authorization)
     Google::APIClient::ClientSecrets.new({"web" =>
       {"access_token" => google_authorization.access_token,

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -3,6 +3,7 @@
     %ul
       - if !presenter.new_assignment?
         = active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(presenter.assignment), class: "button button-edit"
+
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu
@@ -40,3 +41,6 @@
                   Edit Rubric
                 - else
                   Create Rubric
+
+        = active_course_link_to decorative_glyph(:copy) + "Add to Google Calendar",
+          add_assignment_to_google_calendar_google_calendar_path(presenter.assignment), class: "button button-edit", method: :post

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -43,4 +43,4 @@
                   Create Rubric
 
         = active_course_link_to decorative_glyph(:copy) + "Add to Google Calendar",
-          add_assignment_to_google_calendar_google_calendar_path(presenter.assignment), class: "button button-edit", method: :post
+          add_to_google_calendar_google_calendar_path("assignment", presenter.assignment), class: "button button-edit", method: :post

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -15,6 +15,11 @@
 %p.assignment-description.italic= "Opens: #{presenter.assignment.open_at}" if presenter.assignment.open_at?
 %p.assignment-description.italic= "Due: #{presenter.assignment.due_at}" if presenter.assignment.due_at?
 
+%p.assignment-description= active_course_link_to decorative_glyph(:copy) + "Add to Google Calendar",
+  add_assignment_to_google_calendar_google_calendar_path(presenter.assignment),
+  class: "button button-edit",
+    method: :post
+
 - if presenter.assignment_accepting_submissions?(current_student) && !presenter.has_viewable_submission?(current_student, current_user)
   = render partial: "students/submissions", locals: { assignment: presenter.assignment }
 

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -16,7 +16,7 @@
 %p.assignment-description.italic= "Due: #{presenter.assignment.due_at}" if presenter.assignment.due_at?
 
 %p.assignment-description= active_course_link_to decorative_glyph(:copy) + "Add to Google Calendar",
-  add_assignment_to_google_calendar_google_calendar_path(presenter.assignment),
+  add_to_google_calendar_google_calendar_path("assignment", presenter.assignment),
   class: "button button-edit",
     method: :post
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -6,7 +6,7 @@
         %li= link_to decorative_glyph(:edit) + "Edit", edit_event_path(@event), class: "button button-edit"
         %li= link_to decorative_glyph(:copy) + "Copy Event ", copy_events_path(id: @event.id), class: "button button-edit", method: :post
         %li= link_to decorative_glyph(:copy) + "Add to Google Calendar ",
-          add_event_to_google_calendar_google_calendar_path(@event), class: "button button-edit", method: :post
+          add_to_google_calendar_google_calendar_path("event", @event), class: "button button-edit", method: :post
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,8 +187,7 @@ Rails.application.routes.draw do
 
   resource :google_calendar, only: [ ] do
     collection do
-      post "/event/:id", action: :add_event_to_google_calendar, as: :add_event_to_google_calendar
-      post "/assignment/:id", action: :add_assignment_to_google_calendar, as: :add_assignment_to_google_calendar
+      post "/:class/:id", action: :add_to_google_calendar, as: :add_to_google_calendar
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
   resource :google_calendar, only: [ ] do
     collection do
       post "/event/:id", action: :add_event_to_google_calendar, as: :add_event_to_google_calendar
+      post "/assignment/:id", action: :add_assignment_to_google_calendar, as: :add_assignment_to_google_calendar
     end
   end
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -1,0 +1,77 @@
+# Events
+
+  * Is a [customizable term](customizable terms)
+
+### Concerns
+  * [Copyable](copyable)
+  * [UploadsMedia](uploads_media)
+
+#### belongs_to
+  * [Course](courses)
+
+### Validations
+
+  * boolean methods that must be set to either true or false: `name`
+
+### Scopes
+
+  * `with_dates`
+
+### Attributes
+  * `course_id`
+  * `name`
+  * `description`
+  * `open_at`
+  * `due_at`
+  * `media`
+
+### Google Calendar
+
+#### Google Calendar Controller Methods
+
+  * add_event_to_google_calendar - copies an event in the GradeCraft database to the user's primary Google Calendar.
+
+#### Google Calendar Integration Set UP
+
+1. Navigate to `https://console.developers.google.com/` and log in with your Google account. If you do not have a Google account, please create one now.
+1. Click on the “Credentials” button in the left navigation pane.
+1. In the “Select a Resource” box, select “Create”.
+1. Choose a project name.
+1. Agree to the terms and conditions.
+1. Create an OAuth authorization.
+1. Click on Configure Consent Screen button.
+1. Fill out the form including Admin’s Email Address, Product Name, etc.
+1. Add `http://localhost:5000` to the Authorized JavaScript Origins list.
+1. Add `http://localhost:5000/auth/google_oauth2/callback` to the Authorized Redirect URIs.
+1. Copy the Client Id and Client Secret from this page.
+1. Add them to your environment variables in your project:
+1. `GOOGLE_CLIENT_ID` = xyz…
+1. `GOOGLE_SECRET` = xyz…
+1. Navigate to “Library”
+1. Find the API(s) you want to enable for your application in the list shown on the page.
+
+   NOTE: It is mandatory to include the Google+ API. Please enable this API before any others.
+1. Click on the link labeled “Enable API”.
+1. Note the information for the API in the section “About this API”.
+1. Click “Enable”.
+
+#### UI Workflow
+
+1. A user creates or views an event that has at minimum the following attributes:
+	* name
+	* open_at
+	* due_at
+1. The user clicks the `Add to Google Calendar` button.
+1. If this is the user's first time using the `Add to Google Calendar` button, the user is directed to a Google Authorization page where the user will be given the option to allow or deny GradeCraft access to the user's primary Google Calendar.
+1. Allowing GradeCraft access to the user's primary Google Calendar will in turn create a record in the `user_authorizations` table, with the `provider` field being `google_oauth2`. The user is then redirected back to the Events Index Page **WITHOUT** the event being added to the user's primary Google Calendar.
+1. If the User denies GradeCraft access to the User's primary Google Calendar, then the user is directed to the `auth_failure.html` page.
+1. If the user already has an existing `user_authorization` record where the provider is `google_oauth2`, then upon clicking the `Add to Google Calendar` button the `google_calendars_controller` will invoke the `google_calendars_helper` to refresh the `google_oauth2` `user_authorization` if it has expired.
+1. If all checks pass, then the event is added to the user's primary Google Calendar.
+1. For any reason, if there is an error then the user is redirected to the Events Page with the alert message, `Google Calendar encountered an Error. Your event was NOT copied to your Google calendar.`
+
+#### Helpful Links
+
+   * [Google Calendar V3 Class Documentation](http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/CalendarV3)
+   * [Google Calendar V3 Event Class Documentation](http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/CalendarV3/Event)
+   * [Google Calendar V3 CalendarSerive Class Documentation](http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/CalendarV3/CalendarService)
+   * [Google Api Client Gem Documentation](https://github.com/google/google-api-ruby-client)

--- a/spec/controllers/google_calendars_controller_spec.rb
+++ b/spec/controllers/google_calendars_controller_spec.rb
@@ -9,6 +9,10 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
   let(:no_start_event) { create :event, course: course, open_at: nil, due_at: Time.now}
   let(:no_end_event) { create :event, course: course, open_at: Time.now - (24 * 60 * 60), due_at: nil}
   let(:no_name_event) { create :event, course: course, open_at: Time.now - (24 * 60 * 60), due_at: Time.now, name: nil}
+  let(:assignment_type) { create(:assignment_type, course: course) }
+  let(:assignment) { create(:assignment, assignment_type: assignment_type, course: course, due_at: DateTime.new(2017,4,1,17,0,0,-4)) }
+  let(:no_start_assignment) { create(:assignment, assignment_type: assignment_type, course: course, open_at: nil, due_at: DateTime.new(2017,4,1,17,0,0,-4)) }
+  let(:no_end_assignment) { create(:assignment, assignment_type: assignment_type, course: course, open_at: nil, due_at: nil) }
   let(:student) { build :user, courses: [course], role: :student }
 
   before do
@@ -77,6 +81,67 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to google authentication page" do
 
         post :add_event_to_google_calendar, params: { id: no_end_event.id}
+
+        expect(response).to redirect_to "/auth/google_oauth2"
+      end
+    end
+  end
+
+  describe "POST add_assignment_to_google_calendar", focus: true do
+    before(:each) do
+      stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
+        to_return(:status => 200, :body => "", :headers => {})
+    end
+
+    # Authorized User attempting add standard assignment
+    context "with an existing authentication" do
+      let! (:user_auth) { create :user_authorization, :google, user: student, access_token: "token", expires_at: 2.days.from_now}
+
+      it "redirects to assignments path with a successful notice when attempting to add a standard assignment" do
+        post :add_assignment_to_google_calendar, params: { id: assignment.id}
+
+        expect(response).to redirect_to assignments_path
+        expect(flash[:notice]).to eq("Assignment " + assignment.name + " successfully added to your Google Calendar")
+      end
+
+      # Authorized User attempting to add an assignment with no start date
+      it "redirects to assignments path with a successful notice when attempting to add an assignment with no open date, generates open date to be 30 minutes prior to due date" do
+        post :add_assignment_to_google_calendar, params: { id: no_start_assignment.id}
+
+        expect(response).to redirect_to assignments_path
+        expect(flash[:notice]).to eq("Assignment " + no_start_assignment.name + " successfully added to your Google Calendar")
+      end
+
+      # Authorized User attempting to add an assignment with no start and no end date
+      it "redirects to assignments path with an alert notice when attempting to add an event with no due date" do
+        post :add_assignment_to_google_calendar, params: { id: no_end_assignment.id}
+
+        expect(response).to redirect_to assignments_path
+        expect(flash[:alert]).to eq("Google Calendar requires assignment have at least END time!")
+      end
+
+      # Authorized User attempting to add a standard assignment without Google Client Id and Secret
+      it "redirects to assignments path with an unsuccessful alert when user doesn't have proper Google Client Id and/or Secret" do
+
+        stub_request(:post, "https://accounts.google.com/o/oauth2/token").
+          with(:body => {"client_id"=>"WRONG_VALUE", "client_secret"=>"WRONG_VALUE", "grant_type"=>""}).
+          to_return(:status => 401, :body => "", :headers => {'Content-Type'=>'application/x-www-form-urlencoded'})
+
+        stub_const('ENV', ENV.to_hash.merge('GOOGLE_CLIENT_ID' => 'WRONG_VALUE'))
+        stub_const('ENV', ENV.to_hash.merge('GOOGLE_SECRET' => 'WRONG_VALUE'))
+
+        post :add_assignment_to_google_calendar, params: { id: assignment.id}
+
+        expect(response).to redirect_to assignments_path
+        expect(flash[:alert]).to eq("Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar.")
+      end
+    end
+
+    # Unauthorized User attempting to add a standard assignment with no end date
+    context "without an existing authentication" do
+      it "redirects to google authentication page" do
+
+        post :add_assignment_to_google_calendar, params: { id: no_end_event.id}
 
         expect(response).to redirect_to "/auth/google_oauth2"
       end

--- a/spec/controllers/google_calendars_controller_spec.rb
+++ b/spec/controllers/google_calendars_controller_spec.rb
@@ -26,7 +26,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
 
   before(:each) { login_user(student) }
 
-  describe "POST add_event_to_google_calendar" do
+  describe "POST add_to_google_calendar" do
     before(:each) do
       stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
         to_return(:status => 200, :body => "", :headers => {})
@@ -37,26 +37,18 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       let! (:user_auth) { create :user_authorization, :google, user: student, access_token: "token", expires_at: 2.days.from_now}
 
       it "redirects to events path with a successful notice when attempting to add a standard event" do
-        post :add_event_to_google_calendar, params: { id: standard_event.id}
+        post :add_to_google_calendar, params: { class: "event", id: standard_event.id }
 
         expect(response).to redirect_to events_path
         expect(flash[:notice]).to eq("Event " + standard_event.name + " successfully added to your Google Calendar")
       end
 
-      # Authorized User attempting to add an event with no start date
-      it "redirects to events path with an alert notice when attempting to add an event with no open date" do
-        post :add_event_to_google_calendar, params: { id: no_start_event.id}
-
-        expect(response).to redirect_to events_path
-        expect(flash[:alert]).to eq("Google Calendar requires event have both START and END time!")
-      end
-
       # Authorized User attempting to add an event with no end date
       it "redirects to events path with an alert notice when attempting to add an event with no due date" do
-        post :add_event_to_google_calendar, params: { id: no_end_event.id}
+        post :add_to_google_calendar, params: { class: "event", id: no_end_event.id }
 
         expect(response).to redirect_to events_path
-        expect(flash[:alert]).to eq("Google Calendar requires event have both START and END time!")
+        expect(flash[:alert]).to eq("Google Calendar requires event have at least END time!")
       end
 
       # Authorized User attempting to add a standard event without Google Client Id and Secret
@@ -69,7 +61,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
         stub_const('ENV', ENV.to_hash.merge('GOOGLE_CLIENT_ID' => 'WRONG_VALUE'))
         stub_const('ENV', ENV.to_hash.merge('GOOGLE_SECRET' => 'WRONG_VALUE'))
 
-        post :add_event_to_google_calendar, params: { id: standard_event.id}
+        post :add_to_google_calendar, params: { class: "event", id: standard_event.id }
 
         expect(response).to redirect_to events_path
         expect(flash[:alert]).to eq("Google Calendar encountered an Error. Your event was NOT copied to your Google calendar.")
@@ -80,14 +72,14 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
     context "without an existing authentication" do
       it "redirects to google authentication page" do
 
-        post :add_event_to_google_calendar, params: { id: no_end_event.id}
+        post :add_to_google_calendar, params: { class: "event", id: no_end_event.id }
 
         expect(response).to redirect_to "/auth/google_oauth2"
       end
     end
   end
 
-  describe "POST add_assignment_to_google_calendar" do
+  describe "POST add_to_google_calendar" do
     before(:each) do
       stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
         to_return(:status => 200, :body => "", :headers => {})
@@ -98,7 +90,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       let! (:user_auth) { create :user_authorization, :google, user: student, access_token: "token", expires_at: 2.days.from_now}
 
       it "redirects to assignments path with a successful notice when attempting to add a standard assignment" do
-        post :add_assignment_to_google_calendar, params: { id: assignment.id}
+        post :add_to_google_calendar, params: { class: "assignment", id: assignment.id }
 
         expect(response).to redirect_to assignments_path
         expect(flash[:notice]).to eq("Assignment " + assignment.name + " successfully added to your Google Calendar")
@@ -106,7 +98,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
 
       # Authorized User attempting to add an assignment with no start date
       it "redirects to assignments path with a successful notice when attempting to add an assignment with no open date, generates open date to be 30 minutes prior to due date" do
-        post :add_assignment_to_google_calendar, params: { id: no_start_assignment.id}
+        post :add_to_google_calendar, params: { class: "assignment", id: no_start_assignment.id}
 
         expect(response).to redirect_to assignments_path
         expect(flash[:notice]).to eq("Assignment " + no_start_assignment.name + " successfully added to your Google Calendar")
@@ -114,7 +106,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
 
       # Authorized User attempting to add an assignment with no start and no end date
       it "redirects to assignments path with an alert notice when attempting to add an event with no due date" do
-        post :add_assignment_to_google_calendar, params: { id: no_end_assignment.id}
+        post :add_to_google_calendar, params: { class: "assignment", id: no_end_assignment.id}
 
         expect(response).to redirect_to assignments_path
         expect(flash[:alert]).to eq("Google Calendar requires assignment have at least END time!")
@@ -130,7 +122,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
         stub_const('ENV', ENV.to_hash.merge('GOOGLE_CLIENT_ID' => 'WRONG_VALUE'))
         stub_const('ENV', ENV.to_hash.merge('GOOGLE_SECRET' => 'WRONG_VALUE'))
 
-        post :add_assignment_to_google_calendar, params: { id: assignment.id}
+        post :add_to_google_calendar, params: { class: "assignment", id: assignment.id}
 
         expect(response).to redirect_to assignments_path
         expect(flash[:alert]).to eq("Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar.")
@@ -141,7 +133,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
     context "without an existing authentication" do
       it "redirects to google authentication page" do
 
-        post :add_assignment_to_google_calendar, params: { id: no_end_event.id}
+        post :add_to_google_calendar, params: { class: "assignment", id: no_end_event.id}
 
         expect(response).to redirect_to "/auth/google_oauth2"
       end

--- a/spec/controllers/google_calendars_controller_spec.rb
+++ b/spec/controllers/google_calendars_controller_spec.rb
@@ -39,7 +39,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to events path with a successful notice when attempting to add a standard event" do
         post :add_to_google_calendar, params: { class: "event", id: standard_event.id }
 
-        expect(response).to redirect_to events_path
+        expect(response).to redirect_to event_path(standard_event)
         expect(flash[:notice]).to eq("Event " + standard_event.name + " successfully added to your Google Calendar")
       end
 
@@ -47,7 +47,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to events path with an alert notice when attempting to add an event with no due date" do
         post :add_to_google_calendar, params: { class: "event", id: no_end_event.id }
 
-        expect(response).to redirect_to events_path
+        expect(response).to redirect_to event_path(no_end_event)
         expect(flash[:alert]).to eq("Google Calendar requires event have at least END time!")
       end
 
@@ -63,7 +63,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
 
         post :add_to_google_calendar, params: { class: "event", id: standard_event.id }
 
-        expect(response).to redirect_to events_path
+        expect(response).to redirect_to event_path(standard_event)
         expect(flash[:alert]).to eq("Google Calendar encountered an Error. Your event was NOT copied to your Google calendar.")
       end
     end
@@ -92,7 +92,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to assignments path with a successful notice when attempting to add a standard assignment" do
         post :add_to_google_calendar, params: { class: "assignment", id: assignment.id }
 
-        expect(response).to redirect_to assignments_path
+        expect(response).to redirect_to assignment_path(assignment)
         expect(flash[:notice]).to eq("Assignment " + assignment.name + " successfully added to your Google Calendar")
       end
 
@@ -100,7 +100,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to assignments path with a successful notice when attempting to add an assignment with no open date, generates open date to be 30 minutes prior to due date" do
         post :add_to_google_calendar, params: { class: "assignment", id: no_start_assignment.id}
 
-        expect(response).to redirect_to assignments_path
+        expect(response).to redirect_to assignment_path(no_start_assignment)
         expect(flash[:notice]).to eq("Assignment " + no_start_assignment.name + " successfully added to your Google Calendar")
       end
 
@@ -108,7 +108,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
       it "redirects to assignments path with an alert notice when attempting to add an event with no due date" do
         post :add_to_google_calendar, params: { class: "assignment", id: no_end_assignment.id}
 
-        expect(response).to redirect_to assignments_path
+        expect(response).to redirect_to assignment_path(no_end_assignment)
         expect(flash[:alert]).to eq("Google Calendar requires assignment have at least END time!")
       end
 
@@ -124,7 +124,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
 
         post :add_to_google_calendar, params: { class: "assignment", id: assignment.id}
 
-        expect(response).to redirect_to assignments_path
+        expect(response).to redirect_to assignment_path(assignment)
         expect(flash[:alert]).to eq("Google Calendar encountered an Error. Your assignment was NOT copied to your Google calendar.")
       end
     end

--- a/spec/controllers/google_calendars_controller_spec.rb
+++ b/spec/controllers/google_calendars_controller_spec.rb
@@ -87,7 +87,7 @@ describe GoogleCalendarsController, type:[:disable_external_api, :controller] do
     end
   end
 
-  describe "POST add_assignment_to_google_calendar", focus: true do
+  describe "POST add_assignment_to_google_calendar" do
     before(:each) do
       stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
         to_return(:status => 200, :body => "", :headers => {})

--- a/spec/helpers/google_calendars_helper_spec.rb
+++ b/spec/helpers/google_calendars_helper_spec.rb
@@ -37,13 +37,27 @@ describe GoogleCalendarsHelper do
   describe "#create_google_event" do
     let(:course) { build(:course) }
     let(:event) { create(:event, course: course) }
-    it "creates a google calendar event object" do
+    it "creates a google calendar event object from a GradeCraft event" do
       event.open_at = Time.now - (24 * 60 * 60)
       google_event = create_google_event(event)
       expect(google_event).not_to be nil
       expect(event.name).to be google_event.summary
       expect(event.open_at.to_datetime.rfc3339).to eq google_event.start[:date_time]
       expect(event.due_at.to_datetime.rfc3339).to eq google_event.end[:date_time]
+    end
+  end
+
+  describe "#create_google_event_from_assignment", focus: true do
+    let(:course) { build(:course) }
+    let(:assignment_type) { create(:assignment_type, course: course) }
+    let(:assignment) { create(:assignment, assignment_type: assignment_type, course: course) }
+    it "creates a google calendar event object from a GradeCraft assignment" do
+      assignment.due_at = Time.now - (24 * 60 * 60)
+      google_event = create_google_event_from_assignment(assignment)
+      expect(google_event).not_to be nil
+      expect(assignment.name).to be google_event.summary
+      expect((assignment.due_at - 30.minutes).to_datetime.rfc3339).to eq google_event.start[:date_time]
+      expect(assignment.due_at.to_datetime.rfc3339).to eq google_event.end[:date_time]
     end
   end
 

--- a/spec/helpers/google_calendars_helper_spec.rb
+++ b/spec/helpers/google_calendars_helper_spec.rb
@@ -47,7 +47,7 @@ describe GoogleCalendarsHelper do
     end
   end
 
-  describe "#create_google_event_from_assignment", focus: true do
+  describe "#create_google_event_from_assignment" do
     let(:course) { build(:course) }
     let(:assignment_type) { create(:assignment_type, course: course) }
     let(:assignment) { create(:assignment, assignment_type: assignment_type, course: course) }

--- a/spec/helpers/google_calendars_helper_spec.rb
+++ b/spec/helpers/google_calendars_helper_spec.rb
@@ -1,19 +1,8 @@
 require "rails_spec_helper"
 
-# include GoogleCalendarsHelper
+include GoogleCalendarsHelper
 
-describe GoogleCalendarsHelper, focus: true do
-  let(:course) { double(:course) }
-
-  class Helper
-    include GoogleCalendarsHelper
-
-    def current_course
-    end
-  end
-
-  subject(:helper) { Helper.new }
-  before {allow(helper).to receive(:current_course).and_return course}
+describe GoogleCalendarsHelper do
 
   describe "#get_google_authorization" do
     let(:user) { create :user }
@@ -31,14 +20,14 @@ describe GoogleCalendarsHelper, focus: true do
     let(:assignment_type) { create(:assignment_type, course: course) }
     let(:assignment) { create(:assignment, assignment_type: assignment_type, course: course) }
     it "returns the event of the corresponding event object" do
-      # allow(helper).to receive(:current_course).and_return course
-      expect(get_event_or_assignment("event", event.id).id).to be event.id
-      expect(get_event_or_assignment("event", event.id).class).to be Event
+      expect(get_event_or_assignment(course, "event", event.id).id).to be event.id
+      expect(get_event_or_assignment(course, "event", event.id).class).to be Event
     end
 
-    # it "returns the assignment of the corresponding event object" do
-    #
-    # end
+    it "returns the assignment of the corresponding event object" do
+      expect(get_event_or_assignment(course, "assignment", assignment.id).id).to be assignment.id
+      expect(get_event_or_assignment(course, "assignment", assignment.id).class).to be Assignment
+    end
   end
 
   describe "#refresh_if_google_authorization_is_expired" do


### PR DESCRIPTION
### Status
**READY FOR REVIEW**

### Description
When a student/instructor/observer looks at an individual assignment, they should be able to click an "Add to Google Calendar" button that works exactly as Events do. If there is no start time for the assignment (only a due at datetime), then set it to be 30 minutes prior to the due time.

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As a student/observer, go to the assignments menu and click any assignment. In the Description tab, the user should notice that the "Add to Google Calendar" button. Upon clicking the button, the assignment will be copied to the user's corresponding Google Calendar if the user has the User Authorization linking a Google Account to their GradeCraft account.

As an instructor, go to the assignments menu and click any assignment. In the top right corner of the screen the user should notice the "Add to Google Calendar" button. Upon clicking the button, the assignment will be copied to the user's corresponding Google Calendar if the user has the User Authorization linking a Google Account to their GradeCraft account.

### Impacted Areas in Application
* Assignments

======================
Closes #3240 
