### PR TITLE
2923 White List File Upload Types

### DIFF
--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -71,4 +71,12 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   def secure_token_name
     :"@#{mounted_as}_secure_token"
   end
+
+  def extension_black_list
+    %w(action apk app application bat bin cmd com command cpl csh dmg exe
+    gadget hta inf ins inx ipa isu jar job jse lnk msc msh msh1 msh2 mshxml
+    msh1xml msh2xml msi msp mst osx out paf pif prg psc1 psc2 ps1 ps1xml ps2
+    ps2xml reg rgs run scf scr sct shb shs u3p vb vbe vbs vbscript workflow ws
+    wsc wsf wsh)
+  end
 end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
We should not allow a variety of file types to be uploaded Assignment, Badge, Challenge, Grade, or Submission files. The list of things we should prohibit can start [here](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/open_response_assessments/OpenResponseAssessments.html#prohibited-file-extensions)

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As a student, attempt to upload an attachment that is prohibited on an assignment that accepts submissions. If the file type is prohibited, the upload should fail. Otherwise, succeed.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Uploads

======================
Closes #2923 
