### PR TITLE
3355 highlight assignment type caps

### DIFF
--- a/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
@@ -21,6 +21,9 @@
       else
         "width: #{(assignmentType.total_points / vm.totalPoints * 100) }%"
 
+    vm.pointsCapped = (assignmentType) ->
+      assignmentType.is_capped?
+
     vm.pointsGraphPercentOfTotal = (gradeSchemeElement)->
       (gradeSchemeElement.lowest_points / vm.totalPoints * 100) + "%"
 

--- a/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
@@ -22,7 +22,7 @@
         "width: #{(assignmentType.total_points / vm.totalPoints * 100) }%"
 
     vm.pointsCapped = (assignmentType) ->
-      assignmentType.is_capped?
+      assignmentType.is_capped
 
     vm.pointsGraphPercentOfTotal = (gradeSchemeElement)->
       (gradeSchemeElement.lowest_points / vm.totalPoints * 100) + "%"

--- a/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/settings_table.coffee
@@ -17,12 +17,15 @@
 
     vm.pointsGraphStyle = (assignmentType)->
       if vm.pointsOver(assignmentType)
-        "width: 100%; background-color: #D1495B"
+        "width: 100%; background: #D1495B"
       else
         "width: #{(assignmentType.total_points / vm.totalPoints * 100) }%"
 
-    vm.pointsCapped = (assignmentType) ->
-      assignmentType.is_capped
+    vm.pointsGraphStyleCapped = (assignmentType)->
+      "width: #{(assignmentType.summed_assignment_points / vm.totalPoints * 100) }%; background: repeating-linear-gradient(-45deg, transparent, transparent 4px, #2E70BE 4px, #2E70BE 10px);"
+
+    vm.pointsBeingCapped = (assignmentType) ->
+      assignmentType.is_capped && (assignmentType.max_points < assignmentType.summed_assignment_points)
 
     vm.pointsGraphPercentOfTotal = (gradeSchemeElement)->
       (gradeSchemeElement.lowest_points / vm.totalPoints * 100) + "%"

--- a/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
@@ -11,11 +11,11 @@
 
           .points-bar-graph.assignment-settings
             .points-bar-graph-fill.assignment-settings(style="{{vm.pointsGraphStyle(assignmentType)}}")
-            %span.hint(ng-if="pointsOver()") Total for this assignment type exceeds threshold for highest level
+            %span.hint(ng-if="vm.pointsOver(assignmentType)") Total for this assignment type exceeds threshold for highest level
             .grade-level-marker(ng-repeat="gse in vm.GradeSchemeElements" style="width: {{vm.pointsGraphPercentOfTotal(gse)}}")
           .assignment-type-points.assignment-settings 
             %span {{ assignmentType.total_points | number }}
-            %span(ng-if="pointsCapped(assignmentType)") max
+            %span.max-point-label(ng-if="vm.pointsCapped(assignmentType)") max
             %span / {{ vm.totalPoints | number }}
     .assignment-type-container.collapsable{role: "tabpanel"}
       %table(ng-if="!vm.loading")

--- a/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
@@ -13,7 +13,10 @@
             .points-bar-graph-fill.assignment-settings(style="{{vm.pointsGraphStyle(assignmentType)}}")
             %span.hint(ng-if="pointsOver()") Total for this assignment type exceeds threshold for highest level
             .grade-level-marker(ng-repeat="gse in vm.GradeSchemeElements" style="width: {{vm.pointsGraphPercentOfTotal(gse)}}")
-          .assignment-type-points.assignment-settings {{ assignmentType.total_points | number }} / {{ vm.totalPoints | number }}
+          .assignment-type-points.assignment-settings 
+            %span {{ assignmentType.total_points | number }}
+            %span(ng-if="pointsCapped(assignmentType)") max
+            %span / {{ vm.totalPoints | number }}
     .assignment-type-container.collapsable{role: "tabpanel"}
       %table(ng-if="!vm.loading")
         %caption.sr-only {{vm.termFor("assignments")}} for {{assignmentType.name}}

--- a/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/settings_table.html.haml
@@ -11,11 +11,14 @@
 
           .points-bar-graph.assignment-settings
             .points-bar-graph-fill.assignment-settings(style="{{vm.pointsGraphStyle(assignmentType)}}")
+            .points-bar-graph-fill.assignment-settings(ng-if="vm.pointsBeingCapped(assignmentType)" style="{{vm.pointsGraphStyleCapped(assignmentType)}}")
             %span.hint(ng-if="vm.pointsOver(assignmentType)") Total for this assignment type exceeds threshold for highest level
             .grade-level-marker(ng-repeat="gse in vm.GradeSchemeElements" style="width: {{vm.pointsGraphPercentOfTotal(gse)}}")
-          .assignment-type-points.assignment-settings 
-            %span {{ assignmentType.total_points | number }}
-            %span.max-point-label(ng-if="vm.pointsCapped(assignmentType)") max
+          .assignment-type-points.assignment-settings
+            %span(ng-if="!vm.pointsBeingCapped(assignmentType)") {{ assignmentType.total_points | number }}
+            %span(ng-if="vm.pointsBeingCapped(assignmentType)") 
+              {{ assignmentType.summed_assignment_points | number }}
+            %span.max-point-label(ng-if="vm.pointsBeingCapped(assignmentType)") (max {{assignmentType.max_points | number}})
             %span / {{ vm.totalPoints | number }}
     .assignment-type-container.collapsable{role: "tabpanel"}
       %table(ng-if="!vm.loading")

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -288,9 +288,10 @@
       right: -8px
     .hover-style
       width: auto
-      top: -40px
-      left: 50%
-      transform: translateX(-50%)
+      &:last-child
+        left: -60%
+        &::after
+          left: 80%
 
 span.hint
   position: absolute
@@ -302,11 +303,7 @@ span.hint
     display: none
 
 .max-point-label
-  background: $color-red-1
-  color: $color-white
-  padding: 0 0.2rem
-  border-radius: 2px
-  font-size: 0.7rem
+  font-style: italic
 
 .assignment-settings--date-inputs
   &.invalid

--- a/app/assets/stylesheets/pages/_assignments.sass
+++ b/app/assets/stylesheets/pages/_assignments.sass
@@ -139,7 +139,6 @@
     border-bottom: 1px solid $color-grey-6
   &.open
     border-bottom: 3px solid $color-blue-2
-
   a
     padding: 0.75rem
     display: block
@@ -148,6 +147,8 @@
     &:hover
       text-decoration: none
       color: $color-blue-2
+  &.assignment-settings a
+    padding: 1rem
 
   .assignment-type-name
     @include truncate-text(40%)
@@ -299,6 +300,13 @@ span.hint
   width: 400px
   @media (max-width: $media-medium-max)
     display: none
+
+.max-point-label
+  background: $color-red-1
+  color: $color-white
+  padding: 0 0.2rem
+  border-radius: 2px
+  font-size: 0.7rem
 
 .assignment-settings--date-inputs
   &.invalid

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -17,7 +17,7 @@ module AssignmentsHelper
     if current_course.grade_scheme_elements.empty?
       current_course.total_points
     else
-      (current_course.grade_scheme_elements.order_by_points_desc[0].lowest_points * 110) / 100
+      (current_course.grade_scheme_elements.order_by_points_desc[0].lowest_points)
     end
   end
 

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -12,7 +12,7 @@ module AssignmentsHelper
     criterion.levels.ordered.sorted.to_a.index{|level| level.earned_for?(student_id)}
   end
 
-  # Ten percent higher than threshold for highest level
+  # Threshold for highest level
   def total_available_points
     if current_course.grade_scheme_elements.empty?
       current_course.total_points

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -53,7 +53,7 @@ class AssignmentType < ActiveRecord::Base
   end
 
 
-  # Getting the assignment types max value if it's present and less than summed total, else
+  # Getting the assignment types max value if it's present and less than summed total, else 
   # returning the summed total of assignment points
   def total_points_for_settings
     if is_capped?

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -52,8 +52,7 @@ class AssignmentType < ActiveRecord::Base
     end
   end
 
-
-  # Getting the assignment types max value if it's present and less than summed total, else 
+  # Getting the assignment types max value if it's present and less than summed total, else
   # returning the summed total of assignment points
   def total_points_for_settings
     if is_capped?

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -52,6 +52,17 @@ class AssignmentType < ActiveRecord::Base
     end
   end
 
+
+  # Getting the assignment types max value if it's present and less than summed total, else
+  # returning the summed total of assignment points
+  def total_points_for_settings
+    if is_capped?
+      max_points > summed_assignment_points ? summed_assignment_points : max_points
+    else
+      summed_assignment_points
+    end
+  end
+
   # Calculating the total number of assignment points in the type
   def summed_assignment_points
     assignments.map{ |a| a.full_points || 0 }.sum

--- a/app/views/api/assignment_types/index.json.jbuilder
+++ b/app/views/api/assignment_types/index.json.jbuilder
@@ -3,8 +3,10 @@ json.data @assignment_types do |assignment_type|
   json.id assignment_type.id.to_s
   json.attributes do
     json.merge! assignment_type.attributes
-    json.total_points assignment_type.total_points
+    json.total_points assignment_type.total_points_for_settings
     json.is_capped assignment_type.is_capped?
+    json.max_points assignment_type.max_points
+    json.summed_assignment_points assignment_type.summed_assignment_points
 
     if @student.present?
       json.final_points_for_student assignment_type.final_points_for_student(@student)

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -35,9 +35,9 @@ describe AssignmentsHelper do
     end
 
     describe "#total_available_points" do
-       it "returns 10% higher than total number if grading scheme exists" do
+       it "returns total number if grading scheme exists" do
          total_available_points = helper.total_available_points
-         expect(total_available_points).to eq(2201)
+         expect(total_available_points).to eq(2001)
        end
      end
 

--- a/spec/helpers/assignments_helper_spec.rb
+++ b/spec/helpers/assignments_helper_spec.rb
@@ -44,7 +44,7 @@ describe AssignmentsHelper do
     describe "#percent_of_total_points" do
       it "returns grade scheme element's ratio of total points" do
        percent_of_total_points = helper.percent_of_total_points(level_index)
-       expect(percent_of_total_points).to eq(45.48)
+       expect(percent_of_total_points).to eq(50.02)
       end
     end
 

--- a/spec/views/api/assignment_types/index_spec.rb
+++ b/spec/views/api/assignment_types/index_spec.rb
@@ -26,7 +26,7 @@ describe "api/assignment_types/index" do
   end
 
   it "includes the assignment_type total points" do
-    expect(@json["data"].first["attributes"]["total_points"]).to eq(1234)
+    expect(@json["data"].first["attributes"]["total_points"]).to eq(0)
   end
 
   it "includes the assignment_type final points summed for student" do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR highlights assignment type caps in the assignment settings page and fixes a conditional hint for showing when point total for an assignment type exceeds the max threshold for the highest grade in the course. It also updates the total points calc to remove the arbitrary 10% added to the highest level point threshold to relieve confusion.

<img width="1266" alt="screen shot 2017-06-26 at 3 20 32 pm" src="https://user-images.githubusercontent.com/12573921/27556332-2822a026-5a83-11e7-94dc-d41ec43317b9.png">

### Migrations
NO

### To-do
- [x] add striped bar for points exceeding assignment type caps
- [x] update total number on top graph to show bottom threshold for highest grade rather than arbitrary 10% extra
- [x] update method for `total_points` (specifically `is_capped` portion of logic) in order to show assignment type sums if they are less than the assignment type cap
- [x] update specs
- [x] fix extra space for rubocop

### Impacted Areas in Application
List general components of the application that this PR will affect:

* assignment settings page

======================
Closes #3355 
