### PR TITLE
3241 assignment creation style

### DIFF
--- a/app/assets/javascripts/assignment_form.js
+++ b/app/assets/javascripts/assignment_form.js
@@ -1,15 +1,6 @@
 !function($) {
 
   // Toggle label on:
-  //   app/views/assignments/_form.haml
-  $('.pass-fail-toggle :checkbox').click(function(){
-    $('.pass-fail-toggle :checkbox').prop("checked") ?
-      $('.pass-fail-contingent').addClass("hidden") :
-      $('.pass-fail-contingent').removeClass("hidden");
-  });
-
-
-  // Toggle label on:
   //   grades/_standard_edit.html.haml
   $('.pass-fail-grade-toggle :checkbox').click(function(){
     var on = $('.pass-fail-contingent').data("on");
@@ -18,7 +9,15 @@
       $('.pass-fail-contingent label').text(on) :
       $('.pass-fail-contingent label').text(off);
   });
-  
+
+  // Toggle conditional form elements:
+  //   app/views/assignments/_form.haml
+  $('.pass-fail-toggle :checkbox').click(function(){
+    $('.pass-fail-toggle :checkbox').prop("checked") ?
+      $('.pass-fail-contingent').addClass("visually-hidden") :
+      $('.pass-fail-contingent').removeClass("visually-hidden");
+  });
+
   $('.individual-group-select select').change(function(){
     if ($(this).val() === "Group") {
       $('.individual-group-contingent').removeClass("visually-hidden");
@@ -26,6 +25,22 @@
     else {
       $('.individual-group-contingent').addClass("visually-hidden");
     }
-  })
+  });
 
 }(jQuery);
+
+
+//Show and hide conditional form items (used on assignment and badge edit)
+function showConditionalOptions($thisInput) {
+  var $thisConditionalOptionsList = $thisInput.closest('.form-item-with-options').next('.conditional-options');
+  
+  if ($thisInput.is(':checked')) {
+    $thisConditionalOptionsList.removeClass('visually-hidden');
+  } else {
+    $thisConditionalOptionsList.addClass('visually-hidden');
+  }
+}
+
+$('input.has-conditional-options').change(function() {
+  showConditionalOptions($(this));
+});

--- a/app/assets/javascripts/assignment_form.js
+++ b/app/assets/javascripts/assignment_form.js
@@ -21,10 +21,10 @@
   
   $('.individual-group-select select').change(function(){
     if ($(this).val() === "Group") {
-      $('.individual-group-contingent').removeClass("hidden");
+      $('.individual-group-contingent').removeClass("visually-hidden");
     }
     else {
-      $('.individual-group-contingent').addClass("hidden");
+      $('.individual-group-contingent').addClass("visually-hidden");
     }
   })
 

--- a/app/assets/javascripts/assignments.js
+++ b/app/assets/javascripts/assignments.js
@@ -24,25 +24,6 @@ function checkDropdown(select) {
   $($thisSelectedList).find('select, input').attr('disabled', false);
 }
 
-//Show and hide conditional form items (used on assignment and badge edit)
-function showConditionalOptions($thisInput) {
-  var $thisConditionalOptionsList = $thisInput.closest('.form-item-with-options').next('.conditional-options');
-  
-  if ($thisInput.is(':checked')) {
-    $thisConditionalOptionsList.show();
-  } else {
-    $thisConditionalOptionsList.hide();
-  }
-}
-
-$('input.has-conditional-options').change(function() {
-  showConditionalOptions($(this));
-});
-
-$('input.has-conditional-options').each(function() {
-  showConditionalOptions($(this));
-});
-
 
 // add and delete buttons for unlock conditions
 var $form = $('form');

--- a/app/assets/javascripts/image_upload.js
+++ b/app/assets/javascripts/image_upload.js
@@ -1,5 +1,5 @@
-// display badge preview after image upload
-$('.badge-image-upload').change(function () {
+// display media preview after image upload
+$('.media-image-upload').change(function () {
   var file = this.files[0];
   var imageType = /^image\//;
 
@@ -13,21 +13,5 @@ $('.badge-image-upload').change(function () {
       }, false);
       reader.readAsDataURL(file);
       previewWrapper.removeClass('hidden');
-  }
-});
-
-// display media image preview after image upload
-$('.media-image-upload').change(function () {
-  var file = this.files[0];
-  var imageType = /^image\//;
-
-    if (imageType.test(file.type)) {
-      var previewImg = $('.image-preview');
-      var reader = new FileReader();
-
-      reader.addEventListener( 'load', function() {
-        previewImg.css('background-image', 'url('+ reader.result +')');
-      }, false);
-      reader.readAsDataURL(file);
   }
 });

--- a/app/assets/javascripts/image_upload.js
+++ b/app/assets/javascripts/image_upload.js
@@ -15,3 +15,19 @@ $('.badge-image-upload').change(function () {
       previewWrapper.removeClass('hidden');
   }
 });
+
+// display media image preview after image upload
+$('.media-image-upload').change(function () {
+  var file = this.files[0];
+  var imageType = /^image\//;
+
+    if (imageType.test(file.type)) {
+      var previewImg = $('.image-preview');
+      var reader = new FileReader();
+
+      reader.addEventListener( 'load', function() {
+        previewImg.css('background-image', 'url('+ reader.result +')');
+      }, false);
+      reader.readAsDataURL(file);
+  }
+});

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -51,6 +51,7 @@
   *= require ./components/_history_timeline
   *= require ./components/_newsletter
   *= require ./components/_icons
+  *= require ./components/_image_upload
   *= require ./components/_alerts
   *= require ./components/_tooltips
   *= require ./pages/_analytics

--- a/app/assets/stylesheets/components/_image_upload.sass
+++ b/app/assets/stylesheets/components/_image_upload.sass
@@ -8,7 +8,7 @@
   background-size: contain
   background-position: center center
   background-repeat: no-repeat
-// 
+//
 // .simple_form label
 //   &.media-image-label
 //     position: absolute
@@ -25,7 +25,7 @@
 //       display: block
 //       margin: 0.2rem auto
 //       padding-right: 0
-// 
+//
 // input[type="file"]
 //   &.media-image-upload
 //     display: none

--- a/app/assets/stylesheets/components/_image_upload.sass
+++ b/app/assets/stylesheets/components/_image_upload.sass
@@ -1,0 +1,31 @@
+@import "../utilities/variables"
+
+.image-preview
+  width: 200px
+  height: 150px
+  border: 1px dashed $color-grey-3
+  position: relative
+  background-size: contain
+  background-position: center center
+  background-repeat: no-repeat
+
+.simple_form label
+  &.media-image-label
+    position: absolute
+    top: 0
+    left: 0
+    right: 0
+    bottom: 0
+    margin: auto
+    width: 100px
+    height: 3.5rem
+    text-align: center
+    line-height: 1.2
+    .fa-camera
+      display: block
+      margin: 0.2rem auto
+      padding-right: 0
+
+input[type="file"]
+  &.media-image-upload
+    display: none

--- a/app/assets/stylesheets/components/_image_upload.sass
+++ b/app/assets/stylesheets/components/_image_upload.sass
@@ -8,24 +8,24 @@
   background-size: contain
   background-position: center center
   background-repeat: no-repeat
-
-.simple_form label
-  &.media-image-label
-    position: absolute
-    top: 0
-    left: 0
-    right: 0
-    bottom: 0
-    margin: auto
-    width: 100px
-    height: 3.5rem
-    text-align: center
-    line-height: 1.2
-    .fa-camera
-      display: block
-      margin: 0.2rem auto
-      padding-right: 0
-
-input[type="file"]
-  &.media-image-upload
-    display: none
+// 
+// .simple_form label
+//   &.media-image-label
+//     position: absolute
+//     top: 0
+//     left: 0
+//     right: 0
+//     bottom: 0
+//     margin: auto
+//     width: 100px
+//     height: 3.5rem
+//     text-align: center
+//     line-height: 1.2
+//     .fa-camera
+//       display: block
+//       margin: 0.2rem auto
+//       padding-right: 0
+// 
+// input[type="file"]
+//   &.media-image-upload
+//     display: none

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -87,6 +87,21 @@ ul.accepts_submission_types
   font-style: italic
   margin: 0
 
+.form-flex-row
+  display: flex
+  flex-wrap: wrap
+  .form-item
+    flex: 1
+    input, select
+      width: 100%
+    @media (max-width: $media-small-max)
+      margin-right: 0
+      width: 100%
+    &:not(:last-child)
+      margin-right: 1rem
+  @media (max-width: $media-small-max)
+    display: block
+
 span.checkbox
   display: block
 
@@ -168,25 +183,9 @@ ul.locked-display li
 // course settings styles
 .form-wrapper
   max-width: 960px
-  .form-item input, select
-    width: 100%
   .form-item input[type="checkbox"]
     width: auto
 
-.form-flex-container
-  display: flex
-  flex-direction: column
-
-.form-flex-row
-  display: flex
-  .form-item
-    @media (max-width: $media-small-max)
-      margin-right: 0
-      width: 100%
-    &:not(:last-child)
-      margin-right: 1rem
-  @media (max-width: $media-small-max)
-    display: block
 
 // Multi-select box on create new team page
 .select2-container
@@ -223,3 +222,14 @@ select.dynatable-per-page-select,
 // froala toolbar fix
 .fr-sticky
   position: inherit
+
+// assignment creation form
+.individual-group-contingent
+  visibility: visible
+  opacity: 1
+  transition: visibility 0s linear 0s, opacity 300ms
+  &.visually-hidden
+    height: 0
+    visibility: hidden
+    opacity: 0
+    transition: visibility 0s linear 300ms, opacity 300ms

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -20,6 +20,8 @@ textarea
   transition: border-color 0.2s
   &:focus
     border: 1px solid rgba(42, 43, 43, 0.8)
+  @media (max-width: $media-small-max)
+    width: 100%
 
 input[type="file"]
   display: block
@@ -43,6 +45,8 @@ select,
   font-family: 'Open Sans', sans-serif
   &:hover
     background-color: $color-grey-7
+  @media (max-width: $media-small-max)
+    width: 100%
 
 ul.accepts_submission_types
   list-style-type: none
@@ -233,6 +237,7 @@ select.dynatable-per-page-select,
   transition: visibility 0s linear 0s, opacity 300ms
   &.visually-hidden
     height: 0
+    margin: 0
     visibility: hidden
     opacity: 0
     transition: visibility 0s linear 300ms, opacity 300ms

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -71,6 +71,11 @@ ul.accepts_submission_types
   font-style: italic
   font-size: 1.1rem
 
+.form-subtitle
+  margin: 0.5rem 0
+  font-size: 1rem
+  font-weight: 400
+
 .form-item
   margin-bottom: 1rem
   &.no-margin
@@ -132,11 +137,16 @@ ul.locked-display li
       text-align: left
 
 // score levels form (assignment and challenge edit)
+.assignment-score-levels
+  margin: 1rem 0
+  .hint
+    margin: 0.5rem 0
+
 .score-level-container
   display: flex
   justify-content: space-between
   align-items: center
-  margin: 0.5em 0
+  margin: 0.25em 0
   background-color: $color-grey-7
   padding: 0.5em
 

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -92,7 +92,8 @@ ul.accepts_submission_types
   flex-wrap: wrap
   .form-item
     flex: 1
-    input, select
+    input:not([type="checkbox"]),
+    select
       width: 100%
     @media (max-width: $media-small-max)
       margin-right: 0
@@ -129,7 +130,7 @@ error
   font-weight: bold
   padding-left: .5rem
 
-.conditional-options
+.conditional-options.indented
   margin: 0
   padding-left: 1rem
 
@@ -224,7 +225,9 @@ select.dynatable-per-page-select,
   position: inherit
 
 // assignment creation form
-.individual-group-contingent
+.individual-group-contingent,
+.pass-fail-contingent,
+.conditional-options
   visibility: visible
   opacity: 1
   transition: visibility 0s linear 0s, opacity 300ms

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -74,7 +74,7 @@ ul.accepts_submission_types
 .form-subtitle
   margin: 0.5rem 0
   font-size: 1rem
-  font-weight: 400
+  font-weight: 600
 
 .form-item
   margin-bottom: 1rem
@@ -130,7 +130,7 @@ ul.locked-display li
   label
     font-size: 0.9rem
     text-transform: capitalize
-    font-weight: bold
+    // font-weight: bold
     display: inline-block
     margin-bottom: 5px
     @media (max-width: $media-small-max)

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -60,6 +60,11 @@ ul.accepts_submission_types
   border: 0
   border-bottom: 1px dashed $color-green-2
 
+.form-subsection
+  background-color: $color-grey-7
+  padding: 1rem
+  margin-bottom: 1rem
+
 .form-title
   margin-bottom: 0.5rem
   text-transform: capitalize
@@ -68,6 +73,8 @@ ul.accepts_submission_types
 
 .form-item
   margin-bottom: 1rem
+  &.no-margin
+    margin-bottom: 0
 
 .form-hint
   font-size: 80%
@@ -104,7 +111,7 @@ error
 
 .conditional-options
   margin: 0
-  padding-left: 0.5rem
+  padding-left: 1rem
 
 .ui-datepicker
   margin-top: -2.7rem !important
@@ -116,7 +123,6 @@ ul.locked-display li
 
 .simple_form 
   label
-    padding-right: .5rem
     font-size: 0.9rem
     text-transform: capitalize
     font-weight: bold

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -32,12 +32,19 @@ body
     padding-top: 0
 
 .box
-  margin-top: 1rem
-  border: 1px dashed $color-blue-3
-  padding: 1rem
-  &:hover
-    border: 1px dashed $color-green-2
+  a, button
     display: block
+    margin: 1rem 0
+    padding: 1rem
+    font-size: 0.9rem
+    text-align: center
+    border: 1px dashed $color-blue-2
+    width: 100%
+    &:hover
+      text-decoration: none
+      border: 1px dashed $color-blue-3
+    &-padded
+      padding: 0 0.5rem
 
 .no-bullet li
   list-style-type: none
@@ -114,11 +121,6 @@ hr.light-grey
 @media (min-width: $media-medium-max)
   .panel .row
     margin-bottom: 1rem
-
-@media (max-width: $media-medium-max)
-  .box
-    border-bottom: 1px solid $color-grey-3
-    padding: 1rem
 
 @media (max-width: $media-small-max)
   .badge-icon

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -33,6 +33,7 @@ body
 
 .box
   a, button
+    box-sizing: border-box
     display: block
     margin: 1rem 0
     padding: 1rem

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -100,6 +100,10 @@ ul.nav-pill
       color: $color-white !important
       cursor: pointer
 
+ul.nav-pill .has-form
+  margin-bottom: 0
+
+
 /* Positioning and styling of notification badges in staff-sidenav */
 .staff-sidenav li
   position: relative

--- a/app/assets/stylesheets/layout/_topbar.sass
+++ b/app/assets/stylesheets/layout/_topbar.sass
@@ -3,7 +3,7 @@
 
 img.profile-pic
   position: relative
-  margin: 0 0 -5px -5px
+  margin-top: -0.25rem
   padding: 0
   border-radius: 5px
 

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -30,8 +30,58 @@
   li
     display: inline-block
 
-.add-unlock-condition
-  margin-bottom: 1rem
+.unlock-conditions
+  display: inline
+  vertical-align: top
+
+.unlock-condition
+  margin: 1rem 0
+  position: relative
+  width: 25%
+  display: inline-block
+  vertical-align: top
+  &:not(:last-child)
+    margin-right: 0.5rem
+
+  .form-item
+    margin-bottom: 0.5rem
+
+  input,
+  select
+    width: 100%
+
+  label
+    font-size: 0.8rem
+
+  .assignment-or-badge
+    padding: 0.5rem
+    background: $color-blue-2
+    color: $color-white
+
+  .unlock-conditions-list
+    padding: 0.5rem
+    border: 1px solid $color-grey-5
+    border-top: 0
+
+.add-unlock-condition-wrapper
+  display: inline-block
+  margin: 0 0.5rem
+  button
+    padding: 2rem
+    width: 240px
+
+.remove-unlock-condition
+  position: absolute
+  top: -8px
+  right: -8px
+  border-radius: 50%
+  width: 1.5rem
+  background-color: $color-red-1
+  &:hover
+    background-color: darken($color-red-1, 10%)
+  .fa-times
+    width: 100%
+    padding-right: 0
 
 .class-analytics-wrapper
   display: flex

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -185,6 +185,9 @@ ul.earned-badge-list
   &.large-preview
     width: 150px
     height: 150px
+  &.event-preview
+    width: 128px
+    height: 128px
   &.medium-preview
     width: 80px
     height: 80px
@@ -215,6 +218,9 @@ ul.earned-badge-list
   &.large-crop
     width: 150px
     height: 150px
+  &.event-crop
+    width: 128px
+    height: 128px
   &.med-crop
     width: 80px
     height: 80px

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -186,8 +186,8 @@ ul.earned-badge-list
     width: 150px
     height: 150px
   &.event-preview
-    width: 128px
-    height: 128px
+    width: 250px
+    height: 150px
   &.medium-preview
     width: 80px
     height: 80px
@@ -217,7 +217,7 @@ ul.earned-badge-list
   overflow: hidden
   &.event-crop
     width: 250px
-    height: 250px
+    height: 150px
   &.large-crop
     width: 150px
     height: 150px

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -211,16 +211,16 @@ ul.earned-badge-list
   left: 50%
   transform: translateX(-50%)
 
-// image cropper for badges 
+// image cropper for badges
 .img-cropper
   position: relative
   overflow: hidden
+  &.event-crop
+    width: 250px
+    height: 250px
   &.large-crop
     width: 150px
     height: 150px
-  &.event-crop
-    width: 128px
-    height: 128px
   &.med-crop
     width: 80px
     height: 80px

--- a/app/assets/stylesheets/pages/_dashboard.sass
+++ b/app/assets/stylesheets/pages/_dashboard.sass
@@ -239,7 +239,7 @@ ul.badge-grid
 .event-information
   display: flex
   align-items: center
-  @media (max-width: $media-small-max)
+  @media (max-width: $media-medium-max)
     display: block
   p
     margin: 0
@@ -255,9 +255,8 @@ ul.badge-grid
     float: none
 
   img
-    max-width: 128px
+    max-width: 350px
     @media (max-width: $media-small-max)
-      max-width: 100px
       margin: 0 auto
 
 .event-name
@@ -350,7 +349,6 @@ ul.assignments-due
 
    .img-cropper
      vertical-align: middle
-     margin-bottom: .25rem
      display: inline-block
 
 .instructor-dashboard

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,7 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  process resize_and_pad: [200, 200, background = :transparent, gravity = "Center"]
+  process resize_and_pad: [250, 150, background = :transparent, gravity = "Center"]
 
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -13,29 +13,33 @@
       = f.label :name
       = f.text_field :name
 
-    .form-item
-      .form-item-with-options
-        / What's the max number of points a student may earn in this category?
-        = f.label :has_max_points, :label => "Maximum Points?"
-        = f.check_box :has_max_points, {"aria-describedby" => "txtMaxPoints", class: "has-conditional-options"}
-        .form-hint{id: "txtMaxPoints"} Is there a cap on how many points students can earn through this category?
-      
-      .conditional-options
-        / What's the max number of points a student may earn in this category?
-        = f.label :max_points, :label => "Maximum Points Possible"
-        = f.text_field :max_points, data: {autonumeric: true, "m-dec" => "0"}
-        .form-hint{id: "txtMaxPoints"} If you fill this in, students will not be able to earn more than this amount.
+    .form-item.form-item-with-options
+      / What's the max number of points a student may earn in this category?
+      = f.check_box :has_max_points, {class: "has-conditional-options"}
+      = f.label :has_max_points, :label => "Maximum Points?"
+      = tooltip("max-points-hint", "info-circle", placement: "right") do
+        Is there a cap on how many points students can earn through this category?
+
+    .form-item.conditional-options{"class"=>("visually-hidden" if !f.object.has_max_points?)}
+      / What's the max number of points a student may earn in this category?
+      = f.label :max_points, :label => "Maximum Points Possible"
+      = tooltip("points-possible-hint", "info-circle", placement: "right") do
+        If you fill this in, students will not be able to earn more than this amount.
+      = f.text_field :max_points, data: {autonumeric: true, "m-dec" => "0"}
 
     .form-item
       / Do only X number of highest grades count?
       = f.label :top_grades_counted, :label => "Count Highest Grades"
+      -# .form-hint{id: "assignment_type_top_grades_counted"} 
+      = tooltip("count-highest-hint", "info-circle", placement: "right") do
+        Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here (Set to 0 if not).
       = f.text_field :top_grades_counted, data: { autonumeric: true, "m-dec" => "0" }
-      .form-hint{id: "assignment_type_top_grades_counted"} Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here (Set to 0 if not).
 
     .form-item
+      = f.check_box :student_weightable
       = f.label :student_weightable, "Student Weighted"
-      = f.check_box :student_weightable, {"aria-describedby" => "txtStudentWeighted"}
-      .form-hint{id: "txtStudentWeighted"} Do students decide how much this #{term_for :assignment} type will count towards their grade?
+      = tooltip("student-weighted-hint", "info-circle", placement: "right") do
+        Do students decide how much this #{term_for :assignment} type will count towards their grade?
 
   %section.form-section
     %h2.form-title Description

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -1,3 +1,7 @@
+- if presenter.assignment.media.present?
+  %img{:src => presenter.assignment.media }
+
+%h2 Description
 - if !current_student || presenter.assignment.points_visible_for_student?(current_student)
   - if presenter.assignment.pass_fail?
     %p.assignment-description.italic= "#{term_for :pass}/#{term_for :fail} Assignment"

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -20,9 +20,13 @@
         .form-item
           .individual-group-select
             = f.label :grade_scope, "Individual or Group?"
-            = tooltip("group-assignment-hint", "info-circle", placement: "right") do
-              Do students do this individually or as a group?
-            = f.select :grade_scope, [["Individual"], ["Group"]]
+            - if presenter.assignment.grades.instructor_modified.any? || presenter.assignment.has_submitted_submissions?
+              = tooltip("required-hint", "exclamation-triangle") do
+                You have already graded or received submissions for this assignment and cannot change the grading scope. If you would like to change the grading scope, please copy the assignment and change it on the copy.
+              = f.select :grade_scope, [["Individual"], ["Group"]], :disabled => ["Individual", "Group"]
+            - else
+              = f.select :grade_scope, [["Individual"], ["Group"]]
+            .form-hint Do students do this individually or as a group?
 
         .form-item.individual-group-contingent{"class"=>("visually-hidden" if f.object.grade_scope == 'Individual')}
           = f.input :min_group_size, as: :numeric, :input_html => { :value => [ @assignment.try(:min_group_size) || 2 ] }

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -3,187 +3,215 @@
 = simple_form_for(presenter.assignment, :html => { :novalidate => true }) do |f|
   %section.form-section
     %h2.form-title Basic Info
-    .form-item
-      = f.association :assignment_type, collection: current_course.assignment_types.ordered, value_method: :id, include_blank: true, selected: params[:assignment_type_id] || presenter.assignment.assignment_type_id, "aria-required": "true"
-
-    .form-item
-      = f.label :name
-      = f.text_field :name, "aria-required": "true"
-
-    .form-item
-      .pass-fail-toggle
-        = f.label :pass_fail, "Pass/Fail"
-        = f.check_box :pass_fail
-
-    .form-item.pass-fail-contingent{"class"=>("hidden" if f.object.pass_fail?)}
-      = f.label :full_points, "Total Points Possible"
-      = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
-
-    .form-item.pass-fail-contingent{"class"=>("hidden" if f.object.pass_fail?)}
-      = f.label :threshold_points, "Points Threshold"
-      = f.text_field :threshold_points, data: {autonumeric: true, "m-dec" => "0"}
-      .form-hint If you set a points threshold above zero, any student earning fewer points will receive no points for the assignment.
-
-    .form-item
-      = f.input :open_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }
-
-    .form-item
-      = f.input :due_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }
-
-    .form-item
-      = f.input :accepts_submissions_until, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Accept until"
-      .form-hint If you set a due date but no accept-until date, submissions and self-logged grades will be marked as late but always accepted.
-
-    .form-item
-      .individual-group-select
-        = f.label :grade_scope, "Individual or Group?"
-        -if presenter.assignment.grades.instructor_modified.any? || presenter.assignment.has_submitted_submissions?
-          = tooltip("required-hint", "exclamation-triangle") do
-            You have already graded or received submissions for this assignment and cannot change the grading scope. If you would like to change the grading scope, please copy the assignment and change it on the copy.
-          = f.select :grade_scope, [["Individual"], ["Group"]], :disabled => ["Individual", "Group"]
-        -else
-          = f.select :grade_scope, [["Individual"], ["Group"]]
-        .form-hint Do students do this individually or as a group?
-
-    .form-item.individual-group-contingent{"class"=>("hidden" if f.object.grade_scope == 'Individual')}
-      = f.input :min_group_size, as: :numeric, :input_html => { :value => [ @assignment.try(:min_group_size) || 2 ] }
-
-    .form-item.individual-group-contingent{"class"=>("hidden" if f.object.grade_scope == 'Individual')}
-      = f.input :max_group_size, as: :numeric, :input_html => { :value => [ @assignment.try(:max_group_size) || 5 ] }
-
-  %section.form-section
-    %h2.form-title Assignment Description
-    .textarea
-      .form-hint This will be shown to students on their dashboard, and when they submit their assignment.
-      = f.text_area :description, class: "froala"
-
-  %section.form-section
-    %h2.form-title Assignment Purpose
-    .textarea
-      .form-hint This will be shown to students on their dashboard, and when they submit their assignment.
-      = f.text_area :purpose, class: "froala"
-
-  %section.form-section
-    %h2.form-title Advanced Settings
-
-    = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
-
-    .form-item
-      = f.label :visible, "Visible to students"
-      = f.check_box :visible
-      .form-hint Can #{term_for :students} see this #{term_for :assignment} in their dashboard?
-
-    .form-item
-      = f.label :required
-      = f.check_box :required
-      .form-hint Are ALL #{term_for :students} expected to complete this #{term_for :assignment} to pass the course?
-
-    .form-item
-      .assignment_options.form-item-with-options
-        = f.label :accepts_submissions #{term_for :assignment} Submissions
-        = f.check_box :accepts_submissions, {class: "has-conditional-options"}
-        .form-hint Will you be using GradeCraft to accept submissions for this #{term_for :assignment}?
-
-      %ul.submit.accepts_submission_types.conditional-options.indented
-        %li.submit
-          .checkbox
-            = f.label :accepts_links, :label => "Accept Links"
-            = f.check_box :accepts_links
-        %li.submit
-          .checkbox
-            = f.label :accepts_attachments, :label => "Accept Uploads/Attachments"
-            = f.check_box :accepts_attachments
-        %li.submit
-          .checkbox
-            = f.label :accepts_text, :label => "Accept raw text"
-            = f.check_box :accepts_text
-
-    .form-item
-      = f.label :resubmissions_allowed #{term_for :assignment} Resubmissions
-      = f.check_box :resubmissions_allowed
-      .form-hint Can #{term_for :students} resubmit this #{term_for :assignment}?
-
-    .form-item
-      = f.label :release_necessary
-      = f.check_box :release_necessary
-      .form-hint Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
-
-    - if current_course.show_analytics?
+    .form-subsection
       .form-item
-        = f.label :hide_analytics, "Hide Analytics?"
-        = f.check_box :hide_analytics, {"aria-describedby" => "hideAnalytics"}
-        .form-hint{id: "hideAnalytics"}  Do you want to hide comparative assignment analytics from students for this assignment?
+        = f.association :assignment_type, collection: current_course.assignment_types.ordered, value_method: :id, include_blank: true, selected: params[:assignment_type_id] || presenter.assignment.assignment_type_id, "aria-required": "true"
 
-    .form-item
-      = f.label :student_logged
-      = f.check_box :student_logged
-      .form-hint Do #{term_for :students} self-report their grade for this #{term_for :assignment}? If you add grade levels below, they'll be able to select their self-assessed score from the list during the open time period. If you don't, they'll be able to select that they did the work and earn full points.
+      .form-item
+        = f.input :name, "aria-required": "true", label: "Assignment Name"
 
-  %section.form-section
-    %h2.form-title Unlocks
+      .form-item
+        = f.check_box :required
+        = f.label :required
+        = tooltip("required-hint", "info-circle", placement: "right") do
+          Are ALL #{term_for :students} expected to complete this #{term_for :assignment} to pass the course?
 
-    .unlock-conditions
-      %p.hint Unlocks allow you to direct the sequence of content in your course. What do students need to do in order to unlock this #{ term_for :assignment }?
-      %script(id="unlock-condition-template" type="text/x-template")
-        %fieldset.unlock-condition
-          = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: "form-inline", child_index: "child_index" do |ucf|
-            = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
-      - presenter.assignment.unlock_conditions.each do |condition|
-        %fieldset.unlock-condition
-          = f.simple_fields_for :unlock_conditions, condition, class: "form-inline" do |ucf|
-            = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
-    %button.add-unlock-condition Add a Condition
+      .form-flex-row
+        .form-item
+          .individual-group-select
+            = f.label :grade_scope, "Individual or Group?"
+            = tooltip("group-assignment-hint", "info-circle", placement: "right") do
+              Do students do this individually or as a group?
+            = f.select :grade_scope, [["Individual"], ["Group"]]
 
-    .unlock-visibility-settings
-      %h3 Unlock Visibility Settings
-      .locked-visibility-options.form-item-with-options
-        = f.label :visible_when_locked, :label => "Visible when Locked"
-        = f.check_box :visible_when_locked, {class: "has-conditional-options"}
+        .form-item.individual-group-contingent{"class"=>("visually-hidden" if f.object.grade_scope == 'Individual')}
+          = f.input :min_group_size, as: :numeric, :input_html => { :value => [ @assignment.try(:min_group_size) || 2 ] }
 
-      %ul.locked-display.visible_elements.conditional-options.indented
-        %li.locked-display
-          .checkbox
-            = f.label :show_name_when_locked, :label => "Show Name when Locked"
-            = f.check_box :show_name_when_locked
-        %li.locked-display
-          .checkbox
-            = f.label :show_points_when_locked, :label => "Show Points when Locked"
-            = f.check_box :show_points_when_locked
-        %li.locked-display
-          .checkbox
-            = f.label :show_description_when_locked, :label => "Show Description when Locked"
-            = f.check_box :show_description_when_locked
-        %li.locked-display
-          .checkbox
-            = f.label :show_purpose_when_locked, :label => "Show Purpose when Locked"
-            = f.check_box :show_purpose_when_locked
+        .form-item.individual-group-contingent{"class"=>("visually-hidden" if f.object.grade_scope == 'Individual')}
+          = f.input :max_group_size, as: :numeric, :input_html => {  :value => [ @assignment.try(:max_group_size) || 5 ] }
 
-  %section.form-section
-    %h2.form-title Grade Levels
-    .assignment-score-levels
-      %p.hint Example: You could create three levels to produce a quick grading scheme for just this #{term_for :assignment} - Complete (5000 points), Finalist (7000 points), and Winner (10,000 points). These levels will then show in the quick grade, and when students are setting goals in the grade predictor.
-      %script(id="assignment-score-level-template" type="text/x-template")
-        %fieldset.assignment-score-level
-          = f.simple_fields_for :assignment_score_levels, AssignmentScoreLevel.new, class: "form-inline", child_index: "child_index" do |slf|
-            = render partial: "assignment_score_level_fields", locals: { f: slf }
-      - presenter.assignment.assignment_score_levels.order_by_points.each do |assignment_score_level|
-        %fieldset.assignment-score-level
-          = f.simple_fields_for :assignment_score_levels, assignment_score_level, class: "form-inline" do |slf|
-            = render partial: "assignment_score_level_fields", locals: { f: slf }
-    %button.add-assignment-score-level Add a Level
+      .form-item
+        %label{for: "assignment-description"} Assignment Description
+        = tooltip("description-hint", "info-circle", placement: "right") do
+          This will be shown to students on their dashboard, and when they submit their assignment.
+        .textarea{id: "assignment-description"}
+          = f.text_area :description, class: "froala"
 
-  %section.form-section
-    %h2.form-title Attachments
-    = f.simple_fields_for :assignment_files, presenter.assignment.assignment_files.new do |af|
-      = af.file_field :file, :multiple => true
-    - if presenter.assignment.assignment_files.exists?
-      %h5.bold Uploaded files
-      %ul.uploaded-files
-        - presenter.assignment.assignment_files.each do |af|
-          - next if af.new_record?
+
+      .form-item{for: "assignment-purpose"}
+        %label{for: "assignment-purpose"} Assignment Purpose
+        = tooltip("purpose-hint", "info-circle", placement: "right") do
+          This will be shown to students on their dashboard, and when they submit their assignment.
+        .textarea
+          = f.text_area :purpose, class: "froala"
+
+      .form-item
+        = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
+
+      .form-item
+        = f.label :assignment_files, "Attachments"
+        = f.simple_fields_for :assignment_files, presenter.assignment.assignment_files.new do |af|
+          = af.file_field :file, :multiple => true, :label => false, :id => "assignment_assignment_files"
+        - if presenter.assignment.assignment_files.exists?
+          %h5.bold Uploaded files
+          %ul.uploaded-files
+            - presenter.assignment.assignment_files.each do |af|
+              - next if af.new_record?
+              %li
+                = link_to af.filename, af.url, :target => "_blank"
+                = link_to "(Remove)", remove_uploads_path({ :model => "AssignmentFile", assignment_id: presenter.assignment.id, :upload_id => af.id } )
+
+    %h2.form-title Assignment Dates
+    .form-subsection
+      .form-flex-row
+        .form-item
+          = f.input :open_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => glyph(:calendar) + "Open Date"
+
+        .form-item
+          = f.input :due_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => glyph(:calendar) + "Due Date"
+
+        .form-item
+          = f.label :accepts_submissions_until, glyph(:calendar) + "Accept Until Date"
+          = tooltip("accept-until-hint", "info-circle", placement: "right") do
+            If you set a due date but no accept-until date, submissions and self-logged grades will be marked as late but always accepted.
+          = f.input :accepts_submissions_until, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => false
+
+    %h2.form-title Grading & Submission
+    .form-subsection
+      %h3.form-subtitle Grading Style
+      .form-flex-row
+        .form-item
+          .pass-fail-toggle
+            = f.check_box :pass_fail
+            = f.label :pass_fail, "Pass/Fail"
+
+      .form-flex-row.pass-fail-contingent{"class"=>("visually-hidden" if f.object.pass_fail?)}
+        .form-item
+          = f.label :full_points, "Total Points Possible"
+          = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
+
+        .form-item
+          = f.label :threshold_points, "Points Threshold"
+          = tooltip("point-threshold-hint", "info-circle", placement: "right") do
+            If you set a points threshold above zero, any student earning fewer points will receive no points for the assignment.
+          = f.text_field :threshold_points, data: {autonumeric: true, "m-dec" => "0"}
+
+        .form-item
+          = f.label :mass_grade_type, "Quick Grade Style"
+          = tooltip("quick-grade-hint", "info-circle", placement: "right") do
+            How should this assignment appear in Quick Grade?
+          = f.select :mass_grade_type, [[],["Checkbox"], ["Select List"], ["Radio Buttons"], ["Text"]]
+      .assignment-score-level-wrapper.pass-fail-contingent{"class"=>("visually-hidden" if f.object.pass_fail?)}
+        .assignment-score-levels
+          %h4.form-subtitle Grade Levels
+          %p.hint Example: You could create three levels to produce a quick grading scheme for just this #{term_for :assignment} - Complete (5000 points), Finalist (7000 points), and Winner (10,000 points). These levels will then show in the quick grade, and when students are setting goals in the grade predictor.
+          %script(id="assignment-score-level-template" type="text/x-template")
+            %fieldset.assignment-score-level
+              = f.simple_fields_for :assignment_score_levels, AssignmentScoreLevel.new, class: "form-inline", child_index: "child_index" do |slf|
+                = render partial: "assignment_score_level_fields", locals: { f: slf }
+          - presenter.assignment.assignment_score_levels.order_by_points.each do |assignment_score_level|
+            %fieldset.assignment-score-level
+              = f.simple_fields_for :assignment_score_levels, assignment_score_level, class: "form-inline" do |slf|
+                = render partial: "assignment_score_level_fields", locals: { f: slf }
+        .box.box-padded
+          %button.button-link.add-assignment-score-level= decorative_glyph(:plus) + 'Add level'
+
+      %h3.form-subtitle Grading Settings
+      .form-item.no-margin
+        = f.check_box :student_logged
+        = f.label :student_logged
+        = tooltip("student-logged-hint", "info-circle", placement: "right") do
+          Do #{term_for :students} self-report their grade for this #{term_for :assignment}? If you add grade levels, they'll be able to select their self-assessed score from the list during the open time period. If you don't, they'll be able to select that they did the work and earn full points.
+
+      .form-item.no-margin
+        = f.check_box :release_necessary
+        = f.label :release_necessary
+        = tooltip("release-necessary-hint", "info-circle", placement: "right") do
+          Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
+
+      .form-item.no-margin
+        .assignment_options.form-item-with-options
+          = f.check_box :accepts_submissions, {class: "has-conditional-options"}
+          = f.label :accepts_submissions #{term_for :assignment} Submissions
+          = tooltip("accepts-submissions-hint", "info-circle", placement: "right") do
+            Will you be using GradeCraft to accept submissions for this #{term_for :assignment}?
+
+        %ul.submit.accepts_submission_types.conditional-options.indented{"class"=>("visually-hidden" if !f.object.accepts_submissions?)}
           %li
-            = link_to af.filename, af.url, :target => "_blank"
-            = link_to "(Remove)", remove_uploads_path({ :model => "AssignmentFile", assignment_id: presenter.assignment.id, :upload_id => af.id } )
+            = f.check_box :accepts_links
+            = f.label :accepts_links, :label => "Accept Links"
+          %li
+            = f.check_box :accepts_attachments
+            = f.label :accepts_attachments, :label => "Accept Uploads/Attachments"
+          %li
+            = f.check_box :accepts_text
+            = f.label :accepts_text, :label => "Accept raw text"
+
+      .form-item.no-margin
+        = f.check_box :resubmissions_allowed
+        = f.label :resubmissions_allowed #{term_for :assignment} Resubmissions
+        = tooltip("resubmissions-hint", "info-circle", placement: "right") do
+          Can #{term_for :students} resubmit this #{term_for :assignment}?
+
+
+    %h2.form-title Visibility Settings
+    .form-subsection
+      .form-item.no-margin
+        = f.check_box :visible
+        = f.label :visible, "Visible to students"
+        = tooltip("visible-hint", "info-circle", placement: "right") do
+          Can #{term_for :students} see this #{term_for :assignment} in their dashboard?
+
+      - if current_course.show_analytics?
+        .form-item.no-margin
+          = f.check_box :hide_analytics
+          = f.label :hide_analytics, "Hide Analytics?"
+          = tooltip("analytics-visible-hint", "info-circle", placement: "right") do
+            Do you want to hide comparative assignment analytics from students for this assignment?
+
+    %h2.form-title Unlocks
+    .form-subsection
+      %h3.form-subtitle
+        Requirements
+        = tooltip("unlock-hint", "info-circle", placement: "right") do
+          Unlocks allow you to direct the sequence of content in your course. What do students need to do in order to unlock this #{ term_for :assignment }?
+      .unlock-conditions
+        %script(id="unlock-condition-template" type="text/x-template")
+          %fieldset.unlock-condition
+            = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: "form-inline", child_index: "child_index" do |ucf|
+              = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
+        - presenter.assignment.unlock_conditions.each do |condition|
+          %fieldset.unlock-condition
+            = f.simple_fields_for :unlock_conditions, condition, class: "form-inline" do |ucf|
+              = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
+      .box.box-padded.add-unlock-condition-wrapper
+        %button.button-link.add-unlock-condition=glyph(:plus) + "Add a Condition"
+
+      .unlock-visibility-settings
+        %h3.form-subtitle Visibility Settings
+        .locked-visibility-options.form-item-with-options
+          = f.check_box :visible_when_locked, {class: "has-conditional-options"}
+          = f.label :visible_when_locked, :label => "#{ term_for :assignment } Visible when Locked"
+
+        %ul.locked-display.visible_elements.conditional-options.indented{"class"=>("visually-hidden" if !f.object.visible_when_locked?)}
+          %li.locked-display
+            .checkbox
+              = f.check_box :show_name_when_locked
+              = f.label :show_name_when_locked, :label => "Show Name when Locked"
+          %li.locked-display
+            .checkbox
+              = f.check_box :show_points_when_locked
+              = f.label :show_points_when_locked, :label => "Show Points when Locked"
+          %li.locked-display
+            .checkbox
+              = f.check_box :show_description_when_locked
+              = f.label :show_description_when_locked, :label => "Show Description when Locked"
+          %li.locked-display
+            .checkbox
+              = f.check_box :show_purpose_when_locked
+              = f.label :show_purpose_when_locked, :label => "Show Purpose when Locked"
+
+
   .submit-buttons
     %ul
       %li= f.button :submit, "#{presenter.assignment.persisted? ? 'Update' : 'Create'} #{term_for :assignment}"

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -46,7 +46,6 @@
           = f.text_area :purpose, class: "froala"
 
       .form-item
-        %label Media Image
         = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
 
       .form-item

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -46,6 +46,7 @@
           = f.text_area :purpose, class: "froala"
 
       .form-item
+        %label Media Image
         = render partial: "layouts/media_image_form_item", locals: { f: f, model: presenter.assignment }
 
       .form-item

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -51,7 +51,7 @@
                     %td.doobers= points assignment.full_points
                   %td= "Yes" if assignment.grade_with_rubric?
                   %td
-                    - if current_user_is_staff?
+                    - if current_user_is_admin? || current_course.active?
                       .button-container.dropdown
                         %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
                         %ul.options-menu

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -42,7 +42,6 @@
 
       .ui-tabs-panel#tab3{class: ("active" if !presenter.has_viewable_submission?(current_student, current_user) && !presenter.grades_available_for?(current_student)), role: "tabpanel", "aria-hidden" => false }
         %section.assignment-details-container
-          %h2 Description
           = render partial: "assignments/description", locals: { presenter: presenter }
 
       - if presenter.show_rubric_preview?(current_student)

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -58,8 +58,8 @@
 
   %section.form-section
     %h2.form-title Unlocks
+    %p.hint Unlocks allow you to direct the sequence of content in your course. What do students need to do in order to unlock this #{ term_for :badge }?
     .unlock-conditions
-      %p.hint Unlocks allow you to direct the sequence of content in your course. What do students need to do in order to unlock this #{ term_for :badge }?
       %script(id="unlock-condition-template" type="text/x-template")
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, UnlockCondition.new, class: "form-inline", child_index: "child_index" do |ucf|
@@ -68,7 +68,8 @@
         %fieldset.unlock-condition
           = f.simple_fields_for :unlock_conditions, condition, class: "form-inline" do |ucf|
             = render partial: "layouts/unlock_condition_fields", locals: { f: ucf }
-    %button.add-unlock-condition Add a Condition
+    .box.box-padded.add-unlock-condition-wrapper
+      %button.button-link.add-unlock-condition=glyph(:plus) + "Add a Condition"
 
     .unlock-visibility-settings
       %h2.form-title Unlock Visibility Settings

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -15,7 +15,7 @@
 
     .form-item
       = f.label :file_field, "Icon"
-      = f.file_field :icon, {class: "badge-image-upload"}
+      = f.file_field :icon, {class: "media-image-upload"}
       .form-hint Badges appear in different sizes in GradeCraft. Recommended size is 150px x 150px or larger.
       .preview-wrapper{ class: @badge.persisted? ? "" : "hidden"}
         .icon-preview.large-preview

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -3,8 +3,7 @@
 = simple_form_for @badge do |f|
   %section.form-section
 
-    %h2.form-title Basic Settings
-
+    %h2.form-title Basic Info
     .form-item
       = f.label :name, "Name"
       = f.text_field :name
@@ -35,29 +34,44 @@
           %span.yaxis-label 40px
 
     .form-item
+      %label{for: "form-badge-description"} Description
+      .textarea#form-badge-description
+        .form-hint Describe what this #{term_for :badge} means, and how it can be earned. Note that if this #{term_for :badge} is marked as visible then this description will also be viewable in the list of #{term_for :badges}.
+        = f.text_area :description, class: "froala"
+
+    .form-item
+      = f.label :badge_files, "Attachments"
+      = f.simple_fields_for :badge_files, @badge.badge_files.new do |bf|
+        = bf.file_field :file, :multiple => true, :label => false, :id => "badge_badge_files"
+      - if @badge.badge_files.exists?
+        %h5.bold Uploaded files
+        %ul.uploaded-files
+          - @badge.badge_files.each do |bf|
+            - next if bf.new_record?
+            %li
+              = link_to bf.filename, bf.url, :target => "_blank"
+              = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", badge_id: @badge.id, :upload_id => bf.id } )
+
+  %section.form-section
+    %h2.form-title Settings
+    .form-item.no-margin
       = f.check_box :visible
       = f.label :visible
       = tooltip("badges-visible-hint", "info-circle", placement: "right") do
         Can #{term_for :students} see this #{term_for :badge}?
 
-    .form-item
+    .form-item.no-margin
       = f.check_box :can_earn_multiple_times
       = f.label :can_earn_multiple_times,"Multi-award"
       = tooltip("badges-multiple-earn-hint", "info-circle", placement: "right") do
         Can this #{term_for :badge} be given to one #{term_for :student} multiple times through the semester?
 
-    .form-item
+    .form-item.no-margin
       = f.check_box :student_awardable
       = f.label :student_awardable,"Student-awardable"
       = tooltip("student-awardable-hint", "info-circle", placement: "right") do
         Can this #{term_for :badge} be given by one #{term_for :student} to another #{term_for :student}?
 
-  %section.form-section
-    %h2.form-title Description
-
-    .textarea
-      .form-hint Describe what this #{term_for :badge} means, and how it can be earned. Note that if this #{term_for :badge} is marked as visible then this description will also be viewable in the list of #{term_for :badges}.
-      = f.text_area :description, class: "froala"
 
   %section.form-section
     %h2.form-title Unlocks
@@ -92,20 +106,6 @@
             = f.check_box :show_description_when_locked
             = f.label :show_description_when_locked, :label => "Show Description when Locked"
 
-
-  %section.form-section
-    %h2.form-title Attachments
-    .form-item
-      = f.simple_fields_for :badge_files, @badge.badge_files.new do |bf|
-        = bf.file_field :file, :multiple => true
-      - if @badge.badge_files.exists?
-        %h5.bold Uploaded files
-        %ul.uploaded-files
-          - @badge.badge_files.each do |bf|
-            - next if bf.new_record?
-            %li
-              = link_to bf.filename, bf.url, :target => "_blank"
-              = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", badge_id: @badge.id, :upload_id => bf.id } )
   .submit-buttons
     %ul
       %li= submit_tag "#{@badge.persisted? ? 'Update' : 'Create'} #{term_for :badge}", class: "button"

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -35,19 +35,22 @@
           %span.yaxis-label 40px
 
     .form-item
-      = f.label :visible
       = f.check_box :visible
-      .form-hint Can #{term_for :students} see this #{term_for :badge}?
+      = f.label :visible
+      = tooltip("badges-visible-hint", "info-circle", placement: "right") do
+        Can #{term_for :students} see this #{term_for :badge}?
 
     .form-item
-      = f.label :can_earn_multiple_times,"Multi-award"
       = f.check_box :can_earn_multiple_times
-      .form-hint Can this #{term_for :badge} be given to one #{term_for :student} multiple times through the semester?
+      = f.label :can_earn_multiple_times,"Multi-award"
+      = tooltip("badges-multiple-earn-hint", "info-circle", placement: "right") do
+        Can this #{term_for :badge} be given to one #{term_for :student} multiple times through the semester?
 
     .form-item
-      = f.label :student_awardable,"Student-awardable"
       = f.check_box :student_awardable
-      .form-hint Can this #{term_for :badge} be given by one #{term_for :student} to another #{term_for :student}?
+      = f.label :student_awardable,"Student-awardable"
+      = tooltip("student-awardable-hint", "info-circle", placement: "right") do
+        Can this #{term_for :badge} be given by one #{term_for :student} to another #{term_for :student}?
 
   %section.form-section
     %h2.form-title Description
@@ -75,23 +78,19 @@
       %h2.form-title Unlock Visibility Settings
       .form-item
         .locked-visibility-options.form-item-with-options
-          = f.label :visible_when_locked, :label => "Visible when Locked"
           = f.check_box :visible_when_locked, {class: "has-conditional-options"}
+          = f.label :visible_when_locked, :label => "Visible when Locked"
 
-        %ul.locked-display.visible_elements.conditional-options.indented
+        %ul.locked-display.visible_elements.conditional-options.indented{"class"=>("visually-hidden" if !f.object.visible_when_locked?)}
           %li.locked-display
-            .checkbox
-              = f.label :show_name_when_locked, :label => "Show Name when Locked"
-              = f.check_box :show_name_when_locked
+            = f.check_box :show_name_when_locked
+            = f.label :show_name_when_locked, :label => "Show Name when Locked"
           %li.locked-display
-            .checkbox
-              = f.label :show_points_when_locked, :label => "Show Points when Locked"
-              = f.check_box :show_points_when_locked
+            = f.check_box :show_points_when_locked
+            = f.label :show_points_when_locked, :label => "Show Points when Locked"
           %li.locked-display
-            .checkbox
-              = f.label :show_description_when_locked, :label => "Show Description when Locked"
-              = f.check_box :show_description_when_locked
-
+            = f.check_box :show_description_when_locked
+            = f.label :show_description_when_locked, :label => "Show Description when Locked"
 
 
   %section.form-section

--- a/app/views/courses/_course_details.haml
+++ b/app/views/courses/_course_details.haml
@@ -3,51 +3,50 @@
 .form-wrapper
   %section.form-section
     %h2.form-title Class Details
-    .form-flex-container
-      .form-flex-row
-        .form-item.col-50
-          = f.label :location, "Location"
-          = f.text_field :location
+    .form-flex-row
+      .form-item
+        = f.label :location, "Location"
+        = f.text_field :location
 
-        .form-item.col-50
-          = f.label :meeting_times, "Class Meeting Times"
-          = f.text_field :meeting_times
+      .form-item
+        = f.label :meeting_times, "Class Meeting Times"
+        = f.text_field :meeting_times
 
-      .form-flex-row
-        .form-item.col-50
-          = f.label :office, "Professor's Office"
-          = f.text_field :office
+    .form-flex-row
+      .form-item
+        = f.label :office, "Professor's Office"
+        = f.text_field :office
 
-        .form-item.col-50
-          = f.label :office_hours, "Office Hours"
-          = f.text_field :office_hours
+      .form-item
+        = f.label :office_hours, "Office Hours"
+        = f.text_field :office_hours
 
-      .form-flex-row
-        .form-item.col-50
-          = f.label :phone, "Contact Phone #"
-          = f.text_field :phone
+    .form-flex-row
+      .form-item
+        = f.label :phone, "Contact Phone #"
+        = f.text_field :phone
 
-        .form-item.col-50
-          = f.label :class_email, "Class Email"
-          = f.text_field :class_email
+      .form-item
+        = f.label :class_email, "Class Email"
+        = f.text_field :class_email
 
-      .form-flex-row
-        .form-item.col-50
-          = f.label :twitter_handle, "Twitter Handle"
-          = f.text_field :twitter_handle
-          .form-hint Don't include the @ sign
+    .form-flex-row
+      .form-item
+        = f.label :twitter_handle, "Twitter Handle"
+        = f.text_field :twitter_handle
+        .form-hint Don't include the @ sign
 
-        .form-item.col-50
-          = f.label :twitter_hashtag, "Hashtag"
-          = f.text_field :twitter_hashtag
-          .form-hint Don't include the hash sign
+      .form-item
+        = f.label :twitter_hashtag, "Hashtag"
+        = f.text_field :twitter_hashtag
+        .form-hint Don't include the hash sign
 
-      .form-flex-row
-        .form-item.col-100
-          = f.label :syllabus
-          = f.file_field :syllabus
-          - if current_course.syllabus.present?
-            .italic= link_to "Current Syllabus", current_course.syllabus_url
+    .form-flex-row
+      .form-item
+        = f.label :syllabus
+        = f.file_field :syllabus
+        - if current_course.syllabus.present?
+          .italic= link_to "Current Syllabus", current_course.syllabus_url
 
   - unless @course.new_record?
     %section.form-section

--- a/app/views/courses/_custom_terms.haml
+++ b/app/views/courses/_custom_terms.haml
@@ -2,53 +2,52 @@
   %h2.form-title Custom Language
   %p GradeCraft allows you to customize the language used throughout the application. Update the defaults below to customize the language for your class.
 
-  .form-flex-container
-    .form-flex-row
-      .form-item.col-50
-        = f.label :student_term, "User"
-        = f.text_field :student_term, {"aria-describedby" => "txtUserTerm"}
-        .form-hint{id: "txtUserTerm"} What will you call your user? Student, Learner, Player...
+  .form-flex-row
+    .form-item.col-50
+      = f.label :student_term, "User"
+      = f.text_field :student_term, {"aria-describedby" => "txtUserTerm"}
+      .form-hint{id: "txtUserTerm"} What will you call your user? Student, Learner, Player...
 
-      .form-item.col-50
-        = f.label :assignment_term, "Assignment"
-        = f.text_field :assignment_term, {"aria-describedby" => "txtAssignmentTerm"}
-        .form-hint{id: "txtAssignmentTerm"} Would you like to call assignments something else?
+    .form-item.col-50
+      = f.label :assignment_term, "Assignment"
+      = f.text_field :assignment_term, {"aria-describedby" => "txtAssignmentTerm"}
+      .form-hint{id: "txtAssignmentTerm"} Would you like to call assignments something else?
 
-    .form-flex-row
-      .form-item.col-50
-        = f.label :group_term, "Group"
-        = f.text_field :group_term, {"aria-describedby" => "txtGroupTerm"}
-        .form-hint{id: "txtGroupTerm"} What will these groups be called?
+  .form-flex-row
+    .form-item.col-50
+      = f.label :group_term, "Group"
+      = f.text_field :group_term, {"aria-describedby" => "txtGroupTerm"}
+      .form-hint{id: "txtGroupTerm"} What will these groups be called?
 
-      .form-item.col-50
-        = f.label :badge_term, "Badge"
-        = f.text_field :badge_term, {"aria-describedby" => "txtBadgeTerm"}
-        .form-hint{id: "txtBadgeTerm"} Would you like to call badges something else?
+    .form-item.col-50
+      = f.label :badge_term, "Badge"
+      = f.text_field :badge_term, {"aria-describedby" => "txtBadgeTerm"}
+      .form-hint{id: "txtBadgeTerm"} Would you like to call badges something else?
 
-    .form-flex-row
-      .form-item.col-50
-        = f.label :pass_term, "Pass"
-        = f.text_field :pass_term, {"aria-describedby" => "txtPassTerm"}
-        .form-hint{id: "txtPassTerm"} What would you like to call success for a pass/fail assignment?
+  .form-flex-row
+    .form-item.col-50
+      = f.label :pass_term, "Pass"
+      = f.text_field :pass_term, {"aria-describedby" => "txtPassTerm"}
+      .form-hint{id: "txtPassTerm"} What would you like to call success for a pass/fail assignment?
 
-      .form-item.col-50
-        = f.label :fail_term, "Fail"
-        = f.text_field :fail_term, {"aria-describedby" => "txtFailTerm"}
-        .form-hint{id: "txtFailTerm"} What would you like to call failure for a pass/fail assignment?
+    .form-item.col-50
+      = f.label :fail_term, "Fail"
+      = f.text_field :fail_term, {"aria-describedby" => "txtFailTerm"}
+      .form-hint{id: "txtFailTerm"} What would you like to call failure for a pass/fail assignment?
 
-    .form-flex-row
-      .form-item.col-50
-        = f.label :team_term, "Section"
-        = f.text_field :team_term, {"aria-describedby" => "txtSectionTerm"}
-        .form-hint{id: "txtSectionTerm"}  What will you call these? Team, House, Section...
+  .form-flex-row
+    .form-item.col-50
+      = f.label :team_term, "Section"
+      = f.text_field :team_term, {"aria-describedby" => "txtSectionTerm"}
+      .form-hint{id: "txtSectionTerm"}  What will you call these? Team, House, Section...
 
-      .form-item.col-50
-        = f.label :team_leader_term, "Section Leader"
-        = f.text_field :team_leader_term, {"aria-describedby" => "txtTeamLeader"}
-        .form-hint{id: "txtTeamLeader"} TA, GSI, Team Leader...
+    .form-item.col-50
+      = f.label :team_leader_term, "Section Leader"
+      = f.text_field :team_leader_term, {"aria-describedby" => "txtTeamLeader"}
+      .form-hint{id: "txtTeamLeader"} TA, GSI, Team Leader...
 
-    .form-flex-row
-      .form-item
-        = f.label :challenge_term, "Section Assignment"
-        = f.text_field :challenge_term, {"aria-describedby" => "txtChallenge"}
-        .form-hint{id: "txtChallenge"} What would you like to call these section assignments? Quests, Boss Battles, Challenges...
+  .form-flex-row
+    .form-item
+      = f.label :challenge_term, "Section Assignment"
+      = f.text_field :challenge_term, {"aria-describedby" => "txtChallenge"}
+      .form-hint{id: "txtChallenge"} What would you like to call these section assignments? Quests, Boss Battles, Challenges...

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -4,35 +4,34 @@
 .form-wrapper
   %section.form-section
     %h2.form-title Basics
-    .form-flex-container
-      .form-flex-row
-        .form-item.col-50
-          = f.label :course_number, "*Course Number"
-          = f.text_field :course_number
+    .form-flex-row
+      .form-item
+        = f.label :course_number, "*Course Number"
+        = f.text_field :course_number
 
-        .form-item.col-50
-          = f.label :name, "*Course Title"
-          = f.text_field :name
-      .form-flex-row
-        .form-item.col-50
-          = f.label :semester
-          = f.select :semester, [["Winter", "winter"], ["Spring", "spring"], ["Summer", "summer"], ["Fall", "fall"]]
+      .form-item
+        = f.label :name, "*Course Title"
+        = f.text_field :name
+    .form-flex-row
+      .form-item
+        = f.label :semester
+        = f.select :semester, [["Winter", "winter"], ["Spring", "spring"], ["Summer", "summer"], ["Fall", "fall"]]
 
-        .form-item.col-50
-          = f.label :year
-          = f.select :year, (Date.today.year - 3)..(Date.today.year + 2), :selected => "#{@course.year || Date.today.year}"
+      .form-item
+        = f.label :year
+        = f.select :year, (Date.today.year - 3)..(Date.today.year + 2), :selected => "#{@course.year || Date.today.year}"
 
-      .form-flex-row
-        .form-item.col-50
-          = f.input :start_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @course.try(:start_date) }
+    .form-flex-row
+      .form-item
+        = f.input :start_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @course.try(:start_date) }
 
-        .form-item.col-50
-          = f.input :end_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @course.try(:end_date) }
+      .form-item
+        = f.input :end_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @course.try(:end_date) }
 
-      .form-flex-row
-        .form-item.col-100
-          = f.label :tagline, "Course Tagline"
-          = f.text_field :tagline
+    .form-flex-row
+      .form-item
+        = f.label :tagline, "Course Tagline"
+        = f.text_field :tagline
 
   %section.form-section
     %h2.form-title Enable Features

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -2,11 +2,9 @@
   %label.media-image-label{for: "assignment_media"} Media Image
   = f.file_field :media, {class: "media-image-upload"}
   .preview-wrapper{ class: model.media.present? ? "" : "hidden"}
-    .icon-preview.event-preview
-      .img-cropper.event-crop
+    .event-preview
+      .img-cropper
         %img{:src => model.media}
-      %span.xaxis-label 128px
-      %span.yaxis-label 128px
     - if model.media.present? && model.errors[:media].empty?
       = f.check_box :remove_media
       Remove Image

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -2,9 +2,11 @@
   %label.media-image-label{for: "assignment_media"} Media Image
   = f.file_field :media, {class: "media-image-upload"}
   .preview-wrapper{ class: model.media.present? ? "" : "hidden"}
-    .event-preview
-      .img-cropper
+    .icon-preview.event-preview
+      .img-cropper.event-crop
         %img{:src => model.media}
+      %span.xaxis-label 250px
+      %span.yaxis-label 150px
     - if model.media.present? && model.errors[:media].empty?
       = f.check_box :remove_media
       Remove Image

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -1,7 +1,7 @@
 .form-item
+  %label.media-image-label{for: "assignment_media"} Upload an Image
+  = f.file_field :media, {class: "media-image-upload"}
   .image-preview
-    %label.media-image-label{for: "assignment_media"}= glyph(:camera) + "Upload an Image"
-    = f.file_field :media, {class: "media-image-upload"}
     - if model.media.present? && model.errors[:media].empty?
       = f.check_box :remove_media
       Remove Image

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -1,7 +1,7 @@
 .form-item
-  = f.label :media, "Media Image"
-  = f.file_field :media
-  - if model.media.present? && model.errors[:media].empty?
-    %img{src: model.media, width: 40, alt: "Media Image" }
-    = f.check_box :remove_media
-    Remove Image
+  .image-preview
+    %label.media-image-label{for: "assignment_media"}= glyph(:camera) + "Upload an Image"
+    = f.file_field :media, {class: "media-image-upload"}
+    - if model.media.present? && model.errors[:media].empty?
+      = f.check_box :remove_media
+      Remove Image

--- a/app/views/layouts/_media_image_form_item.html.haml
+++ b/app/views/layouts/_media_image_form_item.html.haml
@@ -1,7 +1,12 @@
 .form-item
-  %label.media-image-label{for: "assignment_media"} Upload an Image
+  %label.media-image-label{for: "assignment_media"} Media Image
   = f.file_field :media, {class: "media-image-upload"}
-  .image-preview
+  .preview-wrapper{ class: model.media.present? ? "" : "hidden"}
+    .icon-preview.event-preview
+      .img-cropper.event-crop
+        %img{:src => model.media}
+      %span.xaxis-label 128px
+      %span.yaxis-label 128px
     - if model.media.present? && model.errors[:media].empty?
       = f.check_box :remove_media
       Remove Image

--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -1,27 +1,70 @@
 .conditions
-  %h4 Requirement
   .assignment-or-badge
-    = f.select :condition_type, [["Assignment Type", "AssignmentType"], "Assignment", "Badge", "Course"], :label => "Type", include_blank: true
+    .form-item
+      = f.label :condition_type, "Requirement"
+      = f.select :condition_type, [["Assignment Type", "AssignmentType"], "Assignment", "Badge", "Earned Point Value"], :label => "Type", include_blank: true
+
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment} Type"
-    = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Amount", :required => true, :input_html => { min: '0' }
-    = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
+    .form-flex-row
+      .form-item
+        = f.label :condition_id, "#{term_for :assignment} Type", :for => "assignment_type_selection"
+        = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_type_selection" }
+      .form-item
+        = f.label :condition_state, "State Achieved", :for => "at_state_achieved"
+        = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => false, input_html: { :id => "at_state_achieved" }
+    .form-flex-row
+      .form-item
+        = f.label :condition_value, "Amount", :for => "at_amount"
+        = f.input :condition_value, :label => false, :required => true, :input_html => { min: '0', id: "at_amount"}
+      .form-item
+        = f.label :condition_date, "Completed by", :for => "at_completed_date"
+        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "at_completed_date" }, :label => false
+
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => "#{term_for :assignment}"
-    = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Min Points"
-    = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
+    .form-flex-row
+      .form-item
+        = f.label :condition_id, "#{term_for :assignment}", :for => "assignment_selection"
+        = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_selection" }
+      .form-item
+        = f.label :condition_state, "State Achieved", :for => "assignment_state_achieved"
+        = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => false, input_html: { :id => "assignment_state_achieved" }
+    .form-flex-row
+      .form-item
+        = f.label :condition_value, "Min Points", :for => "assignment_min_points"
+        = f.input :condition_value, :label => false, input_html: { :id => "assignment_min_points" }
+      .form-item
+        = f.label :condition_date, "Completed By", :for => "assignment_completed_date"
+        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "assignment_completed_date" }, :label => false
+
   #badges-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => current_course.badges.order(:name).map { |l| [l.name, l.id] }, :include_blank => true, :label => "#{term_for :badge}"
-    = f.input :condition_state, :collection => ["Earned"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Number of Times Earned"
-    = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
-  #courses-list{:style => "display: none", class: "unlock-conditions-list"}
-    = f.input :condition_id, :collection => [["#{current_course.name}", current_course.id]], label: "Course", include_blank: false
-    = f.input :condition_state, :collection => ["Earned"], :label => "State Achieved"
-    = f.input :condition_value, :label => "Min Points"
-    = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker" }, :label => "Done By"
+    .form-flex-row
+      .form-item
+        = f.label :condition_id, "#{term_for :badge}", :for => "badge_selection"
+        = f.input :condition_id, :collection => current_course.badges.order(:name).map { |l| [l.name, l.id] }, :include_blank => true, :label => false, input_html: { :id => "badge_selection" }
+      .form-item
+        = f.label :condition_state, "State Achieved", :for => "badge_state_achieved"
+        = f.input :condition_state, :collection => ["Earned"], :label => false, input_html: { :id => "badge_state_achieved" }
+    .form-flex-row
+      .form-item
+        = f.label :condition_value, "Number of Times Earned", :for => "badge_times_earned"
+        = f.input :condition_value, :label => false, input_html: { :id => "badge_times_earned" }
+      .form-item
+        = f.label :condition_date, "Completed By", :for => "badge_completed_date"
+        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "badge_completed_date" }, :label => false
+
+  #earned-point-values-list{:style => "display: none", class: "unlock-conditions-list"}
+    .form-item
+      = f.hidden_field :condition_id, :collection => [["#{current_course.name}", current_course.id]], label: "Course", include_blank: false
+    .form-item
+      = f.hidden_field :condition_state, :collection => ["Earned"], :label => "State Achieved", :selected => "Earned"
+    .form-flex-row
+      .form-item
+        = f.label :condition_value, "Min Points", :for => "course_min_points"
+        = f.input :condition_value, :label => false, input_html: { :id => "course_min_points" }
+      .form-item
+        = f.label :condition_date, "Completed By", :for => "course_completed_date"
+        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "course_completed_date" }, :label => false
+
   .right
     = f.hidden_field :_destroy, class: "destroy"
     %button.remove-unlock-condition.right Delete Condition

--- a/app/views/layouts/_unlock_condition_fields.haml
+++ b/app/views/layouts/_unlock_condition_fields.haml
@@ -5,66 +5,57 @@
       = f.select :condition_type, [["Assignment Type", "AssignmentType"], "Assignment", "Badge", "Earned Point Value"], :label => "Type", include_blank: true
 
   #assignment-types-list{:style => "display: none", class: "unlock-conditions-list"}
-    .form-flex-row
-      .form-item
-        = f.label :condition_id, "#{term_for :assignment} Type", :for => "assignment_type_selection"
-        = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_type_selection" }
-      .form-item
-        = f.label :condition_state, "State Achieved", :for => "at_state_achieved"
-        = f.input :condition_state, :collection => ["Assignments Completed", "Min Points"], :label => false, input_html: { :id => "at_state_achieved" }
-    .form-flex-row
-      .form-item
-        = f.label :condition_value, "Amount", :for => "at_amount"
-        = f.input :condition_value, :label => false, :required => true, :input_html => { min: '0', id: "at_amount"}
-      .form-item
-        = f.label :condition_date, "Completed by", :for => "at_completed_date"
-        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "at_completed_date" }, :label => false
+    .form-item
+      = f.label :condition_id, "#{term_for :assignment} Type", :for => "assignment_type_selection"
+      = f.input :condition_id, :collection => current_course.assignment_types.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_type_selection" }
+    .form-item
+      = f.label :condition_state, "State Achieved", :for => "at_state_achieved"
+      = f.input :condition_state, :collection => ["Assignments Completed", "Minimum Points Earned"], :label => false, input_html: { :id => "at_state_achieved" }
+    .form-item
+      = f.label :condition_value, "Number (Points or Assignments)", :for => "at_amount"
+      = f.input :condition_value, :label => false, :required => true, :input_html => { min: '0', id: "at_amount"}
+    .form-item
+      = f.label :condition_date, "Completed by Date", :for => "at_completed_date"
+      = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "at_completed_date" }, :label => false
 
   #assignments-list{:style => "display: none", class: "unlock-conditions-list"}
-    .form-flex-row
-      .form-item
-        = f.label :condition_id, "#{term_for :assignment}", :for => "assignment_selection"
-        = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_selection" }
-      .form-item
-        = f.label :condition_state, "State Achieved", :for => "assignment_state_achieved"
-        = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => false, input_html: { :id => "assignment_state_achieved" }
-    .form-flex-row
-      .form-item
-        = f.label :condition_value, "Min Points", :for => "assignment_min_points"
-        = f.input :condition_value, :label => false, input_html: { :id => "assignment_min_points" }
-      .form-item
-        = f.label :condition_date, "Completed By", :for => "assignment_completed_date"
-        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "assignment_completed_date" }, :label => false
+    .form-item
+      = f.label :condition_id, "#{term_for :assignment}", :for => "assignment_selection"
+      = f.input :condition_id, :collection => current_course.assignments.order(:name).map { |l| [l.name,l.id] }, :include_blank => true, :label => false, input_html: { :id => "assignment_selection" }
+    .form-item
+      = f.label :condition_state, "State Achieved", :for => "assignment_state_achieved"
+      = f.input :condition_state, :collection => ["Submitted", "Grade Earned", "Feedback Read", "Passed"], :label => false, input_html: { :id => "assignment_state_achieved" }
+    .form-item
+      = f.label :condition_value, "Minimum Points Earned", :for => "assignment_min_points"
+      = f.input :condition_value, :label => false, input_html: { :id => "assignment_min_points" }
+    .form-item
+      = f.label :condition_date, "Completed By Date", :for => "assignment_completed_date"
+      = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "assignment_completed_date" }, :label => false
 
   #badges-list{:style => "display: none", class: "unlock-conditions-list"}
-    .form-flex-row
-      .form-item
-        = f.label :condition_id, "#{term_for :badge}", :for => "badge_selection"
-        = f.input :condition_id, :collection => current_course.badges.order(:name).map { |l| [l.name, l.id] }, :include_blank => true, :label => false, input_html: { :id => "badge_selection" }
-      .form-item
-        = f.label :condition_state, "State Achieved", :for => "badge_state_achieved"
-        = f.input :condition_state, :collection => ["Earned"], :label => false, input_html: { :id => "badge_state_achieved" }
-    .form-flex-row
-      .form-item
-        = f.label :condition_value, "Number of Times Earned", :for => "badge_times_earned"
-        = f.input :condition_value, :label => false, input_html: { :id => "badge_times_earned" }
-      .form-item
-        = f.label :condition_date, "Completed By", :for => "badge_completed_date"
-        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "badge_completed_date" }, :label => false
+    .form-item
+      = f.label :condition_id, "#{term_for :badge}", :for => "badge_selection"
+      = f.input :condition_id, :collection => current_course.badges.order(:name).map { |l| [l.name, l.id] }, :include_blank => true, :label => false, input_html: { :id => "badge_selection" }
+    .form-item
+      = f.hidden_field :condition_state, :collection => ["Earned"], :label => false, input_html: { :id => "badge_state_achieved" }, :selected => "Earned"
+    .form-item
+      = f.label :condition_value, "Number of Times Earned", :for => "badge_times_earned"
+      = f.input :condition_value, :label => false, input_html: { :id => "badge_times_earned" }
+    .form-item
+      = f.label :condition_date, "Completed By Date", :for => "badge_completed_date"
+      = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "badge_completed_date" }, :label => false
 
   #earned-point-values-list{:style => "display: none", class: "unlock-conditions-list"}
     .form-item
       = f.hidden_field :condition_id, :collection => [["#{current_course.name}", current_course.id]], label: "Course", include_blank: false
     .form-item
       = f.hidden_field :condition_state, :collection => ["Earned"], :label => "State Achieved", :selected => "Earned"
-    .form-flex-row
-      .form-item
-        = f.label :condition_value, "Min Points", :for => "course_min_points"
-        = f.input :condition_value, :label => false, input_html: { :id => "course_min_points" }
-      .form-item
-        = f.label :condition_date, "Completed By", :for => "course_completed_date"
-        = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "course_completed_date" }, :label => false
+    .form-item
+      = f.label :condition_value, "Minimum Points Earned", :for => "course_min_points"
+      = f.input :condition_value, :label => false, input_html: { :id => "course_min_points" }
+    .form-item
+      = f.label :condition_date, "Completed By Date", :for => "course_completed_date"
+      = f.input :condition_date, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", id: "course_completed_date" }, :label => false
 
-  .right
-    = f.hidden_field :_destroy, class: "destroy"
-    %button.remove-unlock-condition.right Delete Condition
+  = f.hidden_field :_destroy, class: "destroy"
+  %button.remove-unlock-condition= glyph(:times)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
This PR improves the UX and styling of the assignment creation page

### Todos
- [x] remove fields for :include_in_timeline, :include_in_predictor, :include_in_to_do
- [x] add label to multiple file upload link
- [x] revise styling for image upload link per design and add image preview utility
- [x] redesign unlocks section
- [x] transitions for contingent form elements

### Migrations
YES | NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment creation form

======================
Closes #3241, #3173 
