### PR TITLE
Remove visibility settings for predictor, timeline, and to do list

### DIFF
--- a/app/assets/javascripts/angular/services/ChallengeService.coffee
+++ b/app/assets/javascripts/angular/services/ChallengeService.coffee
@@ -34,7 +34,6 @@
   # GET index list of challenges including a student's grades and predictions
   getChallenges = ()->
     $http.get('/api/challenges').success( (response)->
-      return unless response.meta.include_in_predictor
       GradeCraftAPI.loadMany(challenges,response, {"include" : ['prediction','grade']})
       _.each(challenges, (challenge)->
         # add null prediction and grades when JSON contains none

--- a/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
@@ -27,12 +27,6 @@
             %th(scope="col")
               %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="paperclip" tip-text="Accepts Submissions")
             %th(scope="col")
-              %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="calendar" tip-text="Shown in Timeline")
-            %th(scope="col")
-              %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="sliders" tip-text="Shown in Predictor")
-            %th(scope="col")
-              %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="list" tip-text="Shown in Due This Week")
-            %th(scope="col")
               %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="pencil" tip-text="Logged By Students")
             %th(scope="col")
               %tooltip-icon(assignment-id="{{assignmentType.id}}" glyph="unlock" tip-text="Release Required")
@@ -54,12 +48,6 @@
               %assignment-setting(assignment-id="assignment.id" attribute="required" checked="assignment.required")
             %td
               %assignment-setting(assignment-id="assignment.id" attribute="accepts_submissions" checked="assignment.accepts_submissions")
-            %td
-              %assignment-setting(assignment-id="assignment.id" attribute="include_in_timeline" checked="assignment.include_in_timeline")
-            %td
-              %assignment-setting(assignment-id="assignment.id" attribute="include_in_predictor" checked="assignment.include_in_predictor")
-            %td
-              %assignment-setting(assignment-id="assignment.id" attribute="include_in_to_do" checked="assignment.include_in_to_do")
             %td
               %assignment-setting(assignment-id="assignment.id" attribute="student_logged" checked="assignment.student_logged")
             %td

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -55,8 +55,7 @@ class API::AssignmentsController < ApplicationController
 
   def assignment_params
     params.require(:assignment).permit(
-      :accepts_submissions, :accepts_submissions_until, :due_at, :full_points, :include_in_predictor, :include_in_timeline,
-      :include_in_to_do, :open_at, :release_necessary, :required, :student_logged, :visible
+      :accepts_submissions, :accepts_submissions_until, :due_at, :full_points, :open_at, :release_necessary, :required, :student_logged, :visible
     )
   end
 end

--- a/app/controllers/api/challenges_controller.rb
+++ b/app/controllers/api/challenges_controller.rb
@@ -9,7 +9,6 @@ class API::ChallengesController < ApplicationController
       @team = current_student.team_for_course(current_course)
       @student = current_student
       @allow_updates = !impersonating? && current_course.active?
-      @include_in_predictor = true
 
       if !impersonating?
         @challenges.includes(:predicted_earned_challenges)

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -145,7 +145,6 @@ class AssignmentsController < ApplicationController
     params.require(:assignment).permit :accepts_attachments, :accepts_links,
       :accepts_submissions, :accepts_submissions_until, :accepts_resubmissions_until,
       :accepts_text, :assignment_type_id, :course_id, :description, :due_at, :grade_scope,
-      :include_in_predictor, :include_in_timeline, :include_in_to_do,
       :mass_grade_type, :name, :open_at, :pass_fail, :max_submissions,
       :full_points, :purpose, :release_necessary, :hide_analytics,
       :required, :resubmissions_allowed, :show_description_when_locked,

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -66,7 +66,7 @@ class ChallengesController < ApplicationController
   def challenge_params
     params.require(:challenge).permit :name, :description, :visible, :full_points,
       :due_at, :open_at, :release_necessary, :course, :team, :challenge,
-      :challenge_grades_attributes,  :media, :remove_media, :include_in_timeline,
+      :challenge_grades_attributes,  :media, :remove_media,
       challenge_score_levels_attributes: [:id, :name, :points, :_destroy],
       challenge_files_attributes: [:id, file: []]
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -43,8 +43,7 @@ class Assignment < ActiveRecord::Base
   validates_presence_of :name, :course_id, :assignment_type_id, :grade_scope, :threshold_points
 
   validates_inclusion_of :student_logged, :required, :accepts_submissions,
-  :release_necessary, :visible, :resubmissions_allowed, :include_in_timeline,
-  :include_in_predictor, :include_in_to_do, :use_rubric, :accepts_attachments,
+  :release_necessary, :visible, :resubmissions_allowed, :use_rubric, :accepts_attachments,
   :accepts_text, :accepts_links, :pass_fail, :hide_analytics, :visible_when_locked,
   :show_name_when_locked, :show_points_when_locked, :show_description_when_locked,
   :show_purpose_when_locked, in: [true, false], message: "must be true or false"
@@ -57,9 +56,6 @@ class Assignment < ActiveRecord::Base
   validates_with MaxOverMinValidator
 
   scope :group_assignments, -> { where grade_scope: "Group" }
-
-  # Filtering Assignments by where in the interface they are displayed
-  scope :timelineable, -> { where(include_in_timeline: true) }
 
   # Sorting assignments by different properties
   scope :chronological, -> { order("due_at ASC") }

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -29,7 +29,6 @@ class Challenge < ActiveRecord::Base
   scope :visible, -> { where visible: TRUE }
   scope :chronological, -> { order("due_at ASC") }
   scope :alphabetical, -> { order("name ASC") }
-  scope :timelineable, -> { where include_in_timeline: true }
 
   validates_presence_of :course, :name
   validates_numericality_of :full_points, allow_nil: true, length: { maximum: 9 }

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -6,7 +6,7 @@ class Timeline
   end
 
   def assignment_events
-    course.assignments.timelineable.with_dates
+    course.assignments.with_dates
   end
 
   def event_events
@@ -14,7 +14,7 @@ class Timeline
   end
 
   def challenge_events
-    course.challenges.timelineable.with_dates if course.has_team_challenges?
+    course.challenges.with_dates if course.has_team_challenges?
   end
 
   def events_by_due_date

--- a/app/presenters/info/dashboard_course_planner_presenter.rb
+++ b/app/presenters/info/dashboard_course_planner_presenter.rb
@@ -30,9 +30,9 @@ class Info::DashboardCoursePlannerPresenter < Showtime::Presenter
 
   def to_do?(assignment)
     if student
-      assignment.include_in_to_do? && assignment.visible_for_student?(student) && !GradeProctor.new(grade_for(assignment)).viewable?
+      assignment.visible_for_student?(student) && !GradeProctor.new(grade_for(assignment)).viewable?
     else
-      assignment.include_in_to_do?
+      assignment
     end
   end
 

--- a/app/proctors/challenge_proctor.rb
+++ b/app/proctors/challenge_proctor.rb
@@ -1,0 +1,14 @@
+require_relative "challenge_proctor/base"
+require_relative "challenge_proctor/viewable"
+
+# determines what sort of CRUD operations can be performed
+# on a `challenge` resource
+class ChallengeProctor
+  include Viewable
+
+  attr_reader :challenge
+
+  def initialize(challenge)
+    @challenge = challenge
+  end
+end

--- a/app/proctors/challenge_proctor/base.rb
+++ b/app/proctors/challenge_proctor/base.rb
@@ -1,0 +1,11 @@
+# common methods for CRUD operations on a `Grade`
+class ChallengeProctor
+  module Base
+
+    private
+
+    def challenge_for_course?(course)
+      challenge.course_id == course.id
+    end
+  end
+end

--- a/app/proctors/challenge_proctor/viewable.rb
+++ b/app/proctors/challenge_proctor/viewable.rb
@@ -1,11 +1,8 @@
 # Determines if a `Challenge` resource can be viewed for a specific user
 #
 # Options include:
-#   course:  Will verify the challenge is for the course.
-#   team:   Will only show students invisible badges earned for the specific
-#            level. This is used for Rubric views to hide all invisible level
-#            badges on unearned levels, even if the student earned the badge in
-#            another context.
+#   course: Will verify the challenge is for the course.
+#   team: Will only show students invisible challenges if their team has a challenge grade for it
 #
 class ChallengeProctor
   module Viewable
@@ -15,8 +12,7 @@ class ChallengeProctor
       return false if challenge.nil?
 
       course = options[:course] || challenge.course
-      challenge_for_course?(course) &&
-        (user.is_staff?(course) || challenge_visible_by_team?(team, challenge))
+      challenge_for_course?(course) && challenge_visible_by_team?(team, challenge)
     end
 
     private
@@ -26,7 +22,7 @@ class ChallengeProctor
     end
 
     def challenge_grades_visible_by_team?(team, challenge)
-      ChallengeGrade.where(team_id: team.id, challenge_id: challenge.id, student_visible: true).present?
+      ChallengeGrade.where(team_id: team.id, challenge_id: challenge.id, status: "Graded").present?
     end
   end
 end

--- a/app/proctors/challenge_proctor/viewable.rb
+++ b/app/proctors/challenge_proctor/viewable.rb
@@ -1,0 +1,32 @@
+# Determines if a `Challenge` resource can be viewed for a specific user
+#
+# Options include:
+#   course:  Will verify the challenge is for the course.
+#   team:   Will only show students invisible badges earned for the specific
+#            level. This is used for Rubric views to hide all invisible level
+#            badges on unearned levels, even if the student earned the badge in
+#            another context.
+#
+class ChallengeProctor
+  module Viewable
+    include Base
+
+    def viewable?(team, options={})
+      return false if challenge.nil?
+
+      course = options[:course] || challenge.course
+      challenge_for_course?(course) &&
+        (user.is_staff?(course) || challenge_visible_by_team?(team, challenge))
+    end
+
+    private
+
+    def challenge_visible_by_team?(team, challenge)
+      challenge.visible? || challenge_grades_visible_by_team?(team, challenge)
+    end
+
+    def challenge_grades_visible_by_team?(team, challenge)
+      ChallengeGrade.where(team_id: team.id, challenge_id: challenge.id, student_visible: true).present?
+    end
+  end
+end

--- a/app/views/api/assignments/_assignment.json.jbuilder
+++ b/app/views/api/assignments/_assignment.json.jbuilder
@@ -20,9 +20,6 @@ json.attributes do
   json.visible                    assignment.visible
   json.required                   assignment.required
   json.accepts_submissions        assignment.accepts_submissions
-  json.include_in_timeline        assignment.include_in_timeline
-  json.include_in_predictor       assignment.include_in_predictor
-  json.include_in_to_do           assignment.include_in_to_do
   json.student_logged             assignment.student_logged
   json.release_necessary          assignment.release_necessary
 
@@ -130,4 +127,3 @@ json.relationships do
     end
   end
 end
-

--- a/app/views/api/assignments/index.json.jbuilder
+++ b/app/views/api/assignments/index.json.jbuilder
@@ -1,7 +1,6 @@
 json.data @assignments do |assignment|
   next unless assignment.full_points > 0 || assignment.pass_fail?
   next unless !@student.present? || assignment.visible_for_student?(@student)
-  next unless assignment.include_in_predictor?
 
   json.partial! 'api/assignments/assignment', assignment: assignment
 end

--- a/app/views/api/challenges/index.json.jbuilder
+++ b/app/views/api/challenges/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.data @challenges do |challenge|
-  next unless !current_student.present? || challenge.visible?(current_student.team_for_course(current_course))
+  next unless !current_student.present? || ChallengeProctor.new(challenge).viewable?(current_student.team_for_course(current_course))
   json.type "challenges"
   json.id challenge.id.to_s
   json.attributes do

--- a/app/views/api/challenges/index.json.jbuilder
+++ b/app/views/api/challenges/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.data @challenges do |challenge|
-  next unless !@student.present? || challenge.visible?
+  next unless !current_student.present? || challenge.visible?(current_student.team_for_course(current_course))
   json.type "challenges"
   json.id challenge.id.to_s
   json.attributes do

--- a/app/views/api/challenges/index.json.jbuilder
+++ b/app/views/api/challenges/index.json.jbuilder
@@ -68,5 +68,4 @@ end
 json.meta do
   json.term_for_challenges term_for :challenges
   json.allow_updates @allow_updates
-  json.include_in_predictor @include_in_predictor
 end

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -113,21 +113,6 @@
       = f.check_box :release_necessary
       .form-hint Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
 
-    .form-item
-      = f.label :include_in_timeline, "Timeline"
-      = f.check_box :include_in_timeline, {"aria-describedby" => "txtIncludeInTimeline"}
-      .form-hint{id: "txtIncludeInTimeline"} Can #{term_for :students} see this #{term_for :assignment} in the course timeline? Note that #{term_for :assignments} without open or due dates will be excluded automatically.
-
-    .form-item
-      = f.label :include_in_predictor, "Predictor"
-      = f.check_box :include_in_predictor
-      .form-hint Can #{term_for :students} see this #{term_for :assignment} in the grade predictor?
-
-    .form-item
-      = f.label :include_in_to_do, "Due this Week"
-      = f.check_box :include_in_to_do
-      .form-hint Can #{term_for :students} see this #{term_for :assignment} in the "Course Events" panel?
-
     - if current_course.show_analytics?
       .form-item
         = f.label :hide_analytics, "Hide Analytics?"

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -32,11 +32,6 @@
       = f.check_box :visible
 
     .form-item
-      = f.label :include_in_timeline, "Timeline"
-      = f.check_box :include_in_timeline, {"aria-describedby" => "txtIncludeInTimeline"}
-      .form-hint{id: "txtIncludeInTimeline"} Can #{term_for :students} see this #{term_for :challenge} in the course timeline? Note that #{term_for :challenges} without open or due dates will be excluded automatically.
-
-    .form-item
       = f.label :release_necessary, "Release necessary?"
       = f.check_box :release_necessary
       .form-hint Do you want to release all grades at once? This is particularly useful for situations where extensive feedback is important.
@@ -57,7 +52,7 @@
     %button.add-challenge-score-level Add a Level
 
   = render partial: "layouts/media_image_form_item", locals: { f: f, model: @challenge }
-  
+
   %section.form-section
     %h2.form-title Attachments
     = f.simple_fields_for :challenge_files, @challenge.challenge_files.new do |cf|

--- a/app/views/challenges/_index_student.haml
+++ b/app/views/challenges/_index_student.haml
@@ -8,7 +8,7 @@
 
   %tbody
     - current_course.challenges.chronological.alphabetical.includes(:challenge_files, :challenge_grades).each do |challenge|
-      - if challenge.visible? || (@team.present? &&  (ChallengeGradeProctor.new(challenge.challenge_grade_for_team(@team)).viewable? user: current_student))
+      - if ChallengeProctor.new(challenge).viewable?(@team)
         %tr
           %td= link_to challenge.name, challenge
           %td

--- a/db/samples/challenges.rb
+++ b/db/samples/challenges.rb
@@ -77,13 +77,13 @@
   }
 }
 
-@challenges[:invisible] = {
+@challenges[:invisible_graded] = {
   quotes: {
     challenge_created: "Please don't ask me what the score is, I'm not even \
 sure what the game is. - Ashleigh Brilliant"
   },
   attributes: {
-    name: "Invisible Challenge",
+    name: "Invisible Challenge [Grades]",
     due_at: 4.weeks.from_now,
     accepts_submissions: true,
     open_at: rand(8).weeks.ago,
@@ -92,5 +92,19 @@ sure what the game is. - Ashleigh Brilliant"
   grades: true,
   grade_attributes: {
     status: "Graded",
+  }
+}
+
+@challenges[:invisible] = {
+  quotes: {
+    challenge_created: "Please don't ask me what the score is, I'm not even \
+sure what the game is. - Ashleigh Brilliant"
+  },
+  attributes: {
+    name: "Invisible Challenge [No Grades]",
+    due_at: 4.weeks.from_now,
+    accepts_submissions: true,
+    open_at: rand(8).weeks.ago,
+    visible: false,
   }
 }

--- a/doc/assignments.md
+++ b/doc/assignments.md
@@ -53,7 +53,7 @@ When an Assignment is destroyed, all of the following models that belong to it w
   * `submissions_after_due` - fails if the date to no longer accepting submissions and the due date are present, and the due date exceeds the date for no longer accepting submissions
   * `submissions_after_open` - fails if the date to no longer accepting submissions and the open date are present, and the open date exceeds the date for no longer accepting submissions
   * boolean methods that must be set to either true or false: `student_logged`, `required`, `accepts_submissions`,
-  `release_necessary`, `visible`, `resubmissions_allowed`, `include_in_timeline`, `include_in_predictor`, `include_in_to_do`, `use_rubric`, `accepts_attachments`, `accepts_text`, `accepts_links`, `pass_fail`, `hide_analytics`, `visible_when_locked`, `show_name_when_locked`, `show_points_when_locked`, `show_description_when_locked`, `show_purpose_when_locked`
+  `release_necessary`, `visible`, `resubmissions_allowed`, `use_rubric`, `accepts_attachments`, `accepts_text`, `accepts_links`, `pass_fail`, `hide_analytics`, `visible_when_locked`, `show_name_when_locked`, `show_points_when_locked`, `show_description_when_locked`, `show_purpose_when_locked`
 
 ### Callbacks
 
@@ -67,7 +67,6 @@ When an Assignment is destroyed, all of the following models that belong to it w
 ### Scopes
 
   * `group_assignments`
-  * `timelineable`
   * `chronological`
   * `alphabetical`
   * `ordered`
@@ -87,9 +86,6 @@ When an Assignment is destroyed, all of the following models that belong to it w
   * `grade_scope` - kind of assignment being graded. The three values are "Individual", "Group" and "Team". Defaults to "Individual"
   * `grading_due_at`
   * `hide_analytics` - boolean switch controlling whether the assignment's analytics should be hidden from students. The course model's `hide_analytics` attribute must be false for the checkbox to appear in the assignment form view
-  * `include_in_predictor` - boolean switch controlling whether the assignment can be seen by students in the grade predictor. Defaults to true
-  * `include_in_to_do` - boolean switch controlling whether students can see the assignment in the syllabus' todo sidebar ("Due This Week" in the view). Defaults to true
-  * `include_in_timeline` - boolean switch controlling whether the assignment will be included in the class' syllabus. If `open_at` or `due_at` is false, the assignment will not appear in the timeline, regardless of whether this is true. Defaults to true
   * `mass_grade_type` - quick grading type when an instructor is grading all students in the assignment at once. Each student would have the quick grading type next to their name. There are four types:
     * "Checkbox" - a checkbox that, when selected, gives the student the amount of points set by `full_points` multiplied by his/her assignment weight (if he/she has one)
     * "Select List" - a dropdown list, with the items being the grade levels

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -242,7 +242,6 @@ def predictor_assignment_attributes
     :due_at,
     :grade_scope,
     :id,
-    :include_in_predictor,
     :name,
     :pass_fail,
     :full_points,

--- a/spec/factories/assignment_factory.rb
+++ b/spec/factories/assignment_factory.rb
@@ -13,9 +13,6 @@ FactoryGirl.define do
     grade_scope "Individual"
     accepts_submissions true
     visible true
-    include_in_timeline true
-    include_in_predictor true
-    include_in_to_do true
     use_rubric true
     accepts_attachments true
     accepts_text true

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -77,24 +77,6 @@ describe Assignment do
       expect(subject.errors[:resubmissions_allowed]).to include "must be true or false"
     end
 
-    it "is invalid without include_in_timeline" do
-      subject.include_in_timeline = nil
-      expect(subject).to_not be_valid
-      expect(subject.errors[:include_in_timeline]).to include "must be true or false"
-    end
-
-    it "is invalid without include_in_predictor" do
-      subject.include_in_predictor = nil
-      expect(subject).to_not be_valid
-      expect(subject.errors[:include_in_predictor]).to include "must be true or false"
-    end
-
-    it "is invalid without include_in_to_do" do
-      subject.include_in_to_do = nil
-      expect(subject).to_not be_valid
-      expect(subject.errors[:include_in_to_do]).to include "must be true or false"
-    end
-
     it "is invalid without use_rubric" do
       subject.use_rubric = nil
       expect(subject).to_not be_valid

--- a/spec/models/timeline_spec.rb
+++ b/spec/models/timeline_spec.rb
@@ -27,7 +27,7 @@ describe Timeline do
     end
 
     context "with challenges for the course" do
-      let!(:challenge) { create :challenge, course: course, due_at: Date.today, include_in_timeline: true }
+      let!(:challenge) { create :challenge, course: course, due_at: Date.today }
       let!(:challenge_not_due) { create :challenge, course: course, due_at: nil }
 
       context "that accepts team challenges" do

--- a/spec/presenters/info/dashboard_course_events_spec.rb
+++ b/spec/presenters/info/dashboard_course_events_spec.rb
@@ -3,7 +3,7 @@ describe Info::DashboardCourseEventsPresenter do
   let(:student) { create :course_membership, :student, course: course }
   let(:event) { create :event, course: course }
   let(:event_with_open) { create :event, course: course, open_at: Date.yesterday }
-  let(:assignment) { create :assignment, course: course, include_in_timeline: false, due_at: event.due_at }
+  let(:assignment) { create :assignment, course: course, due_at: event.due_at }
 
   subject { described_class.new course: course, student: student, assignments: course.assignments }
 

--- a/spec/views/api/assignments/index_spec.rb
+++ b/spec/views/api/assignments/index_spec.rb
@@ -50,13 +50,6 @@ describe "api/assignments/index" do
     expect(json["data"].length).to eq(0)
   end
 
-  it "not include assignments if include_in_predictor is false" do
-    @assignment.update(include_in_predictor: false)
-    render
-    json = JSON.parse(response.body)
-    expect(json["data"].length).to eq(0)
-  end
-
   describe "passes boolean states for icons" do
     it "adds is_required to model" do
       @assignment.update(required: true)

--- a/spec/views/api/challenges/index_spec.rb
+++ b/spec/views/api/challenges/index_spec.rb
@@ -1,12 +1,15 @@
 describe "api/challenges/index" do
   before(:all) do
     @course = create(:course, challenge_term: "tsallenze")
+    @team = create(:team, course: @course)
     @student = create(:user)
   end
   before(:each) do
     @challenge = create(:challenge, description: "...")
     @challenges = [@challenge]
+    @team.students << @student
     allow(view).to receive(:current_course).and_return(@course)
+    allow(view).to receive(:current_student).and_return(@student)
   end
 
   it "responds with an array of challenges" do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR comprehensively removes the form controls and filters around conditionally hiding assignments and challenges from different pieces in the interface. Goal: if you've marked something invisible, then it's *always* hidden until someone has earned it, otherwise, it's visible everywhere where it has the appropriate data/interaction to display. 

I have not yet removed the database fields, as I'm hoping to test this out first. 

### Todos
- [x] Update Documentation to remove references to `timelineable`, `include_in_to_do`, and `include_in_predictor`.
- [x] Update Sample Data
- [x] Update tests
- [ ] Confirm that invisible challenges and assignments don't show on the events pane, the predictor, or the to do list UNLESS they satisfy the right criteria.

### Migrations
NO

### Steps to Test or Reproduce
1. Confirm that the form fields for area-specific visibility components no longer show
2. Mark an assignment and a challenge as invisible. Check to see if they appear in the grade predictor, on the to do list, and in the events pane


### Impacted Areas in Application
List general components of the application that this PR will affect:

* To Do list
* Timeline
* Grade Predictor

======================
Closes #3051 
