### PR TITLE
Add breadcrumb for auth failure

### DIFF
--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -128,6 +128,10 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Editing ' + objects[:course].group_term + ' Grade')
   end
 
+  def auth_failure
+    dashboard
+  end
+
   def badges_index
     dashboard
     breadcrumb(objects[:course].badge_term.pluralize, badges_path)


### PR DESCRIPTION
### Status
**READY**

### Description
Adding a breadcrumb for the auth failure page, which is showing for a logged-in user failing at Canvas authentication 

