### PR TITLE
Challenge grade modified

### DIFF
--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -40,7 +40,7 @@ class Challenges::ChallengeGradesController < ApplicationController
 
       challenge_grade_ids = []
       @challenge.challenge_grades.each do |challenge_grade|
-        if challenge_grade.previous_changes[:score].present?
+        if challenge_grade.previous_changes[:raw_points].present?
           challenge_grade_ids << challenge_grade.id
         end
       end

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -92,9 +92,11 @@ module GradeStatus
   # temporary method for challenge grades, same as above
   def update_challenge_status_fields
     if self.status == "In Progress"
+      self.instructor_modified = true
       self.complete = false
       self.student_visible = false
     elsif self.status == "Graded"
+      self.instructor_modified = true
       if challenge.release_necessary
         self.complete = true
         self.student_visible = false
@@ -103,6 +105,7 @@ module GradeStatus
         self.student_visible = true
       end
     elsif self.status == "Released"
+      self.instructor_modified = true
       self.complete = true
       self.student_visible = true
     end

--- a/db/migrate/20170619190644_add_modified_to_criterion_grades.rb
+++ b/db/migrate/20170619190644_add_modified_to_criterion_grades.rb
@@ -1,0 +1,5 @@
+class AddModifiedToCriterionGrades < ActiveRecord::Migration[5.0]
+  def change
+    add_column :challenge_grades, :instructor_modified, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615150351) do
+ActiveRecord::Schema.define(version: 20170619190644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 20170615150351) do
     t.text     "adjustment_points_feedback"
     t.boolean  "complete",                   default: false, null: false
     t.boolean  "student_visible",            default: false, null: false
+    t.boolean  "instructor_modified",        default: false, null: false
   end
 
   create_table "challenge_score_levels", force: :cascade do |t|

--- a/lib/tasks/challenge_grades.rake
+++ b/lib/tasks/challenge_grades.rake
@@ -2,13 +2,16 @@ namespace :challenge_grades do
   desc "Update complete and student_visible fields on existing grades"
   task update_status_fields: :environment do
     ChallengeGrade.find_each(batch_size: 500) do |grade|
+      instructor_modified = false
       complete = false
       student_visible = false
 
       if grade.status == "In Progress"
+        instructor_modified = true
         complete = false
         student_visible = false
       elsif grade.status == "Graded"
+        instructor_modified = true
         if grade.challenge.release_necessary
           complete = true
           student_visible = false
@@ -17,9 +20,11 @@ namespace :challenge_grades do
           student_visible = true
         end
       elsif grade.status == "Released"
+        instructor_modified = true
         complete = true
         student_visible = true
       end
+      grade.update_attribute(:instructor_modified, instructor_modified) if instructor_modified
       grade.update_attribute(:complete, complete) if complete
       grade.update_attribute(:student_visible, student_visible) if student_visible
       puts "#{grade.id}: status: #{grade.status}, complete: #{grade.complete}, student_visible: #{grade.student_visible}"


### PR DESCRIPTION
### Status
**READY**

### Description
Adds the `Instructor_modified` field to the `ChallengeGrade` model, and maintains it through the temporary before save callback, as well as updating it on existing grades through the rake task.


### Related PRs

#3376 - which added the status fields to challenge grades and introduced the rake task.

### Migrations

YES