### PR TITLE
override unecessary sticky positioning on froala toolbar

### DIFF
--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -203,3 +203,7 @@ select.dynatable-per-page-select,
 // select to filter teams
 .team-filter
   text-align: right
+
+// froala toolbar fix
+.fr-sticky
+  position: inherit


### PR DESCRIPTION
### Status
**READY**

### Description
This PR overrides a `position: sticky` styling on the froala toolbar that was causing some placement issues on smaller screens.

### Migrations
NO 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* froala text entry toolbar

======================
Closes #3254 
