### PR TITLE
2839 Add resubmission sample data

### DIFF
--- a/db/samples.rb
+++ b/db/samples.rb
@@ -576,8 +576,31 @@ PaperTrail.whodunnit = nil
       if config[:unlock_condition]
         add_unlock_conditions(assignment, config, course_config)
       end
+
+# --------------------------- Create Resubmissions! --------------------------#
+
+      if config[:attributes][:resubmissions_allowed]
+        puts "Generating Resubmissions"
+        @students.each do |student|
+          # Only occurs in course GC105 course_id = 5 because it is the only one with assignments open
+          if assignment.resubmissions_allowed? && assignment.open? && Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).present?
+            PaperTrail.whodunnit = student.id
+            submission = student.submissions.create! do |s|
+              s.assignment = assignment
+              s.text_comment = "Wingardium Leviosa"
+              s.link = "http://www.facebook.com"
+              s.submitted_at = DateTime.now
+            end
+            submission.update_attributes(link: "http://twitch.tv")
+          end
+          print "."
+        end
+        print "\n"
+        puts_success :assignment, assignment_name,
+          :submissions_created if course_name == @courses.keys[-1]
+      end
     end # tap course
-  end
+  end #@courses
   puts_success :assignment, assignment_name, :assignment_created
 end
 
@@ -649,7 +672,7 @@ end
   puts_success :event, event_name, :event_created
 end
 
-# ---------------------------- Create Announcements! ----------------------------#
+# ---------------------------- Create Announcements! --------------------------#
 
 @announcements.each do |announcement_title,config|
   @courses.each do |course_name,course_config|

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -485,6 +485,8 @@ PaperTrail.whodunnit = nil
         end
       end
 
+# -------------------------- Create Submissions! --------------------------#
+
       if config[:student_submissions]
         @students.each do |student|
           PaperTrail.whodunnit = student.id
@@ -500,6 +502,8 @@ PaperTrail.whodunnit = nil
         puts_success :assignment, assignment_name,
           :submissions_created if course_name == @courses.keys[-1]
       end
+
+  # -------------------------- Create Grades! --------------------------#
 
       if config[:grades]
         @students.each do |student|
@@ -583,7 +587,7 @@ PaperTrail.whodunnit = nil
         puts "Generating Resubmissions"
         @students.each do |student|
           # Only occurs in course GC105 course_id = 5 because it is the only one with assignments open
-          if assignment.resubmissions_allowed? && assignment.open? && Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).present?
+          if assignment.resubmissions_allowed? && Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).present?
             PaperTrail.whodunnit = student.id
             submission = student.submissions.create! do |s|
               s.assignment = assignment
@@ -592,6 +596,8 @@ PaperTrail.whodunnit = nil
               s.submitted_at = DateTime.now
             end
             submission.update_attributes(link: "http://twitch.tv")
+            grade = Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).first
+            grade.update_attributes(submission_id: submission.id)
           end
           print "."
         end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -586,7 +586,6 @@ PaperTrail.whodunnit = nil
       if config[:attributes][:resubmissions_allowed]
         puts "Generating Resubmissions"
         @students.each do |student|
-          # Only occurs in course GC105 course_id = 5 because it is the only one with assignments open
           if assignment.resubmissions_allowed? && Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).present?
             PaperTrail.whodunnit = student.id
             submission = student.submissions.create! do |s|
@@ -597,6 +596,7 @@ PaperTrail.whodunnit = nil
             end
             submission.update_attributes(link: "http://twitch.tv")
             grade = Grade.where(assignment_id: assignment.id, student_id: student.id, course_id: course.id).first
+            # Grade must associate with submission to be read as a resubmission
             grade.update_attributes(submission_id: submission.id)
           end
           print "."

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1712,3 +1712,22 @@ the speed, and the route.― Jay Cross",
     status: "Graded"
   }
 }
+
+@assignments[:pass_fail_with_grades_and_allows_resubmissions] = {
+  quotes: {
+    assignment_created: "Do. Or do not. There is no try. -- Yoda"
+  },
+  assignment_type: :grading,
+  attributes: {
+    name: "Pass/Fail [Has grades with submissions and allows resubmissions]",
+    open_at: 1.weeks.from_now,
+    due_at: 1.weeks.from_now + 0.05,
+    pass_fail: true,
+    resubmissions_allowed: true,
+  },
+  grades: true,
+  participation: 90,
+  grade_attributes: {
+    status: "Graded"
+  }
+}

--- a/db/samples/assignments.rb
+++ b/db/samples/assignments.rb
@@ -1724,10 +1724,37 @@ the speed, and the route.― Jay Cross",
     due_at: 1.weeks.from_now + 0.05,
     pass_fail: true,
     resubmissions_allowed: true,
+    accepts_submissions: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
   },
   grades: true,
   participation: 90,
   grade_attributes: {
-    status: "Graded"
+    status: "Released"
+  }
+}
+
+@assignments[:standard_edit_quick_grade_text_graded_and_allows_resubmissions] = {
+  quotes: {
+    assignment_created: "We demand rigidly defined areas of doubt and \
+uncertainty! - Douglas Adams"
+  },
+  assignment_type: :grading,
+  attributes: {
+    name: "Standard Edit + Quick Grade with Text Box [Grades and allows resubmissions]",
+    open_at: 1.weeks.from_now,
+    due_at: 1.weeks.from_now + 0.05,
+    resubmissions_allowed: true,
+    accepts_submissions: true,
+    accepts_attachments: true,
+    accepts_text: true,
+    accepts_links: true,
+  },
+  grades: true,
+  participation: 90,
+  grade_attributes: {
+    status: "Released"
   }
 }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Add Resubmissions to sample data

### Related PRs
N/A

### Todos
- [x] Let's add the assignment to all of the other courses (the courses represent different scenarios or Course-level feature variations, so we try to get the basic assignments, when appropriate, into each shell)
- [x] You added a pass/fail assignment, let's also create and add a graded assignment
- [x] The assignments should each be marked as "Accepting Submissions" - without that, you won't see the submission link on the assignment index, or the submission data on the grading page
- [x] The resubmissions should be marked as ungraded, meaning that they should appear on the Grading Status page and increase the alert number by that item in the menu

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Run
```
$ bundle exec rails db:sample --trace
```
in terminal.
Upon checking the database you should notice several records in the versions database for assignment with ID 475 that have updates submissions. The update will be for the link in the submission.

### Impacted Areas in Application
N/A

======================
Closes #2839 
