### PR TITLE
Check for host for external links

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -72,8 +72,9 @@ module LinkHelper
       uri = URI(self.uri)
       uri.scheme == "mailto" ||
         (!uri.relative? &&
+         (uri.host.present? &&
          !uri.host.end_with?("gradecraft.com") &&
-         !uri.host.end_with?("localhost"))
+         !uri.host.end_with?("localhost")))
     rescue URI::InvalidURIError
       false
     end


### PR DESCRIPTION
### Status
**READY**

### Description
We send non-gradecraft links to open in another tab. Sometimes the links that are passed in don't actually have a host (as in a file link), and these are causing display errors at the moment when the host is checked for and not found. THIS FIX DOES NOT RESOLVE DISPLAYING A BROKEN IMAGE LINK IN THE DESCRIPTION. (But this issue is more user side than we can fully account for)

1. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment Description

