### PR TITLE
3110 user analytics

### DIFF
--- a/app/models/concerns/analytics/user_analytics.rb
+++ b/app/models/concerns/analytics/user_analytics.rb
@@ -37,7 +37,7 @@ module Analytics
     end
 
     def earned_badge_score_for_course(course)
-       earned_badges.where(course: course).student_visible.sum(&:points)
+      earned_badges.where(course: course).student_visible.sum(&:points)
     end
 
     # returns all badges a student has earned for a particular course this week

--- a/app/models/concerns/analytics/user_analytics.rb
+++ b/app/models/concerns/analytics/user_analytics.rb
@@ -2,8 +2,6 @@ module Analytics
   module UserAnalytics
     extend ActiveSupport::Concern
 
-    ### EARNED LEVELS AND GRADE LETTERS
-
     def score_for_course(course)
       @score ||= course_memberships.where(course_id: course).first.score || 0 if
         course_memberships.where(course_id: course).first.present?
@@ -44,7 +42,7 @@ module Analytics
 
     # returns all badges a student has earned for a particular course this week
     def earned_badges_for_course_this_week(course)
-      earned_badges.student_visible.where("course = ? AND created_at > ? ", course, 7.days.ago)
+      earned_badges.student_visible.where(course: course).where("created_at > ? ", 7.days.ago)
     end
   end
 end

--- a/app/models/concerns/analytics/user_analytics.rb
+++ b/app/models/concerns/analytics/user_analytics.rb
@@ -1,0 +1,50 @@
+module Analytics
+  module UserAnalytics
+    extend ActiveSupport::Concern
+
+    ### EARNED LEVELS AND GRADE LETTERS
+
+    def score_for_course(course)
+      @score ||= course_memberships.where(course_id: course).first.score || 0 if
+        course_memberships.where(course_id: course).first.present?
+    end
+
+    def grade_for_course(course)
+      cm = course_memberships.where(course_id: course.id).first
+      return cm.grade_scheme_element if cm.grade_scheme_element.present?
+      return cm.earned_grade_scheme_element
+    end
+
+    def grade_level_for_course(course)
+      @grade_level ||= grade_for_course(course).try(:level)
+    end
+
+    def grade_letter_for_course(course)
+      @grade_letter_for_course ||= grade_for_course(course).try(:letter)
+    end
+
+    # Returning all of the grades a student has received this week
+    def grades_released_for_course_this_week(course)
+      grades = grades_for_course(course).where("graded_at > ? ", 7.days.ago)
+      viewable_grades = []
+      grades.each do |grade|
+        viewable_grades << grade if GradeProctor.new(grade).viewable? && !grade.excluded_from_course_score
+      end
+      return viewable_grades
+    end
+
+    # Returning the total number of points for all grades released this week
+    def points_earned_for_course_this_week(course)
+      grades_released_for_course_this_week(course).map(&:final_points).compact.sum
+    end
+
+    def earned_badge_score_for_course(course)
+       earned_badges.where(course: course).student_visible.sum(&:points)
+    end
+
+    # returns all badges a student has earned for a particular course this week
+    def earned_badges_for_course_this_week(course)
+      earned_badges.student_visible.where("course = ? AND created_at > ? ", course, 7.days.ago)
+    end
+  end
+end

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -128,7 +128,7 @@ class UnlockCondition < ActiveRecord::Base
   end
 
   def check_badge_condition(student)
-    badge = student.earned_badges_for_badge(condition)
+    badge = student.awarded_badges_for_badge(condition)
     return false unless badge.present?
     if condition_value? && condition_date?
       check_if_badge_earned_enough_times_by_date(student)
@@ -140,12 +140,12 @@ class UnlockCondition < ActiveRecord::Base
   end
 
   def check_if_badge_earned_enough_times(student)
-    badge_count = student.earned_badges_for_badge_count(condition_id)
+    badge_count = student.awarded_badges_for_badge_count(condition_id)
     badge_count >= condition_value
   end
 
   def check_if_badge_earned_enough_times_by_date(student)
-    badge_count = student.earned_badges_for_badge_count(condition_id)
+    badge_count = student.awarded_badges_for_badge_count(condition_id)
     badge_count >= condition_value && student.earned_badges.where(badge_id: condition_id).last.created_at < condition_date
   end
 

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -128,7 +128,7 @@ class UnlockCondition < ActiveRecord::Base
   end
 
   def check_badge_condition(student)
-    badge = student.earned_badge_for_badge(condition)
+    badge = student.earned_badges_for_badge(condition)
     return false unless badge.present?
     if condition_value? && condition_date?
       check_if_badge_earned_enough_times_by_date(student)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -287,6 +287,10 @@ class User < ActiveRecord::Base
 
   ### BADGES
 
+  def earned_badges_for_course(course)
+    earned_badges.where(course: course).student_visible
+  end
+
   # includes badges not yet visible to students
   def awarded_badges_for_badge(badge)
     earned_badges.where(badge: badge)
@@ -295,10 +299,6 @@ class User < ActiveRecord::Base
   # includes badges not yet visible to students
   def awarded_badges_for_badge_count(badge)
     earned_badges.where(badge: badge).count
-  end
-
-  def earned_badges_for_course(course)
-    earned_badges.where(course: course).student_visible
   end
 
   # Unique badges associated with all of the earned badges for a given

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  include Analytics::UserAnalytics
+
   authenticates_with_sorcery!
 
   class << self
@@ -236,31 +238,11 @@ class User < ActiveRecord::Base
     courses.where(status: false)
   end
 
-  ### SCORE
-  def score_for_course(course)
-    @score ||= course_memberships.where(course_id: course).first.score || 0 if
-      course_memberships.where(course_id: course).first.present?
-  end
+  # PREDICTIONS
 
   # Checking to see if a student has any positive predictions for a course
   def predictions_for_course?(course)
     predicted_earned_grades.for_course(course).predicted_to_be_done.present?
-  end
-
-  ### EARNED LEVELS AND GRADE LETTERS
-
-  def grade_for_course(course)
-    cm = course_memberships.where(course_id: course.id).first
-    return cm.grade_scheme_element if cm.grade_scheme_element.present?
-    return cm.earned_grade_scheme_element
-  end
-
-  def grade_level_for_course(course)
-    @grade_level ||= grade_for_course(course).try(:level)
-  end
-
-  def grade_letter_for_course(course)
-    @grade_letter_for_course ||= grade_for_course(course).try(:letter)
   end
 
   ### GRADES
@@ -273,21 +255,6 @@ class User < ActiveRecord::Base
 
   def grades_for_course(course)
     grades.where(course: course)
-  end
-
-  # Returning all of the grades a student has received this week
-  def grades_released_for_course_this_week(course)
-    grades = grades_for_course(course).where("graded_at > ? ", 7.days.ago)
-    viewable_grades = []
-    grades.each do |grade|
-      viewable_grades << grade if GradeProctor.new(grade).viewable? && !grade.excluded_from_course_score
-    end
-    return viewable_grades
-  end
-
-  # Returning the total number of points for all grades released this week
-  def points_earned_for_course_this_week(course)
-    grades_released_for_course_this_week(course).map(&:final_points).compact.sum
   end
 
   # Grabbing the grade for an assignment
@@ -324,21 +291,8 @@ class User < ActiveRecord::Base
     earned_badges.where(course: course).student_visible
   end
 
-  def earned_badge_score_for_course(course)
-    earned_badges_for_course(course).sum(&:points)
-  end
-
-  # returns all badges a student has earned for a particular course this week
-  def earned_badges_for_course_this_week(course)
-    earned_badges_for_course(course).where("created_at > ? ", 7.days.ago)
-  end
-
-  def earned_badge_for_badge(badge)
+  def earned_badges_for_badge(badge)
     earned_badges.where(badge: badge)
-  end
-
-  def earned_badges_for_badge_count(badge)
-    earned_badges.where(badge: badge).count
   end
 
   # Unique badges associated with all of the earned badges for a given
@@ -400,6 +354,8 @@ class User < ActiveRecord::Base
       .where(visible: true)
       .where("id not in (select distinct(badge_id) from earned_badges where earned_badges.student_id = ? and earned_badges.course_id = ? and earned_badges.student_visible = ?)", self[:id], course[:id], true)
   end
+
+  # WEIGHTS
 
   # Returns the student's assigned weight for an assignment type category
   def weight_for_assignment_type(assignment_type)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -287,12 +287,18 @@ class User < ActiveRecord::Base
 
   ### BADGES
 
-  def earned_badges_for_course(course)
-    earned_badges.where(course: course).student_visible
+  # includes badges not yet visible to students
+  def awarded_badges_for_badge(badge)
+    earned_badges.where(badge: badge)
   end
 
-  def earned_badges_for_badge(badge)
-    earned_badges.where(badge: badge)
+  # includes badges not yet visible to students
+  def awarded_badges_for_badge_count(badge)
+    earned_badges.where(badge: badge).count
+  end
+
+  def earned_badges_for_course(course)
+    earned_badges.where(course: course).student_visible
   end
 
   # Unique badges associated with all of the earned badges for a given

--- a/app/views/info/earned_badges.html.haml
+++ b/app/views/info/earned_badges.html.haml
@@ -1,4 +1,3 @@
--# TODO: confirm, can this be removed?
 .pageContent
   = render "layouts/alerts"
 

--- a/app/views/info/earned_badges.html.haml
+++ b/app/views/info/earned_badges.html.haml
@@ -24,7 +24,7 @@
               %td{:style => "display: none"}= points student.earned_badges_for_course(current_course).count
               - @badges.each do |badge|
                 %td
-                  -if student.earned_badge_for_badge(badge.id).count > 0
+                  -if student.earned_badges_for_badge(badge.id).count > 0
                     .img-cropper.xsmall-crop.earned-badge-table-img
                       %img{:src => badge.try(:icon), :alt => badge.try(:name), :title => badge.name}
                     %span x#{student.earned_badges_for_badge_count(badge.id)}

--- a/app/views/info/earned_badges.html.haml
+++ b/app/views/info/earned_badges.html.haml
@@ -1,3 +1,4 @@
+-# TODO: confirm, can this be removed?
 .pageContent
   = render "layouts/alerts"
 
@@ -24,10 +25,10 @@
               %td{:style => "display: none"}= points student.earned_badges_for_course(current_course).count
               - @badges.each do |badge|
                 %td
-                  -if student.earned_badges_for_badge(badge.id).count > 0
+                  -if student.awarded_badges_for_badge(badge.id).count > 0
                     .img-cropper.xsmall-crop.earned-badge-table-img
                       %img{:src => badge.try(:icon), :alt => badge.try(:name), :title => badge.name}
-                    %span x#{student.earned_badges_for_badge_count(badge.id)}
+                    %span x#{student.visible_earned_badges_for_badge_count(badge.id)}
 
               - if current_course.valuable_badges?
                 %td= points student.earned_badge_score_for_course(current_course)

--- a/doc/users.md
+++ b/doc/users.md
@@ -47,7 +47,7 @@ When a User is destroyed, all of its Course Memberships, Student Academic Histor
   * `last_name` - must be present. Used to order all student display pages except for the leaderboard and top/bottom 10
   * `display_name` - used as the public name for the user when present. Currently being phased out in favor of moving this to the course membership to allow for multiple settings per user.
   * `last_activity_at` - last datetime that the user logged in. Set by sorcery
-  * `team_role` - role that student will have in a team. Currently being phased out in favor of moving this to the course membership to allow for multiple settings per user. 
+  * `team_role` - role that student will have in a team. Currently being phased out in favor of moving this to the course membership to allow for multiple settings per user.
   * `internal` - boolean representing whether user has an internal University of Michigan email address
 
 #### Unused
@@ -111,7 +111,7 @@ In addition to the methods described below, there are methods of the form `is_<r
   * `submission_for_assignment(assignment)` - returns the student's submission for the assignment
   * `earned_badge_score_for_course(course)` - returns the amount of points the student has earned through badges in the course
   * `earned_badges_for_course(course)` - returns the student's earned badges for the course
-  * `earned_badge_for_badge(badge)` - returns all of the student's earned badges for the passed in badge. Used in the unlock condition model
+  * `earned_badges_for_badge(badge)` - returns all of the student's earned badges for the passed in badge. Used in the unlock condition model
   * `earned_badges_for_badge_count(badge)` - returns the number of badges the student has earned of the type passed in. Used in the unlock condition model
   * `unique_student_earned_badges(course)` - returns all badges combined with their earned badges in the course for the student
   * `student_visible_earned_badges(course)` - returns all of the student's badges that either have been released and are not associated with a grade, or have a grade that is visible

--- a/doc/users.md
+++ b/doc/users.md
@@ -111,8 +111,8 @@ In addition to the methods described below, there are methods of the form `is_<r
   * `submission_for_assignment(assignment)` - returns the student's submission for the assignment
   * `earned_badge_score_for_course(course)` - returns the amount of points the student has earned through badges in the course
   * `earned_badges_for_course(course)` - returns the student's earned badges for the course
-  * `earned_badges_for_badge(badge)` - returns all of the student's earned badges for the passed in badge. Used in the unlock condition model
-  * `earned_badges_for_badge_count(badge)` - returns the number of badges the student has earned of the type passed in. Used in the unlock condition model
+  * `awarded_badges_for_badge(badge)` - returns all of the student's earned badges for the passed in badge. Used in the unlock condition model
+  * `awarded_badges_for_badge_count(badge)` - returns the number of badges the student has earned of the type passed in. Used in the unlock condition model
   * `unique_student_earned_badges(course)` - returns all badges combined with their earned badges in the course for the student
   * `student_visible_earned_badges(course)` - returns all of the student's badges that either have been released and are not associated with a grade, or have a grade that is visible
   * `earnable_course_badges_for_grade(grade)` - returns badges that are in the same course as the grade, and in which one of the following conditions are met:

--- a/spec/models/concerns/analytics/user_analytics_spec.rb
+++ b/spec/models/concerns/analytics/user_analytics_spec.rb
@@ -1,0 +1,86 @@
+describe Analytics::UserAnalytics do
+  let(:course) { create(:course) }
+  let(:student) { create(:course_membership, :student, course: course, score: 100000).user }
+  let(:assignment) { create(:assignment, course: course) }
+  let(:grade) { create(:grade, assignment: assignment, student:student) }
+  let(:badge) { create(:badge, course: course, can_earn_multiple_times: true) }
+  let(:single_badge) { create(:badge, course: course, can_earn_multiple_times: false) }
+
+  describe "#score_for_course(course)" do
+    it "returns the student's score for the course" do
+      expect(student.score_for_course(course)).to eq(100000)
+    end
+
+    # There is a non-null constraint on course_membership.score, so I'm not
+    # sure what this is really testing.
+    it "returns null if the student has no course memebership" do
+      student.course_memberships.where(course_id: course).destroy_all
+      expect(student.score_for_course(course)).to be_nil
+    end
+  end
+
+  describe "#grade_for_course(course)" do
+    it "returns the grade scheme element that matches the students score for the course" do
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000)
+      expect(student.grade_for_course(course)).to eq(gse)
+    end
+  end
+
+  describe "#grade_level_for_course(course)" do
+    it "returns the grade scheme level name that matches the student's score for the course" do
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, level: "Meh")
+      expect(student.grade_level_for_course(course)).to eq("Meh")
+    end
+  end
+
+  describe "#grade_letter_for_course(course)" do
+    it "returns the grade scheme letter name that matches the student's score for the course" do
+      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
+      expect(student.grade_letter_for_course(course)).to eq("Q")
+    end
+  end
+
+  describe "#grades_released_for_course_this_week(course)" do
+    let(:assignment_2) { create :assignment, course: course }
+
+    it "returns the student's earned grades for a course this week" do
+      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
+      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
+      expect(student.grades_released_for_course_this_week(course)).to eq([grade_2])
+    end
+  end
+
+  describe "#points_earned_for_course_this_week(course)" do
+    let(:assignment_2) { create :assignment, course: course }
+
+    it "returns the student's earned points for the course this week" do
+      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
+      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
+      expect(student.points_earned_for_course_this_week(course)).to eq(300)
+    end
+  end
+
+  describe "#earned_badge_score_for_course(course)" do
+    before do
+      create(:earned_badge, student: student, course: course, badge: create(:badge, full_points: 100))
+      create(:earned_badge, student: student, course: course, badge: create(:badge, full_points: 400))
+    end
+
+    it "returns the sum of the badge score for a student" do
+      expect(student.earned_badge_score_for_course(course)).to eq(500)
+    end
+
+    it "does not include earned badges that have not yet been made student visible" do
+      create(:earned_badge, student: student, course: course, grade: (create :unreleased_grade))
+      expect(student.earned_badge_score_for_course(course)).to eq(500)
+    end
+  end
+
+  describe "#earned_badges_for_course_this_week(course)" do
+    it "returns the students' earned_badges for a course" do
+      earned_badge_1 = create(:earned_badge, student: student, course: course, created_at: Date.today - 10)
+      earned_badge_2 = create(:earned_badge, student: student, course: course)
+      expect(student.earned_badges_for_course_this_week(course)).to eq([earned_badge_2])
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -466,7 +466,7 @@ describe User do
     end
   end
 
-  describe "#earned_badge_for_badge(badge)" do
+  describe "#earned_badges_for_badge(badge)" do
     it "returns the students' earned_badges for a particular badge" do
       earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: course)
       expect(student.earned_badge_for_badge(badge)).to eq([earned_badge_1])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -388,18 +388,18 @@ describe User do
     end
   end
 
-  describe "#earned_badges_for_badge(badge)" do
+  describe "#awarded_badges_for_badge(badge)" do
     it "returns the students' earned_badges for a particular badge" do
       earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: course)
-      expect(student.earned_badge_for_badge(badge)).to eq([earned_badge_1])
+      expect(student.awarded_badges_for_badge(badge)).to eq([earned_badge_1])
     end
   end
 
-  describe "#earned_badges_for_badge_count(badge)" do
+  describe "#awarded_badges_for_badge_count(badge)" do
     it "returns the students' earned_badges for a course" do
       earned_badge_1 = create(:earned_badge, badge: badge, student: student, course: course)
       earned_badge_2 = create(:earned_badge, badge: badge, student: student, course: course)
-      expect(student.earned_badges_for_badge_count(badge)).to eq(2)
+      expect(student.awarded_badges_for_badge_count(badge)).to eq(2)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -249,40 +249,6 @@ describe User do
     end
   end
 
-  describe "#score_for_course(course)" do
-    it "returns the student's score for the course" do
-      expect(student.score_for_course(course)).to eq(100000)
-    end
-
-    # There is a non-null constraint on course_membership.score, so I'm not
-    # sure what this is really testing.
-    it "returns null if the student has no course memebership" do
-      student.course_memberships.where(course_id: course).destroy_all
-      expect(student.score_for_course(course)).to be_nil
-    end
-  end
-
-  describe "#grade_for_course(course)" do
-    it "returns the grade scheme element that matches the students score for the course" do
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000)
-      expect(student.grade_for_course(course)).to eq(gse)
-    end
-  end
-
-  describe "#grade_level_for_course(course)" do
-    it "returns the grade scheme level name that matches the student's score for the course" do
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, level: "Meh")
-      expect(student.grade_level_for_course(course)).to eq("Meh")
-    end
-  end
-
-  describe "#grade_letter_for_course(course)" do
-    it "returns the grade scheme letter name that matches the student's score for the course" do
-      gse = create(:grade_scheme_element, course: course, lowest_points: 80000, letter: "Q")
-      expect(student.grade_letter_for_course(course)).to eq("Q")
-    end
-  end
-
   describe "#grade_released_for_assignment?(assignment)" do
     it "returns false if the grade is not student visible" do
       expect(student.grade_released_for_assignment?(assignment)).to eq(false)
@@ -316,26 +282,6 @@ describe User do
       grade_1 = create(:grade, raw_points: 100, student: student, course: course, status: "Released")
       grade_2 = create(:grade, raw_points: 300, student: student, course: course, status: "Released")
       expect(student.grades_for_course(course)).to include(grade_1, grade_2)
-    end
-  end
-
-  describe "#grades_released_for_course_this_week(course)" do
-    let(:assignment_2) { create :assignment, course: course }
-
-    it "returns the student's earned grades for a course this week" do
-      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
-      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
-      expect(student.grades_released_for_course_this_week(course)).to eq([grade_2])
-    end
-  end
-
-  describe "#points_earned_for_course_this_week(course)" do
-    let(:assignment_2) { create :assignment, course: course }
-
-    it "returns the student's earned points for the course this week" do
-      grade_1 = create(:grade, assignment: assignment, raw_points: 100, student: student, course: course, status: "Released", graded_at: Date.today - 10)
-      grade_2 = create(:grade, assignment: assignment_2, raw_points: 300, student: student, course: course, status: "Released", graded_at: Date.today)
-      expect(student.points_earned_for_course_this_week(course)).to eq(300)
     end
   end
 
@@ -432,22 +378,6 @@ describe User do
     end
   end
 
-  describe "#earned_badge_score_for_course(course)" do
-    before do
-      create(:earned_badge, student: student, course: course, badge: create(:badge, full_points: 100))
-      create(:earned_badge, student: student, course: course, badge: create(:badge, full_points: 400))
-    end
-
-    it "returns the sum of the badge score for a student" do
-      expect(student.earned_badge_score_for_course(course)).to eq(500)
-    end
-
-    it "does not include earned badges that have not yet been made student visible" do
-      create(:earned_badge, student: student, course: course, grade: (create :unreleased_grade))
-      expect(student.earned_badge_score_for_course(course)).to eq(500)
-    end
-  end
-
   describe "#earned_badges_for_course(course)", :unreliable do
     let(:student) { create :user, courses: [course], role: :student }
 
@@ -455,14 +385,6 @@ describe User do
       earned_badge_1 = create(:earned_badge, student: student, course: course)
       earned_badge_2 = create(:earned_badge, student: student, course: course)
       expect(student.earned_badges_for_course(course)).to eq([earned_badge_1, earned_badge_2])
-    end
-  end
-
-  describe "#earned_badges_for_course_this_week(course)" do
-    it "returns the students' earned_badges for a course" do
-      earned_badge_1 = create(:earned_badge, student: student, course: course, created_at: Date.today - 10)
-      earned_badge_2 = create(:earned_badge, student: student, course: course)
-      expect(student.earned_badges_for_course_this_week(course)).to eq([earned_badge_2])
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description

This PR moves the analytics off of the User model and into a conern.

It also renames the methods returning earned badges used for unlock conditions to `awarded`: `awarded_badges_for_badge` and `awarded_badges_for_badge_count`. This is in line with the existing `awarded_badges` relationship, and aims to make sure that information sent to the student only uses the `visible_earned_badges_for_badge` type methods.


### Related PRs

Other PRs addressing ticket #3110 

