### PR TITLE
limit custom term casing to select

### DIFF
--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -62,7 +62,8 @@ ul.conditional-options
   padding-bottom: 1rem
   border: 0
   border-bottom: 1px dashed $color-green-2
-  text-transform: capitalize
+  select, label
+    text-transform: capitalize
 
 .form-subsection
   background-color: $color-grey-7


### PR DESCRIPTION
### Status
**READY**

### Description
Custom terms sent to the front end do not preserve casing, and must be capitalized via css. This limits the scope of the casing to selectors and form titles, so that text areas are not corrupted. 

Limitations:
There may be other sections of the forms that need to be addressed. But it is important to get this in quickly so that it doesn't affect persisted Assignment descriptions etc.

======================
Closes #3542 

