### PR TITLE
Grade scheme element fixes

### DIFF
--- a/app/assets/javascripts/assignments.js
+++ b/app/assets/javascripts/assignments.js
@@ -83,8 +83,19 @@ function showVisibilityOptions() {
   } else {
     $('.unlock-visibility-settings').hide();
   }
+  setSubmitButtonVisibility();
+}
+// Toggle disabled state on submit button if there are no unlock conditions
+// being added or deleted
+function setSubmitButtonVisibility() {
+  if ($('fieldset.unlock-condition').length) {
+    $('#edit-grade-scheme-element-button').attr('disabled', false).removeClass('disabled');
+  } else {
+    $('#edit-grade-scheme-element-button').attr('disabled', true).addClass('disabled');
+  }
 }
 showVisibilityOptions();
+setSubmitButtonVisibility();
 
 // for student rubric feedback tab panels
 function showSelectedTab($tab) {

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -351,16 +351,17 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
 
   def grade_scheme_elements_index
     dashboard_path
-    breadcrumb('Grading Scheme')
+    breadcrumb('Grading Scheme', grade_scheme_elements_path)
   end
 
   def grade_scheme_elements_mass_edit
     grade_scheme_elements_index
-    breadcrumb('Editing Grading Scheme')
+    breadcrumb('Edit Grading Scheme')
   end
 
   def grade_scheme_elements_edit
     grade_scheme_elements_index
+    breadcrumb("Editing #{objects[:grade_scheme_element].name}")
   end
 
   def grades_show

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -62,12 +62,12 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def check_and_update_student_earned_level
-    course.grade_scheme_elements.order_by_points_asc.map { |gse| gse.unlock!(user) }
+    course.grade_scheme_elements.with_lowest_points.order_by_points_asc.map { |gse| gse.unlock!(user) }
     update_attributes earned_grade_scheme_element_id: earned_grade_scheme_element.try(:id)
   end
 
   def earned_grade_scheme_element(grade_scheme_elements=nil)
-    elements = grade_scheme_elements || course.grade_scheme_elements.order_by_points_asc
+    elements = grade_scheme_elements || course.grade_scheme_elements.with_lowest_points.order_by_points_asc
     element_earned = nil
 
     elements.sort_by{ |element| element.lowest_points }.each_with_index do |gse, index|

--- a/app/views/grade_scheme_elements/edit.html.haml
+++ b/app/views/grade_scheme_elements/edit.html.haml
@@ -24,5 +24,5 @@
 
     .submit-buttons
       %ul
-        %li= f.button :submit, "Update Level"
+        %li= f.button :submit, "Update Level", id: "edit-grade-scheme-element-button", class: "disabled"
         %li= link_to glyph("times-circle") + "Cancel", grade_scheme_elements_path, class: "button"


### PR DESCRIPTION
### Status
READY

### Description
See issue #3451 for details outlining the two described bugs.

### Migrations
NO

### Steps to Test or Reproduce
1. Ensure that the submit button on the grade scheme element edit page cannot be clicked if there is no unlock condition. It should still be possible to remove the last of any unlock conditions and submit, however.

2. If you delete all grade scheme elements in a course and perform the setup step to create incomplete grade scheme elements without point thresholds, it should still be possible to delete existing grades for students.

### Impacted Areas in Application
Score recalculating and grade scheme elements unlocks

======================
Closes #3451
