### PR TITLE
Show course overview link from navbar, if admin

### DIFF
--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -50,7 +50,10 @@
 %li= link_to_unless_current decorative_glyph(:check) + "#{ term_for :assignment } Settings", settings_assignments_path
 %li= link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
 %li= link_to_unless_current decorative_glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
-%li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
+- if current_user_is_admin?
+  %li= link_to_unless_current decorative_glyph(:university) + "Manage Courses", overview_courses_path
+- else
+  %li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
 
 - if current_user_is_admin?
   .hide-for-small


### PR DESCRIPTION
### Status
READY

### Description
If you go to see all of your courses on a mobile device and try to use the search field, nothing will happen. It appears that dynatable does not work well in conjunction with stacktable, which was our way of making the table responsive.

By my investigation, there is no quick and easy solution to fixing this issue other than just providing admins with the non-responsive table on mobile. A long-term solution should be implemented in #3022.

### Migrations
NO

### Steps to Test or Reproduce
Ensure that on mobile, as an admin, you are directed to `/courses/overview` when you click to view all courses. 

======================
Closes #3511 
