### PR TITLE
Update user score after deleting badge

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -97,6 +97,7 @@ class EarnedBadgesController < ApplicationController
     @name = "#{@badge.name}"
     @student_name = "#{@earned_badge.student.name}"
     @earned_badge.destroy
+    ScoreRecalculatorJob.new(user_id: @earned_badge.student_id, course_id: @earned_badge.course_id).enqueue
     expire_fragment "earned_badges"
     redirect_to @badge,
       notice: "The #{@badge.name} #{term_for :badge} has been taken away from #{@student_name}."


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where student scores weren't updating after a badge with points was deleted 


======================
Closes #3368 
