### PR TITLE
don't assign id in specs

### DIFF
--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -1,12 +1,13 @@
 describe Assignments::Presenter do
   let(:course) { build(:course) }
-  let(:assignment) { create(:assignment, id: 1, name: "Crazy Wizardry", pass_fail: false, full_points: 5000)}
+  let(:assignment) { create(:assignment, name: "Crazy Wizardry", pass_fail: false, full_points: 5000)}
   let(:view_context) { double(:view_context) }
   let(:team) { double(:team) }
   let(:student) { create(:user) }
   subject { Assignments::Presenter.new({ assignment: assignment, course: course, view_context: view_context }) }
 
   describe "#assignment" do
+
     it "is the assignment that is passed in as a property" do
       expect(subject.assignment).to eq assignment
     end


### PR DESCRIPTION
### Status
**READY**

### Description
Removes the direct assignment of an id in a factory create (left over from the double). This was causing errors on codeship like [this one](https://app.codeship.com/projects/106957/builds/26770886?pipeline=b156c71f-a9a2-4525-a0f6-ab353da63587).
