### PR TITLE
Do not double count unreleased grades

### DIFF
--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -2,7 +2,7 @@ module GradesHelper
   extend SubmissionsHelper
 
   def grading_status_count_for(course)
-    unreleased_grades_count_for(course) +
+    ready_for_release_grades_count_for(course) +
       in_progress_grades_count_for(course) +
       ungraded_submissions_count_for(course) +
       resubmission_count_for(course)
@@ -28,17 +28,6 @@ module GradesHelper
   def ready_for_release_count_cache_key(course)
     # This cache key should be expired when a grade is updated
     "#{course.cache_key}/ready_for_release_grades_count"
-  end
-
-  def unreleased_grades_count_for(course)
-    Rails.cache.fetch(unreleased_grades_count_cache_key(course)) do
-      course.grades.for_active_students.not_released.count
-    end
-  end
-
-  def unreleased_grades_count_cache_key(course)
-    # This cache key should be expired when a grade is updated
-    "#{course.cache_key}/unreleased_grades_count"
   end
 
   # Returns the corresponding pass/fail status for a score

--- a/spec/helpers/grades_helper_spec.rb
+++ b/spec/helpers/grades_helper_spec.rb
@@ -18,21 +18,21 @@ describe GradesHelper do
     end
   end
 
-  describe "#unreleased_grades_count_for" do
+  describe "#ready_for_release_grades_count_for" do
     let(:assignment) { create :assignment, course: course }
     let!(:student) { create(:course_membership, :student, course: course, active: true).user }
     let!(:grade) { create :complete_grade, assignment: assignment, course: course, student_id: student.id }
 
     it "returns the number of grades that are unreleased" do
-      expect(unreleased_grades_count_for(course)).to eq 1
+      expect(ready_for_release_grades_count_for(course)).to eq 1
     end
 
     it "caches the result" do
       expect(course).to receive(:grades).and_call_original.at_most(:twice)
-      unreleased_grades_count_for(course)
-      unreleased_grades_count_for(course)
-      Rails.cache.delete unreleased_grades_count_cache_key(course)
-      unreleased_grades_count_for(course)
+      ready_for_release_grades_count_for(course)
+      ready_for_release_grades_count_for(course)
+      Rails.cache.delete ready_for_release_count_cache_key(course)
+      ready_for_release_grades_count_for(course)
     end
   end
 

--- a/spec/helpers/grades_helper_spec.rb
+++ b/spec/helpers/grades_helper_spec.rb
@@ -45,7 +45,7 @@ describe GradesHelper do
 
     it "returns the sum of unreleased grades, in progress grades, and ungraded submissions" do
       allow(helper).to receive(:ungraded_submissions_count_for).with(course).and_return 10
-      allow(helper).to receive(:unreleased_grades_count_for).with(course).and_return 20
+      allow(helper).to receive(:ready_for_release_grades_count_for).with(course).and_return 20
       allow(helper).to receive(:in_progress_grades_count_for).with(course).and_return 30
       allow(helper).to receive(:resubmission_count_for).with(course).and_return 2
       expect(helper.grading_status_count_for(course)).to eq 62


### PR DESCRIPTION
### Status
**READY**

### Description
This removes some unnecesasry code now that we've migrated over to the new grading process, and fixes a scenario where we were double counting unreleased grades 
