### PR TITLE
2970 Do not allow grade scope change after submissions

### DIFF
--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -37,7 +37,12 @@
     .form-item
       .individual-group-select
         = f.label :grade_scope, "Individual or Group?"
-        = f.select :grade_scope, [["Individual"], ["Group"]]
+        -if presenter.assignment.grades.instructor_modified.any? || presenter.assignment.has_submitted_submissions?
+          = tooltip("required-hint", "exclamation-triangle") do
+            You have already graded or received submissions for this assignment and cannot change the grading scope. If you would like to change the grading scope, please copy the assignment and change it on the copy.
+          = f.select :grade_scope, [["Individual"], ["Group"]], :disabled => ["Individual", "Group"]
+        -else
+          = f.select :grade_scope, [["Individual"], ["Group"]]
         .form-hint Do students do this individually or as a group?
 
     .form-item.individual-group-contingent{"class"=>("hidden" if f.object.grade_scope == 'Individual')}

--- a/spec/features/editing_an_assignment_spec.rb
+++ b/spec/features/editing_an_assignment_spec.rb
@@ -4,6 +4,9 @@ feature "editing an assignment" do
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
     let!(:assignment) { create :assignment, name: "Assignment Name", course: course }
+    let!(:assignment_with_submission) { create :assignment, name: "Assignment With Submission", course: course, grade_scope: "Individual" }
+    let!(:student)  { create(:course_membership, :student, course: course).user }
+    let!(:submission) { create(:submission, assignment: assignment_with_submission, student: student, course: course) }
 
     before(:each) do
       login_as professor
@@ -17,6 +20,13 @@ feature "editing an assignment" do
       end
 
       expect(page).to have_notification_message("notice", "Assignment Edited Assignment Name successfully updated")
+    end
+
+    scenario "cannot change grade scope" do
+      visit edit_assignment_path(assignment_with_submission)
+
+      expect(page).to have_selector(:option, "Individual", disabled: true)
+      expect(page).to have_selector(:option, "Group", disabled: true)
     end
   end
 end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
If instructors switch the grading scope after submissions have already come in then they experience an error on the grading status page.

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, create an assignment that accepts submissions. As a student, create a submission for the aforementioned assignment. As an instructor, attempt to change the grading scope for the assignment. The items in the drop down menu should be disabled and the instructor should receive a tool tip indicating the grade scope can't be changed and recommend making a copy of the assignment.

### Impacted Areas in Application
* Assignments

======================
Closes #2970 
