### PR TITLE
3395 resubmit bug for groups

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -174,6 +174,16 @@ class Submission < ActiveRecord::Base
     end
   end
 
+  def term_for_edit(user_is_staff)
+    if !user_is_staff && text_comment_draft.present?
+      "Edit Draft"
+    elsif will_be_resubmitted?
+      "Resubmit"
+    else
+      "Edit Submission"
+    end
+  end
+
   private
 
   def cache_associations

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -72,8 +72,11 @@ class Submission < ActiveRecord::Base
   end
 
   def submission_grade
-    return nil if student.nil?
-    student.grades.where(assignment_id: self.assignment_id).first
+    if assignment.has_groups?
+      group.grade_for_assignment assignment
+    else
+      student.grade_for_assignment assignment
+    end
   end
 
   # Grabbing any submission that has NO instructor-defined grade

--- a/app/presenters/submissions/show_presenter.rb
+++ b/app/presenters/submissions/show_presenter.rb
@@ -53,15 +53,5 @@ module Submissions
     def submitted_at
       submission.submitted_at
     end
-
-    def term_for_edit(current_user)
-      if !current_user.is_staff?(assignment.course) && submission.text_comment_draft.present?
-        "Edit Draft"
-      elsif submission.will_be_resubmitted?
-        "Resubmit"
-      else
-        "Edit Submission"
-      end
-    end
   end
 end

--- a/app/views/submissions/components/_edit.haml
+++ b/app/views/submissions/components/_edit.haml
@@ -1,2 +1,2 @@
 - if current_user_is_admin? || current_course.active?
-  = link_to glyph(:pencil) + "#{presenter.term_for_edit(current_user)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"
+  = link_to glyph(:pencil) + "#{presenter.submission.term_for_edit(current_user_is_staff?)}", edit_assignment_submission_path(presenter.assignment, presenter.submission, group_id: presenter.group), class: "button"

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -254,7 +254,7 @@ describe SubmissionsController do
 
       context "with a group assignment" do
         let(:group_assignment) { create(:group_assignment, course: course) }
-        let(:group_submission) { create(:submission, assignment: group_assignment) }
+        let(:group_submission) { create(:group_submission, assignment: group_assignment) }
 
         it "does not send any emails" do
           params = attributes_for(:submission).merge({ assignment_id: group_assignment.id })

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -536,4 +536,41 @@ describe Submission do
       end
     end
   end
+
+  describe "#term_for_edit" do
+    let(:student) { build_stubbed :user }
+    let(:assignment) { build_stubbed :assignment, course: course }
+    let(:submission) { build_stubbed :submission, assignment: assignment, student: student }
+    let(:draft_submission) { build_stubbed :draft_submission, assignment: assignment, student: student }
+
+    context "when the current user is a student" do
+      let(:current_user_is_staff) { false }
+
+      it "returns 'Edit Draft' if the submission has a text comment draft" do
+        expect(draft_submission.term_for_edit current_user_is_staff).to eq "Edit Draft"
+      end
+
+      it "returns 'Edit Submission' if the submission has no text comment draft" do
+        expect(submission.term_for_edit current_user_is_staff).to eq "Edit Submission"
+      end
+
+      it "returns 'Resubmit' if the submission does not have a draft and will be resubmitted" do
+        create :released_grade, course: course, submission: submission, assignment: assignment, student: student
+        expect(submission.term_for_edit current_user_is_staff).to eq "Resubmit"
+      end
+    end
+
+    context "when the current user is not a student" do
+      let(:current_user_is_staff) { true }
+
+      it "returns 'Edit Submission' if the submission is not a resubmission" do
+        expect(submission.term_for_edit current_user_is_staff).to eq "Edit Submission"
+      end
+
+      it "returns 'Resubmit' if the submission will be resubmitted" do
+        create :released_grade, course: course, submission: submission, assignment: assignment, student: student
+        expect(submission.term_for_edit current_user_is_staff).to eq "Resubmit"
+      end
+    end
+  end
 end

--- a/spec/presenters/submissions/show_presenter_spec.rb
+++ b/spec/presenters/submissions/show_presenter_spec.rb
@@ -170,7 +170,6 @@ describe Submissions::ShowPresenter do
   end
 
   describe "#present_submission_files" do
-    # @present_submission_files ||= submission.submission_files.present
     let(:result) { subject.present_submission_files }
 
     context "presenter has a submission" do
@@ -210,7 +209,6 @@ describe Submissions::ShowPresenter do
   end
 
   describe "#missing_submission_files" do
-    # @missing_submission_files ||= submission.submission_files.missing
     let(:result) { subject.missing_submission_files }
 
     context "presenter has a submission" do
@@ -245,34 +243,6 @@ describe Submissions::ShowPresenter do
 
       it "returns an empty array" do
         expect(result).to eq []
-      end
-    end
-  end
-
-  describe "#term_for_edit" do
-    let(:user) { double(:user) }
-
-    before(:each) { allow(subject).to receive(:submission).and_return submission }
-
-    context "when the current user is a student" do
-      before(:each) { allow(user).to receive(:is_staff?).with(course).and_return false }
-
-      it "returns 'Edit Draft' if the submission has a text comment draft" do
-        allow(submission).to receive(:text_comment_draft).and_return "Dear professor,"
-        expect(subject.term_for_edit(user)).to eq "Edit Draft"
-      end
-
-      it "returns 'Edit Submission' if the submission has no text comment draft" do
-        allow(submission).to receive(:text_comment_draft).and_return nil
-        expect(subject.term_for_edit(user)).to eq "Edit Submission"
-      end
-    end
-
-    context "when the current user is not a student" do
-      before(:each) { allow(user).to receive(:is_staff?).with(course).and_return true }
-
-      it "returns 'Edit Submission'" do
-        expect(subject.term_for_edit(user)).to eq "Edit Submission"
       end
     end
   end


### PR DESCRIPTION
### Status
READY

### Description
This bug addresses an issue where the submission buttons were not displaying the correct text due to the fact that they were relying on a method which did not account for group submissions.

### Migrations
NO

### Steps to Test or Reproduce
As staff, if you attempt to edit a submission and the submission will be resubmitted, then the caption on the edit submission button should read "Resubmit" instead of "Edit Submission".

As a student, if you are editing a submission that has draft content, the edit submission caption should be "Edit Draft". Otherwise, it will read either "Resubmit" or "Edit Submission" according to the correct condition.

### Impacted Areas in Application
Submissions

======================
Closes #3395
