### PR TITLE
3398 refine gse ordering

### DIFF
--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -48,5 +48,10 @@
         DebounceQueue.addEvent(
           'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 3000
         )
+
+      # If lowest_points changes, reorder the elements accordingly
+      scope.$watch('lowest_points', (newValue, oldValue) ->
+        GradeSchemeElementsService.sortElementsByPoints() if newValue != oldValue
+      )
   }
 ]

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/element.coffee
@@ -46,7 +46,7 @@
         return if gseForm.gradeSchemeElementsForm.$invalid
 
         DebounceQueue.addEvent(
-          'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 3000
+          'gradeSchemeElement', 'saveChanges', _save, [scope, isRemoval], 4000
         )
 
       # If lowest_points changes, reorder the elements accordingly

--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -6,7 +6,7 @@
     vm = this
 
     vm.loading = true
-    vm.gradeSchemeElements = null
+    vm.gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
 
     # Add first element
     vm.addElement = () ->
@@ -25,7 +25,6 @@
 
     GradeSchemeElementsService.getGradeSchemeElements().then(() ->
       vm.loading = false
-      vm.gradeSchemeElements = GradeSchemeElementsService.gradeSchemeElements
     )
   ]
 

--- a/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
+++ b/app/assets/javascripts/angular/services/GradeSchemeElementsService.coffee
@@ -1,141 +1,147 @@
 # Shared logic for creating, editing, and otherwise interacting with GradeSchemeElements
-@gradecraft.factory 'GradeSchemeElementsService', ['$http', 'GradeCraftAPI', ($http, GradeCraftAPI) ->
+@gradecraft.factory 'GradeSchemeElementsService', ['$http', 'GradeCraftAPI', 'orderByFilter',
+  ($http, GradeCraftAPI, orderBy) ->
 
-  _deletedElementIds = []
-  gradeSchemeElements = []
-  _totalPoints = 0
+    _deletedElementIds = []
+    gradeSchemeElements = []
+    _totalPoints = 0
 
-  totalPoints = () ->
-    _totalPoints
+    totalPoints = () ->
+      _totalPoints
 
-  # Iterate all elements to ensure that there are no direct point conflicts
-  validateElements = () ->
-    has_zero_threshold = false
-    for element, i in gradeSchemeElements
-      _validateElement(element)
-      has_zero_threshold = true if element.lowest_points == 0
-    addZeroThreshold() if not has_zero_threshold
-
-  # Remove the current element from the collection and add to deleted_ids array
-  removeElement = (currentElement) ->
-    if currentElement.lowest_points == 0 && _isOnlyZeroThreshold(currentElement)
-      currentElement.validationError = "Lowest level threshold must be 0"
-    else
-      _deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
-
-  # Add a new element after the selected element, if one was given
-  addElement = (currentElement, attributes=null) ->
-    if currentElement?
+    # Iterate all elements to ensure that there are no direct point conflicts
+    validateElements = () ->
+      has_zero_threshold = false
       for element, i in gradeSchemeElements
-        if element == currentElement
-          gradeSchemeElements.splice(i + 1, 0, _newElement())
-          return
-    else
-      gradeSchemeElements.push(_newElement(attributes))
+        _validateElement(element)
+        has_zero_threshold = true if element.lowest_points == 0
+      addZeroThreshold() if not has_zero_threshold
 
-  # Add new element to represent zero threshold
-  addZeroThreshold = () ->
-    zeroElement = _newElement()
-    zeroElement.level = "Not yet on the board"
-    zeroElement.lowest_points = 0
-    gradeSchemeElements.push(zeroElement)
+    # Remove the current element from the collection and add to deleted_ids array
+    removeElement = (currentElement) ->
+      if currentElement.lowest_points == 0 && _isOnlyZeroThreshold(currentElement)
+        currentElement.validationError = "Lowest level threshold must be 0"
+      else
+        _deletedElementIds.push(gradeSchemeElements.splice(gradeSchemeElements.indexOf(currentElement), 1)[0].id)
 
-  # GET grade scheme elements for the current course
-  # Returns a promise
-  getGradeSchemeElements = () ->
-    $http.get("/api/grade_scheme_elements").then((response) ->
-      GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
-      _totalPoints = response.data.meta.total_points
-      GradeCraftAPI.logResponse(response)
-    )
+    # Add a new element after the selected element, if one was given
+    addElement = (currentElement, attributes=null) ->
+      if currentElement?
+        for element, i in gradeSchemeElements
+          if element == currentElement
+            gradeSchemeElements.splice(i + 1, 0, _newElement())
+            return
+      else
+        gradeSchemeElements.push(_newElement(attributes))
 
-  # POST grade scheme element updates
-  # Optionally redirects to a specified url
-  postGradeSchemeElements = (redirectUrl=null, validate=true, showAlert=false) ->
-    return if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
+    # Add new element to represent zero threshold
+    addZeroThreshold = () ->
+      zeroElement = _newElement()
+      zeroElement.level = "Not yet on the board"
+      zeroElement.lowest_points = 0
+      gradeSchemeElements.push(zeroElement)
 
-    data = {
-      grade_scheme_elements_attributes: gradeSchemeElements
-      deleted_ids: _deletedElementIds
-    }
-    $http.put('/api/grade_scheme_elements', data).then(
-      (response) ->
-        _clearArray(gradeSchemeElements)
+    # Sorts the grade scheme elements by their point threshold
+    sortElementsByPoints = () ->
+      gradeSchemeElements = orderBy(gradeSchemeElements, 'lowest_points', true)
+
+    # GET grade scheme elements for the current course
+    # Returns a promise
+    getGradeSchemeElements = () ->
+      $http.get("/api/grade_scheme_elements").then((response) ->
         GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
+        _totalPoints = response.data.meta.total_points
         GradeCraftAPI.logResponse(response)
-        window.location.href = redirectUrl if redirectUrl?
-        alert('Changes were successfully saved') if showAlert is true
-      , (error) ->
-        alert('An error occurred while saving changes')
-        GradeCraftAPI.logResponse(error)
-    )
+      )
 
-  deleteGradeSchemeElements = (redirectUrl=null) ->
-    $http.delete('/api/grade_scheme_elements/destroy_all').then(
-      (response) ->
-        GradeCraftAPI.logResponse(response)
-        window.location.href = redirectUrl if redirectUrl?
-      , (error) ->
-        alert('Failed to delete grade scheme elements')
-        GradeCraftAPI.logResponse(error)
-    )
+    # POST grade scheme element updates
+    # Optionally redirects to a specified url
+    postGradeSchemeElements = (redirectUrl=null, validate=true, showAlert=false) ->
+      return if gradeSchemeElements.length < 1 || (validate && !_hasValidPointThresholds())
 
-  # Private
+      data = {
+        grade_scheme_elements_attributes: gradeSchemeElements
+        deleted_ids: _deletedElementIds
+      }
+      $http.put('/api/grade_scheme_elements', data).then(
+        (response) ->
+          _clearArray(gradeSchemeElements)
+          GradeCraftAPI.loadMany(gradeSchemeElements, response.data)
+          GradeCraftAPI.logResponse(response)
+          window.location.href = redirectUrl if redirectUrl?
+          alert('Changes were successfully saved') if showAlert is true
+        , (error) ->
+          alert('An error occurred while saving changes')
+          GradeCraftAPI.logResponse(error)
+      )
 
-  # Ensure that there are no blank point thresholds
-  _hasValidPointThresholds = () ->
-    isValid = true
-    for element in gradeSchemeElements
-      if isNaN(element.lowest_points) || !element.lowest_points?
-        element.validationError = "Point threshold cannot be blank"
-        isValid = false
-    isValid
+    deleteGradeSchemeElements = (redirectUrl=null) ->
+      $http.delete('/api/grade_scheme_elements/destroy_all').then(
+        (response) ->
+          GradeCraftAPI.logResponse(response)
+          window.location.href = redirectUrl if redirectUrl?
+        , (error) ->
+          alert('Failed to delete grade scheme elements')
+          GradeCraftAPI.logResponse(error)
+      )
 
-  # Ensures that the current element does not have a point conflict with another
-  _validateElement = (currentElement) ->
-    currentElement.validationError = undefined
+    # Private
 
-    if !currentElement.lowest_points?
-      currentElement.validationError = "Point threshold does not have a value"
+    # Ensure that there are no blank point thresholds
+    _hasValidPointThresholds = () ->
+      isValid = true
+      for element in gradeSchemeElements
+        if isNaN(element.lowest_points) || !element.lowest_points?
+          element.validationError = "Point threshold cannot be blank"
+          isValid = false
+      isValid
 
-    for element in gradeSchemeElements
-      continue if element == currentElement || !element.lowest_points? || isNaN(element.lowest_points)
+    # Ensures that the current element does not have a point conflict with another
+    _validateElement = (currentElement) ->
+      currentElement.validationError = undefined
 
-      # Invalid because it is in direct conflict with another level
-      if element.lowest_points == currentElement.lowest_points
-        currentElement.validationError = "This level has the same point threshold as another level"
+      if !currentElement.lowest_points?
+        currentElement.validationError = "Point threshold does not have a value"
 
-  # Checks if there are more than one zero threshold elements
-  _isOnlyZeroThreshold = (currentElement) ->
-    result = _.find(gradeSchemeElements, (element) ->
-      currentElement != element && element.lowest_points == 0
-    )?
-    !result
+      for element in gradeSchemeElements
+        continue if element == currentElement || !element.lowest_points? || isNaN(element.lowest_points)
 
-  # New empty grade scheme element object
-  _newElement = (attributes=null) ->
-    element = angular.copy({
-      letter: null
-      level: null
-      lowest_points: null
-    })
-    angular.forEach(attributes, (value, key) ->
-      element[key] = value
-    ) if attributes?
-    element
+        # Invalid because it is in direct conflict with another level
+        if element.lowest_points == currentElement.lowest_points
+          currentElement.validationError = "This level has the same point threshold as another level"
 
-  _clearArray = (array) ->
-    array.length = 0
+    # Checks if there are more than one zero threshold elements
+    _isOnlyZeroThreshold = (currentElement) ->
+      result = _.find(gradeSchemeElements, (element) ->
+        currentElement != element && element.lowest_points == 0
+      )?
+      !result
 
-  {
-    gradeSchemeElements: gradeSchemeElements
-    removeElement: removeElement
-    addElement: addElement
-    addZeroThreshold: addZeroThreshold
-    validateElements: validateElements
-    getGradeSchemeElements: getGradeSchemeElements
-    postGradeSchemeElements: postGradeSchemeElements
-    deleteGradeSchemeElements: deleteGradeSchemeElements
-    totalPoints: totalPoints
-  }
+    # New empty grade scheme element object
+    _newElement = (attributes=null) ->
+      element = angular.copy({
+        letter: null
+        level: null
+        lowest_points: null
+      })
+      angular.forEach(attributes, (value, key) ->
+        element[key] = value
+      ) if attributes?
+      element
+
+    _clearArray = (array) ->
+      array.length = 0
+
+    {
+      gradeSchemeElements: gradeSchemeElements
+      removeElement: removeElement
+      addElement: addElement
+      addZeroThreshold: addZeroThreshold
+      validateElements: validateElements
+      sortElementsByPoints: sortElementsByPoints
+      getGradeSchemeElements: getGradeSchemeElements
+      postGradeSchemeElements: postGradeSchemeElements
+      deleteGradeSchemeElements: deleteGradeSchemeElements
+      totalPoints: totalPoints
+    }
 ]

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -1,7 +1,7 @@
 %loading-message{'loading'=>'vm.loading', 'message'=>"Loading Grade Scheme Elements..."}
 
 .grade-scheme-elements{'ng-if'=>'!vm.loading'}
-  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements | orderBy: ["!-lowest_points", "-lowest_points"]',
+  %grade-scheme-element{'ng-repeat'=>'element in vm.gradeSchemeElements',
                         'ng-attr-index'=>'element.order = $index',
                         'grade_scheme_element'=>'element'}
 


### PR DESCRIPTION
### Status
READY

### Description
Per Evan's experience, the grade scheme elements reordering dynamically on change is a bit jarring. The elements now reorder once they have been saved. Save still occurs after a 3 second delay on change.

### Steps to Test or Reproduce
Change the point threshold on a grade scheme element and ensure that the ordering only happens after save.

======================
Closes #3398
