### PR TITLE
3276 weights

### DIFF
--- a/app/assets/javascripts/angular/directives/weights/weights.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights.coffee
@@ -29,9 +29,6 @@
     controller: WeightsCtrl,
     controllerAs: 'vm',
     restrict: 'EA',
-    scope: {
-      studentId: "="
-    },
     templateUrl: 'weights/assignment_type_weights.html'
   }
 ]

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -116,7 +116,7 @@ class CoursesController < ApplicationController
     params.require(:course).permit :course_number, :name,
       :semester, :year, :has_badges, :has_teams,
       :team_term, :student_term, :section_leader_term, :group_term, :lti_uid,
-      :user_id, :course_id, :course_rules, :syllabus,
+      :user_id, :course_id, :course_rules, :syllabus, :has_multipliers,
       :has_character_names, :has_team_roles, :has_character_profiles, :show_analytics,
       :total_weights, :weights_close_at, :has_public_badges,
       :assignment_weight_type, :has_submissions, :teams_visible,

--- a/app/views/assignment_type_weights/index.html.haml
+++ b/app/views/assignment_type_weights/index.html.haml
@@ -1,6 +1,6 @@
 .pageContent
 
-  - if current_course.assignment_weight_open? || current_user_is_staff?
+  - if current_course.assignment_weight_open?
     .assignment_weights
       %h4 RULES OF THE GAME
       %ul

--- a/app/views/info/multiplier_choices.html.haml
+++ b/app/views/info/multiplier_choices.html.haml
@@ -12,7 +12,6 @@
           - if assignment_type.student_weightable?
             %th= assignment_type.name
         %th Fully Assigned?
-        %th
     %tbody
       - @students.each do |student|
         %tr
@@ -23,7 +22,3 @@
               %td= student.weight_for_assignment_type(assignment_type)
           %td
             = student.weight_spent?(current_course) ? "Yes" : "No"
-          %td
-            .right
-              %ul.button-bar
-                -#%li= link_to decorative_glyph(:edit) + "Edit #{term_for :weights}", assignment_type_weights_path(student_id: student.id), class: "button"


### PR DESCRIPTION
### Status
**READY**

### Description

Proposal solution for #3276:

After investigation, the faculty ability to change a student's weight assignments is not built into either angular or the api controllers or json, and would take some work to implement.

Faculty can currently alter a student's weighting the same way that they can perform any other action on the student's behalf: by logging into the student preview where they have full access to the course as a student.

This PR removes some of the legacy cruft left from before we adopted the new student preview and controller api routes, and assumes all manipulation on behalf of a student should be done through the newer student preview functionality.

======================
Closes #3276
