### PR TITLE
Fix calculation bug when full_points is nil

### DIFF
--- a/app/models/concerns/analytics/badge_analytics.rb
+++ b/app/models/concerns/analytics/badge_analytics.rb
@@ -9,6 +9,7 @@ module Analytics
     end
 
     def earned_badge_total_points_for_student(student)
+      return nil if self.full_points.nil?
       earned_badge_count_for_student(student) * self.full_points
     end
 

--- a/spec/models/concerns/analytics/badge_analytics_spec.rb
+++ b/spec/models/concerns/analytics/badge_analytics_spec.rb
@@ -22,6 +22,11 @@ describe Analytics::BadgeAnalytics do
       it "sums up the total points earned for a specific badge" do
         expect(badge.earned_badge_total_points_for_student(student)).to eq(200)
       end
+
+      it "returns nil if the full points on the badge is null" do
+        badge.full_points = nil
+        expect(badge.earned_badge_total_points_for_student(student)).to be_nil
+      end
     end
 
     describe "#earned_badges_this_week_count" do


### PR DESCRIPTION
### Status
READY

### Description
See Rollbar issue here: https://rollbar.com/gradecraft/gradecraft-development/items/

If a student has earned a badge where the full_points value is `nil`, the `earned_badge_total_points_for_student` method will error out. This results in the badge index page being broken.

### Steps to Test or Reproduce
Award a student a badge that has full_points = `nil`. As that student, they should be able to view their badges without any issues.

### Impacted Areas in Application
Badge index for students

======================
Closes #3520 
