### PR TITLE
3018 Search Courses by Instructor Initial Commit

### DIFF
--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -13,8 +13,7 @@
             resultsClass: 'typeahead dropdown-menu course-result',
             activeClass: 'active',
             itemLabel: function(course) {
-              return course.course_number + " " + course.name +
-                " (" + course.semester + " " + course.year + ")";
+              return course.name;
             },
             itemId: function(course) {
               return course.id;
@@ -23,8 +22,7 @@
               return '<li><a href="#">' + label + '</a></li>';
             },
             filter: function(item, query) {
-              var regex = new RegExp(query, 'i');
-              return item.name.match(regex) || item.course_number.match(regex);
+              return item.search_string.match(new RegExp(query, 'i'));
             }
           }).on('omniselect:select', function(event, id) {
             window.location = "/courses/" + id + "/change"

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -3,11 +3,10 @@ class API::CoursesController < ApplicationController
   # accessed by the dashboard
   # GET api/courses
   def index
-    @courses = []
-    current_user.courses.each do |course|
-      @courses << course.create_searchable_course
+    @courses = current_user.courses.map do |c|
+      { name: c.formatted_long_name, id: c.id, search_string: c.searchable_name }
     end
-    return @courses
+    render json: MultiJson.dump(@courses)
   end
 
   # accessed by the dashboard

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -3,7 +3,11 @@ class API::CoursesController < ApplicationController
   # accessed by the dashboard
   # GET api/courses
   def index
-    @courses = current_user.courses.select(:id, :name, :course_number, :year, :semester)
+    @courses = []
+    current_user.courses.each do |course|
+      @courses << course.create_searchable_course
+    end
+    return @courses
   end
 
   # accessed by the dashboard

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -182,22 +182,20 @@ class Course < ActiveRecord::Base
     end
   end
 
-  def create_searchable_course
-    searchable_course = {"id"=>self.id,
-      "name"=>self.name,
-      "course_number"=>self.course_number,
-      "year"=>self.year,
-      "semester"=>self.semester,
-      "names"=>professor_last_names}
+  def formatted_long_name
+    if semester.present? && year.present?
+      "#{self.course_number} #{self.name} #{(self.semester).capitalize} #{self.year}"
+    else
+      "#{self.name}"
+    end
   end
 
-  def professor_last_names
-    User
-      .joins(:course_memberships)
-      .where("course_memberships.course_id = ? and course_memberships.role = ?", self.id, "professor")
-      .select(:id, :last_name) # only need the ids, please
-      .order("last_name ASC")
-      .collect(&:last_name)
+  def searchable_name
+    @name || "#{ formatted_long_name} - #{ professor_names}"
+  end
+
+  def professor_names
+    self.staff.map(&:name)
   end
 
   def ordered_student_ids

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -182,6 +182,24 @@ class Course < ActiveRecord::Base
     end
   end
 
+  def create_searchable_course
+    searchable_course = {"id"=>self.id,
+      "name"=>self.name,
+      "course_number"=>self.course_number,
+      "year"=>self.year,
+      "semester"=>self.semester,
+      "names"=>professor_last_names}
+  end
+
+  def professor_last_names
+    User
+      .joins(:course_memberships)
+      .where("course_memberships.course_id = ? and course_memberships.role = ?", self.id, "professor")
+      .select(:id, :last_name) # only need the ids, please
+      .order("last_name ASC")
+      .collect(&:last_name)
+  end
+
   def ordered_student_ids
     User
       .joins(:course_memberships)

--- a/app/views/api/courses/index.json.jbuilder
+++ b/app/views/api/courses/index.json.jbuilder
@@ -1,3 +1,0 @@
-# json.array! @courses do |course|
-#   json.merge! course.attributes
-# end

--- a/app/views/api/courses/index.json.jbuilder
+++ b/app/views/api/courses/index.json.jbuilder
@@ -1,3 +1,3 @@
-json.array! @courses do |course|
-  json.merge! course.attributes
-end
+# json.array! @courses do |course|
+#   json.merge! course.attributes
+# end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20170403145349) do
 
   # These are extensions that must be enabled in order to support this database


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an admin, I want to be able to search the course list by instructor name.

This ticket involves updating the course search utility in the upper left hand corner of the admin display to return appropriate courses associated with professor-level users attached to each course.

*Note, let's NOT return GSIs or admins for now, we'll have too many search results.

### Related PRs
N/A


### Todos
- [ ] Add Tests
- [ ] Further Development


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an Admin, when the Dashboard loads, enter a professor's last name into the Search Course field and the professors corresponding courses should populate in the autocomplete dropdown menu.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Dashboard

======================
Closes #3018 
