### PR TITLE
Remove deprecated definition for replace on directive

### DIFF
--- a/app/assets/javascripts/angular/directives/student/submission/hidden_form_method.coffee
+++ b/app/assets/javascripts/angular/directives/student/submission/hidden_form_method.coffee
@@ -15,7 +15,6 @@
   ]
 
   {
-    replace: true
     restrict: 'EA'
     bindToController: true
     controller: HiddenFormMethodCtrl


### PR DESCRIPTION
### Status
READY

### Description
This is an interesting theory but there is a definite possibility that this might be the cause of what users are experiencing.

To explain what's going on:

The submission form for a student is slightly different from the submission form for an instructor in that students are allowed to type and have their text content autosaved on the Froala text area.

When we implemented this feature, we opted to mix the Rails form with Angular components rather than redoing the entire form. This required us to account for certain considerations, particularly when submitting the form, because we have to handle the form behavior the same way that Rails would expect but with Angular.

In our scenario, for a standard Rails form with conventional resource-based routing one would expect that an update request should go to one of the following:

```
PATCH /assignments/:assignment_id/submissions/:id
PUT /assignments/:assignment_id/submissions/:id
```

Long story short, I put a debugger statement in the directive that handles the hidden form field that should render this:

```
<input name="_method" type="hidden" value="patch" />
```

When attempting to edit a submission, the breakpoint never hit and therefore no hidden input was added.

See [this link for additional details](http://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-patch-put-or-delete-methods-work-questionmark). In a gist, some browsers don't know how to PUT or PATCH so Rails expects a `_method` in the request that will tell it whether it's a PUT or a PATCH.

**TL;DR: I think that this is browser-based and that there must be users on older browsers who are experiencing these issues, since the route `/assignments/:assignment_id/submissions/:id` technically exists only for the PUT and PATCH requests and not POST, which it would default to in the absence of the hidden form tag.**

### Todos
- [ ] At a later time, consider garbaging the whole submission form for students, since it currently is an amalgamation of Angular/Rails form, presenter logic.

### Migrations
NO

### Steps to Test or Reproduce
Ensure that submissions work as expected.

### Impacted Areas in Application
Student submission creating/editing