### PR TITLE
3586 Fix Google Rate Limit Issue

### DIFF
--- a/app/controllers/google_calendars/assignments_controller.rb
+++ b/app/controllers/google_calendars/assignments_controller.rb
@@ -28,7 +28,7 @@ class GoogleCalendars::AssignmentsController < ApplicationController
   def add_assignments
     assignment_list = get_all_items_for_current_course(current_course, "assignment", current_user)
     assignment_list_filtered = filter_items_with_no_end_date(assignment_list)
-    assignments_hash = add_multiple_items(current_user, assignment_list, assignment_list_filtered)
+    assignments_hash = add_batch_items(current_user, assignment_list, assignment_list_filtered)
     assignments_hash.store("redirect_to", assignments_path)
     process_hash(assignments_hash)
   end

--- a/app/controllers/google_calendars/events_controller.rb
+++ b/app/controllers/google_calendars/events_controller.rb
@@ -28,7 +28,7 @@ class GoogleCalendars::EventsController < ApplicationController
   def add_events
     event_list = get_all_items_for_current_course(current_course, "event", current_user)
     event_list_filtered = filter_items_with_no_end_date(event_list)
-    events_hash = add_multiple_items(current_user, event_list, event_list_filtered)
+    events_hash = add_batch_items(current_user, event_list, event_list_filtered)
     events_hash.store("redirect_to", events_path)
     process_hash(events_hash)
   end

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -100,8 +100,8 @@ module GoogleCalendarsHelper
 
   # note: if there is a server error during a batch process the items processed before the server error will be copied to the associated google calendar
   def add_batch_items(current_user, item_list, item_list_filtered)
-    calendar = refresh_google_calendar_authorization(current_user)
     begin
+      calendar = refresh_google_calendar_authorization(current_user)
       calendar.batch do |batch|
         item_list_filtered.each do |item|
           batch.insert_event('primary', create_google_event(item))

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -102,9 +102,9 @@ module GoogleCalendarsHelper
   def add_batch_items(current_user, item_list, item_list_filtered)
     calendar = refresh_google_calendar_authorization(current_user)
     begin
-      calendar.batch do |calendar|
+      calendar.batch do |batch|
         item_list_filtered.each do |item|
-          calendar.insert_event('primary', create_google_event(item))
+          batch.insert_event('primary', create_google_event(item))
         end
       end
       return {"message_type" => "notice", "message" => "#{item_list_filtered.count} item(s) successfully added to your Google Calendar"} unless item_list.count != item_list_filtered.count

--- a/app/helpers/google_calendars_helper.rb
+++ b/app/helpers/google_calendars_helper.rb
@@ -99,10 +99,13 @@ module GoogleCalendarsHelper
   end
 
   # note: if there is a server error during a batch process the items processed before the server error will be copied to the associated google calendar
-  def add_multiple_items(current_user, item_list, item_list_filtered)
+  def add_batch_items(current_user, item_list, item_list_filtered)
+    calendar = refresh_google_calendar_authorization(current_user)
     begin
-      item_list_filtered.each do |item|
-        add(current_user, item)
+      calendar.batch do |calendar|
+        item_list_filtered.each do |item|
+          calendar.insert_event('primary', create_google_event(item))
+        end
       end
       return {"message_type" => "notice", "message" => "#{item_list_filtered.count} item(s) successfully added to your Google Calendar"} unless item_list.count != item_list_filtered.count
       return {"message_type" => "notice", "message" => "#{item_list_filtered.count} item(s) successfully added to your Google Calendar. #{item_list.count - item_list_filtered.count} item(s) were not added because of missing due date(s)."}

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -24,4 +24,4 @@
                   %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.strftime("%l:%M%p") }
 
   .calendar-access
-    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, method: :post
+    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/spec/controllers/google_calendars/assignments_controller_spec.rb
+++ b/spec/controllers/google_calendars/assignments_controller_spec.rb
@@ -87,7 +87,7 @@ describe GoogleCalendars::AssignmentsController, type:[:disable_external_api, :c
 
   describe "POST add_assignments" do
     before(:each) do
-      stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
+      stub_request(:post, "https://www.googleapis.com/batch").
         to_return(:status => 200, :body => "", :headers => {})
     end
     context "with an existing authentication" do

--- a/spec/controllers/google_calendars/events_controller_spec.rb
+++ b/spec/controllers/google_calendars/events_controller_spec.rb
@@ -79,7 +79,7 @@ describe GoogleCalendars::EventsController, type:[:disable_external_api, :contro
 
   describe "POST add_events" do
     before(:each) do
-      stub_request(:post, "https://www.googleapis.com/calendar/v3/calendars/primary/events").
+      stub_request(:post, "https://www.googleapis.com/batch").
         to_return(:status => 200, :body => "", :headers => {})
     end
     context "with an existing authentication" do


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Users are attempting to add so many assignments at once that the API's rate limit is exceeded. We need to either implement batching or a backoff strategy. 

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
On the Dashboard, if a user spams the "Add All Assignments to Calendar" link

1. The link text should change to "Adding Assignments to your Calendar..."

2. The button, although it will seem active will be disabled, so no matter how many times a user hits it, it will only make the API call once.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Dashboard
* Assignments
* Google Calendar

======================
Closes #3586 
