### PR TITLE
3579 add syllabus link to student view

### DIFF
--- a/app/views/info/syllabus.html.haml
+++ b/app/views/info/syllabus.html.haml
@@ -6,6 +6,11 @@
   - if current_course.gameful_philosophy.present?
     %h3.bold Grading Philosophy
     = render partial: "courses/grading_philosophy", locals: {course: current_course}
+    %p
+  - if current_course.syllabus.present?
+    %h3.bold Course Syllabus
+    = link_to "Click here to download the Current Syllabus", current_course.syllabus_url
+    %p
 
   - if current_course.grade_scheme_elements.with_lowest_points.present?
     %h3.bold Grading Scheme

--- a/app/views/info/syllabus.html.haml
+++ b/app/views/info/syllabus.html.haml
@@ -9,7 +9,7 @@
     %p
   - if current_course.syllabus.present?
     %h3.bold Course Syllabus
-    = link_to "Download the Current Syllabus", current_course.syllabus_url
+    = external_link_to "Download the Current Syllabus", current_course.syllabus_url
     %p
 
   - if current_course.grade_scheme_elements.with_lowest_points.present?

--- a/app/views/info/syllabus.html.haml
+++ b/app/views/info/syllabus.html.haml
@@ -9,7 +9,7 @@
     %p
   - if current_course.syllabus.present?
     %h3.bold Course Syllabus
-    = link_to "Click here to download the Current Syllabus", current_course.syllabus_url
+    = link_to "Download the Current Syllabus", current_course.syllabus_url
     %p
 
   - if current_course.grade_scheme_elements.with_lowest_points.present?


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Currently, the syllabus file is an attachment that instructors can upload via the course form and appears in the course info dropdown menu at the top of the screen. This should stay the same, but it should also be added to the student-view that is the "Syllabus" page - at the very top of the page.

### Related PRs
N/A


### Todos
- [ ] Add Tests
- [ ] Update/Add Documentation
- [ ] Update Sample Data


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Assuming a syllabus exists for a course, as a student, login and go to the syllabus page. As a student, I should see a link for Current Syllabus.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Syllabus (for student)

======================
Closes #3579 
