### PR TITLE
Team page bug

### DIFF
--- a/app/views/courses/_basic_settings.haml
+++ b/app/views/courses/_basic_settings.haml
@@ -99,7 +99,7 @@
           = f.label :teams_visible, "Section Leaderboard"
           = f.check_box :teams_visible, {class: "feature-checkbox dependent-on-section has-settings-menu"}
         .form-card-body
-          .feature-description{id: "txtSectionLeaderboard"} Students can choose to participate in anonymous, section-based leaderboards if they enjoy competition, and opt-out if they don't.
+          .feature-description{id: "txtSectionLeaderboard"} Show students the results of the competition between sections - either their average score, or their achievement on Section Assignments
         .form-card-advanced-settings
           %button.button-advanced-settings= glyph(:cog) + "Settings"
         .advanced-settings-card

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -12,6 +12,6 @@
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path
-  - if current_course.teams_visible? || current_course.has_in_team_leaderboards?
+  - if current_course.teams_visible? || current_course.has_in_team_leaderboards? || current_course.has_team_challenges?
     %li{class: ("active" if current_page?(teams_path)) }
       = link_to_unless_current "#{term_for :teams}", teams_path


### PR DESCRIPTION
Fixed issue where students did not see the teams page if only team challenges were turned on but no leaderboards

### Status
**READY**

### Description
This PR fixes a bug where courses that did not use leaderboards but DO have team challenges would never show them to students.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Student dashboard

======================
Closes #3464 
