### PR TITLE
Fix breadcrumb-related issues

### DIFF
--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -19,9 +19,10 @@ class Assignments::ImportersController < ApplicationController
   # GET /assignments/importers/:importer_provider_id/courses/:id/assignments
   def assignments
     @provider_name = params[:importer_provider_id]
-    @course = syllabus.course(params[:id])
+    @lms_course = syllabus.course(params[:id])
     @assignments = syllabus.assignments(params[:id])
     @assignment_types = current_course.assignment_types.ordered
+    @course = current_course
   end
 
   # POST /assignments/importers/:importer_provider_id/courses/:id/assignments

--- a/app/controllers/assignments/importers_controller.rb
+++ b/app/controllers/assignments/importers_controller.rb
@@ -10,7 +10,7 @@ class Assignments::ImportersController < ApplicationController
     controller.redirect_path assignments_importers_path
   end
   before_action :require_authorization, except: :index
-  before_action :use_current_course, only: [:index, :assignments_import]
+  before_action :use_current_course, only: [:index, :assignments_import, :assignments]
 
   # GET /assignments/importers
   def index
@@ -22,7 +22,6 @@ class Assignments::ImportersController < ApplicationController
     @lms_course = syllabus.course(params[:id])
     @assignments = syllabus.assignments(params[:id])
     @assignment_types = current_course.assignment_types.ordered
-    @course = current_course
   end
 
   # POST /assignments/importers/:importer_provider_id/courses/:id/assignments

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -17,8 +17,9 @@ class Grades::ImportersController < ApplicationController
   def assignments
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
-    @course = syllabus.course(params[:id])
+    @lms_course = syllabus.course(params[:id])
     @assignments = syllabus.assignments(params[:id])
+    @course = current_course
   end
 
   # GET /assignments/:assignment_id/grades/download

--- a/app/controllers/grades/importers_controller.rb
+++ b/app/controllers/grades/importers_controller.rb
@@ -12,14 +12,13 @@ class Grades::ImportersController < ApplicationController
       assignment_grades_importers_path(params[:assignment_id])
   end
   before_action :require_authorization, except: [:download, :index, :show, :upload]
-  before_action :use_current_course, only: [:upload, :grades, :grades_import, :index, :show, :upload]
+  before_action :use_current_course, only: [:upload, :grades, :grades_import, :index, :show, :upload, :assignments]
 
   def assignments
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
     @lms_course = syllabus.course(params[:id])
     @assignments = syllabus.assignments(params[:id])
-    @course = current_course
   end
 
   # GET /assignments/:assignment_id/grades/download

--- a/app/views/assignments/importers/assignments.html.haml
+++ b/app/views/assignments/importers/assignments.html.haml
@@ -1,7 +1,7 @@
 .pageContent
   = render partial: "layouts/alerts"
 
-  = form_tag assignments_importer_assignments_import_path(@provider_name, @course["id"]) do
+  = form_tag assignments_importer_assignments_import_path(@provider_name, @lms_course["id"]) do
     %table.dynatable.no-table-header
       %thead
         %tr

--- a/app/views/grades/importers/assignments.html.haml
+++ b/app/views/grades/importers/assignments.html.haml
@@ -20,5 +20,5 @@
             .right
               %ul.button-bar
                 %li
-                  = link_to assignment_grades_importer_grades_path(@assignment, @provider_name, @course["id"], assignment_ids: assignment["id"]), class: "button" do
+                  = link_to assignment_grades_importer_grades_path(@assignment, @provider_name, @lms_course["id"], assignment_ids: assignment["id"]), class: "button" do
                     = decorative_glyph(:download) + "Import Grades for this assignment"


### PR DESCRIPTION
### Status
READY

### Description
Some of the Canvas-related routes are broken due to an error that is occurring in the breadcrumbs. The breadcrumbs expect a Course model to be set, but in the context of our Canvas controller methods the course is actually the Canvas course which is hash.

### Migrations
NO

### Steps to Test or Reproduce
Ensure that Canvas import routes are accessible and that there are no breadcrumb errors.

### Impacted Areas in Application
Canvas user, assignment, and grade import

======================
Closes #3281
