### PR TITLE
limit new unsaved criteria and levels to one

### DIFF
--- a/app/assets/javascripts/angular/directives/rubrics/design.coffee
+++ b/app/assets/javascripts/angular/directives/rubrics/design.coffee
@@ -17,7 +17,7 @@
       RubricService.openNewCriterion()
 
     vm.hasNewCriterion = ()->
-      _.filter(vm.criteria, { new_criterion: true }).length > 0
+      _.filter(vm.criteria, { newCriterion: true }).length > 0
 
     services(vm.rubricId).then(()->
       vm.loading = false

--- a/app/assets/javascripts/angular/directives/rubrics/levels.coffee
+++ b/app/assets/javascripts/angular/directives/rubrics/levels.coffee
@@ -31,7 +31,7 @@
         RubricService.openNewLevel(@criterion)
 
       scope.canAddNewLevel = ()->
-        _.filter(RubricService.levels, {new_level: true, criterion_id : @criterion.id}).length == 0
+        _.filter(RubricService.levels, {newLevel: true, criterion_id : @criterion.id}).length == 0
 
   }
 ]


### PR DESCRIPTION
### Status
**READY**

### Description

Bugfix for camelCase/snake_case translation error when checking to see if there is already a new criterion or level in progress. Removes the add level and add criterion buttons when an unsaved one is already being created.