### PR TITLE
form validation fix for teams

### DIFF
--- a/app/views/teams/_form.html.haml
+++ b/app/views/teams/_form.html.haml
@@ -2,8 +2,7 @@
   %section.form-section
     %h2.form-title Basic Info
     .form-item
-      = f.label :name, "#{current_course.team_term} Name"
-      = f.text_field :name
+      = f.input :name, label: "#{current_course.team_term} Name"
     .form-item
       %label Banner
       = f.file_field :banner, {class: "media-image-upload"}


### PR DESCRIPTION
### Status
**READY**

### Description
This fixes a bug where team creation would fail if the team were left blank
