### PR TITLE
adding status fields to challenge grades

### DIFF
--- a/app/models/challenge_grade.rb
+++ b/app/models/challenge_grade.rb
@@ -13,8 +13,9 @@ class ChallengeGrade < ActiveRecord::Base
   delegate :name, :description, :due_at, :full_points, to: :challenge
 
   releasable_through :challenge
-  
+
   before_save :calculate_final_points
+  before_save :update_challenge_status_fields
 
   validates :challenge_id, uniqueness: { scope: :team_id }
   validates_presence_of :team_id
@@ -27,7 +28,7 @@ class ChallengeGrade < ActiveRecord::Base
   def raw_points
     super.presence || nil
   end
-  
+
   # totaled points (adds adjustment, without weighting)
   def calculate_final_points
     return nil unless raw_points.present?

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -88,4 +88,24 @@ module GradeStatus
     end
     return true
   end
+
+  # temporary method for challenge grades, same as above
+  def update_challenge_status_fields
+    if self.status == "In Progress"
+      self.complete = false
+      self.student_visible = false
+    elsif self.status == "Graded"
+      if challenge.release_necessary
+        self.complete = true
+        self.student_visible = false
+      else
+        self.complete = true
+        self.student_visible = true
+      end
+    elsif self.status == "Released"
+      self.complete = true
+      self.student_visible = true
+    end
+    return true
+  end
 end

--- a/db/migrate/20170615150351_add_release_fields_to_challenge_grade.rb
+++ b/db/migrate/20170615150351_add_release_fields_to_challenge_grade.rb
@@ -1,0 +1,6 @@
+class AddReleaseFieldsToChallengeGrade < ActiveRecord::Migration[5.0]
+  def change
+    add_column :challenge_grades, :complete, :boolean, null: false, default: false
+    add_column :challenge_grades, :student_visible, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612023643) do
+ActiveRecord::Schema.define(version: 20170615150351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,16 +181,18 @@ ActiveRecord::Schema.define(version: 20170612023643) do
   end
 
   create_table "challenge_grades", force: :cascade do |t|
-    t.integer  "challenge_id",                           null: false
+    t.integer  "challenge_id",                               null: false
     t.integer  "raw_points"
     t.string   "status"
-    t.integer  "team_id",                                null: false
+    t.integer  "team_id",                                    null: false
     t.integer  "final_points"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
     t.text     "feedback"
     t.integer  "adjustment_points",          default: 0
     t.text     "adjustment_points_feedback"
+    t.boolean  "complete",                   default: false, null: false
+    t.boolean  "student_visible",            default: false, null: false
   end
 
   create_table "challenge_score_levels", force: :cascade do |t|

--- a/lib/tasks/challenge_grades.rake
+++ b/lib/tasks/challenge_grades.rake
@@ -1,0 +1,28 @@
+namespace :challenge_grades do
+  desc "Update complete and student_visible fields on existing grades"
+  task update_status_fields: :environment do
+    ChallengeGrade.find_each(batch_size: 500) do |grade|
+      complete = false
+      student_visible = false
+
+      if grade.status == "In Progress"
+        complete = false
+        student_visible = false
+      elsif grade.status == "Graded"
+        if grade.challenge.release_necessary
+          complete = true
+          student_visible = false
+        else
+          complete = true
+          student_visible = true
+        end
+      elsif grade.status == "Released"
+        complete = true
+        student_visible = true
+      end
+      grade.update_attribute(:complete, complete) if complete
+      grade.update_attribute(:student_visible, student_visible) if student_visible
+      puts "#{grade.id}: status: #{grade.status}, complete: #{grade.complete}, student_visible: #{grade.student_visible}"
+    end
+  end
+end


### PR DESCRIPTION
### Status
**READY**

### Description
This follows the work of #3327 and replicates for challenge grades. Since both models share the `GradeStatus` I realized I will have to update them both in the same PR when we move over to using `complete` and `student_visible`.

### Related PRs
#3327

### Deploy Notes
  * run migration
  * run rake task: `rails challenge_grades:update_status_fields`

### Migrations
YES