### PR TITLE
Unable to Update/Refresh Assignments from Canvas

### DIFF
--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -23,11 +23,11 @@
                 locals: { assignment: presenter.assignment, team: presenter.team }
 
             - unless presenter.assignment.imported_assignment.nil?
-              = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), nil, "hide-for-small", method: :post do
+              = active_course_link_to assignments_importer_refresh_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), { method: :post }, nil, "hide-for-small" do
                 = decorative_glyph(:refresh)
                 = "Update Assignment from #{presenter.assignment.imported_assignment.provider.capitalize}"
 
-              = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), nil, "hide-for-small", method: :post do
+              = active_course_link_to assignments_importer_update_assignment_path(presenter.assignment.imported_assignment.provider, presenter.assignment), { method: :post }, nil, "hide-for-small" do
                 = decorative_glyph(:refresh)
                 = "Update #{presenter.assignment.imported_assignment.provider.capitalize} with Assignment"
 


### PR DESCRIPTION
### Status
READY

### Description
Two of our more complex use cases for the `active_course_link_to` helper were not recognizing the intended HTTP methods. Since the parameter to specify the action was being passed into the helper incorrectly, the link was performing a GET instead of a POST resulting in the page not found error.

### Migrations
NO

### Steps to Test or Reproduce
Ensure that it is possible to not only `Update Assignment from Canvas` but also to `Update Canvas with Assignment`.

![screen shot 2017-05-05 at 10 43 04 am](https://cloud.githubusercontent.com/assets/17604722/25750440/bdbb2c98-317f-11e7-860c-ade7665909ef.png)

======================
Closes #3248 
