### PR TITLE
guard against missing group or student on submission file

### DIFF
--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -50,10 +50,11 @@ class SubmissionFile < ActiveRecord::Base
     "#{submission.base_filename} - Submission File#{file_number}#{extension}"
   end
 
+  # returns nil if group or student has been deleted but file still exists
   def owner_name
-    if submission.assignment.grade_scope == "Group"
+    if submission.assignment.grade_scope == "Group"  && submission.group.present?
       submission.group.name.gsub(/\s/, "-")
-    else
+    elsif submission.assignment.grade_scope == "Individual" && submission.student.present?
       "#{submission.student.last_name}-#{submission.student.first_name}"
     end
   end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -124,16 +124,33 @@ describe SubmissionFile do
   end
 
   describe "#owner_name" do
-    it "returns the formatted student name associated with the submission" do
-      expect(subject.owner_name).to eq("#{student.last_name}-#{student.first_name}")
+
+    context "student submission" do
+      it "returns the formatted student name associated with the submission" do
+        expect(subject.owner_name).to eq("#{student.last_name}-#{student.first_name}")
+      end
+
+      it "returns nil if the student has been deleted" do
+        allow(submission).to receive(:student).and_return nil
+        expect(subject.owner_name).to be_nil
+      end
     end
 
-    it "returns the group name associated with a group submission" do
-      group = build(:group, name: "Group Name")
-      group_assignment = build(:assignment, grade_scope: "Group")
-      group_submission = build(:submission, course: course, assignment: group_assignment, group: group)
-      group_file = group_submission.submission_files.new image_file_attrs
-      expect(group_file.owner_name).to eq("Group-Name")
+    context "group submission" do
+      let(:group) { build :group }
+      let(:group_assignment) { build(:assignment, grade_scope: "Group") }
+      let(:group_submission) { build(:submission, course: course, assignment: group_assignment, group: group) }
+
+      it "returns the group name associated with a group submission" do
+        group_file = group_submission.submission_files.new image_file_attrs
+        expect(group_file.owner_name).to eq(group.name)
+      end
+
+      it "returns nil if the group has been deleted" do
+        group_file = group_submission.submission_files.new image_file_attrs
+        allow(group_submission).to receive(:group).and_return nil
+        expect(group_file.owner_name).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
Adds guards in `SubmissionFile#owner_name` for missing student or group to avoid failure seen in Rollbar.  I was not able to replicate the error in development, but the specs added here, before refactoring the method, seemed to replicate the error we have seen:

<img width="769" alt="screen shot 2017-07-12 at 10 41 00 am" src="https://user-images.githubusercontent.com/1138350/28123524-25cef874-66ef-11e7-962e-8864df3e4709.png">

======================
Closes #3468
