### PR TITLE
1246 email notes

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -8,9 +8,9 @@ class AnnouncementsController < ApplicationController
 
   def show
     @announcement = Announcement.find params[:id]
-    if @announcement.course == current_course 
+    if @announcement.course == current_course
       authorize! :show, @announcement
-    else 
+    else
       redirect_to dashboard_path, notice: "It looks like that announcement isn't for this course. Try switching courses to #{view_context.link_to(@announcement.course.name, change_course_path(@announcement.course))}."
     end
     @announcement.mark_as_read! current_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -193,6 +193,6 @@ class UsersController < ApplicationController
         :submission_id, :course_id, :assignment_id, :level_id, :criterion_id, :grade_id,
         :student_visible, :id, :_destroy],
       course_memberships_attributes: [:auditing, :pseudonym, :character_profile, :course_id,
-        :instructor_of_record, :user_id, :role, :last_login_at, :id, :team_role, :_destroy]
+        :instructor_of_record, :user_id, :role, :last_login_at, :id, :team_role, :email_announcements, :email_badge_awards, :email_grade_notifications, :email_challenge_grade_notifications, :_destroy]
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -29,9 +29,9 @@ class Announcement < ActiveRecord::Base
       AnnouncementMailer.announcement_email(self, recipient).deliver_now
     elsif !course.nil?
       course.users.each do |user|
-         if user.email_announcements?(course)
-           AnnouncementMailer.announcement_email(self, user).deliver_now
-         end
+        if user.email_announcements?(course)
+          AnnouncementMailer.announcement_email(self, user).deliver_now
+        end
       end
     end
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -25,11 +25,13 @@ class Announcement < ActiveRecord::Base
   end
 
   def deliver!
-    if !recipient.nil?
+    if !recipient.nil? && recipient.email_announcements?(course)
       AnnouncementMailer.announcement_email(self, recipient).deliver_now
     elsif !course.nil?
       course.users.each do |user|
-        AnnouncementMailer.announcement_email(self, user).deliver_now
+         if user.email_announcements?(course)
+           AnnouncementMailer.announcement_email(self, user).deliver_now
+         end
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,6 +167,22 @@ class User < ActiveRecord::Base
     course_memberships.where(course: course).first.team_role
   end
 
+  def email_badge_awards?(course)
+    return true if course_memberships.where(course: course).first.email_badge_awards?
+  end
+
+  def email_grade_notifications?(course)
+    return true if course_memberships.where(course: course).first.email_grade_notifications?
+  end
+
+  def email_announcements?(course)
+    return true if course_memberships.where(course: course).first.email_announcements?
+  end
+
+  def email_challenge_grade_notifications?(course)
+    return true if course_memberships.where(course: course).first.email_challenge_grade_notifications?
+  end
+
   def submitter_directory_name
     "#{last_name.camelize}, #{first_name.camelize}"
   end

--- a/app/performers/challenge_grade_update_performer.rb
+++ b/app/performers/challenge_grade_update_performer.rb
@@ -40,6 +40,8 @@ class ChallengeGradeUpdatePerformer < ResqueJob::Performer
   end
 
   def notify_challenge_grade_released
-    NotificationMailer.challenge_grade_released(@challenge_grade).deliver_now
+    if @challenge_grade.student.email_challenge_grade_notifications?(@challenge_grade.course)
+      NotificationMailer.challenge_grade_released(@challenge_grade).deliver_now
+    end
   end
 end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -42,7 +42,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
   end
 
   def notify_grade_released
-    # GradeAnnouncement.create @grade
+    GradeAnnouncement.create @grade
     NotificationMailer.grade_released(@grade.id).deliver_now
   end
 end

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -43,6 +43,8 @@ class GradeUpdatePerformer < ResqueJob::Performer
 
   def notify_grade_released
     GradeAnnouncement.create @grade
-    NotificationMailer.grade_released(@grade.id).deliver_now
+    if @grade.student.email_grade_notifications?(@grade.course)
+      NotificationMailer.grade_released(@grade.id).deliver_now
+    end
   end
 end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -8,7 +8,7 @@ module Services
       executed do |context|
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
-          # EarnedBadgeAnnouncement.create earned_badge
+          EarnedBadgeAnnouncement.create earned_badge
           NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
         end
       end

--- a/app/services/creates_earned_badge/notifies_of_earned_badge.rb
+++ b/app/services/creates_earned_badge/notifies_of_earned_badge.rb
@@ -9,7 +9,9 @@ module Services
         earned_badge = context.earned_badge
         if earned_badge.student_visible?
           EarnedBadgeAnnouncement.create earned_badge
-          NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
+          if earned_badge.student.email_badge_awards?(earned_badge.course)
+            NotificationMailer.earned_badge_awarded(earned_badge).deliver_now
+          end
         end
       end
     end

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -8,10 +8,6 @@
   = render partial: "layouts/alerts"
 
   %p
-    %strong Course:
-    = @announcement.course.name
-
-  %p
     %strong Sent:
     = @announcement.created_at.strftime("%A, %B %d, %Y, at %l:%M%p")
 
@@ -19,6 +15,6 @@
     %strong Subject:
     = @announcement.title
 
-  %hr
-
-  %p= @announcement.body.html_safe
+  %p
+    %strong Message:
+    = @announcement.body.html_safe

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -12,7 +12,7 @@
         %th{ :width => 70}
       %th{ :width => 230}
   %tbody
-    - presenter.students.each do |student|
+    - presenter.students.order_by_name.each do |student|
       %tr
         - if presenter.badge.is_unlockable?
           %td

--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -51,6 +51,16 @@
             = p.input :team_role, :input_html => { :maxlength => 255 }, :label => "#{term_for :team} Role"
             .form-hint What will you contribute to your #{term_for :team}?
 
+        %h3 Email Settings
+        .form-hint You will always see your notifications in announcement center above. If there's a type of email you'd rather not get from GradeCraft, just uncheck the box below.
+        .form-item
+          = p.input :email_announcements
+          - if current_course.has_badges?
+            = p.input :email_badge_awards
+          = p.input :email_grade_notifications
+          - if current_course.has_team_challenges?
+            = p.input :email_challenge_grade_notifications
+
       - if impersonating?
         You cannot update this information in preview mode
       - else

--- a/db/migrate/20170612023643_send_email_controls_per_course.rb
+++ b/db/migrate/20170612023643_send_email_controls_per_course.rb
@@ -1,0 +1,8 @@
+class SendEmailControlsPerCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :course_memberships, :email_announcements, :boolean, nil: false, default: true
+    add_column :course_memberships, :email_badge_awards, :boolean, nil: false, default: true
+    add_column :course_memberships, :email_grade_notifications, :boolean, nil: false, default: true
+    add_column :course_memberships, :email_challenge_grade_notifications, :boolean, nil: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170611172829) do
+ActiveRecord::Schema.define(version: 20170612023643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -252,16 +252,20 @@ ActiveRecord::Schema.define(version: 20170611172829) do
   create_table "course_memberships", force: :cascade do |t|
     t.integer  "course_id"
     t.integer  "user_id"
-    t.integer  "score",                          default: 0,          null: false
+    t.integer  "score",                               default: 0,          null: false
     t.text     "character_profile"
     t.datetime "last_login_at"
-    t.boolean  "auditing",                       default: false,      null: false
-    t.string   "role",                           default: "observer", null: false
-    t.boolean  "instructor_of_record",           default: false
+    t.boolean  "auditing",                            default: false,      null: false
+    t.string   "role",                                default: "observer", null: false
+    t.boolean  "instructor_of_record",                default: false
     t.integer  "earned_grade_scheme_element_id"
-    t.boolean  "has_seen_course_onboarding",     default: false
+    t.boolean  "has_seen_course_onboarding",          default: false
     t.string   "pseudonym"
     t.string   "team_role"
+    t.boolean  "email_announcements",                 default: true
+    t.boolean  "email_badge_awards",                  default: true
+    t.boolean  "email_grade_notifications",           default: true
+    t.boolean  "email_challenge_grade_notifications", default: true
     t.index ["course_id", "user_id"], name: "index_courses_users_on_course_id_and_user_id", using: :btree
     t.index ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id", using: :btree
   end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -72,6 +72,7 @@ describe Announcement do
 
     it "sends an email only to the recipient if it is set" do
       another_student = create :user
+      create(:course_membership, :student, course_id: course.id, user_id: another_student.id)
       subject.update_attributes recipient: another_student
 
       expect(AnnouncementMailer).to \

--- a/spec/models/earned_badge_announcement_spec.rb
+++ b/spec/models/earned_badge_announcement_spec.rb
@@ -5,21 +5,20 @@ describe EarnedBadgeAnnouncement do
   let(:user) { create :user }
 
   describe ".create" do
-    skip "pending semester end"
-    # it "creates an announcement for the earned badge" do
-    #   expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
-    #   expect(announcement.course).to eq earned_badge.course
-    #   expect(announcement.author).to eq user
-    #   expect(announcement.recipient).to eq earned_badge.student
-    #   expect(announcement.title).to \
-    #     eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
-    #   expect(announcement.body).to include \
-    #     "<p>Congratulations #{earned_badge.student.first_name}!</p>"
-    #   expect(announcement.body).to include \
-    #     "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
-    #   expect(announcement.body).to include \
-    #     "<p>Check out your new "\
-    #       "<a href='http://localhost:5000/badges'>badge</a>.</p>"
-    # end
+    it "creates an announcement for the earned badge" do
+      expect { described_class.create earned_badge }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq earned_badge.course
+      expect(announcement.author).to eq user
+      expect(announcement.recipient).to eq earned_badge.student
+      expect(announcement.title).to \
+        eq "#{course.course_number} - You've earned a new #{course.badge_term}!"
+      expect(announcement.body).to include \
+        "<p>Congratulations #{earned_badge.student.first_name}!</p>"
+      expect(announcement.body).to include \
+        "<p>You've earned the #{earned_badge.badge.name} #{course.badge_term}.</p>"
+      expect(announcement.body).to include \
+        "<p>Check out your new "\
+          "<a href='http://localhost:5000/badges'>badge</a>.</p>"
+    end
   end
 end

--- a/spec/models/grade_announcement_spec.rb
+++ b/spec/models/grade_announcement_spec.rb
@@ -4,20 +4,19 @@ describe GradeAnnouncement do
   let(:user) { create :user }
 
   describe ".create" do
-    skip "pending semester change"
-    # it "creates an announcement for the grade" do
-    #   expect { described_class.create grade }.to change { Announcement.count }.by 1
-    #   expect(announcement.course).to eq grade.course
-    #   expect(announcement.author).to eq grade.graded_by
-    #   expect(announcement.recipient).to eq grade.student
-    #   expect(announcement.title).to eq \
-    #     "#{grade.course.course_number} - #{grade.assignment.name} Graded"
-    #   expect(announcement.body).to include \
-    #     "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
-    #       "#{grade.assignment.name} in #{grade.course.name}."
-    #   expect(announcement.body).to include \
-    #     "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
-    #       "#{grade.assignment.name}</a> to view your results."
-    # end
+    it "creates an announcement for the grade" do
+      expect { described_class.create grade }.to change { Announcement.count }.by 1
+      expect(announcement.course).to eq grade.course
+      expect(announcement.author).to eq grade.graded_by
+      expect(announcement.recipient).to eq grade.student
+      expect(announcement.title).to eq \
+        "#{grade.course.course_number} - #{grade.assignment.name} Graded"
+      expect(announcement.body).to include \
+        "You can now view the grade for your #{grade.course.assignment_term.downcase} "\
+          "#{grade.assignment.name} in #{grade.course.name}."
+      expect(announcement.body).to include \
+        "Visit <a href=http://localhost:5000/assignments/#{(grade.assignment.id)}>"\
+          "#{grade.assignment.name}</a> to view your results."
+    end
   end
 end

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -187,8 +187,7 @@ RSpec.describe GradeUpdatePerformer, type: :background_job do
     end
 
     it "creates a new announcement for the student" do
-      skip "pending fine grain control"
-      #expect { notify }.to change { Announcement.count }.by(1)
+      expect { notify }.to change { Announcement.count }.by(1)
     end
   end
 

--- a/spec/performers/grade_updater_performer_spec.rb
+++ b/spec/performers/grade_updater_performer_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe GradeUpdatePerformer, type: :background_job do
-  let(:assignment) { create(:assignment) }
+  let(:course) { build :course }
+  let(:assignment) { create(:assignment, course: course) }
+  let!(:student) { create(:course_membership, :student, course: course).user }
   let(:instructor) { create :user }
-  let(:grade) { create(:grade, assignment_id: assignment.id, graded_by_id: instructor.id) }
+  let(:grade) { create(:grade, assignment_id: assignment.id, student: student, graded_by_id: instructor.id) }
   let(:attrs) {{ grade_id: grade[:id] }}
   let(:performer) { GradeUpdatePerformer.new(attrs) }
   subject { performer }

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -19,11 +19,10 @@ describe Services::Actions::NotifiesOfEarnedBadge do
     end
 
     it "creates an announcement for the student" do
-      skip "pending fine grain controls"
-      # allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
-      # 
-      # expect { described_class.execute earned_badge: earned_badge }.to \
-      #   change { Announcement.count }.by 1
+      allow(NotificationMailer).to receive(:earned_badge_awarded).and_return delivery
+
+      expect { described_class.execute earned_badge: earned_badge }.to \
+        change { Announcement.count }.by 1
     end
   end
 

--- a/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
+++ b/spec/services/creates_earned_badge/notifies_of_earned_badge_spec.rb
@@ -1,7 +1,8 @@
 describe Services::Actions::NotifiesOfEarnedBadge do
-  let(:course) { earned_badge.course }
+  let(:course) { create :course }
   let(:delivery) { double(:email, deliver_now: nil) }
-  let(:earned_badge) { create :earned_badge, awarded_by: user }
+  let!(:student) { create(:course_membership, :student, course: course).user }
+  let!(:earned_badge) { create :earned_badge, student: student, awarded_by: user, course: course }
   let(:user) { create :user }
 
   it "expects an earned badge to send the notification about" do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR allows users to declare at the course membership level exactly what emails they want to receive as opposed to just have show up in their announcements tab. 

### Todos
- [ ] Add Tests
- [ ] Update/Add Documentation
- [ ] Update Sample Data

### Migrations
YES

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Award a badge - confirm that shows for the student recipient as (1) a notification in the announcements pane, and (2) in the log file as an email receipt
2. Turn email_badge_awards false for the student (by editing their profile, or by doing so in the rails console). Confirm that awarding a badge does *not* create an email receipt in the log file. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* All emails to students (Challenge Grades, Badges, Grades, Announcements) 

======================
Closes #1246 
