### PR TITLE
Provide better errors for decimal/string scores

### DIFF
--- a/app/importers/grade_importers/csv_grade_importer.rb
+++ b/app/importers/grade_importers/csv_grade_importer.rb
@@ -107,7 +107,7 @@ class CSVGradeImporter
     end
 
     if row.grade.include? "."
-      append_unsuccessful row, "Grade must not be a decimal value"
+      append_unsuccessful row, "Grade cannot be a decimal value"
       return false
     end
 

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -402,7 +402,8 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
   end
 
   def grades_importers_import_results
-    assignments_index
+    grades_importers_index
+    breadcrumb('Import Results')
   end
 
   def rubrics_index_for_copy

--- a/app/views/grades/importers/csv.html.haml
+++ b/app/views/grades/importers/csv.html.haml
@@ -15,4 +15,7 @@
 
     = form_tag({action: :upload, importer_provider_id: params[:provider_id]}, :multipart => true) do
       = file_field_tag "file"
-      = submit_tag("Import", class: "button")
+
+      .submit-buttons
+        %ul
+          %li= submit_tag("Import", class: "button")

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -20,8 +20,10 @@
       = check_box_tag "send_welcome", "1", false, { disabled: true }
       = label_tag "send_welcome", "Send welcome email to new user accounts", { class: "disabled" }
     = file_field_tag "file"
-    = submit_tag("Import")
+
+    .submit-buttons
+      %ul
+        %li= submit_tag("Import", class: :button)
 
   - if current_user_is_admin?
-
     %h4 K-12 Import: Import as activated accounts with passwords

--- a/spec/controllers/grades/importers_controller_spec.rb
+++ b/spec/controllers/grades/importers_controller_spec.rb
@@ -66,7 +66,7 @@ describe Grades::ImportersController do
         it "renders any errors that have occured" do
           post :upload, params: { assignment_id: assignment.id, importer_provider_id: :csv, file: file }
 
-          expect(response.body).to include "4 Grades Not Imported"
+          expect(response.body).to include "6 Grades Not Imported"
           expect(response.body).to include "Student not found in course"
         end
       end

--- a/spec/fixtures/files/grades.csv
+++ b/spec/fixtures/files/grades.csv
@@ -2,4 +2,6 @@ First Name,Last Name,Email,Score,Feedback
 Robert,Plant,robert@example.com,4000,"You did great!"
 That,Guy,that.guy@somewhere.com,1369.897959,
 Jimmy,Page,jimmy,3000,
+Kurt,Cobain,kurt.cobain@nirvana.com,10.1,
+Mick,Jagger,mick.jagger@rollingstones.com,sheep,...sheep?
 John,Bohnem,john@example.com, ,

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -127,7 +127,7 @@ describe CSVGradeImporter do
         result = subject.import(course, assignment)
         expect(result.unsuccessful).to_not be_empty
         expect(result.unsuccessful).to include({ data: "Kurt,Cobain,kurt.cobain@nirvana.com,10.1,\n",
-          errors: "Grade must not be a decimal value" })
+          errors: "Grade cannot be a decimal value" })
       end
 
       it "contains an unsuccessful row if the grade is a string" do

--- a/spec/importers/grade_importers/csv_grade_importer_spec.rb
+++ b/spec/importers/grade_importers/csv_grade_importer_spec.rb
@@ -3,6 +3,8 @@ describe CSVGradeImporter do
 
   describe "#import" do
     let(:course) { create :course }
+    let(:file) { fixture_file "grades.csv", "text/csv" }
+    let(:assignment) { create :assignment, course: course }
 
     it "returns empty results when there is no file" do
       result = described_class.new(nil).import
@@ -10,150 +12,137 @@ describe CSVGradeImporter do
       expect(result.unsuccessful).to be_empty
     end
 
-    context "with a file" do
-      let(:file) { fixture_file "grades.csv", "text/csv" }
-      let(:assignment) { create :assignment, course: course }
+    context "when no students exist in the course" do
+      it "does not create a grade" do
+        expect { subject.import(course, assignment) }.to_not change { Grade.count }
+      end
 
-      context "with a student not in the file" do
-        let!(:student) { create :user, courses: [course], role: :student }
+      it "returns unsuccessful rows" do
+        result = subject.import(course, assignment)
+        expect(result.unsuccessful).to_not be_empty
+        expect(result.unsuccessful.pluck(:errors)).to all eq "Student not found in course"
+      end
+    end
 
-        it "does not create a grade if the student does not exist" do
-          expect { subject.import(course, assignment) }.to_not change { User.count }
+    context "when the students exist in the course" do
+      let!(:student) { create :user, email: "robert@example.com", courses: [course], role: :student }
+
+      context "with a pass/fail type assignment" do
+        let(:assignment) { create :assignment, :pass_fail, course: course }
+        let(:file) { fixture_file "pass_fail_grades.csv", "text/csv" }
+
+        it "creates the grade if one did not previously exist" do
+          result = subject.import(course, assignment)
+          grade = Grade.unscoped.last
+          expect(grade.raw_points).to eq 0
+          expect(grade.pass_fail_status).to eq "Pass"
+          expect(grade.feedback).to eq "Rock on!"
+          expect(grade.status).to eq "Graded"
+          expect(grade.instructor_modified).to eq true
+          expect(result.successful.count).to eq 1
+          expect(result.successful.last).to eq grade
         end
 
-        it "is unsuccessful if the student does not exist" do
+        it "contains an unsuccessful row if the grade is not 0 or 1" do
+          create :user, email: "don.henley@eagles.com", courses: [course], role: :student
           result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 4
-          expect(result.unsuccessful.first[:errors]).to eq "Student not found in course"
+          expect(result.unsuccessful).to include({ data: "Don,Henley,don.henley@eagles.com,2,\n",
+            errors: "Grade must be 0 (false) or 1 (true)"})
+        end
+
+        it "contains an unsuccessful row if the grade is a string" do
+          create :user, email: "steve.perry@journey.com", courses: [course], role: :student
+          result = subject.import(course, assignment)
+          expect(result.unsuccessful).to include({ data: "Steve,Perry,steve.perry@journey.com,pass,\n",
+            errors: "Grade is invalid" })
+        end
+
+        it "updates the grade if one previously existed" do
+          grade = create :grade, assignment: assignment, student: student, pass_fail_status: "Fail"
+          subject.import(course, assignment)
+          grade.reload
+          expect(grade.raw_points).to eq 0
+          expect(grade.pass_fail_status).to eq "Pass"
+          expect(grade.feedback).to eq "Rock on!"
+          expect(grade.graded_at).to_not be_nil
         end
       end
 
-      context "with a student in the file" do
-        let!(:student) { create :user, email: "robert@example.com", courses: [course], role: :student }
-        let(:another_student) { create :user, email: "eric.clapton@guitarlegends.com", courses: [course], role: :student}
-
-        context "when the assignment is of pass/fail type" do
-          let(:assignment) { create :assignment, course: course, pass_fail: true }
-          let(:file) { fixture_file "pass_fail_grades.csv", "text/csv" }
-
-          it "creates the grade if it is not there" do
-            result = subject.import(course, assignment)
-            grade = Grade.unscoped.last
-            expect(grade.raw_points).to eq 0
-            expect(grade.pass_fail_status).to eq "Pass"
-            expect(grade.feedback).to eq "Rock on!"
-            expect(grade.status).to eq "Graded"
-            expect(grade.instructor_modified).to eq true
-            expect(result.successful.count).to eq 1
-            expect(result.successful.last).to eq grade
-          end
-
-          it "contains an unsuccessful row if the grade is not valid" do
-            create :user, email: "don.henley@eagles.com", courses: [course], role: :student
-            result = subject.import(course, assignment)
-            expect(result.unsuccessful.count).to be >= 1
-            expect(result.unsuccessful.pluck(:errors)).to include "Grade is invalid"
-          end
-
-          it "contains an unsuccessful row if the grade is not valid" do
-            create :user, email: "steve.perry@journey.com", courses: [course], role: :student
-            result = subject.import(course, assignment)
-            expect(result.unsuccessful.count).to be >= 1
-            expect(result.unsuccessful.pluck(:errors)).to include "Grade is invalid"
-          end
-
-          it "updates the grade to pass if the grade previously existed" do
-            grade = create :grade, assignment: assignment, student: student, pass_fail_status: "Fail"
-            subject.import(course, assignment)
-            grade.reload
-            expect(grade.raw_points).to eq 0
-            expect(grade.pass_fail_status).to eq "Pass"
-            expect(grade.feedback).to eq "Rock on!"
-            expect(grade.graded_at).to_not be_nil
-          end
-
-          it "updates the grade to fail if the grade previously existed" do
-            grade = create :grade, assignment: assignment, student: another_student, pass_fail_status: "Pass"
-            subject.import(course, assignment)
-            grade.reload
-            expect(grade.raw_points).to eq 0
-            expect(grade.pass_fail_status).to eq "Fail"
-            expect(grade.feedback).to be_empty
-            expect(grade.graded_at).to_not be_nil
-          end
-        end
-
-        context "when the assignment is not pass/fail type" do
-          it "creates the grade if it is not there" do
-            result = subject.import(course, assignment)
-            grade = Grade.unscoped.last
-            expect(grade.raw_points).to eq 4000
-            expect(grade.feedback).to eq "You did great!"
-            expect(grade.status).to eq "Graded"
-            expect(grade.instructor_modified).to eq true
-            expect(result.successful.count).to eq 1
-            expect(result.successful.last).to eq grade
-          end
-
-          it "updates the grade if it is already there" do
-            create :grade, assignment: assignment, student: student, raw_points: 1000
-            subject.import(course, assignment)
-            grade = Grade.last
-            expect(grade.raw_points).to eq 4000
-            expect(grade.feedback).to eq "You did great!"
-            expect(grade.graded_at).to_not be_nil
-          end
-        end
-
-        it "timestamps the grade" do
-          current_time = DateTime.now
+      context "with a non pass/fail type assignment" do
+        it "creates the grade if one did not previously exist" do
           result = subject.import(course, assignment)
           grade = Grade.unscoped.last
-          expect(grade.graded_at).to be > current_time
-        end
-
-        it "does not update the grade if the grade and the feedback are the same as the one being imported" do
-          grade = create :grade, assignment: assignment, student: student, raw_points: 4000, feedback: "You did great!"
-          expect {
-            result = subject.import(course, assignment)
-            expect(result.successful).to be_empty
-            expect(result.unchanged.count).to eq 1
-            expect(result.unchanged.first).to eq grade
-          }.to_not change grade, :updated_at
-        end
-
-        it "does not update the grade if it is already there and the score is null" do
-          student = create(:user, email: "john@example.com")
-          grade = create :grade, assignment: assignment, student: student, raw_points: 4000
-          create(:course_membership, :student, course: course, user: student)
-          result = subject.import(course, assignment)
-          expect(grade.reload.raw_points).to eq 4000
-          expect(grade.graded_at).to be_nil
-          expect(result.unsuccessful.last[:errors]).to eq "Grade not specified"
-        end
-
-        it "updates the grade if the grade is the same but the feedback is different" do
-          grade = create :grade, assignment: assignment, student: student, raw_points: 4000, feedback: "You need some work"
-          result = subject.import(course, assignment)
+          expect(grade.raw_points).to eq 4000
+          expect(grade.feedback).to eq "You did great!"
+          expect(grade.status).to eq "Graded"
+          expect(grade.instructor_modified).to eq true
           expect(result.successful.count).to eq 1
-          expect(result.successful.first).to eq grade
+          expect(result.successful.last).to eq grade
         end
 
-        it "contains an unsuccessful row if the grade is not valid" do
-          allow_any_instance_of(Grade).to receive(:valid?).and_return false
-          allow_any_instance_of(Grade).to receive(:errors).and_return double(full_messages: ["The grade is not cool"])
-          result = subject.import(course, assignment)
-          expect(result.unsuccessful.count).to eq 4
-          expect(result.unsuccessful.first[:errors]).to eq "The grade is not cool"
+        it "updates the grade if one previously existed" do
+          create :grade, assignment: assignment, student: student, raw_points: 1000
+          subject.import(course, assignment)
+          grade = Grade.last
+          expect(grade.raw_points).to eq 4000
+          expect(grade.feedback).to eq "You did great!"
+          expect(grade.graded_at).to_not be_nil
         end
+      end
 
-        it "creates a grade for a student by username" do
-          username_student = create :user, username: "jimmy"
-          create :course_membership, :student, user_id: username_student.id, course_id: course.id
+      it "timestamps the grade" do
+        result = subject.import(course, assignment)
+        expect(Grade.unscoped.last.graded_at).to be_within(1.second).of(DateTime.now)
+      end
+
+      it "does not update the grade if the grade and the feedback are the same as the one being imported" do
+        grade = create :grade, assignment: assignment, student: student, raw_points: 4000, feedback: "You did great!"
+        expect {
           result = subject.import(course, assignment)
-          grade = assignment.grades.where(student_id: username_student.id).first
-          expect(grade).to_not be_nil
-        end
+          expect(result.successful).to be_empty
+          expect(result.unchanged.count).to eq 1
+          expect(result.unchanged.first).to eq grade
+        }.to_not change grade, :updated_at
+      end
+
+      it "does not update the grade if it is already there and the score is null" do
+        student = create(:user, email: "john@example.com", courses: [course], role: :student)
+        grade = create :grade, assignment: assignment, student: student, raw_points: 4000
+        result = subject.import(course, assignment)
+        expect(grade.reload.raw_points).to eq 4000
+        expect(grade.graded_at).to be_nil
+        expect(result.unsuccessful.last[:errors]).to eq "Grade not specified"
+      end
+
+      it "updates the grade if the grade is the same but the feedback is different" do
+        grade = create :grade, assignment: assignment, student: student,
+          raw_points: 4000, feedback: "You need some work"
+        result = subject.import(course, assignment)
+        expect(result.successful.count).to eq 1
+        expect(result.successful.first).to eq grade
+      end
+
+      it "contains an unsuccessful row if the grade is a decimal value" do
+        create :user, email: "kurt.cobain@nirvana.com", courses: [course], role: :student
+        result = subject.import(course, assignment)
+        expect(result.unsuccessful).to_not be_empty
+        expect(result.unsuccessful).to include({ data: "Kurt,Cobain,kurt.cobain@nirvana.com,10.1,\n",
+          errors: "Grade must not be a decimal value" })
+      end
+
+      it "contains an unsuccessful row if the grade is a string" do
+        create :user, email: "mick.jagger@rollingstones.com", courses: [course], role: :student
+        result = subject.import(course, assignment)
+        expect(result.unsuccessful).to_not be_empty
+        expect(result.unsuccessful).to include({ data: "Mick,Jagger,mick.jagger@rollingstones.com,sheep,...sheep?\n",
+          errors: "Grade is invalid" })
+      end
+
+      it "creates a grade for a student by username" do
+        username_student = create :user, username: "jimmy", courses: [course], role: :student
+        result = subject.import(course, assignment)
+        grade = assignment.grades.where(student_id: username_student.id).first
+        expect(grade).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
### Status
READY

### Description
Previously if the score provided in a CSV grade import was a string or a decimal value, there was the possibility for an unhandled exception.

This catches the exceptions and provides more detailed error messages.

### Migrations
NO

### Steps to Test or Reproduce
Import some grades via CSV, with erroneous score inputs such as "sheep" or "123.45". Ensure that the import does not error out and that a meaningful message is displayed for the errant data columns.

### Impacted Areas in Application
CSV Grade Import

======================
Closes #3433 
