### PR TITLE
Re-enable deleting courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -160,6 +160,13 @@ class CoursesController < ApplicationController
   def syllabus
   end
 
+  def destroy
+    authorize! :destroy, @course
+    @name = @course.name
+    @course.destroy
+    redirect_to overview_courses_url, notice: "Course #{@name} successfully deleted"
+  end
+
   private
 
   def course_params

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -16,7 +16,7 @@ class Submission < ActiveRecord::Base
 
   accepts_nested_attributes_for :grade
   has_many :submission_files,
-    dependent: :destroy,
+    #dependent: :destroy,
     autosave: true,
     inverse_of: :submission
   accepts_nested_attributes_for :submission_files

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -16,7 +16,7 @@ class Submission < ActiveRecord::Base
 
   accepts_nested_attributes_for :grade
   has_many :submission_files,
-    #dependent: :destroy,
+    dependent: :destroy,
     autosave: true,
     inverse_of: :submission
   accepts_nested_attributes_for :submission_files

--- a/app/views/courses/_admin_table.haml
+++ b/app/views/courses/_admin_table.haml
@@ -57,3 +57,4 @@
                 %li= link_to decorative_glyph(:edit) + "Edit", edit_course_path(course)
                 %li= link_to decorative_glyph(:copy) + "Copy", copy_courses_path(id: course.id), :method => :copy
                 %li= link_to decorative_glyph(:copy) + "Copy + Students", copy_courses_path(id: course.id, copy_type: "with_students"), :method => :copy
+                %li= link_to glyph(:trash) + "Delete", course, id: "course-id-#{course.id}", data: { confirm: "This will delete #{course.name} - are you sure?" }, :method => :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,7 +197,7 @@ Rails.application.routes.draw do
 
   #9. Courses
 
-  resources :courses, except: [:show, :destroy] do
+  resources :courses, except: [:show] do
     post :copy, on: :collection
     post :recalculate_student_scores, on: :member
     put :publish, on: :member


### PR DESCRIPTION
### Status
**Ready**

### Description
This PR re-enables the ability for admin users to delete whole courses 

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the course management page. Delete a course. Confirm that it and all of it's data 


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Course Management
