### PR TITLE
remove limits on predictor title lengths

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/article.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/article.html.haml
@@ -1,7 +1,7 @@
 .predictor-article-card{'ng-class'=>'{"status-completed":articleCompleted(), "status-no-points": articleNoPoints(), "focus-article": isFocusArticle()}'}
 
   .predictor-article-title{'title' => '{{article.name}}', 'ng-click'=>'changeFocusArticle()'}
-    {{article.name | limitTo:29}}
+    {{ article.name }}
     .info-icon
       %i.fa.fa-fw.fa-info-circle
 


### PR DESCRIPTION
### Status
**READY**

### Description
Removes the 29 character limit on titles in the predictor.

This was an intentional limit at one time -- perhaps there were icons in the title bar that required space or the blocks were smaller? Anyway, this seems to look better, lengthy names are still cut off 
by the css style overflow hidden, but only once they reach the end of the bar:

![screen shot 2017-07-10 at 1 46 55 pm](https://user-images.githubusercontent.com/1138350/28031745-4d23a6c4-6576-11e7-8b53-221e536f20a6.png)


Closes #3463 