### PR TITLE
natural sort of team names

### DIFF
--- a/app/helpers/team_filter_helper.rb
+++ b/app/helpers/team_filter_helper.rb
@@ -4,7 +4,7 @@ module TeamFilterHelper
     content_tag :div, class: 'team-filter' do
       form_tag(request.url, class: "team-selector", onchange: "$('.team-selector').submit();", method: :get) do
         label_tag :team_id, "Select #{(term_for :team).titleize}", class: 'sr-only'
-        select_tag(:team_id, options_for_select(teams.alpha.map { |t| [t.name, t.id] }, params[:team_id]), prompt: "– Select #{(term_for :team).titleize} –")
+        select_tag(:team_id, options_for_select(teams.alpha.sort_by{|f| f.name.split(" ").last.to_i }.map { |t| [t.name, t.id] }, params[:team_id]), prompt: "– Select #{(term_for :team).titleize} –")
       end
     end
   end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR sorts the team filter naturally, making sense of the way that they are commonly numbered and therefore don't sort alphabetically all that well 
