### PR TITLE
Sorting analytics events by date

### DIFF
--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -18,7 +18,8 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
         scoreWithWeights: 'numeric',
         finalScore: 'numeric',
         predictedScore: 'numeric',
-        id: 'numeric'
+        id: 'numeric',
+        lastLogin: 'date'
       }
     }
 });

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -191,10 +191,11 @@ class Course < ActiveRecord::Base
       .collect(&:id)
   end
 
-  # creating a list of students who do not have any predictions
+  # creating a list of students who are taking the class for a grade who do
+  # not have any predictions
   def nonpredictors
     nonpredictors = []
-    self.students.each do |student|
+    self.students_being_graded.each do |student|
       if student.predictions_for_course?(self) == false
         nonpredictors << student
       end

--- a/app/views/analytics/students.html.haml
+++ b/app/views/analytics/students.html.haml
@@ -5,7 +5,7 @@
 
   / Login counts
   #role-logins-chart.analytics-chart{data: {:chart => "timeseries", :url => "/analytics/login_role_events.json", :url_data => "role_group=student", :title => "Logins", :subtitle => "{{granularity}}", :y_axis_label => "Logins {{granularity}}"}}
-  
+
   / Pageviews Total
   #all-pageviews-chart.analytics-chart{data: {:chart => "timeseries", :url => "/analytics/all_role_pageview_events.json?role_group=student", :title => "Pageviews", :subtitle => "{{granularity}}"}}
 
@@ -13,21 +13,23 @@
   %table#pageviews-chart.analytics-table{data: {:chart => "timeseries-table", :url => "/analytics/role_pageview_events.json?role_group=student", :title => "Pageviews per Page", :subtitle => "{{granularity}}"}}
     %caption.sr-only= "#{term_for :student} page views per page"
     %thead
-      %tr 
+      %tr
         %th{:"data-dynatable-column" => "name"} Page
         %th{:"data-dynatable-column" => "total"} Pageviews
     %tbody
-  
+
   / Students who have not predicted any grades for this course
   %h3.bold Non-predictors
   .italic.small= "#{term_for :students} who have not yet used the grade predictor"
   %table.dynatable
-    %thead 
-      %tr 
+    %thead
+      %tr
         %th #{ term_for :student }
-        %th Last Login
+        %th.hidden Last Login Date
+        %th{:"data-dynatable-column" => "lastLoginDate"} Last Login
     %tbody
       - @nonpredictors.each do |student|
         %tr
-          %td= student.name
-          %td= student.last_course_login(current_course) || "never logged in"
+          %td= link_to student.name, student_path(student)
+          %td.hidden= student.last_course_login(current_course).strftime("%H%M%m%Y") if student.last_course_login(current_course).present?
+          %td= student.last_course_login(current_course)


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where the last login field was not properly sorting by date 

### Migrations
NO

### Steps to Test or Reproduce
1. Go to the Analytics page (which is by default the student analytics page)
2. Delete all of the predicted earned grades for a couple of students via the console
3. Log in each student to create a `last_login_at` date

======================
Closes #3247 
