### PR TITLE
include points breakdown for faculty student view

### DIFF
--- a/app/assets/javascripts/angular/directives/analytics/points_breakdown.coffee
+++ b/app/assets/javascripts/angular/directives/analytics/points_breakdown.coffee
@@ -3,9 +3,8 @@
 
 @gradecraft.directive 'pointsBreakdownAnalytics', ['$q', '$window', 'AnalyticsService', 'DebounceQueue', ($q, $window, AnalyticsService, DebounceQueue) ->
     pointsBreakdownCtrl = [()->
-      vm = this
-
-      services(vm.assignmentId, vm.studentId).then(()->
+      vmPtsBreakdown = this
+      services(vmPtsBreakdown.studentId).then(()->
         plotGraph(AnalyticsService.studentData)
       )
 
@@ -15,9 +14,9 @@
         )
     ]
 
-    services = (assignmentId, studentId)->
+    services = (studentId)->
       promises = [
-        AnalyticsService.getStudentAnalytics(assignmentId, studentId)
+        AnalyticsService.getStudentAnalytics(studentId)
       ]
       return $q.all(promises)
 
@@ -108,8 +107,10 @@
     {
       bindToController: true,
       controller: pointsBreakdownCtrl,
-      controllerAs: 'vm',
-      scope: {}
+      controllerAs: 'vmPtsBreakdown',
+      scope: {
+        studentId: "="
+      }
       templateUrl: 'analytics/points_breakdown.html'
     }
 ]

--- a/app/assets/javascripts/angular/services/AnalyticsService.coffee
+++ b/app/assets/javascripts/angular/services/AnalyticsService.coffee
@@ -25,8 +25,13 @@
         GradeCraftAPI.logResponse(response)
     )
 
-  getStudentAnalytics = ()->
-    $http.get("/api/students/analytics").then(
+  getStudentAnalytics = (studentId)->
+    if studentId
+      url = "/api/students/#{studentId}/analytics"
+    else
+      url = "/api/students/analytics"
+
+    $http.get(url).then(
       (response) ->
         angular.copy(response.data, studentData)
         GradeCraftAPI.logResponse(response.data)

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -29,7 +29,7 @@ class API::StudentsController < ApplicationController
   def analytics_params(student)
     @student = student
     @assignment_types = current_course.assignment_types
-    @earned_badge_points = @student.earned_badges.where(course: current_course).sum(&:points)
+    @earned_badge_points = @student.earned_badge_score_for_course current_course
     @course_potential_points_for_student = current_course.total_points + @earned_badge_points
   end
 end

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -14,9 +14,22 @@ class API::StudentsController < ApplicationController
   # accessed on the student dashboard
   # GET api/students/analytics
   def analytics
-    @student = current_user
+    analytics_params current_user
+  end
+
+  # accessed by faculty on the student show page
+  # GET api/students/:id/analytics
+  def student_analytics
+    analytics_params User.find(params[:id])
+    render "api/students/analytics"
+  end
+
+  private
+
+  def analytics_params(student)
+    @student = student
     @assignment_types = current_course.assignment_types
-    @earned_badge_points = @student.earned_badges.sum(&:points)
+    @earned_badge_points = @student.earned_badges.where(course: current_course).sum(&:points)
     @course_potential_points_for_student = current_course.total_points + @earned_badge_points
   end
 end

--- a/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
@@ -2,7 +2,10 @@ You have earned
 %span.bold #{points presenter.score_for_course } points
 - cache multi_cache_key :student_dashboard_total_score, current_student, current_course do
 
-  %points-breakdown-analytics
+  - if current_user_is_student?
+    %points-breakdown-analytics
+  - else
+    %points-breakdown-analytics(student-id="#{current_student.id}")
 
 - if presenter.next_element.present?
   .progress.bar_magic.center

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -454,6 +454,7 @@ Rails.application.routes.draw do
     resources :rubrics, only: [:show]
     resources :students, only: [:index]
     get "students/analytics", to: "students#analytics"
+    get "students/:id/analytics", to: "students#student_analytics"
 
     resources :students, only: [], module: :students do
       resources :badges, only: :index

--- a/spec/controllers/api/students_controller_spec.rb
+++ b/spec/controllers/api/students_controller_spec.rb
@@ -55,7 +55,8 @@ describe API::StudentsController do
 
       it "assigns information for charting course progress" do
         assignment_type = create(:assignment_type, course: course)
-        allow(student).to receive(:earned_badges).and_return double(where: double(sum: 600))
+        badge = create(:badge, full_points: 600)
+        create :earned_badge, badge: badge, course: course, student: student
         allow(course).to receive(:total_points).and_return 1000
         get :analytics, format: :json
 

--- a/spec/controllers/api/students_controller_spec.rb
+++ b/spec/controllers/api/students_controller_spec.rb
@@ -16,6 +16,19 @@ describe API::StudentsController do
         expect(response.status).to eq(200)
       end
     end
+
+    describe "GET student analytics" do
+
+      it "assigns information for charting course progress" do
+        assignment_type = create(:assignment_type, course: course)
+        allow(course).to receive(:total_points).and_return 1000
+        get :student_analytics, params: {id: student.id}, format: :json
+
+        expect(assigns(:student)).to eq(student)
+        expect(assigns(:assignment_types)).to eq([assignment_type])
+        expect(assigns(:course_potential_points_for_student)).to eq(1000)
+      end
+    end
   end
 
   context "as a student" do
@@ -31,11 +44,18 @@ describe API::StudentsController do
       end
     end
 
+    describe "GET student analytics" do
+      it "redirects" do
+        get :student_analytics, params: {id: student.id}, format: :json
+        expect(response.status).to eq(302)
+      end
+    end
+
     describe "GET analytics" do
 
       it "assigns information for charting course progress" do
         assignment_type = create(:assignment_type, course: course)
-        allow(student).to receive(:earned_badges).and_return double(sum: 600)
+        allow(student).to receive(:earned_badges).and_return double(where: double(sum: 600))
         allow(course).to receive(:total_points).and_return 1000
         get :analytics, format: :json
 


### PR DESCRIPTION
### Status
**READY**

### Description

Fixes missing points breakdown on student show page.

Also scopes the points from earned badges to the current course, to avoid badges from other classes.

======================
Closes #3416 

