### PR TITLE
3482 Make Delete Warnings More Informative

### DIFF
--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -23,7 +23,7 @@
         .assignment-type-container{role: "tabpanel"}
           %ul.assignment-action-buttons
             = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
-            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure?", method: :delete }
+            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure you want to delete Assignment Type #{assignment_type.name}?", method: :delete }
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr
@@ -65,7 +65,7 @@
                             = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(assignment)
                           = active_course_link_to decorative_glyph(:edit) + "Edit", edit_assignment_path(assignment)
                           = active_course_link_to decorative_glyph(:copy) + "Copy", copy_assignments_path(id: assignment), :method => :copy
-                          = active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure?", method: :delete }
+                          = active_course_link_to decorative_glyph(:trash) + "Delete", assignment_path(assignment), data: { confirm: "Are you sure you want to delete #{assignment.name}?", method: :delete }
           - if current_course.active?
             .box{ style: "width: 95%; margin: 1em auto;"}
               .center

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -23,7 +23,7 @@
         .assignment-type-container{role: "tabpanel"}
           %ul.assignment-action-buttons
             = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
-            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure you want to delete Assignment Type #{assignment_type.name}?", method: :delete }
+            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure you want to delete #{term_for :assignment_type} #{assignment_type.name}?", method: :delete }
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -83,7 +83,7 @@
                     %li= link_to decorative_glyph(:paperclip) + "See Submission", assignment_submission_path(presenter.assignment, student_submission.id)
                 - if grade.instructor_modified?
                   %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade)
-                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure?", method: :delete }
+                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure you want to delete #{student.name}'s grade for #{presenter.assignment.name}?", method: :delete }
 
     %td
       .center

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -4,4 +4,4 @@
     = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)
     = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge)
     = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge)
-    = active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), data: { confirm: "Are you sure?",  method: :delete }
+    = active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), data: { confirm: "Are you sure you want to delete #{badge.name}?",  method: :delete }

--- a/app/views/challenges/_index_staff.haml
+++ b/app/views/challenges/_index_staff.haml
@@ -25,4 +25,4 @@
             %ul.options-menu.dropdown-content
               = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_challenge_challenge_grades_path(challenge)
               = active_course_link_to decorative_glyph(:edit) + "Edit", edit_challenge_path(challenge)
-              = active_course_link_to decorative_glyph(:trash) + "Delete", challenge,  :method => :delete, data: { confirm: "Are you sure?" }
+              = active_course_link_to decorative_glyph(:trash) + "Delete", challenge,  :method => :delete, data: { confirm: "Are you sure you want to delete #{challenge.name}?" }

--- a/app/views/challenges/_show_staff.haml
+++ b/app/views/challenges/_show_staff.haml
@@ -35,7 +35,7 @@
                     %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
                     %ul.options-menu.dropdown-content
                       %li= link_to decorative_glyph(:eye) + "See Grade", challenge_grade_path(challenge_grade.id)
-                      = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), data: { confirm: 'Are you sure?', method: :delete }
+                      = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge_grade.id), data: { confirm: "Are you sure you want to delete #{team.name}'s grade for #{challenge_grade.name} ?", method: :delete }
                 - else
                   = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: @challenge, team_id: team.id), class: "button"
           %td

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -28,4 +28,4 @@
                 %ul.options-menu.dropdown-content
                   %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), method: :post
                   = active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event)
-                  = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure?" }
+                  = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure you want to delete #{event.name}?" }

--- a/app/views/observers/index.html.haml
+++ b/app/views/observers/index.html.haml
@@ -24,4 +24,4 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
                 = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                = active_course_link_to decorative_glyph(:trash) + "Delete", user, data: { confirm: "Are you sure?" }, :method => :delete
+                = active_course_link_to decorative_glyph(:trash) + "Delete", user, data: { confirm: "Are you sure you want to delete #{user.name}?" }, :method => :delete

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -32,7 +32,7 @@
               %ul.options-menu.dropdown-content
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
                 = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
-                = active_course_link_to decorative_glyph(:trash) + "Delete",  user.course_memberships.where(course: current_course).first, data: { confirm: "Are you sure?"}, :method => :delete
+                = active_course_link_to decorative_glyph(:trash) + "Delete",  user.course_memberships.where(course: current_course).first, data: { confirm: "Are you sure you want to delete #{user.name}'s course membership in #{current_course.name}?"}, :method => :delete
                 - if !user.activated?
                   = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
                   = active_course_link_to glyph(:envelope) + "Resend Invite Email", resend_invite_email_user_path(user.id)

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -36,4 +36,4 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
                 = active_course_link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
-                = active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure?", method: :delete }
+                = active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure you want to delete #{grade.student.name}'s grade for #{grade.assignment.name}?", method: :delete }

--- a/app/views/students/_grade_index.haml
+++ b/app/views/students/_grade_index.haml
@@ -31,4 +31,4 @@
               - if current_user_is_admin? || current_course.active?
                 %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade)
                 %li= link_to glyph(:eye) + "See Grade", grade_path(grade)
-                %li= link_to glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure?" }
+                %li= link_to glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure you want to delete #{grade.student.name}'s grade for #{grade.assignment.name}?" }

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -7,7 +7,7 @@
           class: "button button-edit"
         = active_course_link_to decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit",
-          data: { confirm: "Are you sure?", method: :delete }
+          data: { confirm: "Are you sure you want to delete #{presenter.student.name}'s submission for #{presenter.assignment.name}?", method: :delete }
         = active_course_link_to decorative_glyph(:check) + "Grade",
           assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
 - elsif presenter.assignment.has_groups?
@@ -19,6 +19,6 @@
           class: "button button-edit"
         = active_course_link_to decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ),
-          data: { confirm: "Are you sure?",  method: :delete }, class: "button button-edit"
+          data: { confirm: "Are you sure you want to delete #{presenter.group.name}'s submission for #{presenter.assignment.name}?",  method: :delete }, class: "button button-edit"
         = active_course_link_to decorative_glyph(:check) + "Grade",
           grade_assignment_group_path(presenter.assignment,  presenter.group), class: "button button-edit"

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -31,4 +31,4 @@
             %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
             %ul.options-menu.dropdown-content
               = active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team)
-              = active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), data: { confirm: "Are you sure?" }, :method => :delete
+              = active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), data: { confirm: "Are you sure you want to delete team #{team.name}?" }, :method => :delete

--- a/app/views/teams/_stats.haml
+++ b/app/views/teams/_stats.haml
@@ -31,4 +31,4 @@
             %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
             %ul.options-menu.dropdown-content
               = active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :team}", edit_team_path(team)
-              = active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), data: { confirm: "Are you sure you want to delete team #{team.name}?" }, :method => :delete
+              = active_course_link_to decorative_glyph(:trash) + "Delete #{term_for :team}", team_path(team), data: { confirm: "Are you sure you want to delete #{term_for :team} #{team.name}?" }, :method => :delete

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -65,6 +65,6 @@
               %ul.options-menu.dropdown-content
                 - if challenge.challenge_grade_for_team(@team).present?
                   = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id), class: "button"
-                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), data: { confirm: "Are you sure?", method: :delete }
+                  = active_course_link_to decorative_glyph(:trash) + "Delete Grade", challenge_grade_path(challenge, challenge.challenge_grade_for_team(@team).id, team_id: @team.id), data: { confirm: "Are you sure you want to delete #{@team.name}'s grade for #{challenge.name}?", method: :delete }
                 - else
                   = active_course_link_to decorative_glyph(:check) + "Grade", new_challenge_challenge_grade_path(challenge_id: challenge, team_id: @team.id)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor, I need to delete various things throughout the interface at different moments. Currently, we have an alert that asks them to confirm, but it has no detailed information to help them ensure they're deleting the right thing. We should universally update the "Are you sure?" to say "Are you sure you want to delete { assignment/badge/challenge/etc } { name }?"

### Related PRs
N/A

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Systematically go through the application and attempt to delete every unique type of item and verify that it says more that "Are you sure?" for confirmation.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Most views

======================
Closes #3482 
