### PR TITLE
3408-forgot-pasword-button

### DIFF
--- a/app/views/user_sessions/instructors.haml
+++ b/app/views/user_sessions/instructors.haml
@@ -23,10 +23,11 @@
           = render partial: "user_sessions/form"
           %button.button-link.small#forgot-password Forgot your password?
 
-        .password-forgot-form{"aria-hidden": "true"}
-          %h1 Forgot Your Password?
-          %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
-          = render partial: "passwords/reset_form"
+      .password-forgot-form{"aria-hidden": "true"}
+        %h1 Forgot Your Password?
+        %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
+        = render partial: "passwords/reset_form"
+        %button.button-link.small#show-login-form Back to log in
 
       .login-form
         .login-block

--- a/app/views/user_sessions/new.html.haml
+++ b/app/views/user_sessions/new.html.haml
@@ -14,10 +14,10 @@
         = render partial: "user_sessions/form"
         %button.button-link.small#forgot-password Forgot your password?
 
-    .password-forgot-form{"aria-hidden": "true"}
-      %h1 Forgot Your Password?
-      %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
-      = render partial: "passwords/reset_form"
+  .password-forgot-form{"aria-hidden": "true"}
+    %h1 Forgot Your Password?
+    %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
+    = render partial: "passwords/reset_form"
 
-      %p.small * This will not work if you use a @umich email address to log in. You must reset your password through the UM system.
-      %button.button-link.small#show-login-form Back to log in
+    %p.small * This will not work if you use a @umich email address to log in. You must reset your password through the UM system.
+    %button.button-link.small#show-login-form Back to log in

--- a/app/views/user_sessions/students.haml
+++ b/app/views/user_sessions/students.haml
@@ -25,7 +25,8 @@
           = render partial: "user_sessions/form"
           %button.button-link.small#forgot-password Forgot your password?
 
-        .password-forgot-form{"aria-hidden": "true"}
-          %h1 Forgot Your Password?
-          %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
-          = render partial: "passwords/reset_form"
+      .password-forgot-form{"aria-hidden": "true"}
+        %h1 Forgot Your Password?
+        %p Enter the email address associated with your account, and you'll receive a link via email that will allow you to create a new password.*
+        = render partial: "passwords/reset_form"
+        %button.button-link.small#show-login-form Back to log in


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updates the haml for the login pages so that the password form was not inside the login form that was being hidden when clicking forgot password button.

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* public login pages

======================
Closes #3408 
