### PR TITLE
add validations to unlocks on form

### DIFF
--- a/app/assets/javascripts/angular/services/UnlockConditionsService.coffee
+++ b/app/assets/javascripts/angular/services/UnlockConditionsService.coffee
@@ -115,7 +115,7 @@
 
   conditionIsValid = (condition)->
     return false if !(condition.condition_id && condition.condition_type && condition.condition_state)
-    if condition.condition_type == "Badge" || condition.condition_type == "Course"
+    if condition.condition_type == "Badge" || condition.condition_type == "Course" || condition.condition_type == "AssignmentType"
       return false if !condition.condition_value
     return true
 

--- a/app/assets/javascripts/angular/services/UnlockConditionsService.coffee
+++ b/app/assets/javascripts/angular/services/UnlockConditionsService.coffee
@@ -114,8 +114,10 @@
 
 
   conditionIsValid = (condition)->
-    return true if condition.condition_id && condition.condition_type && condition.condition_state
-    return false
+    return false if !(condition.condition_id && condition.condition_type && condition.condition_state)
+    if condition.condition_type == "Badge" || condition.condition_type == "Course"
+      return false if !condition.condition_value
+    return true
 
   {
     termFor: termFor

--- a/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
+++ b/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
@@ -5,11 +5,15 @@
       {{termFor(type)}}
 
 .unlock-condition-parameters(ng-if="condition.condition_type=='Assignment'")
-  %label {{ termFor("assignment") }}
+  %label
+    {{ termFor("assignment") }}
+    %span.required(ng-if="!condition.condition_id") *required
   %select(ng-model="condition.condition_id" name="condition_id" ng-change="updateCondition()")
     %option(ng-repeat="assignment in assignments" ng-selected="assignment.id == condition.condition_id" value="{{assignment.id}}")
       {{assignment.name}}
-  %label State Achieved
+  %label
+    State Achieved
+    %span.required(ng-if="!condition.condition_state") *required
   %select(ng-model="condition.condition_state" ng-change="updateCondition()")
     %option(ng-repeat="state in assignmentStates(condition.condition_id)"  ng-selected="state == condition.condition_state" value="{{state}}")
       {{state}}
@@ -19,27 +23,37 @@
   %input(id="{{assignment.id}}-completed-by" ng-model="condition.condition_date" gc-date-time-input ng-change="updateCondition()")
 
 .unlock-condition-parameters(ng-if="condition.condition_type=='Badge'")
-  %label {{ termFor("badge") }}
+  %label
+    {{ termFor("badge") }}
+    %span.required(ng-if="!condition.condition_id") *required
   %select(ng-model="condition.condition_id" name="condition_id" ng-change="updateCondition()")
     %option(ng-repeat="badge in badges" ng-selected="badge.id == condition.condition_id" value="{{badge.id}}")
       {{badge.name}}
-  %label Number of Times Earned
+  %label
+    Number of Times Earned
+    %span.required(ng-if="!condition.condition_value") *required
   %input(ng-model="condition.condition_value" gc-number-input ng-change="updateCondition()")
   %label Completed By Date
   %input(id="{{condition.id}}-completed-by" ng-model="condition.condition_date" gc-date-time-input ng-change="updateCondition()")
 
 .unlock-condition-parameters(ng-if="condition.condition_type=='Course'")
-  %label Minimum Points Earned
+  %label
+    Minimum Points Earned
+    %span.required(ng-if="!condition.condition_value") *required
   %input(ng-model="condition.condition_value" gc-number-input ng-change="updateCondition()")
   %label Completed By Date
   %input(id="{{condition.id}}-completed-by" ng-model="condition.condition_date" gc-date-time-input ng-change="updateCondition()")
 
 .unlock-condition-parameters(ng-if="condition.condition_type=='AssignmentType'")
-  %label {{ termFor("assignment_type") }}
+  %label
+    {{ termFor("assignment_type") }}
+    %span.required(ng-if="!condition.condition_id") *required
   %select(ng-model="condition.condition_id" name="condition_id" ng-change="updateCondition()")
     %option(ng-repeat="assignmentType in assignmentTypes" ng-selected="assignmentType.id == condition.condition_id" value="{{assignmentType.id}}")
       {{assignmentType.name}}
-  %label State Achieved
+  %label
+    State Achieved
+    %span.required(ng-if="!condition.condition_state") *required
   %select(ng-model="condition.condition_state" ng-change="updateCondition()")
     %option(ng-repeat="state in assignmentTypeStates"  ng-selected="state == condition.condition_state" value="{{state}}")
       {{state}}

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -134,6 +134,11 @@ span.checkbox
 .textarea ul.wysihtml5-toolbar
   background-color: $color-grey-4
 
+.required
+  color: $color-red-1
+  text-transform: lowercase;
+  font-style: italic;
+
 error
   color: $color-red-1
   font-weight: bold


### PR DESCRIPTION
### Status
**READY**

### Description

Adds validations to conditions on the assignment and badge forms.

  * UX indication that a field is still required to be saved
  * Only persists data once the condition is valid

<img width="293" alt="screen shot 2017-08-29 at 5 15 38 pm" src="https://user-images.githubusercontent.com/1138350/29844563-b6e68bc4-8cdd-11e7-8ed3-870a8c797c85.png">

======================
Closes #3608
