### PR TITLE
Set last_login_date When Authenticating Via LTI

### DIFF
--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -27,21 +27,22 @@ class CourseMembership < ActiveRecord::Base
 
   def self.create_or_update_from_lti(student, course, auth_hash)
     return false unless auth_hash["extra"] && auth_hash["extra"]["raw_info"] && auth_hash["extra"]["raw_info"]["roles"]
-    course_membership = student.course_memberships.find_or_create_by(course_id: course.id)
+    course_membership = student.course_memberships.find_or_initialize_by(course_id: course.id)
 
     auth_hash["extra"]["raw_info"].tap do |extra|
       case extra["roles"].downcase
       when /instructor/
-        course_membership.update(role: "professor")
+        course_membership.role = "professor"
       when /teachingassistant/
-        course_membership.update(role: "gsi")
+        course_membership.role = "gsi"
       when /learner/
-        course_membership.update(role: "student")
-        course_membership.update(instructor_of_record: false)
+        course_membership.role = "student"
+        course_membership.instructor_of_record = false
       else
-        course_membership.update(instructor_of_record: false)
+        course_membership.instructor_of_record = false
       end
     end
+    course_membership.last_login_at = DateTime.now
     course_membership.save
   end
 

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -39,6 +39,7 @@ class CourseMembership < ActiveRecord::Base
         course_membership.role = "student"
         course_membership.instructor_of_record = false
       else
+        course_membership.role = "observer"
         course_membership.instructor_of_record = false
       end
     end

--- a/spec/models/course_membership_spec.rb
+++ b/spec/models/course_membership_spec.rb
@@ -39,6 +39,8 @@ describe CourseMembership do
         course_membership = create(:course_membership, user: user, course: course, role: "professor")
         expect{ CourseMembership.create_or_update_from_lti(user, course, auth_hash) }.to_not \
           change(CourseMembership, :count)
+        expect(course_membership.reload.role).to eq "observer"
+        expect(course_membership.reload.instructor_of_record).to eq false
         expect(course_membership.reload.last_login_at).to be_within(1.second).of(DateTime.now)
       end
     end


### PR DESCRIPTION
### Status
READY

### Description
If the user is authenticating via LTI, the `last_login_date` should be updated on the course membership.

This PR also tidies up the associated specs and reduces the number of database transactions performed.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Ensure that it is still possible to authenticate to Gradecraft via LTI and that the user's `last_login_date` is updated accordingly.

### Impacted Areas in Application
Authentication via LTI

======================
Closes #3269 
