### PR TITLE
3508 Remove pointer from analytics charts

### DIFF
--- a/app/assets/stylesheets/pages/_analytics.sass
+++ b/app/assets/stylesheets/pages/_analytics.sass
@@ -1,20 +1,14 @@
 @import "../utilities/variables"
 
-/* Styles the hover state on the box plot on class analytics tab */
 #assignment-distribution-graph
   box-sizing: border-box
-  &.js-plotly-plot .plotly .cursor-pointer
-    cursor: default
 
 #levels_per_assignment
   width: 60%
-  &.js-plotly-plot .plotly .cursor-pointer
-    cursor: default
-
 
 .js-plotly-plot .plotly
   .cursor-pointer
-    cursor: default
+    cursor: default !important
   .hovertext
     path
       stroke: rgba(31, 119, 180, 1) !important

--- a/app/views/grades/show.html.haml
+++ b/app/views/grades/show.html.haml
@@ -22,7 +22,6 @@
         %hr.dotted
 
     %section
-      %h2 Description
       = render partial: "assignments/description", locals: { presenter: presenter }
 
     - if presenter.grades_available_for?(@grade.student) && presenter.show_rubric_preview?(@grade.student)


### PR DESCRIPTION
### Status
**READY**

### Description
This PR updates cursor for plotly charts and removes duplicate description header on instructor assignment show page.

### Migrations
NO

======================
Closes #3508 
