### PR TITLE
initialize all angular from one location

### DIFF
--- a/app/views/assignment_type_weights/index.html.haml
+++ b/app/views/assignment_type_weights/index.html.haml
@@ -13,7 +13,7 @@
         - if current_course.max_assignment_types_weighted?
           %li You may work on up to #{ current_course.max_assignment_types_weighted} #{ (term_for :assignment_types).downcase}
 
-    %assignment-type-weights{"ng-app" => "gradecraft"}
+    %assignment-type-weights
 
   - else
     %h3 Your #{term_for :weight} choices:

--- a/app/views/assignments/groups/grade.html.haml
+++ b/app/views/assignments/groups/grade.html.haml
@@ -1,4 +1,4 @@
-.pageContent{"ng-app" => "gradecraft"}
+.pageContent
   = render "layouts/alerts"
 
   = render partial: "submissions/assignment_guidelines", locals: { assignment: @assignment }

--- a/app/views/assignments/settings.html.haml
+++ b/app/views/assignments/settings.html.haml
@@ -3,7 +3,7 @@
     %ul
       %li= link_to decorative_glyph(:plus) + "New #{(term_for :assignment).titleize}", new_assignment_path, class: "button button-edit"
 
-.pageContent{"ng-app": "gradecraft"}
+.pageContent
 
   = render partial: "layouts/alerts"
 

--- a/app/views/badges/_index_student.haml
+++ b/app/views/badges/_index_student.haml
@@ -1,2 +1,2 @@
 #student-main-content
-  %student-badge-index{"ng-app" => "gradecraft"}
+  %student-badge-index

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_setup.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_setup.haml
@@ -1,1 +1,1 @@
-%grade_scheme_elements_setup{"ng-app"=>"gradecraft"}
+%grade_scheme_elements_setup

--- a/app/views/grade_scheme_elements/mass_edit.html.haml
+++ b/app/views/grade_scheme_elements/mass_edit.html.haml
@@ -1,3 +1,3 @@
 .pageContent
-  #grade_scheme_elements_main_content{'ng-app'=>'gradecraft'}
+  #grade_scheme_elements_main_content
     %grade_scheme_elements_mass_edit_form{'ng-form'=>'', 'name'=>'gradeSchemeElementsForm'}

--- a/app/views/grades/_analytics.haml
+++ b/app/views/grades/_analytics.haml
@@ -3,7 +3,7 @@
   - assignment = presenter.assignment
   - student_id = current_student.present? ? current_student.id : nil?
 
-  .class-analytics{ "ng-app": "gradecraft", class: analytics_class }
+  .class-analytics.analytics_class
     - if assignment.pass_fail?
       .class-analytics-wrapper
         .class-analytics-graph

--- a/app/views/grades/edit.html.haml
+++ b/app/views/grades/edit.html.haml
@@ -1,4 +1,4 @@
-.pageContent{"ng-app" => "gradecraft"}
+.pageContent
   = render partial: "layouts/alerts", locals: { model: @grade }
 
   = render partial: "submissions/assignment_guidelines", locals: { assignment: @grade.assignment }

--- a/app/views/grades/importers/grades.html.haml
+++ b/app/views/grades/importers/grades.html.haml
@@ -1,4 +1,4 @@
-.pageContent{"ng-app"=>"gradecraft"}
+.pageContent
   %grade-import-form{"assignment-ids"=>"#{@assignment_ids}",
                      "current_assignment_id"=>"#{@assignment.id}",
                      "provider"=>"#{@provider_name}",

--- a/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
@@ -2,7 +2,7 @@ You have earned
 %span.bold #{points presenter.score_for_course } points
 - cache multi_cache_key :student_dashboard_total_score, current_student, current_course do
 
-  %points-breakdown-analytics{"ng-app": "gradecraft"}
+  %points-breakdown-analytics
 
 - if presenter.next_element.present?
   .progress.bar_magic.center

--- a/app/views/info/predictor.haml
+++ b/app/views/info/predictor.haml
@@ -1,2 +1,2 @@
-#student-main-content{"ng-app" => "gradecraft"}
+#student-main-content
   %predictor

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,7 @@
     = javascript_include_tag "https://cdn.statuspage.io/se-v2.js"
     = yield(:head)
 
-  %body(class="#{body_class}")
+  %body(class="#{body_class}" ng-app="gradecraft")
     = render partial: "layouts/top_bar", locals: { presenter: Navigation::CourseInfoPresenter.new(course: current_course, student: current_student) }
     - if current_user
       %a.nav-flyout-contentmask

--- a/app/views/rubrics/design.html.haml
+++ b/app/views/rubrics/design.html.haml
@@ -17,4 +17,4 @@
         = glyph(:sliders)
         = "Copy Rubric from Another #{ term_for :assignment }"
 
-  %rubric-design.rubric-design(ng-app="gradecraft" rubric-id="#{@rubric.id}")
+  %rubric-design.rubric-design(rubric-id="#{@rubric.id}")

--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -1,6 +1,6 @@
 = render partial: "assignment_guidelines", locals: { assignment: presenter.assignment }
 
-%student-submission{"ng-app"=>"#{'gradecraft' if presenter.assignment.accepts_text}", class: "ng-cloak"}
+%student-submission{class: "ng-cloak"}
   = simple_form_for [presenter.assignment, presenter.submission], :html => { class: "student-submission-form", "assignment_id"=>"#{presenter.assignment.id}" } do |f|
     %hidden-form-method
     - if presenter.assignment.has_groups?

--- a/app/views/users/importers/users.html.haml
+++ b/app/views/users/importers/users.html.haml
@@ -1,6 +1,6 @@
-.pageContent{"ng-app"=>"gradecraft"}
+.pageContent
   = render partial: "layouts/alerts"
-  
+
   %user-import-form{"provider"=>"#{@provider_name}",
                      "course-id"=>"#{@course_id}",
                      "authenticity-token"=>"#{form_authenticity_token}"}

--- a/app/views/users/search.html.haml
+++ b/app/views/users/search.html.haml
@@ -1,2 +1,2 @@
 .pageContent
-  %user-search-utility{"ng-app"=>"gradecraft"}
+  %user-search-utility

--- a/doc/angular_directives.md
+++ b/doc/angular_directives.md
@@ -2,13 +2,14 @@
 
 There are many ways to initiate an Angular app, the primary way we have settled on in GC is by using directives.
 In order to "wire-up" a directive from the rails view, we need two things. We need to call our gradecraft app using `ng-app` on a parent element, and we need to add an element whose name will be picked up by our Angular directive.
+Currently, we declare ng-app directly on the body element.
 
 ## Initiating in the View
 
 Let's say we are going to create a directive called `myAwesomeGraph`, which needs two pieces of information, a student's id to collect the data from the endpoint, and a student's name in order to title the graph. In our rails view, we have something like this:
 
 ```
-#class-analytics-graph{"ng-app" => "gradecraft"}
+#class-analytics-graph
     %my-awesome-graph{ "student-name" => @student.name,
       "student-id" => @student.id}
 ```


### PR DESCRIPTION
### Status
**READY**

### Description
Moves all initialization of our angular app to one location, in the application layout. This will allow angular to be used in more than one place on a page, without fear of interference from other uses.

### Related PRs
This follow the work on #3278 (merged)

### Impacted Areas in Application
All pages with Angular components.