### PR TITLE
3159 Add sample users file for download

### DIFF
--- a/app/controllers/users/importers_controller.rb
+++ b/app/controllers/users/importers_controller.rb
@@ -12,7 +12,8 @@ class Users::ImportersController < ApplicationController
     controller.redirect_path \
       users_importer_users_path(params[:importer_provider_id], params[:id])
   end
-  before_action :link_canvas_credentials, if: Proc.new { |c| c.params[:importer_provider_id] == "canvas" }
+  before_action :link_canvas_credentials, except: :index,
+    if: Proc.new { |c| c.params[:importer_provider_id] == "canvas" }
   before_action :require_authorization, except: [:index, :download]
 
   # GET /users/importers/:importer_provider_id/users
@@ -24,7 +25,8 @@ class Users::ImportersController < ApplicationController
   # Sends a CSV file to the user with a sample list of users in the proper format
   def download
     respond_to do |format|
-      format.csv { send_data StudentSampleExporter.new.generate_csv, filename: "Sample Users File - #{ Date.today}.csv" }
+      format.csv { send_data StudentSampleExporter.new.generate_csv,
+        filename: "Sample Users File - #{ Date.today}.csv" }
     end
   end
 

--- a/app/controllers/users/importers_controller.rb
+++ b/app/controllers/users/importers_controller.rb
@@ -13,11 +13,23 @@ class Users::ImportersController < ApplicationController
       users_importer_users_path(params[:importer_provider_id], params[:id])
   end
   before_action :link_canvas_credentials, if: Proc.new { |c| c.params[:importer_provider_id] == "canvas" }
-  before_action :require_authorization, except: :index
+  before_action :require_authorization, except: [:index, :download]
 
   # GET /users/importers/:importer_provider_id/users
   def users
     @provider_name = params[:importer_provider_id]
+  end
+
+  # GET /users/download
+  # Sends a CSV file to the user with a sample list of users in the proper format
+  def download
+    respond_to do |format|
+      format.csv do
+        file = generate_csv
+        send_data file,
+          filename: "Sample Users File - #{ Date.today}.csv"
+      end
+    end
   end
 
   # POST /users/importers/:importer_provider_id/course/:id/users/import
@@ -35,4 +47,26 @@ class Users::ImportersController < ApplicationController
         alert: "Failed to import #{params[:importer_provider_id]} users"
     end
   end
+end
+
+private
+
+def generate_csv(options={})
+  CSV.generate(options) do |csv|
+    csv << user_headers
+    csv << user_a_details
+    csv << user_b_details
+  end
+end
+
+def user_headers
+  ["First Name", "Last Name", "Username", "Email", "Team Name"].freeze
+end
+
+def user_a_details
+  ["John", "Doe", "johnd", "johnd@school.edu", "Team Doe"].freeze
+end
+
+def user_b_details
+  ["Jane", "Doe", "janed", "janed@school.edu", "Team Doe"].freeze
 end

--- a/app/controllers/users/importers_controller.rb
+++ b/app/controllers/users/importers_controller.rb
@@ -24,11 +24,7 @@ class Users::ImportersController < ApplicationController
   # Sends a CSV file to the user with a sample list of users in the proper format
   def download
     respond_to do |format|
-      format.csv do
-        file = generate_csv
-        send_data file,
-          filename: "Sample Users File - #{ Date.today}.csv"
-      end
+      format.csv { send_data StudentSampleExporter.new.generate_csv, filename: "Sample Users File - #{ Date.today}.csv" }
     end
   end
 
@@ -47,26 +43,5 @@ class Users::ImportersController < ApplicationController
         alert: "Failed to import #{params[:importer_provider_id]} users"
     end
   end
-end
 
-private
-
-def generate_csv(options={})
-  CSV.generate(options) do |csv|
-    csv << user_headers
-    csv << user_a_details
-    csv << user_b_details
-  end
-end
-
-def user_headers
-  ["First Name", "Last Name", "Username", "Email", "Team Name"].freeze
-end
-
-def user_a_details
-  ["John", "Doe", "johnd", "johnd@school.edu", "Team Doe"].freeze
-end
-
-def user_b_details
-  ["Jane", "Doe", "janed", "janed@school.edu", "Team Doe"].freeze
 end

--- a/app/controllers/users/importers_controller.rb
+++ b/app/controllers/users/importers_controller.rb
@@ -25,8 +25,7 @@ class Users::ImportersController < ApplicationController
   # Sends a CSV file to the user with a sample list of users in the proper format
   def download
     respond_to do |format|
-      format.csv { send_data StudentSampleExporter.new.generate_csv,
-        filename: "Sample Users File - #{ Date.today}.csv" }
+      format.csv { send_data StudentSampleExporter.new.generate_csv, filename: "Sample Users File - #{ Date.today}.csv" }
     end
   end
 

--- a/app/exporters/student_sample_exporter.rb
+++ b/app/exporters/student_sample_exporter.rb
@@ -1,0 +1,24 @@
+class StudentSampleExporter
+  def generate_csv(options={})
+    CSV.generate(options) do |csv|
+      csv << user_headers
+      csv << user_a_details
+      csv << user_b_details
+    end
+  end
+
+  private
+
+  def user_headers
+    ["First Name", "Last Name", "Username", "Email", "Team Name"].freeze
+  end
+
+  def user_a_details
+    ["John", "Doe", "johnd", "johnd@school.edu", "Team Doe"].freeze
+  end
+
+  def user_b_details
+    ["Jane", "Doe", "janed", "janed@school.edu", "Team Doe"].freeze
+  end
+  
+end

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -10,6 +10,8 @@
       %li Email
       %li Team name
 
+    You can download a sample file #{link_to "here", users_importer_download_path(:csv, format: "csv"), class: "bold"}
+
   = form_tag({action: :upload}, :multipart => true) do
     %div
       = check_box_tag "internal_students", "1", false, { data: { behavior: "toggle-disable", "toggle-disable-target": ".send-welcome *" }}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,6 +264,7 @@ Rails.application.routes.draw do
   namespace :users do
     resources :importers, only: :index, param: :provider_id do
       get :users
+      get :download
       post "/course/:id/users/import", action: :users_import, as: :users_import
     end
   end

--- a/spec/controllers/users/importers_controller_spec.rb
+++ b/spec/controllers/users/importers_controller_spec.rb
@@ -49,5 +49,15 @@ describe Users::ImportersController do
         end
       end
     end
+
+    describe "GET #download" do
+      it "returns sample csv data" do
+        get :download, params: { importer_provider_id: "csv", format: "csv" }
+
+        expect(response.body).to \
+          include("First Name","Last Name","Username","Email","Team Name")
+      end
+    end
+
   end
 end

--- a/spec/exporters/student_sample_exporter_spec.rb
+++ b/spec/exporters/student_sample_exporter_spec.rb
@@ -1,4 +1,4 @@
-describe StudentSampleExporter, focus: true do
+describe StudentSampleExporter do
 
   subject { StudentSampleExporter.new }
 

--- a/spec/exporters/student_sample_exporter_spec.rb
+++ b/spec/exporters/student_sample_exporter_spec.rb
@@ -1,0 +1,12 @@
+describe StudentSampleExporter, focus: true do
+
+  subject { StudentSampleExporter.new }
+
+  describe "#generate_csv" do
+    it "generates a CSV with a header and two sample students" do
+      csv = subject.generate_csv
+      expect(csv).to include "First Name", "Last Name", "Username", "Email", "Team Name"
+    end
+  end
+
+end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
/users/import page should have a link to download a sample .csv file for submitting student roster import, similar to the "Download Sample File" link on the /assignments/:id/grades/importers/csv page. Downloaded file should only contain comma separated column names for the file.

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the "/users/import" page. Click the link for the sample file. Verify the format and data integrity of the downloaded file.

### Impacted Areas in Application
* Users Import

======================
Closes #3159 
