### PR TITLE
Challenge Grade Improvements

### DIFF
--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -30,11 +30,11 @@ class Challenges::ChallengeGradesController < ApplicationController
   # Grade many teams on a particular challenge at once
   # GET /challenges/:challenge_id/challenge_grades/mass_edit
   def mass_edit
-    @teams = current_course.teams
+    @teams = current_course.teams.alpha
     @challenge_grades = @teams.map { |t| @challenge.challenge_grades.find_or_initialize_for_team(t) }
   end
 
-  # PUT /challenges/:id/challenge_grades/mass_update
+  # PUT /challenges/:challenge_id/challenge_grades/mass_update
   def mass_update
     filter_params_with_no_challenge_grades!
     if @challenge.update_attributes(challenge_params)

--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -36,6 +36,7 @@ class Challenges::ChallengeGradesController < ApplicationController
 
   # PUT /challenges/:id/challenge_grades/mass_update
   def mass_update
+    filter_params_with_no_challenge_grades!
     if @challenge.update_attributes(challenge_params)
 
       challenge_grade_ids = []
@@ -86,5 +87,11 @@ class Challenges::ChallengeGradesController < ApplicationController
 
   def find_challenge
     @challenge = current_course.challenges.find(params[:challenge_id])
+  end
+
+  def filter_params_with_no_challenge_grades!
+    params[:challenge][:challenge_grades_attributes] = params[:challenge][:challenge_grades_attributes].delete_if do |key, value|
+      value[:raw_points].blank?
+    end
   end
 end

--- a/app/controllers/challenges/challenge_grades_controller.rb
+++ b/app/controllers/challenges/challenge_grades_controller.rb
@@ -89,6 +89,8 @@ class Challenges::ChallengeGradesController < ApplicationController
     @challenge = current_course.challenges.find(params[:challenge_id])
   end
 
+  # This is used to check whether or not the challenge grades being created have any associated data
+  # No data? Don't create empty grades for teams
   def filter_params_with_no_challenge_grades!
     params[:challenge][:challenge_grades_attributes] = params[:challenge][:challenge_grades_attributes].delete_if do |key, value|
       value[:raw_points].blank?

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -49,4 +49,9 @@ class Challenge < ActiveRecord::Base
   def future?
     !due_at.nil? && due_at >= Date.today
   end
+
+  # Finding what challenge grade level was earned for a particular challenge
+  def challenge_grade_level(challenge_grade)
+    challenge_score_levels.find { |csl| challenge_grade.final_points == csl.points }.try(:name)
+  end
 end

--- a/app/models/challenge_grade.rb
+++ b/app/models/challenge_grade.rb
@@ -1,7 +1,6 @@
 class ChallengeGrade < ActiveRecord::Base
   include GradeStatus
 
-  belongs_to :course
   belongs_to :challenge
   belongs_to :team, autosave: true
 
@@ -23,10 +22,6 @@ class ChallengeGrade < ActiveRecord::Base
 
   def score
     final_points
-  end
-
-  def raw_points
-    super.presence || nil
   end
 
   # totaled points (adds adjustment, without weighting)

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -30,7 +30,7 @@
     .form-item
       / Do only X number of highest grades count?
       = f.label :top_grades_counted, :label => "Count Highest Grades"
-      -# .form-hint{id: "assignment_type_top_grades_counted"} 
+      -# .form-hint{id: "assignment_type_top_grades_counted"}
       = tooltip("count-highest-hint", "info-circle", placement: "right") do
         Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here (Set to 0 if not).
       = f.text_field :top_grades_counted, data: { autonumeric: true, "m-dec" => "0" }

--- a/app/views/assignments/_assignment_score_level_fields.haml
+++ b/app/views/assignments/_assignment_score_level_fields.haml
@@ -3,8 +3,7 @@
     .level-name-form.score-level-form
       = f.input :name, :label => "Level Name"
     .points-awarded-form.score-level-form
-      = f.label :points, "Points Awarded"
-      = f.text_field :points, data: {autonumeric: true, "m-dec" => "0"}
+      = f.input :points, data: {autonumeric: true, "m-dec" => "0"}, label: "Points Awarded"
       = f.hidden_field :id
   .btn-container
     = f.hidden_field :_destroy, class: "destroy"

--- a/app/views/assignments/_form.haml
+++ b/app/views/assignments/_form.haml
@@ -91,8 +91,7 @@
 
       .form-flex-row.pass-fail-contingent{"class"=>("visually-hidden" if f.object.pass_fail?)}
         .form-item
-          = f.label :full_points, "Total Points Possible"
-          = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
+          = f.input :full_points, data: {autonumeric: true, "m-dec" => "0"}, label: "Total Points Possible"
 
         .form-item
           = f.label :threshold_points, "Points Threshold"

--- a/app/views/badges/_form.haml
+++ b/app/views/badges/_form.haml
@@ -8,8 +8,7 @@
       = f.input :name
 
     .form-item
-      = f.label :full_points, "Points Awarded"
-      = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
+      = f.input :full_points, data: {autonumeric: true, "m-dec" => "0"}, label: "Points Awarded"
 
     .form-item
       = f.label :file_field, "Icon"

--- a/app/views/challenge_grades/_form.html.haml
+++ b/app/views/challenge_grades/_form.html.haml
@@ -6,8 +6,7 @@
     = f.hidden_field :challenge_id, value: @challenge.id
 
     .form-item
-      = f.label :raw_points
-      = f.text_field :raw_points, data: {autonumeric: true, "m-dec" => "0"}
+      = f.input :raw_points, data: {autonumeric: true, "m-dec" => "0"}
       .form-hint out of #{points @challenge.full_points} points
 
     .form-item

--- a/app/views/challenges/_challenge_score_level_fields.haml
+++ b/app/views/challenges/_challenge_score_level_fields.haml
@@ -3,8 +3,7 @@
     .level-name-form.score-level-form
       = f.input :name, :label => "Level Name"
     .points-awarded-form.score-level-form
-      = f.label :points, "Points Awarded"
-      = f.text_field :points, data: {autonumeric: true, "m-dec" => "0"}
+      = f.input :points, data: {autonumeric: true, "m-dec" => "0"}, label: "Points Awarded"
   .btn-container
     = f.hidden_field :_destroy, class: "destroy"
     %button.button.remove-challenge-score-level{role: "button", type: "button"} Remove Level

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -9,8 +9,7 @@
       = f.text_field :name, "aria-required": "true"
 
     .form-item
-      = f.label :full_points
-      = f.text_field :full_points, data: {autonumeric: true, "m-dec" => "0"}
+      = f.input :full_points, data: {autonumeric: true, "m-dec" => "0"}
 
     .form-item
       = f.input :open_at, as: :string, :input_html => { class: "datetimepicker", :value => @challenge.try(:open_at) }

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -26,19 +26,21 @@
           %td= link_to team.name, team
           %td= points challenge_grade.final_points if challenge_grade
           - if @challenge.has_levels?
-            %td= @challenge.grade_level(grade) if challenge_grade
+            %td= @challenge.challenge_grade_level(challenge_grade) if challenge_grade
           - if @challenge.release_necessary?
             %td= challenge_grade.status if challenge_grade
           %td
-            .button-container.dropdown
-              %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
-              %ul.options-menu.dropdown-content
+            .table-menu
+              %ul
                 - if challenge_grade
-                  %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id)
-                  = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge_grade.id)
-                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), data: { confirm: 'Are you sure?', method: :delete }
+                  = active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_grade_path(challenge_grade.id), class: "button"
+                  %li.dropdown
+                    %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
+                    %ul.options-menu.dropdown-content
+                      %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id)
+                      = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), data: { confirm: 'Are you sure?', method: :delete }
                 - else
-                  = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id)
+                  = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: "button"
           - if @challenge.release_necessary?
             %td
               - if challenge_grade && !challenge_grade.is_released?

--- a/app/views/challenges/challenge_grades/mass_edit.html.haml
+++ b/app/views/challenges/challenge_grades/mass_edit.html.haml
@@ -13,7 +13,7 @@
                 = cgf.hidden_field :team_id
                 = cgf.input :status, as: :hidden, :input_html => { :value => "Graded" }
                 - if @challenge.challenge_score_levels.present?
-                  = cgf.select :raw_points, options_from_collection_for_select(@challenge.challenge_score_levels, :value, :name, cg.try(:raw_points)), include_blank: true
+                  = cgf.select :raw_points, options_from_collection_for_select(@challenge.challenge_score_levels, :points, :name, cg.try(:raw_points)), include_blank: true
                 - else
                   - if cg.persisted?
                     = cgf.text_field :raw_points, data: {autonumeric: true, "m-dec" => "0"}

--- a/app/views/challenges/challenge_grades/mass_edit.html.haml
+++ b/app/views/challenges/challenge_grades/mass_edit.html.haml
@@ -15,10 +15,7 @@
                 - if @challenge.challenge_score_levels.present?
                   = cgf.select :raw_points, options_from_collection_for_select(@challenge.challenge_score_levels, :points, :name, cg.try(:raw_points)), include_blank: true
                 - else
-                  - if cg.persisted?
-                    = cgf.text_field :raw_points, data: {autonumeric: true, "m-dec" => "0"}
-                  - else
-                    = cgf.text_field :raw_points, :value => nil, data: {autonumeric: true, "m-dec" => "0"}
+                  = cgf.input :raw_points, label: false, data: {autonumeric: true, "m-dec" => "0"}
 
       .submit-buttons
         %ul

--- a/config/locales/views/titles/en.yml
+++ b/config/locales/views/titles/en.yml
@@ -80,6 +80,8 @@ en:
     challenge_grades:
       new:
         title: "Grade #{ @team.name }'s #{ @challenge.name }"
+      mass_edit:
+        title: "Quick Grade #{ @challenge.name }"
   courses:
     index:
       title: "My Courses"
@@ -96,8 +98,6 @@ en:
       title: "#{ @team.name }'s #{@challenge_grade.name} Grade"
     edit:
       title: "Editing #{ @team.name }'s #{ @challenge.name } Grade"
-    mass_edit:
-      title: "Quick Grade #{ @challenge.name }"
   downloads:
     index:
       title: "Course Data Exports"

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -1,10 +1,10 @@
 describe Assignments::GradesController do
   let(:course) { build(:course) }
+  let(:professor) { create(:course_membership, :professor, course: course).user }
+  let!(:student) { create(:course_membership, :student, course: course).user }
   let(:assignment) { create(:assignment, course: course) }
   let(:assignment_with_groups) { create(:group_assignment, course: course) }
-  let!(:student) { create(:course_membership, :student, course: course).user }
   let!(:grade) { create(:grade, student: student, assignment: assignment, course: course) }
-  let(:professor) { create(:course_membership, :professor, course: course).user }
 
   context "as professor" do
     before(:each) { login_user(professor) }

--- a/spec/controllers/challenges/challenge_grades_controller_spec.rb
+++ b/spec/controllers/challenges/challenge_grades_controller_spec.rb
@@ -5,7 +5,7 @@ describe Challenges::ChallengeGradesController do
   let(:team) { create(:team, course: course) }
   let(:challenge) { create(:challenge, course: course) }
   let(:challenge_grade) { create(:challenge_grade, team: team, challenge: challenge) }
-    
+
   context "as professor" do
     before(:each) do
       login_user(professor)
@@ -49,7 +49,7 @@ describe Challenges::ChallengeGradesController do
       end
     end
 
-    describe "POST mass_update" do
+    describe "POST mass_update", focus: true do
       it "updates the challenge grades for the specific challenge" do
         challenge_grades_attributes = { "#{challenge.challenge_grades.to_a.index(challenge_grade)}" =>
           { team_id: team.id, raw_points: 1000, status: "Released",

--- a/spec/controllers/challenges/challenge_grades_controller_spec.rb
+++ b/spec/controllers/challenges/challenge_grades_controller_spec.rb
@@ -1,5 +1,5 @@
 describe Challenges::ChallengeGradesController do
-  let(:course) { build :course }
+  let(:course) { create :course }
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let(:student) { create(:course_membership, :student, course: course).user }
   let(:team) { create(:team, course: course) }
@@ -49,12 +49,10 @@ describe Challenges::ChallengeGradesController do
       end
     end
 
-    describe "POST mass_update", focus: true do
+    describe "POST mass_update" do
       it "updates the challenge grades for the specific challenge" do
-        challenge_grades_attributes = { "#{challenge.challenge_grades.to_a.index(challenge_grade)}" =>
-          { team_id: team.id, raw_points: 1000, status: "Released",
-            id: challenge_grade.id
-          }
+        challenge_grades_attributes = { "0" =>
+          { team_id: team.id, status: "Graded", raw_points: 1000, id: challenge_grade.id }
         }
         put :mass_update, params: { challenge_id: challenge.id,
           challenge: { challenge_grades_attributes: challenge_grades_attributes }}
@@ -62,10 +60,8 @@ describe Challenges::ChallengeGradesController do
       end
 
       it "redirects to the mass_edit form if attributes are invalid" do
-        challenge_grades_attributes = { "#{challenge.challenge_grades.to_a.index(challenge_grade)}" =>
-          { team_id: nil, raw_points: 1000, status: "Released",
-            id: challenge_grade.id
-          }
+        challenge_grades_attributes = { "0" =>
+          { team_id: nil, raw_points: 1000, status: "Released", id: challenge_grade.id }
         }
         put :mass_update, params: { challenge_id: challenge.id,
           challenge: { challenge_grades_attributes: challenge_grades_attributes }}


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes:
- [x] a bug where challenge score levels were not properly validating for whether or not there were points attached on creation. 
- [x] a bug where quick grading team challenges would fail if there were score levels present
- [x] a bug where quick grading team challenges would create grades for all teams - regardless of wether or not there was data entered
- [x] a bug where the associated level name for a challenge grade would not display on the show page
- [x] adds the missing page title to the challenge quick grade form

It also begins to replace the use of separate labels and text_fields for numeric data entry with a single, input that leverages simple_form. 

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Quick Grading Challenges
* Team display page
* Challenge creation page
