### PR TITLE
redirect grading to status when referred

### DIFF
--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -4,7 +4,6 @@ class GradesController < ApplicationController
   before_action :ensure_staff?,
     except: [:feedback_read, :show, :async_update]
   before_action :ensure_student?, only: :feedback_read
-  before_action :save_referer, only: :edit
   before_action :use_current_course, only: [:show, :edit]
 
   protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format == "application/json" }
@@ -29,7 +28,9 @@ class GradesController < ApplicationController
     @grade = Grade.find params[:id]
     @submission = @grade.student.submission_for_assignment(@grade.assignment)
     @team = Team.find(params[:team_id]) if params[:team_id]
-    if @team.present?
+    if request.referer && request.referer.match(grading_status_path)
+      @submit_path = request.referer
+    elsif @team.present?
       @submit_path =  assignment_path(@grade.assignment, team_id: @team.id)
     else
       @submit_path = assignment_path(@grade.assignment)

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -43,9 +43,32 @@ describe GradesController do
 
       it "assigns existing submissions" do
         submission = create(:submission, student: student, assignment: assignment)
-
         get :edit, params: { id: grade.id }
         expect(assigns(:submission)).to eq(submission)
+      end
+
+      describe "on submit" do
+        it "redirects to the assignment show page by default" do
+          get :edit, params: { id: grade.id }
+          expect(assigns(:submit_path)).to eq(assignment_path(grade.assignment))
+        end
+
+        describe "from the grading status page" do
+          before do
+            request.env["HTTP_REFERER"] = grading_status_path
+          end
+
+          it "redirects back to the grading status page" do
+            get :edit, params: { id: grade.id }
+            expect(assigns(:submit_path)).to eq(grading_status_path)
+          end
+        end
+
+        it "includes the team filter if team is in the params" do
+          team = create :team, course: course
+          get :edit, params: { id: grade.id, team_id: team.id }
+          expect(assigns(:submit_path)).to eq(assignment_path(grade.assignment) + "?team_id=#{team.id}")
+        end
       end
     end
 
@@ -91,7 +114,7 @@ describe GradesController do
       end
     end
 
-    describe "POST inlude" do
+    describe "POST include" do
       before do
         allow_any_instance_of(ScoreRecalculatorJob).to \
           receive(:enqueue).and_return true


### PR DESCRIPTION
### Status
**READY**

### Description

This PR makes sure graders who start grading from the grading status page and select submit (not "submit and grade next") will be redirected back to the grading status page. It also adds specs for redirects.

Grading from any other page will still redirect to the assignment show page on submit. If there is a team in the paras, the index of students will filter to that team.

======================
Closes #3530
