### PR TITLE
fix specs that fail for unique key violation from database

### DIFF
--- a/spec/presenters/submissions/show_presenter_spec.rb
+++ b/spec/presenters/submissions/show_presenter_spec.rb
@@ -7,12 +7,12 @@ describe Submissions::ShowPresenter do
     { course: course }
   end
 
-  let(:submission) { create(:submission, student: student, assignment: assignment, id: 200, submitted_at: Time.now) }
-  let(:assignment) { create(:assignment, course: course, threshold_points: 13200, grade_scope: "Group", id: 300) }
-  let(:course) { build(:course, name: "Some Course") }
-  let(:student) { create(:user, first_name: "Jimmy", id: 500)}
-  let(:group) { create(:group, name: "My group", course: course, id: 400) }
-  let(:grade) { create(:grade) }
+  let(:submission) { double(:submission, student: student, assignment: assignment, id: 200, submitted_at: Time.now, will_be_resubmitted?: false) }
+  let(:assignment) { double(:assignment, course: course, threshold_points: 13200, grade_scope: "Group", id: 300, is_individual?: true) }
+  let(:course) { double(:course, name: "Some Course") }
+  let(:student) { double(:user, first_name: "Jimmy", id: 500)}
+  let(:group) { double(:group, name: "My group", course: course, id: 400) }
+  let(:grade) { double(:grade) }
 
   before(:each) do
     allow(subject).to receive_messages(


### PR DESCRIPTION
### Status
**READY**

### Description

Reverts failing specs to using doubles. Doubles run much faster for these specs than hitting the database, but if there is a reason why we want these specs to run with real AR models, the other solution would be to remove the hard-coded ids from the calls to the factories.

See: https://app.codeship.com/projects/106957/builds/26122135?pipeline=db3badd7-664d-4ab2-9fed-2a90c324381b as an example of how these specs fail due to hard-coded ids.
