### PR TITLE
alert for course creation errors

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -77,6 +77,7 @@ class CoursesController < ApplicationController
       redirect_to edit_course_path(@course),
       notice: "Course #{@course.name} successfully updated"
     else
+      @institutions = Institution.where(has_site_license: true)
       render action: "edit"
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -33,21 +33,20 @@ class CoursesController < ApplicationController
 
   def create
     @course = Course.new(course_params)
-    respond_to do |format|
-      if @course.save
-        if !current_user_is_admin?
-          @course.course_memberships.create(user_id: current_user.id,
-                                            role: current_user.role(current_course))
-        end
-        session[:course_id] = @course.id
-        bust_course_list_cache current_user
-        format.html do
-          redirect_to edit_course_path(@course),
-          notice: "Course #{@course.name} successfully created"
-        end
-      else
-        format.html { render action: "new" }
+    if @course.save
+      if !current_user_is_admin?
+        @course.course_memberships.create(user_id: current_user.id,
+                                          role: current_user.role(current_course))
       end
+      session[:course_id] = @course.id
+      bust_course_list_cache current_user
+      redirect_to edit_course_path(@course), flash: {
+        notice: "Course #{@course.name} successfully created"
+      }
+    else
+      redirect_to new_course_path, flash: {
+        alert: @course.errors.full_messages.to_sentence
+      }
     end
   end
 
@@ -60,11 +59,13 @@ class CoursesController < ApplicationController
       end
       duplicated.recalculate_student_scores unless duplicated.student_count.zero?
       session[:course_id] = duplicated.id
-      redirect_to edit_course_path(duplicated.id),
-        notice: "#{@course.name} successfully copied" and return
+      redirect_to edit_course_path(duplicated.id), flash: {
+        notice: "#{@course.name} successfully copied"
+      }
     else
-      redirect_to courses_path,
-        alert: "#{@course.name} was not successfully copied" and return
+      redirect_to courses_path, flash: {
+        alert: "#{@course.name} was not successfully copied"
+      }
     end
   end
 
@@ -74,12 +75,10 @@ class CoursesController < ApplicationController
       if @course.update_attributes(course_params)
         @course.recalculate_student_scores if add_team_score_to_student_changed?
         bust_course_list_cache current_user
-        format.html do
-          redirect_to edit_course_path(@course),
-          notice: "Course #{@course.name} successfully updated"
-        end
+        redirect_to edit_course_path(@course),
+        notice: "Course #{@course.name} successfully updated"
       else
-        format.html { render action: "edit" }
+        render action: "edit"
       end
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -71,15 +71,13 @@ class CoursesController < ApplicationController
 
   def update
     authorize! :update, @course
-    respond_to do |format|
-      if @course.update_attributes(course_params)
-        @course.recalculate_student_scores if add_team_score_to_student_changed?
-        bust_course_list_cache current_user
-        redirect_to edit_course_path(@course),
-        notice: "Course #{@course.name} successfully updated"
-      else
-        render action: "edit"
-      end
+    if @course.update_attributes(course_params)
+      @course.recalculate_student_scores if add_team_score_to_student_changed?
+      bust_course_list_cache current_user
+      redirect_to edit_course_path(@course),
+      notice: "Course #{@course.name} successfully updated"
+    else
+      render action: "edit"
     end
   end
 

--- a/app/views/courses/_form.html.haml
+++ b/app/views/courses/_form.html.haml
@@ -10,7 +10,7 @@
         = f.text_field :course_number
 
       .form-item
-        = f.label :name, "*Course Title"
+        = f.label :name, "*Course Name"
         = f.text_field :name
     .form-flex-row
       .form-item

--- a/app/views/courses/new.html.haml
+++ b/app/views/courses/new.html.haml
@@ -1,4 +1,5 @@
 .pageContent
+  = render partial: "layouts/alerts"
   = simple_form_for(@course, :validate => false)  do |f|
     #tabs.ui-tabs.ui-widget
       %ul.ui-tabs-nav{role: "tablist"}
@@ -24,7 +25,7 @@
           = render partial: "courses/student_onboarding_setup", locals: { f: f }
         .ui-tabs-panel#tab5{role: "tabpanel", "aria-hidden" => false }
           = render partial: "courses/advanced_settings", locals: { f: f }
-  
+
       .submit-buttons
         %ul
           %li= f.button :submit, "#{@course.persisted? ? 'Update' : 'Create'} Course", class: "button"

--- a/spec/features/editing_course_options_spec.rb
+++ b/spec/features/editing_course_options_spec.rb
@@ -11,7 +11,7 @@ feature "editing a course's basic settings" do
 
     scenario "successfully" do
       within(".pageContent") do
-        fill_in "Course Title", with: "New Course Name"
+        fill_in "Course Name", with: "New Course Name"
         click_button "Save Settings"
       end
 


### PR DESCRIPTION
### Status
**READY**

### Description

Adds error messages to failed course creation. We could also add javascript validation but this seemed like a simpler solution to maintain for such a simple form.

### Related PRs

May affect #3182 - alerts refactor, on rebase. This removes the surrounding format block from the controller methods, and adds the `render partial: "layouts/alerts"` that won't be needed once this partial is centralized.

### Steps to Test or Reproduce

Add a new course without a number, name, or both, and you will now see an error message on redirect.

======================
Closes #3322 
