### PR TITLE
3410 Make email login not case sensitive

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -20,7 +20,7 @@ class UserSessionsController < ApplicationController
   # sorcery login - users have passwords stored in our db
   def create
     respond_to do |format|
-      if @user = login(params[:user][:email], params[:user][:password])
+      if @user = login(params[:user][:email].downcase, params[:user][:password])
         record_course_login_event user: @user
         format.html { redirect_back_or_to current_user_is_observer? ? assignments_path : dashboard_path }
         format.xml { render xml: @user, status: :created, location: @user }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Remove match case restriction on login for email field.

### Related PRs
N/A


### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Attempt to login as Dumbledore with login DumbleDore@hogwarts.edu. Regardless what characters are capitalized, the user should still be allowed to login.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Login

======================
Closes #3410 
