### PR TITLE
3155 autosave grade scheme elements

### DIFF
--- a/app/assets/javascripts/angular/directives/common/maintain_focus.coffee
+++ b/app/assets/javascripts/angular/directives/common/maintain_focus.coffee
@@ -1,0 +1,15 @@
+# Keep focus on the input when the DOM is being updated or re-rendered
+# Inspired by: https://stackoverflow.com/a/31929381
+@gradecraft.directive 'maintainFocus', ['$timeout', ($timeout) ->
+  {
+    restrict: 'A'
+    require: 'ngModel'
+    link: ($scope, $element, attrs, ngModel) ->
+      ngModel.$parsers.unshift((value) ->
+        $timeout(() ->
+          $element[0].focus()
+        )
+        value
+      )
+  }
+]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -34,14 +34,14 @@
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)
-        scope.persistChanges(true) if @gradeSchemeElement.id?
+        scope.persistChanges(true) if not @gradeSchemeElement.validationError?
 
       scope.persistChanges = (isRemoval=false) ->
         _validateElements()
         return if gseForm.gradeSchemeElementsForm.$invalid
 
         DebounceQueue.addEvent(
-          'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 1500
+          'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 3000
         )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -1,24 +1,47 @@
-# Renders a single grade scheme element in the grade scheme element
-# mass edit form
+# Renders a single grade scheme element in the grade scheme element mass edit form
+# Note: This directive can exist only as a child of the gradeSchemeElementsMassEditForm
 @gradecraft.directive 'gradeSchemeElement',
-['GradeSchemeElementsService', (GradeSchemeElementsService) ->
+['GradeSchemeElementsService', 'DebounceQueue', '$timeout', (GradeSchemeElementsService, DebounceQueue, $timeout) ->
   {
     scope:
       gradeSchemeElement: '='
-      updateFormValidity: '&'
       index: '@'
+    require: '^^gradeSchemeElementsMassEditForm'
     templateUrl: 'grade_scheme_elements/element.html'
     restrict: 'E'
-    link: (scope, element, attrs) ->
+    link: (scope, element, attrs, gseForm) ->
+      _validateElements = () ->
+        GradeSchemeElementsService.validateElements()
+        gseForm.updateFormValidity()
+
+      _clearAlert = () ->
+        $timeout(() ->
+          scope.status = null
+        , 3000)
+
+      _save = (scope, showAlert) ->
+        scope.status = 'saving'
+        GradeSchemeElementsService.postGradeSchemeElements(null, true, showAlert).then(() ->
+          scope.status = 'saved'
+        ).finally(() ->
+          _clearAlert()
+        )
+
+      scope.status = undefined
+
       scope.addElement = () ->
         GradeSchemeElementsService.addElement(@gradeSchemeElement)
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)
-        @updateFormValidity()
+        scope.persistChanges(true) if @gradeSchemeElement.id?
 
-      scope.validateElements = () ->
-        GradeSchemeElementsService.validateElements()
-        @updateFormValidity()
+      scope.persistChanges = (isRemoval=false) ->
+        _validateElements()
+        return if gseForm.gradeSchemeElementsForm.$invalid
+
+        DebounceQueue.addEvent(
+          'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 1500
+        )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -5,7 +5,7 @@
   {
     scope:
       gradeSchemeElement: '='
-      index: '@'
+      index: '='
     require: '^^gradeSchemeElementsMassEditForm'
     templateUrl: 'grade_scheme_elements/element.html'
     restrict: 'E'
@@ -20,6 +20,10 @@
         , 3000)
 
       _save = (scope, showAlert) ->
+        # Ensure that the current state is still valid
+        _validateElements()
+        return if gseForm.gradeSchemeElementsForm.$invalid
+
         scope.status = 'saving'
         GradeSchemeElementsService.postGradeSchemeElements(null, true, showAlert).then(() ->
           scope.status = 'saved'

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -12,12 +12,16 @@
     vm.addElement = () ->
       GradeSchemeElementsService.addElement()
 
-    vm.postGradeSchemeElements = () ->
-      GradeSchemeElementsService.postGradeSchemeElements('/grade_scheme_elements/')
-
     vm.deleteGradeSchemeElements = () ->
       if confirm "Are you sure you want to delete all grade scheme elements?"
         GradeSchemeElementsService.deleteGradeSchemeElements('/grade_scheme_elements/')
+
+    # For manually triggering form validation by child directives
+    vm.updateFormValidity = () ->
+      _.each(vm.gradeSchemeElements, (element, index) ->
+        if vm.gradeSchemeElementsForm["point_threshold_#{index}"]?
+          vm.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
+      )
 
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false
@@ -31,12 +35,5 @@
     controllerAs: 'vm'
     restrict: 'EA'
     templateUrl: 'grade_scheme_elements/main.html'
-    link: (scope, element, attrs, ctrl) ->
-      # For manually triggering form validation by child directives
-      ctrl.updateFormValidity = () ->
-        _.each(ctrl.gradeSchemeElements, (element, index) ->
-          if scope.gradeSchemeElementsForm["point_threshold_#{index}"]?
-            scope.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
-        )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -18,9 +18,9 @@
 
     # For manually triggering form validation by child directives
     vm.updateFormValidity = () ->
-      _.each(vm.gradeSchemeElements, (element, index) ->
-        if vm.gradeSchemeElementsForm["point_threshold_#{index}"]?
-          vm.gradeSchemeElementsForm["point_threshold_#{index}"].$setValidity('validPointThreshold', !element.validationError?)
+      _.each(vm.gradeSchemeElements, (element) ->
+        if vm.gradeSchemeElementsForm["point_threshold_#{element.order}"]?
+          vm.gradeSchemeElementsForm["point_threshold_#{element.order}"].$setValidity('validPointThreshold', !element.validationError?)
       )
 
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -53,16 +53,14 @@
   # POST grade scheme element updates
   # Optionally redirects to a specified url
   postGradeSchemeElements = (redirectUrl=null, validate=true, showAlert=false) ->
-    if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
-      return
+    return if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
 
     data = {
       grade_scheme_elements_attributes: gradeSchemeElements
       deleted_ids: _deletedElementIds
     }
-    $http.put('/grade_scheme_elements/mass_update', data).then(
+    $http.put('/api/grade_scheme_elements', data).then(
       (response) ->
-        # angular.copy(response.grade_scheme_elements, gradeSchemeElements)
         GradeCraftAPI.logResponse(response)
         window.location.href = redirectUrl if redirectUrl?
         alert('Changes were successfully saved') if showAlert is true
@@ -72,7 +70,7 @@
     )
 
   deleteGradeSchemeElements = (redirectUrl=null) ->
-    $http.delete('/api/grade_scheme_elements/').then(
+    $http.delete('/api/grade_scheme_elements/destroy_all').then(
       (response) ->
         GradeCraftAPI.logResponse(response)
         window.location.href = redirectUrl if redirectUrl?

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -1,12 +1,87 @@
 # Shared logic for creating, editing, and otherwise interacting with GradeSchemeElements
 @gradecraft.factory 'GradeSchemeElementsService', ['$http', 'GradeCraftAPI', ($http, GradeCraftAPI) ->
 
-  deletedElementIds = []
+  _deletedElementIds = []
   gradeSchemeElements = []
   _totalPoints = 0
 
   totalPoints = () ->
     _totalPoints
+
+  # Iterate all elements to ensure that there are no direct point conflicts
+  validateElements = () ->
+    has_zero_threshold = false
+    for element, i in gradeSchemeElements
+      _validateElement(element)
+      has_zero_threshold = true if element.lowest_points == 0
+    addZeroThreshold() if not has_zero_threshold
+
+  # Remove the current element from the collection and add to deleted_ids array
+  removeElement = (currentElement) ->
+    if currentElement.lowest_points == 0 && _isOnlyZeroThreshold(currentElement)
+      currentElement.validationError = "Lowest level threshold must be 0"
+    else
+      _deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
+      validateElements() if gradeSchemeElements.length > 0
+
+  # Add a new element after the selected element, if one was given
+  addElement = (currentElement, attributes=null) ->
+    if currentElement?
+      for element, i in gradeSchemeElements
+        if element == currentElement
+          gradeSchemeElements.splice(i + 1, 0, _newElement())
+          return
+    else
+      gradeSchemeElements.push(_newElement(attributes))
+
+  # Add new element to represent zero threshold
+  addZeroThreshold = () ->
+    zeroElement = _newElement()
+    zeroElement.level = "Not yet on the board"
+    zeroElement.lowest_points = 0
+    gradeSchemeElements.push(zeroElement)
+
+  # GET grade scheme elements for the current course
+  # Returns a promise
+  getGradeSchemeElements = () ->
+    $http.get("/api/grade_scheme_elements").then((response) ->
+      GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
+      _totalPoints = response.data.meta.total_points
+      GradeCraftAPI.logResponse(response)
+    )
+
+  # POST grade scheme element updates
+  # Optionally redirects to a specified url
+  postGradeSchemeElements = (redirectUrl=null, validate=true, showAlert=false) ->
+    if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
+      return
+
+    data = {
+      grade_scheme_elements_attributes: gradeSchemeElements
+      deleted_ids: _deletedElementIds
+    }
+    $http.put('/grade_scheme_elements/mass_update', data).then(
+      (response) ->
+        # angular.copy(response.grade_scheme_elements, gradeSchemeElements)
+        GradeCraftAPI.logResponse(response)
+        window.location.href = redirectUrl if redirectUrl?
+        alert('Changes were successfully saved') if showAlert is true
+      , (error) ->
+        alert('An error occurred while saving changes')
+        GradeCraftAPI.logResponse(error)
+    )
+
+  deleteGradeSchemeElements = (redirectUrl=null) ->
+    $http.delete('/api/grade_scheme_elements/').then(
+      (response) ->
+        GradeCraftAPI.logResponse(response)
+        window.location.href = redirectUrl if redirectUrl?
+      , (error) ->
+        alert('Failed to delete grade scheme elements')
+        GradeCraftAPI.logResponse(error)
+    )
+
+  # Private
 
   # Ensure that there are no blank point thresholds
   _hasValidPointThresholds = () ->
@@ -16,14 +91,6 @@
         element.validationError = "Point threshold cannot be blank"
         isValid = false
     isValid
-
-  # Iterate all elements to ensure that there are no direct point conflicts
-  validateElements = () ->
-    has_zero_threshold = false
-    for element, i in gradeSchemeElements
-      _validateElement(element)
-      has_zero_threshold = true if element.lowest_points == 0
-    addZeroThreshold() if not has_zero_threshold
 
   # Ensures that the current element does not have a point conflict with another
   _validateElement = (currentElement) ->
@@ -39,23 +106,12 @@
       if element.lowest_points == currentElement.lowest_points
         currentElement.validationError = "This level has the same point threshold as another level"
 
-  # Remove the current element from the collection and add to deleted_ids array
-  removeElement = (currentElement) ->
-    if currentElement.lowest_points == 0 && _isOnlyZeroThreshold(currentElement)
-      currentElement.validationError = "Lowest level threshold must be 0"
-    else
-      deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
-      validateElements() if gradeSchemeElements.length > 0
-
-  # Add a new element after the selected element, if one was given
-  addElement = (currentElement, attributes=null) ->
-    if currentElement?
-      for element, i in gradeSchemeElements
-        if element == currentElement
-          gradeSchemeElements.splice(i + 1, 0, _newElement())
-          return
-    else
-      gradeSchemeElements.push(_newElement(attributes))
+  # Checks if there are more than one zero threshold elements
+  _isOnlyZeroThreshold = (currentElement) ->
+    result = _.find(gradeSchemeElements, (element) ->
+      currentElement != element && element.lowest_points == 0
+    )?
+    !result
 
   # New empty grade scheme element object
   _newElement = (attributes=null) ->
@@ -68,59 +124,6 @@
       element[key] = value
     ) if attributes?
     element
-
-  # Add new element to represent zero threshold
-  addZeroThreshold = () ->
-    zeroElement = _newElement()
-    zeroElement.level = "Not yet on the board"
-    zeroElement.lowest_points = 0
-    gradeSchemeElements.push(zeroElement)
-
-  # Checks if there are more than one zero threshold elements
-  _isOnlyZeroThreshold = (currentElement) ->
-    result = _.find(gradeSchemeElements, (element) ->
-      currentElement != element && element.lowest_points == 0
-    )?
-    !result
-
-  # GET grade scheme elements for the current course
-  # Returns a promise
-  getGradeSchemeElements = () ->
-    $http.get("/api/grade_scheme_elements").then((response) ->
-      GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
-      _totalPoints = response.data.meta.total_points
-      GradeCraftAPI.logResponse(response)
-    )
-
-  # POST grade scheme element updates
-  # Optionally redirects to a specified url
-  postGradeSchemeElements = (redirectUrl=null, validate=true) ->
-    if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
-      return
-
-    data = {
-      grade_scheme_elements_attributes: gradeSchemeElements
-      deleted_ids: deletedElementIds
-    }
-    $http.put('/grade_scheme_elements/mass_update', data).then(
-      (response) ->
-        angular.copy(response.grade_scheme_elements, gradeSchemeElements)
-        GradeCraftAPI.logResponse(response)
-        window.location.href = redirectUrl if redirectUrl?
-      , (error) ->
-        alert('An error occurred that prevented saving.')
-        GradeCraftAPI.logResponse(error)
-    )
-
-  deleteGradeSchemeElements = (redirectUrl=null) ->
-    $http.delete('/api/grade_scheme_elements/').then(
-      (response) ->
-        GradeCraftAPI.logResponse(response)
-        window.location.href = redirectUrl if redirectUrl?
-      , (error) ->
-        alert('Failed to delete grade scheme elements.')
-        GradeCraftAPI.logResponse(error)
-    )
 
   {
     gradeSchemeElements: gradeSchemeElements

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -19,11 +19,11 @@
       %input.low-range{'type'=>'text',
         'name'=>'point_threshold_{{index}}',
         'ng-model'=>'gradeSchemeElement.lowest_points',
-        'ng-model-options'=>"{ updateOn: 'blur' }",
         'ng-change'=>"persistChanges()",
         'required'=>'',
         'gc-number-input'=>'',
-        'allow-negatives'=>'false'}
+        'allow-negatives'=>'false',
+        'maintain-focus'=>''}
 
     %span{'ng-show'=>'status === "saving"'}
       %i.fa.fa-spinner.fa-spin.fa-fw

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -20,7 +20,7 @@
         'name'=>'point_threshold_{{index}}',
         'ng-model'=>'gradeSchemeElement.lowest_points',
         'ng-model-options'=>"{ updateOn: 'blur' }",
-        'ng-blur'=>"persistChanges()",
+        'ng-change'=>"persistChanges()",
         'required'=>'',
         'gc-number-input'=>'',
         'allow-negatives'=>'false'}

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -19,6 +19,7 @@
       %input.low-range{'type'=>'text',
         'name'=>'point_threshold_{{index}}',
         'ng-model'=>'gradeSchemeElement.lowest_points',
+        'ng-model-options'=>"{ updateOn: 'blur' }",
         'ng-blur'=>"persistChanges()",
         'required'=>'',
         'gc-number-input'=>'',

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -2,21 +2,35 @@
   .gse-form-container
     %label.gse-label.form-hint
       Grade Letter
-      %input.letter{'type'=>'text', 'name'=>'letter', 'ng-model'=>'gradeSchemeElement.letter'}
+      %input.letter{'type'=>'text',
+                    'name'=>'letter',
+                    'ng-model'=>'gradeSchemeElement.letter',
+                    'ng-blur'=>"persistChanges()"}
 
     %label.gse-label.form-hint
       Level name
-      %input.level{'type'=>'text', 'name'=>'level', 'ng-model'=>'gradeSchemeElement.level'}
+      %input.level{'type'=>'text',
+                   'name'=>'level',
+                   'ng-model'=>'gradeSchemeElement.level',
+                   'ng-blur'=>"persistChanges()"}
 
     %label.gse-label.form-hint
       Point Threshold
       %input.low-range{'type'=>'text',
         'name'=>'point_threshold_{{index}}',
         'ng-model'=>'gradeSchemeElement.lowest_points',
-        'ng-blur'=>'validateElements()',
+        'ng-blur'=>"persistChanges()",
         'required'=>'',
         'gc-number-input'=>'',
         'allow-negatives'=>'false'}
+
+    %span{'ng-show'=>'status === "saving"'}
+      %i.fa.fa-spinner.fa-spin.fa-fw
+      Saving changes...
+
+    %span.save-success{'ng-show'=>'status === "saved"'}
+      %i.fa.fa-thumbs-o-up
+      Changes successfully saved!
 
     %span.validation-error{'ng-show'=>'gradeSchemeElement.validationError'}
       %span.error
@@ -25,9 +39,13 @@
 
   .action-button-container
     %span
-      %button.add-element.button{'type'=>'button', 'ng-click'=>'addElement()', 'tabindex'=>'0'}
+      %button.add-element.button{'type'=>'button',
+                                 'ng-click'=>'addElement()',
+                                 'tabindex'=>'0'}
         %i.fa.fa-plus
         Add a level below
-      %button.remove-element.button.alert{'type'=>'button', 'ng-click'=>'removeElement()', 'aria-label'=>"Remove Level"}
+      %button.remove-element.button.alert{'type'=>'button',
+                                          'ng-click'=>'removeElement()',
+                                          'aria-label'=>"Remove Level"}
         Remove
         %i.fa.fa-times

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -2,7 +2,6 @@
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
   %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements',
-                        'update_form_validity'=>'vm.updateFormValidity()',
                         'index'=>'{{$index}}',
                         'grade_scheme_element'=>'element'}
 
@@ -16,9 +15,3 @@
         .button.right{'type'=>'button',
                       'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0',
                       'ng-click'=>'vm.deleteGradeSchemeElements()'} Delete All Elements
-      %li
-        .button.right{'type'=>'button',
-                      'ng-click'=>'vm.postGradeSchemeElements()',
-                      'ng-class'=>'{"disabled": gradeSchemeElementsForm.$invalid}',
-                      'ng-disabled'=>'gradeSchemeElementsForm.$invalid',
-                      'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'} Submit

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -2,7 +2,7 @@
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
   %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements | orderBy: "-lowest_points"',
-                        'index'=>'{{$index}}',
+                        'ng-attr-index'=>'element.order = $index',
                         'grade_scheme_element'=>'element'}
 
   %button.button.right{'type'=>'button',

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -1,7 +1,7 @@
 %loading-message{'loading'=>'vm.loading', 'message'=>"Loading Grade Scheme Elements..."}
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
-  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements',
+  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements | orderBy: "-lowest_points"',
                         'index'=>'{{$index}}',
                         'grade_scheme_element'=>'element'}
 

--- a/app/assets/stylesheets/pages/_grading_scheme.sass
+++ b/app/assets/stylesheets/pages/_grading_scheme.sass
@@ -132,6 +132,12 @@ p.predictor-description
   @media (max-width: $media-small-max)
     text-align: right
 
+.save-success
+  color: $color-green-3
+
+.save-failure
+  color: $color-red-1
+
 .grading-scheme-setup
   max-width: 450px
   ul

--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -2,16 +2,12 @@
 # earn course wide levels and grades
 class API::GradeSchemeElementsController < ApplicationController
   before_action :ensure_staff?, except: :index
+  before_action :use_current_course, only: :update
 
   # GET /api/grade_scheme_elements
   def index
-    @grade_scheme_elements = current_course
-                             .grade_scheme_elements
-                             .order_by_points_desc.select(
-                               :id,
-                               :lowest_points,
-                               :letter,
-                               :level)
+    @grade_scheme_elements = grade_scheme_elements_for current_course
+
     if @grade_scheme_elements.present?
       @total_points = (@grade_scheme_elements.first.lowest_points).to_i
     else
@@ -19,15 +15,52 @@ class API::GradeSchemeElementsController < ApplicationController
     end
   end
 
+  # POST /api/grade_scheme_elements
+  def update
+    begin
+      GradeSchemeElement.transaction do
+        @course.grade_scheme_elements.where(id: params[:deleted_ids]).destroy_all
+        @course.update! grade_scheme_elements_params
+      end
+
+      @course.students.pluck(:id).each do |id|
+        ScoreRecalculatorJob.new(user_id: id, course_id: @course.id).enqueue
+      end
+      render json: { message: "Successfully saved grade scheme elements", success: true },
+        status: :ok
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved
+      render json: { message: "Failed to update grade scheme elements", success: false },
+        status: :internal_server_error
+    end
+  end
+
   # DELETE /api/grade_scheme_elements
-  def destroy
+  def destroy_all
     current_course.grade_scheme_elements.destroy_all
+
     if current_course.grade_scheme_elements.any?
       render json: { message: "Failed to delete grade scheme elements", success: false },
-        status: 500
+        status: :internal_server_error
     else
       render json: { message: "Grade scheme elements successfully deleted", success: true },
-        status: 200
+        status: :ok
     end
+  end
+
+  private
+
+  def grade_scheme_elements_params
+    params.permit grade_scheme_elements_attributes: [:id, :letter, :lowest_points,
+      :level, :description, :course_id]
+  end
+
+  def grade_scheme_elements_for(course)
+    course
+      .grade_scheme_elements
+      .order_by_points_desc.select(
+        :id,
+        :lowest_points,
+        :letter,
+        :level)
   end
 end

--- a/app/views/grade_scheme_elements/mass_edit.html.haml
+++ b/app/views/grade_scheme_elements/mass_edit.html.haml
@@ -1,3 +1,3 @@
 .pageContent
   #grade_scheme_elements_main_content
-    %grade_scheme_elements_mass_edit_form{'ng-form'=>'', 'name'=>'gradeSchemeElementsForm'}
+    %grade_scheme_elements_mass_edit_form{'ng-form'=>'', 'name'=>'vm.gradeSchemeElementsForm'}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,10 +239,9 @@ Rails.application.routes.draw do
   end
 
   #12. Grade Schemes
-  resources :grade_scheme_elements, only: [:index, :edit, :show, :update] do
+  resources :grade_scheme_elements, only: [:index, :edit, :update] do
     collection do
       get :mass_edit
-      put :mass_update
       get :export_structure
     end
   end
@@ -421,7 +420,10 @@ Rails.application.routes.draw do
     end
 
     resources :grade_scheme_elements, only: :index do
-      delete :destroy, on: :collection
+      collection do
+        put :update, as: :update
+        delete :destroy_all
+      end
     end
     resources :levels, only: [:create, :update, :destroy]
     resources :level_badges, only: [:create, :destroy]

--- a/spec/controllers/api/grades_scheme_elements_controller_spec.rb
+++ b/spec/controllers/api/grades_scheme_elements_controller_spec.rb
@@ -1,55 +1,97 @@
 describe API::GradeSchemeElementsController do
   let(:course) { build :course }
 
+  before(:each) { login_user user }
+
   context "as a student" do
-    let(:student) { build_stubbed :user, courses: [course], role: :student }
-    before(:each) { login_user student }
+    let(:user) { build_stubbed :user, courses: [course], role: :student }
 
     describe "GET index" do
-      context "with Grade Scheme elements" do
-        let!(:grade_scheme_element_high) { create :grade_scheme_element, course: course }
+      context "when grade scheme elements exist" do
+        let!(:grade_scheme_element) { create :grade_scheme_element, course: course }
 
-        it "returns grade scheme elements with total points as json" do
+        it "returns grade scheme elements with total points" do
           get :index, format: :json
-          expect(assigns(:grade_scheme_elements)).to eq([grade_scheme_element_high])
-          expect(assigns(:total_points)).to eq(grade_scheme_element_high.lowest_points)
-          expect(response).to render_template(:index)
+          expect(assigns(:grade_scheme_elements)).to eq [grade_scheme_element]
+          expect(assigns(:total_points)).to eq grade_scheme_element.lowest_points
+          expect(response).to render_template :index
         end
       end
 
-      context "with no Grade Scheme elements" do
+      context "when no grade scheme elements exist" do
         it "returns the total points in the course if no grade scheme elements are present" do
           create :assignment, course: course, full_points: 1000
           get :index, format: :json
-          expect(assigns(:total_points)).to eq(1000)
+          expect(assigns(:total_points)).to eq 1000
         end
-      end
 
-      context "with no Grade Scheme elements and no assignments" do
         it "returns the total points in the course if no grade scheme elements are present" do
           get :index, format: :json
-          expect(assigns(:total_points)).to eq(0)
+          expect(assigns(:total_points)).to eq 0
         end
       end
     end
 
-    describe "DELETE destroy" do
-      it "redirects to root" do
-        expect(delete :destroy).to redirect_to root_path
+    describe "protected routes" do
+      it "redirect to root" do
+        [
+          -> { delete :destroy_all },
+          -> { put :update, params: { id: 1 } }
+        ].each do |protected_route|
+          expect(protected_route.call).to redirect_to :root
+        end
       end
     end
   end
 
   context "as a professor" do
-    let(:professor) { build_stubbed :user, courses: [course], role: :professor }
-    before(:each) { login_user professor }
+    let(:user) { build_stubbed :user, courses: [course], role: :professor }
 
-    describe "DELETE destroy" do
+    describe "GET index" do
+      let!(:grade_scheme_element) { create :grade_scheme_element, course: course }
+
+      it "returns the grade scheme elements with total points" do
+        get :index, format: :json
+        expect(assigns(:grade_scheme_elements)).to eq [grade_scheme_element]
+        expect(assigns(:total_points)).to eq grade_scheme_element.lowest_points
+        expect(response).to render_template :index
+      end
+    end
+
+    describe "PUT update" do
+      let(:grade_scheme_element) { create :grade_scheme_element, course: course }
+      let(:params) do
+        { "grade_scheme_elements_attributes" => [{
+          id: grade_scheme_element.id, letter: "C", level: "Sea Slug", lowest_points: 0,
+          course_id: course.id }, { id: nil,
+          letter: "B", level: "Snail", lowest_points: 100001,
+          course_id: course.id }], "deleted_ids"=>nil }
+      end
+
+      it "updates the grade scheme elements" do
+        put :update, params: params, format: :json
+        expect(course.reload.grade_scheme_elements.count).to eq 2
+        expect(grade_scheme_element.reload.level).to eq "Sea Slug"
+      end
+
+      it "recalculates scores for all students in the course" do
+        expect{ put :update, params: params, format: :json }.to \
+          change{ queue(ScoreRecalculatorJob).size }.by course.students.count
+      end
+
+      it "deletes grades scheme elements" do
+        params = { "deleted_ids"=>[grade_scheme_element.id] }
+        expect{ put :update, params: params, format: :json }.to \
+          change{ GradeSchemeElement.count }.by -1
+      end
+    end
+
+    describe "DELETE destroy_all" do
       before(:each) { allow(controller).to receive(:current_course).and_return course }
 
       context "with no grade scheme elements" do
         it "returns a status OK" do
-          delete :destroy
+          delete :destroy_all
           expect(response.status).to eq 200
         end
       end
@@ -58,14 +100,14 @@ describe API::GradeSchemeElementsController do
         let!(:grade_scheme_element) { create :grade_scheme_element, course: course }
 
         it "returns a status OK if the elements were deleted" do
-          delete :destroy
+          delete :destroy_all
           expect(response.status).to eq 200
         end
 
-        it "returns a status Internal Server Error if the elements were not deleted" do
+        it "returns a 500 status if not all elements were deleted" do
           allow(course.grade_scheme_elements).to receive(:any?).and_return 1
-          delete :destroy
-          expect(response.status).to eq 500
+          delete :destroy_all
+          expect(response).to have_http_status :internal_server_error
         end
       end
     end

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -1,31 +1,29 @@
 describe GradeSchemeElementsController do
   let(:course) { build(:course) }
-  let(:professor) { create(:course_membership, :professor, course: course).user }
-  let(:student) { create(:course_membership, :student, course: course).user }
-  let(:grade_scheme_element) { create(:grade_scheme_element, letter: "A", course: course, lowest_points: 3000) }
-  let(:empty_grade_scheme_element) { create(:grade_scheme_element, letter: "F", course: course) }
-  let(:course_membership) { create(:course_membership, :student, course: course, score: 100000,
-    earned_grade_scheme_element_id: grade_scheme_element.id) }
-  let(:another_course_membership) { create(:course_membership, :student, course: course, score: 80000,
-    earned_grade_scheme_element_id: grade_scheme_element.id) }
+  let!(:grade_scheme_element) do
+    create :grade_scheme_element, letter: "A", course: course,
+      lowest_points: 3000
+  end
+
+  before(:each) do
+    login_user user
+  end
 
   context "as professor" do
-    before(:each) do
-      login_user(professor)
-    end
+    let(:user) { build_stubbed :user, courses: [course], role: :professor }
 
     describe "GET index" do
       it "assigns all grade scheme elements" do
         get :index
-        expect(assigns(:grade_scheme_elements)).to eq([grade_scheme_element])
+        expect(assigns(:grade_scheme_elements)).to eq [grade_scheme_element]
       end
     end
 
     describe "GET edit" do
       it "renders the edit grade scheme form" do
         get :edit, params: { id: grade_scheme_element.id }
-        expect(assigns(:grade_scheme_element)).to eq(grade_scheme_element)
-        expect(response).to render_template(:edit)
+        expect(assigns(:grade_scheme_element)).to eq grade_scheme_element
+        expect(response).to render_template :edit
       end
     end
 
@@ -33,63 +31,31 @@ describe GradeSchemeElementsController do
       it "updates the grade scheme element" do
         grade_scheme_element_params = { letter: "B" }
         put :update, params: { id: grade_scheme_element.id, grade_scheme_element: grade_scheme_element_params }
-        expect(grade_scheme_element.reload.letter).to eq("B")
+        expect(grade_scheme_element.reload.letter).to eq "B"
       end
-    end
-
-    describe "GET mass_edit" do
-      it "shows the mass edit form" do
-        get :mass_edit
-        expect(assigns(:grade_scheme_elements)).to eq(course.grade_scheme_elements)
-      end
-    end
-
-    describe "PUT mass_update" do
-      it "updates the grade scheme elements all at once" do
-        params = { "grade_scheme_elements_attributes" => [{
-          id: grade_scheme_element.id, letter: "C", level: "Sea Slug", lowest_points: 0,
-          course_id: course.id }, { id: GradeSchemeElement.new.id,
-          letter: "B", level: "Snail", lowest_points: 100001,
-          course_id: course.id }], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
-        put :mass_update, params: params, format: :json
-        expect(course.reload.grade_scheme_elements.count).to eq(2)
-        expect(grade_scheme_element.reload.level).to eq("Sea Slug")
-      end
-    end
-
-    it "recalculates scores for all students in the course" do
-      params = { "grade_scheme_elements_attributes" => [{
-        id: grade_scheme_element.id, letter: "C", level: "Sea Slug", lowest_points: 0,
-        course_id: course.id }, { id: GradeSchemeElement.new.id,
-        letter: "B", level: "Snail", lowest_points: 100001,
-        course_id: course.id }], "deleted_ids"=>nil, "grade_scheme_element"=>{} }
-      expect{ put :mass_update, params: params, format: :json }.to \
-        change { queue(ScoreRecalculatorJob).size }.by(course.students.count)
     end
 
     describe "GET export_structure" do
       it "retrieves the export_structure download" do
         get :export_structure, params: { id: course.id }, format: :csv
-        expect(response.body).to include("Level ID,Letter Grade,Level Name,Lowest Points")
+        expect(response.body).to include "Level ID,Letter Grade,Level Name,Lowest Points"
       end
     end
   end
 
   context "as student" do
-    before(:each) do
-      login_user(student)
-    end
+    let(:user) { build_stubbed :user, courses: [course], role: :user }
 
-    describe "protected routes" do
+    it "redirects protected routes to root" do
       [
-        :index,
-        :mass_edit,
-        :mass_update
-      ].each do |route|
-          it "#{route} redirects to root" do
-            expect(get route).to redirect_to(:root)
-          end
-        end
+        -> { get :index },
+        -> { get :mass_edit },
+        -> { get :edit, params: { id: 1 } },
+        -> { put :update, params: { id: 1 } },
+        -> { get :export_structure }
+      ].each do |protected_route|
+        expect(protected_route.call).to redirect_to :root
+      end
     end
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
This PR adds the ability to make grade scheme element changes and have them persist automatically in the background. Any change made on the form, whether it is an input change or the removal of a persisted element will save after a 3 second delay.

Once the AJAX call is initiated, the user will see the caption 'Saving..' on the affected element followed by either a success caption or an alert if the save was unsuccessful.

If the save is for the removal of a persisted element, an alert will inform the user regardless of whether the change was successful or not.

As part of this PR, the previous `mass_update` method on the `GradeSchemeElementsController` was moved to the API namespace and refactored for better error handling. Also, a fair amount of cruft was trimmed off some of the grade scheme element related specs.

Furthermore, onChange now triggers autosave as well as the dynamic reordering of grade scheme elements by lowest points.

### Migrations
NO

### Steps to Test or Reproduce
Ensure that all features work as expected when adding, updating, or deleting grade scheme elements. Changes should persist oChange after a 3 second day and messages should appear to inform the user on the status of the save. Grade scheme elements should also reorder dynamically onChange based on lowest points in descending order.

### Impacted Areas in Application
Mass editing for individually-graded assignments

======================
Closes #3155
