### PR TITLE
3346 group resubmissions bug

### DIFF
--- a/app/assets/javascripts/angular/directives/student/submission/text_comment_input.coffee
+++ b/app/assets/javascripts/angular/directives/student/submission/text_comment_input.coffee
@@ -5,10 +5,12 @@
     vm = this
     vm.loading = true
     vm.submission = StudentSubmissionService.submission
+
     vm.queueSaveDraftSubmission = () ->
       StudentSubmissionService.queueSaveDraftSubmission(vm.assignmentId)
 
     StudentSubmissionService.getDraftSubmission(vm.assignmentId).then(() ->
+      vm.submission.text_comment_draft = vm.submission.text_comment if !vm.submission.text_comment_draft?
       vm.loading = false
     )
   ]

--- a/app/services/creates_grade/associates_submission_with_grade.rb
+++ b/app/services/creates_grade/associates_submission_with_grade.rb
@@ -2,16 +2,20 @@ module Services
   module Actions
     class AssociatesSubmissionWithGrade
       extend LightService::Action
-      
+
       expects :student, :assignment, :grade
 
       executed do |context|
-        if context[:group]
-          s = Submission.where({ assignment_id: context[:assignment].id,
-                               group_id: context[:group].id }).first
+        assignment = context.assignment
+        student = context.student
+
+        if assignment.has_groups?
+          group = student.group_for_assignment(assignment)
+          s = Submission.find_by(assignment_id: assignment.id,
+                                 group_id: group.id)
         else
-          s = Submission.where({ assignment_id: context[:assignment].id,
-                               student_id: context[:student].id }).first
+          s = Submission.find_by(assignment_id: assignment.id,
+                                 student_id: student.id)
         end
         context[:grade].submission_id = s.nil? ? nil : s.id
       end

--- a/app/services/creates_grade/verifies_assignment_student.rb
+++ b/app/services/creates_grade/verifies_assignment_student.rb
@@ -2,7 +2,7 @@ module Services
   module Actions
     class VerifiesAssignmentStudent
       extend LightService::Action
-      
+
       expects :raw_params
       promises :student, :assignment
 
@@ -10,9 +10,6 @@ module Services
         begin
           context[:assignment] = Assignment.find(context[:raw_params]["assignment_id"])
           context[:student] = User.find(context[:raw_params]["student_id"])
-          if context[:raw_params]["group_id"]
-            context[:group] = Group.find(context[:raw_params]["group_id"])
-          end
         rescue ActiveRecord::RecordNotFound
           context.fail_with_rollback!("Unable to verify both student and assignment", error_code: 404)
         end

--- a/app/views/submissions/_assignment_guidelines.haml
+++ b/app/views/submissions/_assignment_guidelines.haml
@@ -35,9 +35,9 @@
 - if current_user_is_staff?
   %section.grade-form-section
     - if assignment.has_groups?
-      %h2.grade-form-header= "Grade for #{@group.name}:"
+      %h2.grade-form-header= "Grade for #{(@group || group).try(:name)}:"
       %ul
-        - @group.students.each do |s|
+        - (@group || group).students.each do |s|
           %li= link_to s.name, student_path(s)
     - else
       - if @grade.present?

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -1,4 +1,4 @@
-= render partial: "assignment_guidelines", locals: { assignment: presenter.assignment }
+= render partial: "assignment_guidelines", locals: { assignment: presenter.assignment, group: presenter.group }
 
 %hr
 

--- a/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
+++ b/spec/services/creates_criterion_grade/verifies_assignment_student_spec.rb
@@ -2,7 +2,6 @@ describe Services::Actions::VerifiesAssignmentStudent do
   let(:course) { build_stubbed :course }
   let(:student) { create :user }
   let(:assignment) { create :assignment }
-  let(:group) { create :group }
   let(:route_params) {{ "assignment_id" => assignment.id, "student_id" => student.id }}
   let(:raw_params) { RubricGradePUT.new(assignment).params.merge route_params }
 
@@ -14,12 +13,6 @@ describe Services::Actions::VerifiesAssignmentStudent do
   it "promises the found assignment" do
     result = described_class.execute raw_params: raw_params
     expect(result).to have_key :assignment
-  end
-
-  it "returns the group if present" do
-    raw_params["group_id"] = group.id
-    result = described_class.execute raw_params: raw_params
-    expect(result).to have_key :group
   end
 
   it "halts with error if assignment is not found" do

--- a/spec/services/creates_grade/associates_submission_with_grade_spec.rb
+++ b/spec/services/creates_grade/associates_submission_with_grade_spec.rb
@@ -1,52 +1,65 @@
 describe Services::Actions::AssociatesSubmissionWithGrade do
-  let(:course) { create :course }
-  let(:assignment) { create :assignment, course: course }
-  let(:student) { create(:course_membership, :student, course: course).user }
-  let(:grade) { create(:grade, assignment: assignment, student: student) }
-  let(:group) { create(:group) }
-  
-  let(:context) {{ assignment: assignment, student: student, grade: grade }}
+  let(:course) { build_stubbed :course }
+  let(:student) { build_stubbed(:course_membership, :student, course: course).user }
+  let(:grade) { build_stubbed :grade, assignment: assignment, student: student }
 
-  it "expect student to be added to the context" do
-    context.delete(:student)
-    expect { described_class.execute context }.to \
-      raise_error LightService::ExpectedKeysNotInContextError
+  let(:context) do
+    {
+      assignment: assignment,
+      student: student,
+      grade: grade
+    }
   end
 
-  it "expect assignment to be added to the context" do
-    context.delete(:assignment)
-    expect { described_class.execute context }.to \
-      raise_error LightService::ExpectedKeysNotInContextError
-  end
+  context "when the assignment is individually graded" do
+    let(:assignment) { build_stubbed :assignment, course: course }
 
-  it "expect grade to be added to the context" do
-    context.delete(:grade)
-    expect { described_class.execute context }.to \
-      raise_error LightService::ExpectedKeysNotInContextError
-  end
+    it "expect student to be added to the context" do
+      context.delete(:student)
+      expect { described_class.execute context }.to \
+        raise_error LightService::ExpectedKeysNotInContextError
+    end
 
-  it "adds a submission_id to the grade" do
-    submission = create(:submission, assignment: assignment, student: student)
-    result = described_class.execute context
-    expect(result[:grade].submission_id).to eq submission.id
-  end
+    it "expect assignment to be added to the context" do
+      context.delete(:assignment)
+      expect { described_class.execute context }.to \
+        raise_error LightService::ExpectedKeysNotInContextError
+    end
 
-  it "adds nil as submission_id if no submission" do
-    result = described_class.execute context
-    expect(result[:grade].submission_id).to be_nil
-  end
+    it "expect grade to be added to the context" do
+      context.delete(:grade)
+      expect { described_class.execute context }.to \
+        raise_error LightService::ExpectedKeysNotInContextError
+    end
 
-  describe "with a group in the context" do
-    it "adds the group submission_id to the grade" do
-      context[:group] = group
-      submission = create(:group_submission, assignment: assignment, group: group)
+    it "adds a submission_id to the grade if one is found" do
+      submission = build :submission, assignment: assignment, student: student
       result = described_class.execute context
       expect(result[:grade].submission_id).to eq submission.id
     end
 
-    it "adds nil as submission_id if no submission" do
-      context[:group] = group
+    it "adds nil as submission_id if no submission is found" do
       result = described_class.execute context
+      expect(result[:grade].submission_id).to be_nil
+    end
+  end
+
+  context "when the assignment is group graded" do
+    let(:group) { create :group, course: course }
+    let(:assignment) { build_stubbed :group_assignment, course: course }
+    let!(:assignment_group) { create :assignment_group, assignment: assignment, group: group }
+    let!(:group_membership) { create :group_membership, student: student, group: group }
+
+    let(:group_context) { context.merge group: group }
+
+    it "adds the group submission_id to the grade if one is found" do
+      submission = build :group_submission, assignment: assignment, group: group
+      result = described_class.execute group_context
+      expect(result[:grade].submission_id).to eq submission.id
+    end
+
+    it "adds nil as submission_id if no submission if no submission is found" do
+      result = described_class.execute group_context
       expect(result[:grade].submission_id).to be_nil
     end
   end


### PR DESCRIPTION
### Status
READY

### Description
This PR address a bug where a group submission was not showing on the grade status page if it was a resubmission. The issue was in the `AssociatesSubmissionWithGrade` service, which was not properly linking the grade with the submission since the group grades were being updated iteratively in the Angular service.

**This also includes a fix for a preexisting bug in master where the group was not within the context of the assignment guidelines partial.**

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Create a submission on a group-graded assignment, and grade it as an instructor. Resubmit and ensure that the submission appears on the grading status page.

### Impacted Areas in Application
`AssociatesSubmissionWithGrade` service and group grading

======================
Closes #3346 
