### PR TITLE
properly compact earned badge score before summing

### DIFF
--- a/app/models/concerns/analytics/user_analytics.rb
+++ b/app/models/concerns/analytics/user_analytics.rb
@@ -37,7 +37,7 @@ module Analytics
     end
 
     def earned_badge_score_for_course(course)
-      earned_badges.where(course: course).student_visible.sum(&:points)
+      earned_badges.where(course: course).student_visible.map(&:points).compact.sum
     end
 
     # returns all badges a student has earned for a particular course this week


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a longstanding bug where summing some badges without points failed the score tab

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Badge calculation, show student page
