### PR TITLE
3558 negative grades

### DIFF
--- a/app/assets/javascripts/angular/services/GradeService.coffee
+++ b/app/assets/javascripts/angular/services/GradeService.coffee
@@ -27,6 +27,7 @@
     g.raw_points = modelGrade.raw_points
     g.adjustment_points = parseInt(g.adjustment_points) || 0
     g.final_points = g.raw_points + g.adjustment_points
+    return unless g.final_points > 0
     g.final_points = 0 if g.final_points < thresholdPoints
 
   # This must be triggered whenever there is a

--- a/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
@@ -13,7 +13,7 @@
       .form-item
         %label
           Total Points Possible
-          %input(ng-model="assignment.full_points" gc-number-input ng-change="updateAssignment()")
+          %input(ng-model="assignment.full_points" gc-number-input allow-negatives="true" ng-change="updateAssignment()")
       .form-item
         %label
           Points Threshold

--- a/app/assets/javascripts/angular/templates/assignments/full_points.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/full_points.html.haml
@@ -3,6 +3,7 @@
     %input( id="{{assignment.id}}-full-points"
       ng-model="assignment.full_points"
       gc-number-input
+      allow-negatives="true"
       ng-change="updateAssignmentPoints()")
 .assignment-settings--full-points(ng-if="assignment.pass_fail")
   {{termFor("pass")}}/{{termFor("fail")}}

--- a/app/assets/javascripts/angular/templates/assignments/score_levels.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/score_levels.html.haml
@@ -10,7 +10,7 @@
     .form-item
       %label
         Points Awarded
-        %input(ng-model="scoreLevel.points" gc-number-input ng-change="updateScoreLevel(scoreLevel)")
+        %input(ng-model="scoreLevel.points" gc-number-input allow-negatives="true" ng-change="updateScoreLevel(scoreLevel)")
 
     .remove-line-item(ng-click="deleteScoreLevel(scoreLevel)")
       %i.fa.fa-fw.fa-times

--- a/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/points_overview.html.haml
@@ -19,4 +19,4 @@
   %p(ng-show="isBelowThreshold()") Points below the threshold: {{ pointsBelowThreshold() | number:0 }}
   %hr.grading-divider
   %p.total-points-score(ng-show="pointsArePresent()") Total Points: {{ finalPoints() | number:0 }} / {{ assignment().full_points | number:0 }}
-    
+

--- a/app/assets/javascripts/angular/templates/grades/raw_points_input.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/raw_points_input.html.haml
@@ -5,4 +5,5 @@
   placeholder="Enter raw points for grade"
   ng-model="grade.raw_points"
   gc-number-input
+  allow-negatives="true"
   ng-change="queueUpdateGrade()")

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -146,7 +146,7 @@ class Grade < ActiveRecord::Base
 
   private
 
-  # full points (with student's weighting)
+  # full points for assignment, including student's weighting
   def calculate_full_points
     assignment.full_points_for_student(student)
   end
@@ -155,6 +155,7 @@ class Grade < ActiveRecord::Base
   def calculate_final_points
     return nil unless raw_points.present?
     final_points = raw_points + adjustment_points
+    return final_points if final_points < 0
     final_points >= assignment.threshold_points ? final_points : 0
   end
 

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -6,7 +6,7 @@ class Level < ActiveRecord::Base
   has_many :badges, through: :level_badges
   has_many :criterion_grades
 
-  validates :points, presence: true, numericality: {greater_than_or_equal_to: 0}
+  validates :points, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :name, presence: true, length: { maximum: 30 }
 
   scope :ordered, -> { order("points ASC") }

--- a/doc/points.md
+++ b/doc/points.md
@@ -1,7 +1,5 @@
 # Points, Scores, Values
 
-*note many of these changes are in progress, I will update this file once they have been merged into Production -jg*
-
 Points, Score, and Value nomenclature in Gradecraft has been standardized around the following rules:
 
 ## Points

--- a/spec/models/grade_spec.rb
+++ b/spec/models/grade_spec.rb
@@ -121,6 +121,26 @@ describe Grade do
       expect(subject.score).to eq(1000)
     end
 
+    context "for negative points" do
+      it "will calculate a negative score for the grade" do
+        subject.update(raw_points: "-766", adjustment_points: -234)
+        expect(subject.score).to eq(-1000)
+      end
+
+      it "will remain below zero with a threshold" do
+        subject.assignment.update(threshold_points: 2000)
+        subject.update(raw_points: "-766", adjustment_points: -234)
+        expect(subject.score).to eq(-1000)
+      end
+
+      it "will treat weights as a multiplication of negative points" do
+        subject.assignment.assignment_type.update(student_weightable: true)
+        create(:assignment_type_weight, student: subject.student, assignment_type: subject.assignment_type, weight: 3 )
+        subject.update(raw_points: "-766", adjustment_points: -234)
+        expect(subject.score).to eq(-3000)
+      end
+    end
+
     it "is the final score weighted by the students weight for the assignment" do
       subject.assignment.assignment_type.update(student_weightable: true)
       create(:assignment_type_weight, student: subject.student, assignment_type: subject.assignment_type, weight: 3 )

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -26,6 +26,11 @@ describe Level do
     end
   end
 
+  it "is invalid with negative points" do
+    subject.points = -100
+    expect(subject).to_not be_valid
+  end
+
   describe "#above_expectations?" do
     it "is false if points are equal to or below expectations" do
       subject.criterion.update(meets_expectations_points: subject.points)


### PR DESCRIPTION
### Status
**READY**

### Description

Gradcraft has many checks and assumptions in place that limit raw score and calculated points on a grade to positive numbers, but this is not the expected behavior. 

This PR adds the ability to score a grade as a negative number in the UX, and allows for proper calculations of grades where the `raw_points` or `adjusted_points` drops the score below zero.

It also removes the limit on assignment `total_points` fields on the edit and settings pages, as well as for `score_levels` on the assignment edit page. I don't believe these adjustments require any additional logic for calculating points on the back end.

This PR does not add the ability for students to predict negative grades, as this would require a complicated additional set of conditions to handle with the slider/input combo element.

It also leaves the limit on Rubrics levels, but the changes in this PR will probably affect user expected behavior for rubrics as well, so this may need to be addressed in a separate ticket. I have added a spec that verifies this limit here just to point it out.

I have also added specs for the calculation of negative points on a grade both for verification as well as to demonstrate other side effects. The logic is somewhat arbitrary but this is what I chose based on what seemed to make the most sense:
  * If an assignment has a threshold, negative scores remain negative rather than changing to zero
  * If an assignment type has weights, negative scores will have the weight applied (-1000 x 3 coins = -3000)

======================
Closes #3558 