### PR TITLE
Fix bug where activated students were sent to the wrong path

### DIFF
--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -523,6 +523,12 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
     breadcrumb('Editing ' + objects[:user].name)
   end
 
+  def passwords_edit
+  end
+
+  def pages_index
+  end
+
   def pages_auth_failure
     dashboard
   end

--- a/app/views/users/activate_set_password.html.haml
+++ b/app/views/users/activate_set_password.html.haml
@@ -2,7 +2,7 @@
   .password-reset.login-form-container
     %h1 Welcome to GradeCraft
     %p Enter a password and a confirmation below to complete your account
-    = simple_form_for @user, :url => activate_user_path(@token), :method => :post do |f|
+    = simple_form_for @user, :url => activate_set_password_user_path(@token), :method => :post do |f|
       = hidden_field_tag :token, @token
       = f.label :password, class: "sr-only"
       = f.password_field :password, placeholder: "Password"


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where students activating accounts were sent to the course creation form 


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Course Creation
* Account Activation