### PR TITLE
Removed duplicate link in submission form

### DIFF
--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -23,9 +23,10 @@
             %h3.bold Uploaded files
             %ul.file-attachments-list
               - presenter.submission.submission_files.each do |sf|
-                %li.file-attachment-list-item
-                  = link_to sf.filename, sf.url, :target => "_blank"
-                  = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id } )
+                - if sf.persisted?
+                  %li.file-attachment-list-item
+                    = link_to "#{sf.filename}", sf.url, target: "_blank"
+                    = link_to "(Remove)", remove_uploads_path(:model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id)
 
       - if presenter.assignment.accepts_links
         .grade-form-subsection


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where any uploaded submission attachment would both display properly, and as a duplicate link to the filepath. 

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. Upload a submission file
2. Re-enter the edit submission form
3. Observe that there is only one link to the file (and that it opens in a second tab), and that the Remove link works properly

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Submission uploads

======================
Closes #2859 
