### PR TITLE
3555 copied course shells default to active

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -102,7 +102,7 @@ class Course < ActiveRecord::Base
     else
       begin
         Course.skip_callback(:create, :after, :create_admin_memberships)
-        copy_with_associations(attributes.merge(lti_uid: nil), [:course_memberships, :teams])
+        copy_with_associations(attributes.merge(lti_uid: nil, status: true), [:course_memberships, :teams])
       ensure
         Course.set_callback(:create, :after, :create_admin_memberships)
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -98,7 +98,7 @@ class Course < ActiveRecord::Base
 
   def copy(copy_type, attributes={})
     if copy_type != "with_students"
-      copy_with_associations(attributes.merge(lti_uid: nil), [])
+      copy_with_associations(attributes.merge(lti_uid: nil, status: true), [])
     else
       begin
         Course.skip_callback(:create, :after, :create_admin_memberships)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
A copied course shell should default to active.

### Related PRs
N/A

### Todos
N/A

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an administrator, navigate to manage courses, inactive courses, copy course. A duplicated version of the course should appear as "Copy of... [name of course" in the ACTIVE courses table.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Courses

======================
Closes #3555 
