### PR TITLE
Grade scheme element bugs

### DIFF
--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -26,14 +26,14 @@ class GradeSchemeElement < ActiveRecord::Base
   def self.next_highest_element_for(element, with_lowest_points_only=true)
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
     ordered_course_elements = ordered_course_elements.with_lowest_points if with_lowest_points_only
-    ordered_course_elements[ordered_course_elements.to_a.find_index(element) + 1]
+    ordered_course_elements[ordered_course_elements.find_index(element) + 1] unless ordered_course_elements.empty?
   end
 
   # By default, return only valid elements with lowest_points not equal to nil
   def self.next_lowest_element_for(element, with_lowest_points_only=true)
     ordered_course_elements = GradeSchemeElement.for_course(element.course).order_by_points_asc
     ordered_course_elements = ordered_course_elements.with_lowest_points if with_lowest_points_only
-    current_index = ordered_course_elements.to_a.find_index(element)
+    current_index = ordered_course_elements.find_index(element)
     return nil if current_index == 0
     ordered_course_elements[current_index - 1]
   end

--- a/app/views/grade_scheme_elements/edit.html.haml
+++ b/app/views/grade_scheme_elements/edit.html.haml
@@ -2,9 +2,10 @@
   = render partial: "layouts/alerts"
 
   %h4.bold= @grade_scheme_element.name
-  .point-range
-    %span.bold Range:
-    %span #{ points @grade_scheme_element.lowest_points } - #{ points @grade_scheme_element.highest_points }
+  - if @grade_scheme_element.lowest_points.present?
+    .point-range
+      %span.bold Range:
+      %span #{ points @grade_scheme_element.lowest_points } - #{ points @grade_scheme_element.highest_points }
 
   %hr.dotted
   = simple_form_for(@grade_scheme_element, :html => { :novalidate => true }) do |f|

--- a/app/views/info/syllabus.html.haml
+++ b/app/views/info/syllabus.html.haml
@@ -7,7 +7,7 @@
     %h3.bold Grading Philosophy
     = render partial: "courses/grading_philosophy", locals: {course: current_course}
 
-  - if current_course.grade_scheme_elements.present?
+  - if current_course.grade_scheme_elements.with_lowest_points.present?
     %h3.bold Grading Scheme
     - if current_user_is_student?
       = render partial: "grade_scheme_elements/index_student", locals: { "@grade_scheme_elements": current_course.grade_scheme_elements.order_by_points_desc }

--- a/spec/models/grade_scheme_element_spec.rb
+++ b/spec/models/grade_scheme_element_spec.rb
@@ -53,6 +53,13 @@ describe GradeSchemeElement do
     end
 
     context "when there is not a grade scheme element with a higher point threshold" do
+      it "returns nil if all elements have a nil point threshold" do
+        GradeSchemeElement.destroy_all
+        elements = create_list(:grade_scheme_element, 2, course: course, lowest_points: nil)
+        subject = elements.first
+        expect(GradeSchemeElement.next_highest_element_for(subject)).to be_nil
+      end
+
       it "returns nil" do
         expect(GradeSchemeElement.next_highest_element_for(subject)).to be_nil
       end


### PR DESCRIPTION
### Status
READY

### Description
This PR addresses two bugs in master:

1. If an instructor has just set up new grade scheme elements through the setup utility, meaning that all persisted elements for the course have a `nil` point threshold value, a student will be unable to access the syllabus page from their dashboard.

2. Similarly if an instructor has created `nil` point threshold elements through the setup utility but then leaves the page, they will be unable to edit unlock conditions.

### Migrations
NO

### Steps to Test or Reproduce
On a course with no grade scheme elements, create at least one element through the setup step but leave the point threshold empty. Attempt to view the syllabus as a student and ensure that it is possible as an instructor to edit unlock conditions.

### Impacted Areas in Application
Grade scheme elements

======================
Closes #3403
