### PR TITLE
2690 Made Amount a required field for assignment type badge category

### DIFF
--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -5,7 +5,7 @@
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
     = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
     = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Amount"
+    = f.input :condition_value, :label => "Amount", :required => true
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
     = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"

--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -5,7 +5,7 @@
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
     = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
     = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Amount", :required => true
+    = f.input :condition_value, :label => "Amount", :required => true, :input_html => { min: '0' }
     = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
     = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Expected Behavior
I should not be able to set the unlock requirement "Assignments Completed" without setting a numeric value for it

Actual Behavior
I can enter unlock requirements without numeric values, and because the way we compare this later expects there to be a number, this causes errors down the line.

To see the place affected by this, try loading the badge edit page as Dumbledore (or any other staff member:

http://localhost:5000/badges/1/edit

Scroll to the bottom of the page, and click the button "Add Condition" with the following details:

Select "Assignment Type"
Select "Grading Settings"
Select "Assignments Completed"
You can now submit the form...but you shouldn't be able to. The form should prevent you from submitting (and give you an alert/validation prompt to enter a value for "Amount"

### Related PRs
N/A


### Todos
- [ ] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
See Description

### Impacted Areas in Application

* Badges

======================
Closes #2690 
