### PR TITLE
Fix issue where visible_when_locked was not saved

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -113,6 +113,7 @@ class API::AssignmentsController < ApplicationController
       :student_logged,
       :threshold_points,
       :visible,
+      :visible_when_locked,
 
       # We pass score levels through assignment update for now,
       # planning on replacing them with a single criterion rubric


### PR DESCRIPTION
### Status
READY (Pending Codeship Build)

### Description
If the user tried to click on the checkbox for Assignment Visible When Locked while in the unlock conditions tab of the assignment edit page, the value would end up not persisting due to the fact that it had not been included in the safe params hash. This would result in the checkbox being reverted to the last saved value.

### Migrations
NO

### Steps to Test or Reproduce
Go to the Assignment Edit page and click on Assignment Visible When Locked. Ensure that the value persists, either on autosave or upon clicking the submit button.

### Impacted Areas in Application
Assignment Edit

======================
Closes #3540
