### PR TITLE
Pull need for 0 values in assignment types top grades counted function

### DIFF
--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -39,7 +39,7 @@ class AssignmentType < ActiveRecord::Base
   # Checking to see if the instructor has set a maximum number of grades that
   # should count towards the assignment type score - always the highest ones
   def count_only_top_grades?
-    top_grades_counted > 0
+    top_grades_counted.present? && top_grades_counted > 0
   end
 
   # Getting the assignment types max value if it's present, else returning the

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -33,7 +33,7 @@
       -# .form-hint{id: "assignment_type_top_grades_counted"}
       = tooltip("count-highest-hint", "info-circle", placement: "right") do
         Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here (Set to 0 if not).
-      = f.text_field :top_grades_counted, data: { autonumeric: true, "m-dec" => "0" }
+      = f.input :top_grades_counted, input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }
 
     - if current_course.has_multipliers?
       .form-item

--- a/db/migrate/20170805193014_allow_nil_top_grades.rb
+++ b/db/migrate/20170805193014_allow_nil_top_grades.rb
@@ -1,0 +1,5 @@
+class AllowNilTopGrades < ActiveRecord::Migration[5.0]
+  def change
+    change_column :assignment_types, :top_grades_counted, :integer, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622131838) do
+ActiveRecord::Schema.define(version: 20170805193014) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 20170622131838) do
     t.integer  "course_id",                          null: false
     t.boolean  "student_weightable", default: false, null: false
     t.integer  "position",                           null: false
-    t.integer  "top_grades_counted", default: 0,     null: false
+    t.integer  "top_grades_counted"
     t.boolean  "has_max_points",     default: false, null: false
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes the UX and validation challenge that has been assignment type grades feature: now, instructors will have a default of nil, the database is okay with that, and if they want to use the feature they set a value. A value of 0 is still ignored (thereby supporting legacy assignment types, although we should probably still do an `update_all` and set these to nil). 


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment Type creation and editing

