### PR TITLE
Restyle observer assignment index view

### DIFF
--- a/app/views/assignments/_index_observer.haml
+++ b/app/views/assignments/_index_observer.haml
@@ -9,14 +9,15 @@
           .points-summary
             %span.assignment-type-points #{points assignment_type.total_points} points
         .assignment-type-container{role: "tabpanel"}
-          .assignment-type-message
-            - if assignment_type.description?
-              %h3 #{assignment_type.name} Guidelines
-              %p.description= raw assignment_type.description
-            - if assignment_type.is_capped?
-              .italic This #{ (term_for :assignment_type).downcase } is capped at #{ points assignment_type.max_points } points.
-            -# - if assignment_type.count_only_top_grades?
-            -#   .italic You have completed #{ assignment_type.count_grades_for(current_student) } #{ (term_for :assignments).downcase } in this category. Your top #{ assignment_type.top_grades_counted } grades count towards your course score.
+          - if assignment_type.description? || assignment_type.is_capped? || assignment_type.count_only_top_grades?
+            .assignment-type-message
+              - if assignment_type.description?
+                %h3 #{assignment_type.name} Guidelines
+                %p.description= raw assignment_type.description
+              - if assignment_type.is_capped?
+                .italic This #{ (term_for :assignment_type).downcase } is capped at #{ points assignment_type.max_points } points.
+              - if assignment_type.count_only_top_grades?
+                .italic #{ term_for :students} top #{ assignment_type.top_grades_counted } grades in this category count towards their course score
 
           // Display the assignments for each assignment type
           .student-assignment-list
@@ -29,7 +30,7 @@
 
                 .assignment-name
                   = link_to assignment.name, assignment_path(assignment)
-                  //= render partial: "assignments/index_student/components/assignment_icons", locals: { assignment: assignment }
+                  = render partial: "index_icons", locals: { assignment: assignment }
                 .assignment-info.assignment-due-date
                   = render partial: "assignments/index_student/components/due_at", locals: { assignment: assignment }
 

--- a/app/views/assignments/_index_observer.haml
+++ b/app/views/assignments/_index_observer.haml
@@ -1,33 +1,40 @@
 .pageContent
   = render partial: "layouts/alerts"
 
-  .assignments{role: "tablist"}
+  .assignment-index-container{role: "tablist"}
     - @assignment_types.each do |assignment_type|
-      .assignment_type{id: "assignment-type-#{assignment_type.id}" }
-        .collapse.collapse-toggle{role: "tab"}
-          %h2.assignment-type-name
-            %i.fa.fa-chevron-circle-right.fa-fw
-            #{assignment_type.name} – #{points assignment_type.total_points} points
-        .collapse-hidden{role: "tabpanel"}
-          %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
-            %thead
-              %tr
-                %th{scope: "col", :width => "20%"} Name
-                %th
-                %th Due
-                %th{:style => "display: none"} Due Date
-                %th{scope: "col", :width => "10%"}  Max Points
-            %tbody.sort-assignments
-              - assignments = assignment_type.assignments.ordered.includes(:rubric, :assignment_type)
-              - assignments.each do |assignment|
-                %tr{id: "assignment-#{assignment.id}"}
-                  %td= link_to assignment.name, assignment
-                  %td= render partial: "index_icons", locals: { assignment: assignment }
-                  %td= assignment.try(:due_at) || "Ongoing"
-                  %td{:style => "display: none"}
-                    - if assignment.due_at.present?
-                      = assignment.try(:due_at).to_formatted_s(:db)
-                  - if assignment.pass_fail?
-                    %td.foobers= "#{term_for :pass}/#{term_for :fail}"
-                  - else
-                    %td.doobers= points assignment.full_points
+      .assignment_type.student{id: "assignment-type-#{assignment_type.id}" }
+        .assignment-type-bar.collapse{role: "tab"}
+          %h2.assignment-type-name= glyph('chevron-circle-right') + "#{assignment_type.try(:name)}"
+          .points-summary
+            %span.assignment-type-points #{points assignment_type.total_points} points
+        .assignment-type-container{role: "tabpanel"}
+          .assignment-type-message
+            - if assignment_type.description?
+              %h3 #{assignment_type.name} Guidelines
+              %p.description= raw assignment_type.description
+            - if assignment_type.is_capped?
+              .italic This #{ (term_for :assignment_type).downcase } is capped at #{ points assignment_type.max_points } points.
+            -# - if assignment_type.count_only_top_grades?
+            -#   .italic You have completed #{ assignment_type.count_grades_for(current_student) } #{ (term_for :assignments).downcase } in this category. Your top #{ assignment_type.top_grades_counted } grades count towards your course score.
+
+          // Display the assignments for each assignment type
+          .student-assignment-list
+            - assignment_type.assignments.each do |assignment|
+              .assignment-container
+                .assignment-info.assignment-indicator-icon
+                  - if assignment.required?
+                    = tooltip("required-assignment-tip_#{assignment.id}", :asterisk, placement: "right") do
+                      This #{term_for :assignment} is required!
+
+                .assignment-name
+                  = link_to assignment.name, assignment_path(assignment)
+                  //= render partial: "assignments/index_student/components/assignment_icons", locals: { assignment: assignment }
+                .assignment-info.assignment-due-date
+                  = render partial: "assignments/index_student/components/due_at", locals: { assignment: assignment }
+
+                - if assignment.pass_fail?
+                  .assignment-info.assignment-pass-fail= "#{term_for :pass}/#{term_for :fail}"
+                - else
+                  // Checking to see if this assignment type is student weightable
+                  .assignment-info.assignment-points= "#{points assignment.full_points} points possible"


### PR DESCRIPTION
### Status
**READY**

### Description
This PR restyles the observer assignment index view to match the styling of the student view, minus personal details (since observers will never have grades)

### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Observer assignment index page

======================
Closes #2884 
