### PR TITLE
Fixes for possible invalid GSE levels

### DIFF
--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -38,6 +38,7 @@
 
       scope.removeElement = () ->
         GradeSchemeElementsService.removeElement(@gradeSchemeElement)
+        _validateElements()
         scope.persistChanges(true) if not @gradeSchemeElement.validationError?
 
       scope.persistChanges = (isRemoval=false) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -22,7 +22,6 @@
       currentElement.validationError = "Lowest level threshold must be 0"
     else
       _deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
-      validateElements() if gradeSchemeElements.length > 0
 
   # Add a new element after the selected element, if one was given
   addElement = (currentElement, attributes=null) ->

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -61,6 +61,8 @@
     }
     $http.put('/api/grade_scheme_elements', data).then(
       (response) ->
+        _clearArray(gradeSchemeElements)
+        GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
         GradeCraftAPI.logResponse(response)
         window.location.href = redirectUrl if redirectUrl?
         alert('Changes were successfully saved') if showAlert is true
@@ -122,6 +124,9 @@
       element[key] = value
     ) if attributes?
     element
+
+  _clearArray = (array) ->
+    array.length = 0
 
   {
     gradeSchemeElements: gradeSchemeElements

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/element.html.haml
@@ -5,14 +5,14 @@
       %input.letter{'type'=>'text',
                     'name'=>'letter',
                     'ng-model'=>'gradeSchemeElement.letter',
-                    'ng-blur'=>"persistChanges()"}
+                    'ng-change'=>"persistChanges()"}
 
     %label.gse-label.form-hint
       Level name
       %input.level{'type'=>'text',
                    'name'=>'level',
                    'ng-model'=>'gradeSchemeElement.level',
-                   'ng-blur'=>"persistChanges()"}
+                   'ng-change'=>"persistChanges()"}
 
     %label.gse-label.form-hint
       Point Threshold
@@ -23,7 +23,8 @@
         'required'=>'',
         'gc-number-input'=>'',
         'allow-negatives'=>'false',
-        'maintain-focus'=>''}
+        'maintain-focus'=>'',
+        'maxLength'=>'11'}
 
     %span{'ng-show'=>'status === "saving"'}
       %i.fa.fa-spinner.fa-spin.fa-fw

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -1,7 +1,7 @@
 %loading-message{'loading'=>'vm.loading', 'message'=>"Loading Grade Scheme Elements..."}
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
-  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements | orderBy: "-lowest_points"',
+  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements | orderBy: ["!-lowest_points", "-lowest_points"]',
                         'ng-attr-index'=>'element.order = $index',
                         'grade_scheme_element'=>'element'}
 

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -6,7 +6,8 @@ class GradeSchemeElement < ActiveRecord::Base
   belongs_to :course
 
   validates_presence_of :course
-  validates :lowest_points, length: { maximum: 9 }, numericality: { only_integer: true }, allow_nil: true
+  validates :lowest_points, length: { maximum: 9 },
+    numericality: { only_integer: true }, allow_nil: true
 
   scope :with_lowest_points, -> { where.not(lowest_points: nil) }
   scope :for_course, -> (course_id) { where(course_id: course_id) }

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -5,7 +5,8 @@ describe GradeSchemeElement do
   subject { create :grade_scheme_element, lowest_points: 1000, course: course }
 
   before do
-    create :course_membership, :student, user: student, course: course, score: 82, earned_grade_scheme_element_id: subject.id
+    create :course_membership, :student, user: student, course: course,
+      score: 82, earned_grade_scheme_element_id: subject.id
   end
 
   describe "validations" do
@@ -37,13 +38,15 @@ describe GradeSchemeElement do
   describe ".next_highest_element_for" do
     context "when there is a grade scheme element with a higher point threshold" do
       it "returns the next highest element with lowest points by default" do
-        grade_scheme_element = create :grade_scheme_element, lowest_points: 5000, course: course
+        grade_scheme_element = create :grade_scheme_element, lowest_points: 5000,
+          course: course
         expect(GradeSchemeElement.next_highest_element_for(subject)).to \
           eq grade_scheme_element
       end
 
       it "returns the next highest element with or without lowest points if requested" do
-        grade_scheme_element = create :grade_scheme_element, lowest_points: nil, course: course
+        grade_scheme_element = create :grade_scheme_element, lowest_points: nil,
+          course: course
         expect(GradeSchemeElement.next_highest_element_for(subject, false)).to \
           eq grade_scheme_element
       end
@@ -59,14 +62,16 @@ describe GradeSchemeElement do
   describe ".next_lowest_element_for" do
     context "when there is a grade scheme element with a lower point threshold" do
       it "returns the next lowest element with lowest points by default" do
-        grade_scheme_element = create :grade_scheme_element, lowest_points: 500, course: course
+        grade_scheme_element = create :grade_scheme_element, lowest_points: 500,
+          course: course
         expect(GradeSchemeElement.next_lowest_element_for(subject)).to \
           eq grade_scheme_element
       end
 
       it "returns the next lowest element with or without lowest points if requested" do
         subject.lowest_points = nil
-        grade_scheme_element = create :grade_scheme_element, lowest_points: nil, course: course
+        grade_scheme_element = create :grade_scheme_element, lowest_points: nil,
+          course: course
         expect(GradeSchemeElement.next_lowest_element_for(grade_scheme_element, false)).to \
           eq subject
       end


### PR DESCRIPTION
### Status
READY

### Description
See issue description for additional details.

TL;DR: Since newly created grade scheme elements were not being updated with their persisted ids, it was possible to autosave invalid grade scheme levels with overlapping point thresholds.

### Steps to Test or Reproduce
Change the zero threshold point value to a non-zero value and allow to persist. Change the new zero threshold point value again and allow to persist. The changes should be persisted as expected and there should be no errant levels with overlapping points upon page refresh.

### Impacted Areas in Application
List general components of the application that this PR will affect:
- Grade scheme elements

======================
Closes #3332 
