### PR TITLE
3378 allow institutions without canvas

### DIFF
--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -289,7 +289,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
 
   def institutions_index
     dashboard
-    breadcrumb("Institutions")
+    breadcrumb("Institutions", institutions_path)
   end
 
   def institutions_new

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -4,5 +4,5 @@ class Institution < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
 
-  accepts_nested_attributes_for :providers
+  accepts_nested_attributes_for :providers, reject_if: proc { |attr| attr[:consumer_key].blank? }
 end

--- a/app/views/institutions/components/_form.haml
+++ b/app/views/institutions/components/_form.haml
@@ -1,4 +1,4 @@
-= simple_form_for @institution do |f|
+= simple_form_for @institution, html: { novalidate: true } do |f|
   %section.form-section
     %h2.form-title= "Institution Settings"
     .form-item


### PR DESCRIPTION
### Status
READY

### Description
This PR tweaks the validation of associated providers when creating an institution, such that the attributes are ignored if the consumer key is not provided. This allows for the creation of an institution without having to provide provider credentials.

### Migrations
NO

### Steps to Test or Reproduce
Try to create a new institution without providing provider fields. It should remain possible to create and edit institutions with validated provider attributes if the consumer key is not blank.

======================
Closes #3378
