### PR TITLE
2563 course on-boarding

### DIFF
--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -1,25 +1,39 @@
 # Creates a checklist during course creation for Faculty to check off as they
 # design the course.
 
-@gradecraft.directive 'courseCreationChecklist', ['AssignmentService', (AssignmentService) ->
+@gradecraft.directive 'courseCreationChecklist', ['$q', 'CourseService', ($q, CourseService) ->
+  CourseCreationController = [()->
+    vm = this
+    vm.loading = true
+    vm.CourseService = CourseService
+
+    services(vm.courseId).then(()->
+      vm.loading = false
+    )
+
+    vm.inputId = (item)->
+      "course_#{vm.courseId}-#{item.item}"
+
+    vm.checklistItems = ()->
+      vm.CourseService.creationChecklist()
+
+    vm.toggleChecklistItem = (item)->
+      console.log(item)
+  ]
+
+  services = (courseId)->
+    promises = [
+      CourseService.getCourseCreation(courseId)
+    ]
+    return $q.all(promises)
 
   return {
+    bindToController: true,
+    controller: CourseCreationController,
+    controllerAs: 'vm',
     scope: {
       courseId: "="
     }
     templateUrl: 'courses/creation_checklist.html',
-    link: (scope, el, attr)->
-      scope.checklistItems = [
-        "Course Settings",
-        "Attendance",
-        "Assignments",
-        "Calendar Events",
-        "Set Up Teaching Term",
-        "Import Roster"
-      ]
-
-      scope.toggleChecklistItem = (item)->
-        debugger
-        console.log(item)
   }
 ]

--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -18,7 +18,8 @@
       vm.CourseService.creationChecklist()
 
     vm.toggleChecklistItem = (item)->
-      console.log(item)
+      item.done = !item.done
+      CourseService.updateCourseCreationItem(item)
   ]
 
   services = (courseId)->

--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -9,6 +9,17 @@
     }
     templateUrl: 'courses/creation_checklist.html',
     link: (scope, el, attr)->
-      console.log("sam i am");
+      scope.checklistItems = [
+        "Course Settings",
+        "Attendance",
+        "Assignments",
+        "Calendar Events",
+        "Set Up Teaching Term",
+        "Import Roster"
+      ]
+
+      scope.toggleChecklistItem = (item)->
+        debugger
+        console.log(item)
   }
 ]

--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -35,9 +35,6 @@
     bindToController: true,
     controller: CourseCreationController,
     controllerAs: 'vm',
-    scope: {
-      courseId: "="
-    }
     templateUrl: 'courses/creation_checklist.html',
   }
 ]

--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -1,0 +1,14 @@
+# Creates a checklist during course creation for Faculty to check off as they
+# design the course.
+
+@gradecraft.directive 'courseCreationChecklist', ['AssignmentService', (AssignmentService) ->
+
+  return {
+    scope: {
+      courseId: "="
+    }
+    templateUrl: 'courses/creation_checklist.html',
+    link: (scope, el, attr)->
+      console.log("sam i am");
+  }
+]

--- a/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_checklist.coffee
@@ -14,6 +14,9 @@
     vm.inputId = (item)->
       "course_#{vm.courseId}-#{item.item}"
 
+    vm.termFor = (term)->
+      vm.CourseService.termFor(term)
+
     vm.checklistItems = ()->
       vm.CourseService.creationChecklist()
 

--- a/app/assets/javascripts/angular/directives/courses/creation_progress_bar.coffee
+++ b/app/assets/javascripts/angular/directives/courses/creation_progress_bar.coffee
@@ -1,0 +1,25 @@
+# Iterates through levels in a criterion
+
+@gradecraft.directive 'courseCreationProgressBar', [() ->
+
+  return {
+    templateUrl: 'courses/creation_progress_bar.html'
+    scope: {
+      items: "="
+    }
+    link: (scope, el, attr)->
+
+      totalItems = ()->
+        scope.items.length
+
+      itemsComplete = ()->
+        _.reject(scope.items, {done: false}).length
+
+      scope.barWidth = ()->
+        itemsComplete() / totalItems() * 100 + "%"
+
+      scope.barTitle = ()->
+        "#{itemsComplete()}/#{totalItems()} items complete!"
+
+  }
+]

--- a/app/assets/javascripts/angular/helpers/serviceHelpers.js.coffee
+++ b/app/assets/javascripts/angular/helpers/serviceHelpers.js.coffee
@@ -13,7 +13,7 @@ angular.module('helpers').factory('GradeCraftAPI', ()->
   }
 
   termFor = (article)->
-    _termFor[article.toLowerCase()]
+    _termFor[article.toLowerCase()] || article
 
   setTermFor = (article,term)->
     _termFor[article] = term

--- a/app/assets/javascripts/angular/services/CourseService.coffee
+++ b/app/assets/javascripts/angular/services/CourseService.coffee
@@ -18,8 +18,9 @@
     $http.get("/api/course_creation").then(
       (response)->
         GradeCraftAPI.loadItem(courseCreation, "course_creation", response.data)
-        # GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)
-        # GradeCraftAPI.setTermFor("badge", response.meta.term_for_badge)
+        GradeCraftAPI.setTermFor("assignments", response.data.meta.term_for_assignments)
+        GradeCraftAPI.setTermFor("badges", response.data.meta.term_for_badges)
+        GradeCraftAPI.setTermFor("teams", response.data.meta.term_for_teams)
         GradeCraftAPI.logResponse(response)
       ,(response)->
         GradeCraftAPI.logResponse(response)

--- a/app/assets/javascripts/angular/services/CourseService.coffee
+++ b/app/assets/javascripts/angular/services/CourseService.coffee
@@ -1,0 +1,30 @@
+# Manages state of Badges including API calls.
+# Can be used independently, or via another service (see PredictorService)
+
+@gradecraft.factory 'CourseService', ['$http', 'GradeCraftAPI', ($http, GradeCraftAPI) ->
+
+  courseCreation = {}
+
+  creationChecklist = ()->
+    return [] if !courseCreation.checklist
+    return courseCreation.checklist
+
+  termFor = (article)->
+    GradeCraftAPI.termFor(article)
+
+  #------ API Calls -----------------------------------------------------------#
+
+  getCourseCreation = (courseId)->
+    $http.get("/api/courses/#{courseId}/course_creation").success( (response)->
+      GradeCraftAPI.loadItem(courseCreation, "course_creation", response)
+      # GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)
+      # GradeCraftAPI.setTermFor("badge", response.meta.term_for_badge)
+    )
+
+  return {
+    termFor,
+    getCourseCreation,
+    courseCreation,
+    creationChecklist
+  }
+]

--- a/app/assets/javascripts/angular/services/CourseService.coffee
+++ b/app/assets/javascripts/angular/services/CourseService.coffee
@@ -15,15 +15,29 @@
   #------ API Calls -----------------------------------------------------------#
 
   getCourseCreation = (courseId)->
-    $http.get("/api/courses/#{courseId}/course_creation").success( (response)->
-      GradeCraftAPI.loadItem(courseCreation, "course_creation", response)
-      # GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)
-      # GradeCraftAPI.setTermFor("badge", response.meta.term_for_badge)
+    $http.get("/api/course_creation").then(
+      (response)->
+        GradeCraftAPI.loadItem(courseCreation, "course_creation", response.data)
+        # GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)
+        # GradeCraftAPI.setTermFor("badge", response.meta.term_for_badge)
+        GradeCraftAPI.logResponse(response)
+      ,(response)->
+        GradeCraftAPI.logResponse(response)
+    )
+
+  updateCourseCreationItem = (item)->
+    params = {"course_creation" : { "#{item.name}" : item.done }}
+    $http.put("/api/course_creation", params).then(
+      (response)->
+        GradeCraftAPI.logResponse(response)
+      ,(response)->
+        GradeCraftAPI.logResponse(response)
     )
 
   return {
     termFor,
     getCourseCreation,
+    updateCourseCreationItem
     courseCreation,
     creationChecklist
   }

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -1,15 +1,15 @@
-.course-creation-checklist
+.course-creation-checklist(ng-if="!vm.loading")
   .course-creation-checklist-title Course Creation
 
   .course-creation-progress-bar
 
   %ul
-    %li.course-creation-checklist-item(ng-repeat="item in checklistItems")
-      %input(id="{{inputId(item)}}"
+    %li.course-creation-checklist-item(ng-repeat="item in vm.checklistItems()")
+      %input(id="{{vm.inputId(item)}}"
         type="checkbox"
-        ng-checked="checked"
-        ng-click="toggleChecklistItem(item)"
+        ng-checked="item.done"
+        ng-click="vm.toggleChecklistItem(item)"
       )
-      .title {{ item }}
+      .title {{ item.title }}
 
 

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -1,7 +1,7 @@
 .course-creation-checklist(ng-if="!vm.loading")
   .course-creation-checklist-title Course Creation
 
-  .course-creation-progress-bar
+  %course-creation-progress-bar(items="vm.checklistItems()")
 
   %ul
     %li.course-creation-checklist-item(ng-repeat="item in vm.checklistItems()")

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -10,6 +10,6 @@
         ng-checked="item.done"
         ng-click="vm.toggleChecklistItem(item)"
       )
-      .title {{ vm.termFor(item.title) }}
-
+      .title
+        %a{"ng-href"=>"{{item.url}}"} {{ vm.termFor(item.title) }}
 

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -1,0 +1,2 @@
+.course-creation-checklist
+  .title Course Creation

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -10,6 +10,6 @@
         ng-checked="item.done"
         ng-click="vm.toggleChecklistItem(item)"
       )
-      .title {{ item.title }}
+      .title {{ vm.termFor(item.title) }}
 
 

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -12,4 +12,3 @@
       )
       .title
         %a{"ng-href"=>"{{item.url}}"} {{ vm.termFor(item.title) }}
-

--- a/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_checklist.html.haml
@@ -1,2 +1,15 @@
 .course-creation-checklist
-  .title Course Creation
+  .course-creation-checklist-title Course Creation
+
+  .course-creation-progress-bar
+
+  %ul
+    %li.course-creation-checklist-item(ng-repeat="item in checklistItems")
+      %input(id="{{inputId(item)}}"
+        type="checkbox"
+        ng-checked="checked"
+        ng-click="toggleChecklistItem(item)"
+      )
+      .title {{ item }}
+
+

--- a/app/assets/javascripts/angular/templates/courses/creation_progress_bar.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/creation_progress_bar.html.haml
@@ -1,0 +1,4 @@
+.progress-bar-container
+  .progress-bar-fill(style="width: {{barWidth()}}")
+
+.progress-bar-title {{ barTitle()}}

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -99,13 +99,9 @@ hr.light-grey
   padding-top: .5rem
   font-weight: 100
   .publish-button
-    border: 1px solid white
-    border-radius: .5rem
-    margin-left: 2rem
-    padding: 0 .5rem
-    a
-      color: white
-      text-transform: capitalize
+    margin-left: 1rem
+    margin-top: -1rem
+    display: inline-block
 
 @media (min-width: $media-medium-max)
   .panel .row

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -80,6 +80,33 @@ hr.light-grey
 .page-header
   padding: 0.5rem 1rem
 
+.collapse-toggler
+  i.fa.fa-angle-double-right.fa-fw
+    transform: rotate(90deg)
+
+.collapse-toggler.collapsed
+  i.fa.fa-angle-double-right.fa-fw
+    transform: rotate(0deg)
+
+.unpublished-course-notification
+  background-color: $color-red-1
+  width: 100%
+  height: 2.5rem
+  color: white
+  font-size: 1.25rem
+  text-transform: uppercase
+  text-align: center
+  padding-top: .5rem
+  font-weight: 100
+  .publish-button
+    border: 1px solid white
+    border-radius: .5rem
+    margin-left: 2rem
+    padding: 0 .5rem
+    a
+      color: white
+      text-transform: capitalize
+
 @media (min-width: $media-medium-max)
   .panel .row
     margin-bottom: 1rem

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -98,10 +98,18 @@ hr.light-grey
   text-align: center
   padding-top: .5rem
   font-weight: 100
-  .publish-button
+  .publish-button a
     margin-left: 1rem
-    margin-top: -1rem
     display: inline-block
+    color: $color-white
+    background-color: $color-green-3
+    border-radius: $global-radius
+    padding: .125rem .5rem
+    font-size: 1rem
+    text-transform: capitalize
+    &:hover
+      text-decoration: none
+      background: darken($color-green-2, 10%)
 
 @media (min-width: $media-medium-max)
   .panel .row

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -37,7 +37,7 @@
       text-decoration: none
 
     a:hover, a:focus
-      background-color: $color-blue-3 !important
+      background-color: $color-blue-3
       color: $color-white
 
     span.sidebar-nav
@@ -96,7 +96,7 @@ ul.nav-pill
     li.active,
     li.active a:hover,
     li.active:hover
-      background-color: $color-blue-3 !important
+      background-color: $color-blue-3
       color: $color-white !important
       cursor: pointer
 
@@ -122,22 +122,27 @@ ul.nav-pill
   width: 100%
   padding-bottom: .125rem
   margin-bottom: .5rem
+  border-radius: $global-radius
 
 .course-creation-checklist-title
   background-color: $color-red-1
   color: $color-white
   text-align: center
   padding: .5rem 0
+  border-radius: $global-radius
 
 .course-creation-checklist-item
-  padding: .25rem 0
+  padding: .25rem .5rem
   input[type="checkbox"]
     float: left
     margin-top: 0.55rem
   .title a
     color: $color-blue-3
     margin-left: 1.5rem
-
+    &:hover, &:active
+      color: $color-blue-3
+      background-color: white
+      text-decoration: underline
 
 .progress-bar-container
   width: 90%
@@ -153,6 +158,3 @@ ul.nav-pill
 
 .progress-bar-title
   margin-left: 10%
-
-
-

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -133,8 +133,8 @@ ul.nav-pill
   padding: .25rem 0
   input[type="checkbox"]
     float: left
-    margin-top: 0.35rem
-  .title
-    color: black
+    margin-top: 0.55rem
+  .title a
+    color: $color-blue-3
     padding-left: 1.35rem;
 

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -120,7 +120,8 @@ ul.nav-pill
 .course-creation-checklist
   background-color: $color-white
   width: 100%
-  padding-bottom: .5rem
+  padding-bottom: .125rem
+  margin-bottom: .5rem
 
 .course-creation-checklist-title
   background-color: $color-red-1

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -136,5 +136,23 @@ ul.nav-pill
     margin-top: 0.55rem
   .title a
     color: $color-blue-3
-    padding-left: 1.35rem;
+    margin-left: 1.5rem
+
+
+.progress-bar-container
+  width: 90%
+  height: 1rem
+  overflow: hidden
+  background-color: $color-grey-6
+  border-radius: .5rem
+  margin: .5rem 0 0 5%
+
+.progress-bar-fill
+  height: 1rem
+  background-color: $color-green-3
+
+.progress-bar-title
+  margin-left: 10%
+
+
 

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -133,6 +133,8 @@ ul.nav-pill
   padding: .25rem 0
   input[type="checkbox"]
     float: left
+    margin-top: 0.35rem
   .title
     color: black
+    padding-left: 1.35rem;
 

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -118,3 +118,20 @@ ul.nav-pill
     width: 78%
 
 .course-creation-checklist
+  background-color: $color-white
+  width: 100%
+  padding-bottom: .5rem
+
+.course-creation-checklist-title
+  background-color: $color-red-1
+  color: $color-white
+  text-align: center
+  padding: .5rem 0
+
+.course-creation-checklist-item
+  padding: .25rem 0
+  input[type="checkbox"]
+    float: left
+  .title
+    color: black
+

--- a/app/assets/stylesheets/layout/_staff_sidebar.sass
+++ b/app/assets/stylesheets/layout/_staff_sidebar.sass
@@ -45,7 +45,7 @@
       padding: 2.4px
 
 /* Styling of search fields in sidenav and nav */
-.sidebar, 
+.sidebar,
 ul.nav-pill
   .has-form
     margin-bottom: .75rem
@@ -116,3 +116,5 @@ ul.nav-pill
     border: 0
     border-bottom: 1px dashed $color-white
     width: 78%
+
+.course-creation-checklist

--- a/app/controllers/api/course_creation_controller.rb
+++ b/app/controllers/api/course_creation_controller.rb
@@ -1,0 +1,31 @@
+class API::CourseCreationController < ApplicationController
+  before_action :ensure_staff?
+
+  # GET api/course_creation
+  def show
+    @course_creation = CourseCreation.find_or_create_for_course(current_course.id)
+  end
+
+
+  # PUT api/course_creation
+  def update
+    @course_creation = CourseCreation.find_or_create_for_course(current_course.id)
+
+    if @course_creation.update_attributes(course_creation_params)
+      render "api/course_creation/show", status: 200
+    else
+      render json: {
+        errors: [{ detail: "failed to update course creation" }], success: false
+        },
+        status: 500
+    end
+  end
+
+  private
+
+  def course_creation_params
+    params.require(:course_creation).permit(
+      :settings_done, :attendance_done, :assignments_done, :calendar_done,
+      :instructors_done, :roster_done, :badges_done, :teams_done)
+  end
+end

--- a/app/controllers/api/course_creation_controller.rb
+++ b/app/controllers/api/course_creation_controller.rb
@@ -6,7 +6,6 @@ class API::CourseCreationController < ApplicationController
     @course_creation = CourseCreation.find_or_create_for_course(current_course.id)
   end
 
-
   # PUT api/course_creation
   def update
     @course_creation = CourseCreation.find_or_create_for_course(current_course.id)

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -1,4 +1,5 @@
 class API::CoursesController < ApplicationController
+  before_action :ensure_staff?, only: :course_creation
 
   # accessed by the dashboard
   # GET api/courses
@@ -7,6 +8,11 @@ class API::CoursesController < ApplicationController
       { name: c.formatted_long_name, id: c.id, search_string: c.searchable_name }
     end
     render json: MultiJson.dump(@courses)
+  end
+
+  # GET api/courses/:course_id/course_creation
+  def course_creation
+    @course_creation = CourseCreation.find_or_create_for_course(params[:course_id])
   end
 
   # accessed by the dashboard

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -10,11 +10,6 @@ class API::CoursesController < ApplicationController
     render json: MultiJson.dump(@courses)
   end
 
-  # GET api/courses/:course_id/course_creation
-  def course_creation
-    @course_creation = CourseCreation.find_or_create_for_course(params[:course_id])
-  end
-
   # accessed by the dashboard
   # GET api/timeline_events
   def timeline_events

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -13,6 +13,7 @@ class CoursesController < ApplicationController
                                      :update,
                                      :destroy,
                                      :badges,
+                                     :publish,
                                      :recalculate_student_scores]
   skip_before_action :verify_authenticity_token, only: [:change]
   before_action :ensure_not_impersonating?, only: [:change]
@@ -81,6 +82,14 @@ class CoursesController < ApplicationController
         format.html { render action: "edit" }
       end
     end
+  end
+
+  def publish
+    authorize! :update, @course
+    @course.update(published: true)
+    redirect_to dashboard_path, flash: {
+      success: "This course has been published"
+    }
   end
 
   # Switch between enrolled courses

--- a/app/models/course_creation.rb
+++ b/app/models/course_creation.rb
@@ -32,7 +32,10 @@ class CourseCreation < ActiveRecord::Base
 
   # returns all boolean fields as array of checklist items
   def checklist
-    self.class.columns.map(&:name) - ["id", "course_id", "created_at", "updated_at"]
+    ignored_fields = ["id", "course_id", "created_at", "updated_at"]
+    ignored_fields << "badges_done" unless self.course.has_badges
+    ignored_fields << "teams_done" unless self.course.has_teams
+    self.class.columns.map(&:name) - ignored_fields
   end
 end
 

--- a/app/models/course_creation.rb
+++ b/app/models/course_creation.rb
@@ -1,4 +1,5 @@
 class CourseCreation < ActiveRecord::Base
+  include Rails.application.routes.url_helpers
   belongs_to :course
 
   validates_presence_of :course
@@ -9,7 +10,6 @@ class CourseCreation < ActiveRecord::Base
 
   # returns the human readable version of any checklist item
   def title_for_item(item)
-    # settings_done => :settings
     case item[0..-6].to_sym
     when :settings
       "course settings"
@@ -30,9 +30,32 @@ class CourseCreation < ActiveRecord::Base
     end
   end
 
+  def url_for_item(item)
+    case item[0..-6].to_sym
+    when :settings
+      edit_course_url(self.course, only_path: true)
+    when :attendance
+      # add when feature is implemented
+    when :assignments
+      assignments_url(only_path: true)
+    when :calendar
+      events_url(only_path: true)
+    when :instructors
+      staff_index_url(only_path: true)
+    when :roster
+     import_users_url(only_path: true)
+    when :badges
+      badges_url(only_path: true)
+    when :teams
+      teams_url(only_path: true)
+    end
+  end
+
   # returns all boolean fields as array of checklist items
+  # only adds badges and teams for courses with these items
+  # attendance is ignored for now, until the feature is in place
   def checklist
-    ignored_fields = ["id", "course_id", "created_at", "updated_at"]
+    ignored_fields = ["id", "course_id", "created_at", "updated_at", "attendance_done"]
     ignored_fields << "badges_done" unless self.course.has_badges
     ignored_fields << "teams_done" unless self.course.has_teams
     self.class.columns.map(&:name) - ignored_fields

--- a/app/models/course_creation.rb
+++ b/app/models/course_creation.rb
@@ -1,0 +1,40 @@
+class CourseCreation < ActiveRecord::Base
+  belongs_to :course
+
+  validates_presence_of :course
+
+  def self.find_or_create_for_course(course_id)
+    CourseCreation.find_or_create_by(course_id: course_id)
+  end
+
+  # returns the human readable version of any checklist item
+  def title_for_item(item)
+    # settings_done => :settings
+    case item[0..-6].to_sym
+    when :settings
+      "course settings"
+    when :attendance
+      "attendance"
+    when :assignments
+      "assignments"
+    when :calendar
+      "calendar events"
+    when :instructors
+      "set up teaching team"
+    when :roster
+      "import roster"
+    when :badges
+      "badges"
+    when :teams
+      "teams"
+    end
+  end
+
+  # returns all boolean fields as array of checklist items
+  def checklist
+    self.class.columns.map(&:name) - ["id", "course_id", "created_at", "updated_at"]
+  end
+end
+
+
+

--- a/app/models/course_creation.rb
+++ b/app/models/course_creation.rb
@@ -10,7 +10,7 @@ class CourseCreation < ActiveRecord::Base
 
   # returns the human readable version of any checklist item
   def title_for_item(item)
-    case item[0..-6].to_sym
+    case checklist_sym item
     when :settings
       "course settings"
     when :attendance
@@ -31,7 +31,7 @@ class CourseCreation < ActiveRecord::Base
   end
 
   def url_for_item(item)
-    case item[0..-6].to_sym
+    case checklist_sym item
     when :settings
       edit_course_url(self.course, only_path: true)
     when :attendance
@@ -43,7 +43,7 @@ class CourseCreation < ActiveRecord::Base
     when :instructors
       staff_index_url(only_path: true)
     when :roster
-     import_users_url(only_path: true)
+      import_users_url(only_path: true)
     when :badges
       badges_url(only_path: true)
     when :teams
@@ -60,7 +60,12 @@ class CourseCreation < ActiveRecord::Base
     ignored_fields << "teams_done" unless self.course.has_teams
     self.class.columns.map(&:name) - ignored_fields
   end
+
+  private
+
+  # Convert column attributes into symbols for evaluating
+  # example: "settings_done" => :settings
+  def checklist_sym(item)
+    item[0..-6].to_sym
+  end
 end
-
-
-

--- a/app/views/api/course_creation/show.json.jbuilder
+++ b/app/views/api/course_creation/show.json.jbuilder
@@ -10,6 +10,7 @@ json.data do
       json.array! @course_creation.checklist do |item|
         json.name item
         json.title @course_creation.title_for_item(item)
+        json.url @course_creation.url_for_item(item)
         json.done @course_creation[item]
       end
     end

--- a/app/views/api/course_creation/show.json.jbuilder
+++ b/app/views/api/course_creation/show.json.jbuilder
@@ -8,11 +8,10 @@ json.data do
 
     json.checklist do
       json.array! @course_creation.checklist do |item|
-        json.item item
+        json.name item
         json.title @course_creation.title_for_item(item)
         json.done @course_creation[item]
       end
     end
   end
 end
-

--- a/app/views/api/course_creation/show.json.jbuilder
+++ b/app/views/api/course_creation/show.json.jbuilder
@@ -15,3 +15,10 @@ json.data do
     end
   end
 end
+
+json.meta do
+  json.term_for_assignments term_for :assignments
+  json.term_for_teams term_for :teams
+  json.term_for_badges term_for :badges
+end
+

--- a/app/views/api/courses/course_creation.json.jbuilder
+++ b/app/views/api/courses/course_creation.json.jbuilder
@@ -1,0 +1,18 @@
+json.data do
+  json.type "course_creation"
+  json.id   @course_creation.id.to_s
+
+  json.attributes do
+    json.id          @course_creation.id
+    json.course_id   @course_creation.course_id
+
+    json.checklist do
+      json.array! @course_creation.checklist do |item|
+        json.item item
+        json.title @course_creation.title_for_item(item)
+        json.done @course_creation[item]
+      end
+    end
+  end
+end
+

--- a/app/views/layouts/_course_publication.haml
+++ b/app/views/layouts/_course_publication.haml
@@ -2,4 +2,4 @@
 - if !current_course.published
   .unpublished-course-notification
     This Course is Currently Unpublished
-    %span.publish-button= link_to "Publish", publish_course_path(current_course), method: :put
+    .publish-button= link_to glyph(:play) + "Publish", publish_course_path(current_course), method: :put, class: "button"

--- a/app/views/layouts/_course_publication.haml
+++ b/app/views/layouts/_course_publication.haml
@@ -1,0 +1,4 @@
+- if !current_course.published
+  .unpublished-course-notification
+    This Course is Currently Unpublished
+    %span.publish-button= link_to "Publish", publish_course_path(current_course), method: :put

--- a/app/views/layouts/_course_publication.haml
+++ b/app/views/layouts/_course_publication.haml
@@ -2,4 +2,4 @@
 - if !current_course.published
   .unpublished-course-notification
     This Course is Currently Unpublished
-    .publish-button= link_to glyph(:play) + "Publish", publish_course_path(current_course), method: :put, class: "button"
+    %span.publish-button= link_to glyph(:rocket) + "Publish", publish_course_path(current_course), method: :put

--- a/app/views/layouts/_course_publication.haml
+++ b/app/views/layouts/_course_publication.haml
@@ -1,3 +1,4 @@
+-# Top banner for faculty on all pages until a course is published
 - if !current_course.published
   .unpublished-course-notification
     This Course is Currently Unpublished

--- a/app/views/layouts/_course_unpublished.haml
+++ b/app/views/layouts/_course_unpublished.haml
@@ -1,3 +1,6 @@
+-# This partials is visible to students for an unpublished course
+-# It replaces the regular course content until published.
+
 .unpublished-course-notification
   This Course is Currently Under Construction
 

--- a/app/views/layouts/_course_unpublished.haml
+++ b/app/views/layouts/_course_unpublished.haml
@@ -1,0 +1,8 @@
+.unpublished-course-notification
+  This Course is Currently Under Construction
+
+.pageContent
+
+  = render "layouts/alerts"
+
+  This Course is currently unpublished.  Until is is published, the content will not available to students.

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -3,7 +3,7 @@
   = render partial: "layouts/navigation/staff_subnav"
 
 %main.mainContainer#main-content{role: "main", class: "staff"}
-
+  = render partial: "layouts/course_publication"
   / Page content
   .mainContent
     - if current_student.present?

--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -2,6 +2,9 @@
   / Display errors and notifications
   = render partial: "layouts/navigation/student_profile_tabs", locals: {nav_class: 'sub-nav'}
   %main.mainContent#main-content{role: "main"}
-    .page-header
-      %h1.pagetitle= title
-    = render partial: "layouts/content"
+    - if current_course.published
+      .page-header
+        %h1.pagetitle= title
+      = render partial: "layouts/content"
+    - else
+      = render partial: "layouts/course_unpublished"

--- a/app/views/layouts/navigation/_staff_subnav.haml
+++ b/app/views/layouts/navigation/_staff_subnav.haml
@@ -4,5 +4,5 @@
     = render partial: "layouts/navigation/course_search"
   %ul.staff-sidenav{role: "navigation", "aria-label" => "staff-navigation"}
     - if !current_course.published
-      %course-creation-checklist
+      %course-creation-checklist(course-id="#{current_course.id}")
     = render partial: "layouts/navigation/staff_subnav_links"

--- a/app/views/layouts/navigation/_staff_subnav.haml
+++ b/app/views/layouts/navigation/_staff_subnav.haml
@@ -3,4 +3,6 @@
     = render partial: "layouts/navigation/student_search"
     = render partial: "layouts/navigation/course_search"
   %ul.staff-sidenav{role: "navigation", "aria-label" => "staff-navigation"}
+    - if !current_course.published
+      %course-creation-checklist
     = render partial: "layouts/navigation/staff_subnav_links"

--- a/app/views/layouts/navigation/_staff_subnav.haml
+++ b/app/views/layouts/navigation/_staff_subnav.haml
@@ -4,5 +4,5 @@
     = render partial: "layouts/navigation/course_search"
   %ul.staff-sidenav{role: "navigation", "aria-label" => "staff-navigation"}
     - if !current_course.published
-      %course-creation-checklist(course-id="#{current_course.id}")
+      %course-creation-checklist
     = render partial: "layouts/navigation/staff_subnav_links"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Rails.application.routes.draw do
   resources :courses, except: [:show, :destroy] do
     post :copy, on: :collection
     post :recalculate_student_scores, on: :member
+    put :publish, on: :member
     get :badges, on: :member
     get :change, on: :member
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,9 +392,10 @@ Rails.application.routes.draw do
     end
 
     resources :challenges, only: :index
-    resources :courses, only: [:index] do
-      get :course_creation
-    end
+    resources :courses, only: [:index]
+
+    get "course_creation", to: "course_creation#show"
+    put "course_creation", to: "course_creation#update"
 
     resources :criteria, only: [:create, :update, :destroy] do
       put "levels/:level_id/set_expectations", to: "criteria#set_expectations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -392,7 +392,9 @@ Rails.application.routes.draw do
     end
 
     resources :challenges, only: :index
-    resources :courses, only: [:index]
+    resources :courses, only: [:index] do
+      get :course_creation
+    end
 
     resources :criteria, only: [:create, :update, :destroy] do
       put "levels/:level_id/set_expectations", to: "criteria#set_expectations"

--- a/db/migrate/20170501153921_add_published_to_course.rb
+++ b/db/migrate/20170501153921_add_published_to_course.rb
@@ -1,0 +1,5 @@
+class AddPublishedToCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :published, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20170518180521_add_course_creation.rb
+++ b/db/migrate/20170518180521_add_course_creation.rb
@@ -1,0 +1,16 @@
+class AddCourseCreation < ActiveRecord::Migration[5.0]
+  def change
+    create_table :course_creations do |t|
+      t.integer :course_id
+      t.boolean :settings_done, default: false, null: false
+      t.boolean :attendance_done, default: false, null: false
+      t.boolean :assignments_done, default: false, null: false
+      t.boolean :calendar_done, default: false, null: false
+      t.boolean :instructors_done, default: false, null: false
+      t.boolean :roster_done, default: false, null: false
+      t.boolean :badges_done, default: false, null: false
+      t.boolean :teams_done, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/samples/courses.rb
+++ b/db/samples/courses.rb
@@ -52,6 +52,7 @@
     office: nil,
     office_hours: nil,
     phone: nil,
+    published: true,
     semester: "Winter",
     tagline: nil,
     has_team_challenges: false,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,6 +235,20 @@ ActiveRecord::Schema.define(version: 20170524170059) do
     t.datetime "updated_at",                            null: false
   end
 
+  create_table "course_creations", force: :cascade do |t|
+    t.integer  "course_id"
+    t.boolean  "settings_done",    default: false, null: false
+    t.boolean  "attendance_done",  default: false, null: false
+    t.boolean  "assignments_done", default: false, null: false
+    t.boolean  "calendar_done",    default: false, null: false
+    t.boolean  "instructors_done", default: false, null: false
+    t.boolean  "roster_done",      default: false, null: false
+    t.boolean  "badges_done",      default: false, null: false
+    t.boolean  "teams_done",       default: false, null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+  end
+
   create_table "course_memberships", force: :cascade do |t|
     t.integer  "course_id"
     t.integer  "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -306,8 +306,9 @@ ActiveRecord::Schema.define(version: 20170524170059) do
     t.boolean  "has_multipliers",                                         default: false,                        null: false
     t.boolean  "has_paid",                                                default: true,                         null: false
     t.boolean  "allows_canvas",                                           default: true,                         null: false
+    t.boolean  "published",                                               default: false,                        null: false
     t.integer  "institution_id"
-    t.index ["institution_id"], name: "index_courses_on_institution_id", using: :btree
+    t.index ["institution_id"], name: "index_courses_on_institution_id",  using: :btree
   end
 
   create_table "criteria", force: :cascade do |t|

--- a/lib/tasks/courses.rake
+++ b/lib/tasks/courses.rake
@@ -14,6 +14,11 @@ namespace :courses do
     end
   end
 
+  desc "Sets all existing courses as Published"
+  task publish_all: :environment do
+    Course.update_all(published: true)
+  end
+
   desc "Removes all the orphaned data for course memberships"
   task :remove_orphaned_memberships, [:dry_run] => :environment do |t, args|
     args.with_defaults(dry_run: true)

--- a/spec/controllers/api/course_creation_controller_spec.rb
+++ b/spec/controllers/api/course_creation_controller_spec.rb
@@ -1,0 +1,33 @@
+describe API::CourseCreationController do
+  let!(:course) { build(:course)}
+  let(:professor) { create(:course_membership, :professor, course: course).user }
+
+  context "as a professor" do
+    before do
+      login_user(professor)
+      allow(controller).to receive(:current_course).and_return(course)
+    end
+
+    describe "GET course creation" do
+      it "returns the CourseCreation checklist for course" do
+        course_creation = create :course_creation, course: course
+        get :show, format: :json
+        expect(assigns(:course_creation)).to eq(course_creation)
+      end
+
+      it "creates the CourseCreation model if none exists" do
+        expect{get :show, format: :json}.to \
+          change{ CourseCreation.count }.by(1)
+      end
+    end
+
+    describe "PUT update course creation" do
+
+      it "updates the field on the course creation" do
+        course_creation = create :course_creation, course: course
+        put :update, params: { course_creation: { settings_done: true }}, format: :json
+        expect(course_creation.reload.settings_done).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/controllers/api/courses_controller_spec.rb
+++ b/spec/controllers/api/courses_controller_spec.rb
@@ -24,19 +24,6 @@ describe API::CoursesController do
         expect(assigns(:events)).to eq(Timeline.new(course).events_by_due_date)
       end
     end
-
-    describe "GET course creation" do
-      it "returns the CourseCreation checklist for course" do
-        course_creation = create :course_creation, course: course
-        get :course_creation, params: {course_id: course.id}, format: :json
-        expect(assigns(:course_creation)).to eq(course_creation)
-      end
-
-      it "creates the CourseCreation model if none exists" do
-        expect{get :course_creation, params: {course_id: course.id}, format: :json}.to \
-          change{ CourseCreation.count }.by(1)
-      end
-    end
   end
 
   context "as a student" do

--- a/spec/controllers/api/courses_controller_spec.rb
+++ b/spec/controllers/api/courses_controller_spec.rb
@@ -24,6 +24,19 @@ describe API::CoursesController do
         expect(assigns(:events)).to eq(Timeline.new(course).events_by_due_date)
       end
     end
+
+    describe "GET course creation" do
+      it "returns the CourseCreation checklist for course" do
+        course_creation = create :course_creation, course: course
+        get :course_creation, params: {course_id: course.id}, format: :json
+        expect(assigns(:course_creation)).to eq(course_creation)
+      end
+
+      it "creates the CourseCreation model if none exists" do
+        expect{get :course_creation, params: {course_id: course.id}, format: :json}.to \
+          change{ CourseCreation.count }.by(1)
+      end
+    end
   end
 
   context "as a student" do

--- a/spec/factories/course_creation_factory.rb
+++ b/spec/factories/course_creation_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :course_creation do
+    association :course
+  end
+end

--- a/spec/factories/course_factory.rb
+++ b/spec/factories/course_factory.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
     semester "Fall"
     has_badges false
     has_paid false
+    published true
 
     factory :course_with_weighting do
       total_weights 6

--- a/spec/models/course_creation_spec.rb
+++ b/spec/models/course_creation_spec.rb
@@ -1,5 +1,5 @@
 describe CourseCreation do
-  let(:course) { create :course }
+  let(:course) { create :course, has_badges: true, has_teams: true }
   subject { create :course_creation, course: course }
 
   context "validations" do
@@ -51,6 +51,16 @@ describe CourseCreation do
          "badges_done",
          "teams_done"]
       )
+    end
+
+    it "does not return badges if the course has no badges" do
+      course.update(has_badges: false)
+      expect(subject.checklist).not_to include("badges_done")
+    end
+
+    it "does not return teams if the course has no teams" do
+      course.update(has_teams: false)
+      expect(subject.checklist).not_to include("teams_done")
     end
   end
 end

--- a/spec/models/course_creation_spec.rb
+++ b/spec/models/course_creation_spec.rb
@@ -29,7 +29,7 @@ describe CourseCreation do
   describe "title for item" do
     it "returns the human readable expanation for each list item" do
       expect(subject.title_for_item("settings_done")).to eq("course settings")
-      expect(subject.title_for_item("attendance_done")).to eq("attendance")
+      #expect(subject.title_for_item("attendance_done")).to eq("attendance")
       expect(subject.title_for_item("assignments_done")).to eq("assignments")
       expect(subject.title_for_item("calendar_done")).to eq("calendar events")
       expect(subject.title_for_item("instructors_done")).to eq("set up teaching team")
@@ -39,11 +39,24 @@ describe CourseCreation do
     end
   end
 
+  describe "url for item" do
+    it "returns the url for each list item" do
+      expect(subject.url_for_item("settings_done")).to eq("/courses/#{course.id}/edit")
+      #expect(subject.url_for_item("attendance_done")).to eq("...")
+      expect(subject.url_for_item("assignments_done")).to eq("/assignments")
+      expect(subject.url_for_item("calendar_done")).to eq("/events")
+      expect(subject.url_for_item("instructors_done")).to eq("/staff")
+      expect(subject.url_for_item("roster_done")).to eq("/users/import")
+      expect(subject.url_for_item("badges_done")).to eq("/badges")
+      expect(subject.url_for_item("teams_done")).to eq("/teams")
+    end
+  end
+
   describe "checklist" do
     it "returns all checklist items on the model" do
       expect(subject.checklist).to eq(
         ["settings_done",
-         "attendance_done",
+         #"attendance_done",
          "assignments_done",
          "calendar_done",
          "instructors_done",

--- a/spec/models/course_creation_spec.rb
+++ b/spec/models/course_creation_spec.rb
@@ -1,0 +1,56 @@
+describe CourseCreation do
+  let(:course) { create :course }
+  subject { create :course_creation, course: course }
+
+  context "validations" do
+    it "is valid with a course" do
+      expect(subject).to be_valid
+    end
+
+    it "is invalid without course" do
+      subject.course = nil
+      expect(subject).to_not be_valid
+      expect(subject.errors[:course]).to include "can't be blank"
+    end
+  end
+
+  describe "find or create" do
+    it "finds an existing course creation for course" do
+      subject
+      expect(CourseCreation.find_or_create_for_course(course.id)).to eq(subject)
+    end
+
+    it "creates a new course creation if not exists for course" do
+      expect{CourseCreation.find_or_create_for_course(course.id)}.to \
+        change{ CourseCreation.count }.by(1)
+    end
+  end
+
+  describe "title for item" do
+    it "returns the human readable expanation for each list item" do
+      expect(subject.title_for_item("settings_done")).to eq("course settings")
+      expect(subject.title_for_item("attendance_done")).to eq("attendance")
+      expect(subject.title_for_item("assignments_done")).to eq("assignments")
+      expect(subject.title_for_item("calendar_done")).to eq("calendar events")
+      expect(subject.title_for_item("instructors_done")).to eq("set up teaching team")
+      expect(subject.title_for_item("roster_done")).to eq("import roster")
+      expect(subject.title_for_item("badges_done")).to eq("badges")
+      expect(subject.title_for_item("teams_done")).to eq("teams")
+    end
+  end
+
+  describe "checklist" do
+    it "returns all checklist items on the model" do
+      expect(subject.checklist).to eq(
+        ["settings_done",
+         "attendance_done",
+         "assignments_done",
+         "calendar_done",
+         "instructors_done",
+         "roster_done",
+         "badges_done",
+         "teams_done"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Status
**READY**

### Description

Adds a course setup process to GradeCraft.
  * new courses are "unpublished" and not visible to students
  * faculty will see a sidebar menu with a checklist on unpublished courses
  * faculty can check off items as they are completed on an unpublished course
  * the list items link to the appropriate page
  * a button in the top bar publishes the course, making it visible to students

![screen shot 2017-05-22 at 11 37 04 am](https://cloud.githubusercontent.com/assets/1138350/26316679/0c4dd200-3ee3-11e7-87e0-3edc45139dca.png)


### Deploy Notes

After deployment, run `rails courses:publish_all` to set all existing courses as published.

### Migrations
YES

### Steps to Test or Reproduce

Current sample date should show all courses as "unpublished" when you checkout this branch.

  * You can run the rake task to verify it will work.
  * You can rerun sample data, and our current sample courses will be updated as published.
  * You can create a new course and verify that it is unpublished.
  * Verify that badges and sections only show up in the checklist if they are active on the course.
  * Verify that custom terms carry over to the checklist (assignments, badges, teams).
  * Verify that checked list items persist from page to page.

### Test UX

@mariehooper I used the solution we originally discussed, where the names of the list items are also links to the pages. We should just verify this isn't too confusing to users since it shares the line with the checkbox.  

Currently there is an `!important` on the anchor link hover style on these items that colors them blue. I'm not sure I like it but It does make the action clearer.  I also don't want override by adding yet another `!important`.  The style does not fill the length of the widget; it will if we change `.course-creation-checklist-item {margin-left: 1.5rem}` to `{padding-left: 1.5rem}` but then it becomes too easy to trigger the link when trying to check off a box.

![screen shot 2017-05-22 at 11 41 19 am](https://cloud.githubusercontent.com/assets/1138350/26316858/9b2f0d36-3ee3-11e7-964a-3b0ec6a98cd0.png)

======================
Closes #2563 
