### PR TITLE
reload grade to examine for updater job

### DIFF
--- a/app/controllers/api/grades_controller.rb
+++ b/app/controllers/api/grades_controller.rb
@@ -22,7 +22,7 @@ class API::GradesController < ApplicationController
     result = Services::UpdatesGrade.update grade, grade_params, current_user.id
     if result
       # Only send notifications etc. when handling the form submission
-      if params[:submit] && grade.student_visible?
+      if params[:submit] && grade.reload.student_visible?
         GradeUpdaterJob.new(grade_id: grade.id).enqueue
       end
       @grade = result.grade


### PR DESCRIPTION
### Status
**READY**

### Description

Reloads grade before testing for student visible. This should make a more valid trigger for running a grade updater job on grades that have been switched to "student visible". 

The score recalculation still happens in a background process -- if we find this is not running fast enough or reliably enough on production we may need to trigger the recalculation directly in the controller method.

### Related PRs

#3565 which updates course score when weights change.  This PR also outlines the callback stack which manages the course score. 

======================
Closes #3594
