### PR TITLE
3421 Default User Role Based On Previous Page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,16 +27,20 @@ class UsersController < ApplicationController
   end
 
   def new
-    @selected_role = 'observer'
-    referer_path = URI(request.referer).path
-    case referer_path
-    when students_path
-      @selected_role = 'student'
-    when staff_index_path
-       @selected_role = 'gsi'
-    end
     @user = User.new
     @course_membership = @user.course_memberships.new
+    if request.referer.nil?
+      @selected_role = 'observer'
+    else
+      case URI(request.referer).path
+      when students_path
+        @selected_role = 'student'
+      when staff_index_path
+        @selected_role = 'gsi'
+      else
+        @selected_role = 'observer'
+      end
+    end
   end
 
   # set up the form for users to create their own accounts without being logged

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 require_relative "../importers/user_importers/csv_student_importer"
 require_relative "../services/cancels_course_membership"
 require_relative "../services/creates_or_updates_user"
+require 'uri'
 
 class UsersController < ApplicationController
   include UsersHelper
@@ -26,6 +27,14 @@ class UsersController < ApplicationController
   end
 
   def new
+    @selected_role = 'observer'
+    referer_path = URI(request.referer).path
+    case referer_path
+    when students_path
+      @selected_role = 'student'
+    when staff_index_path
+       @selected_role = 'gsi'
+    end
     @user = User.new
     @course_membership = @user.course_memberships.new
   end

--- a/app/views/observers/_buttons.html.haml
+++ b/app/views/observers/_buttons.html.haml
@@ -2,4 +2,4 @@
   .context-menu
     %ul
       - if current_user_is_admin? || current_course.has_paid?
-        = active_course_link_to decorative_glyph(:plus) + "New User", new_user_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:plus) + "New Observer", new_user_path, class: "button button-edit"

--- a/app/views/students/_buttons.haml
+++ b/app/views/students/_buttons.haml
@@ -1,0 +1,9 @@
+- content_for :context_menu do
+  .context-menu
+    %ul
+      - if current_user_is_admin? || current_course.has_paid?
+        = active_course_link_to decorative_glyph(:plus) + "New #{term_for :student}", new_user_path, class: "button button-edit"
+        = active_course_link_to decorative_glyph(:download) + "Import", users_importers_path, class: "button button-edit"
+      - if @user.present? && @user.persisted?
+        = active_course_link_to decorative_glyph(:edit) + "Edit #{term_for :student}", edit_user_path(@user), class: "button button-edit"
+        %li= link_to decorative_glyph(:list) + "Show #{term_for :student}", student_path(@user), class: "button button-edit"

--- a/app/views/students/index.html.haml
+++ b/app/views/students/index.html.haml
@@ -1,4 +1,4 @@
-= render "users/buttons"
+= render "students/buttons"
 
 .pageContent
   = render "layouts/alerts"

--- a/app/views/users/_courses.html.haml
+++ b/app/views/users/_courses.html.haml
@@ -4,7 +4,7 @@
     = cm.hidden_field :course_id, value: current_course.id
     .form-item
       = cm.label :role, "Select Role"
-      = cm.select :role, available_roles(current_course), selected: @course_membership.try(:role)
+      = cm.select :role, available_roles(current_course), selected: @selected_role
     - if current_course.has_in_team_leaderboards?
       .form-item
         = cm.label :pseudonym, "Pseudonym"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As a staff member, when I click 'Add new student' or "Add Staff" I expect that the form that follows will know which role I identified as wanting to create. Currently, the new user form (where they're sent) defaults to creating Observers.

### Related PRs
N/A


### Todos
- [ ] Add Tests
- [ ] Update/Add Documentation
- [ ] Update Sample Data


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the "Learners", "Staff", or "Observer" pages in Gradecraft. Click the "New User" button in the top right of the page. Based on your previous page, the role in the select box should default as follows:
"Learners" -> Student
"Staff" -> GSI
"Observers" - > Observer

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Users

======================
Closes #3421 
