### PR TITLE
Closes #3299

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -82,6 +82,11 @@ class AssignmentsController < ApplicationController
   def update
     assignment = current_course.assignments.find(params[:id])
     if assignment.update_attributes assignment_params
+      if assignment.grades.present?
+        assignment.grades.each do |g|
+          g.save
+        end
+      end
       respond_to do |format|
         format.html do
           redirect_to assignments_path,

--- a/app/models/concerns/gradable.rb
+++ b/app/models/concerns/gradable.rb
@@ -2,7 +2,7 @@ module Gradable
   extend ActiveSupport::Concern
 
   included do
-    has_many :grades, dependent: :destroy
+    has_many :grades, dependent: :destroy, autosave: true
     has_many :predicted_earned_grades, dependent: :destroy
 
     accepts_nested_attributes_for :grades, reject_if: :no_grade

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -5,7 +5,7 @@ class Grade < ActiveRecord::Base
   include Sanitizable
 
   belongs_to :course, touch: true
-  belongs_to :assignment, touch: true
+  belongs_to :assignment
   belongs_to :assignment_type
   belongs_to :student, class_name: "User"
   belongs_to :team

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -5,7 +5,7 @@ class Grade < ActiveRecord::Base
   include Sanitizable
 
   belongs_to :course, touch: true
-  belongs_to :assignment
+  belongs_to :assignment, touch: true
   belongs_to :assignment_type
   belongs_to :student, class_name: "User"
   belongs_to :team

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -166,7 +166,7 @@ class Grade < ActiveRecord::Base
   def cache_associations
     self.student_id ||= submission.try(:student_id)
     self.assignment_id ||= submission.try(:assignment_id)
-    self.assignment_type_id ||= assignment.try(:assignment_type_id)
+    self.assignment_type_id = assignment.try(:assignment_type_id)
     self.course_id ||= assignment.try(:course_id)
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where if you move an assignment with associated grades between assignment types, the grades' assignment_type_ids don't appropriately update 

### Migrations
NO

### Steps to Test or Reproduce

1. Take a graded assignment and move it between assignment types.
2. Observe that the assignment type id stays as it was on the grade, while the assignment type id changes appropriately on the assignment

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment Type Summary scores

======================
Closes #3299 
