### PR TITLE
Change src attribute to ng-src to allow markup

### DIFF
--- a/app/assets/javascripts/angular/templates/analytics/weekly_stats.html.haml
+++ b/app/assets/javascripts/angular/templates/analytics/weekly_stats.html.haml
@@ -21,7 +21,7 @@
     %ul
       %li(ng-repeat='badge in data.student_data.badges_this_week')
         .img-cropper.xsmall-crop
-          %img(src="{{badge.icon}}" alt="{{badge.name}} icon")
+          %img(ng-src="{{badge.icon}}" alt="{{badge.name}} icon")
         %span {{badge.name}} earned
 
   .dashboard-message(ng-if="hasNoStudentEarnings()")
@@ -42,7 +42,7 @@
     %ul
       %li(ng-repeat='badge in data.faculty_data.badges_this_week')
         .img-cropper.xsmall-crop
-          %img(src="{{badge.icon}}" alt="{{badge.name}} icon")
+          %img(ng-src="{{badge.icon}}" alt="{{badge.name}} icon")
         %span {{badge.name}}: {{badge.count}}
 
   .dashboard-message(ng-if="hasNoClassEarnings()")


### PR DESCRIPTION
### Status
READY (Pending Codeship build)

### Description
See original issue for Rollbar details.

Per Angular docs. markup cannot be used within a `src` attribute and must be replaced with `ng-src`.

### Steps to Test or Reproduce
Ensure that there is no console error when visiting `/students/725`. The error that was previously provided looks like this:

![screen shot 2017-07-28 at 1 34 08 pm](https://user-images.githubusercontent.com/17604722/28729167-8055a8ae-7399-11e7-8a29-1c6e6ea4d87d.png)

### Impacted Areas in Application
Weekly stats

======================
Closes #3523
