### PR TITLE
copy course id to copied rubrics from assignment

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -69,15 +69,21 @@ class Assignment < ActiveRecord::Base
   delegate :student_weightable?, to: :assignment_type
 
   def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
-                               associations: [:assignment_score_levels,
-                                 { assignment_files: { assignment_id: :id }}
-                               ],
-                               options: { prepend: { name: "Copy of "},
-                                          overrides: [->(copy) {
-                                 copy.rubric = self.rubric.copy if self.rubric.present?
-                               }]})
-  end
+    ModelCopier.new(self).copy(
+      attributes: attributes,
+      associations: [
+        :assignment_score_levels,
+        { assignment_files: { assignment_id: :id }}
+      ],
+      options: {
+        prepend: { name: "Copy of "},
+        overrides: [
+          ->(copy) { copy.rubric = self.rubric.copy if self.rubric.present? },
+          ->(copy) { copy.rubric.course_id = copy.course_id if self.rubric.present? },
+        ]
+      }
+    )
+end
 
   def to_json(options = {})
     super(options.merge(only: [:id]))

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -311,6 +311,18 @@ describe Assignment do
       expect(subject.rubric.assignment_id).to eq subject.id
       expect(subject.rubric).to_not be_new_record
     end
+
+    describe "copies on a new course" do
+      let(:assignment) {create :assignment}
+
+      it "copies the course id onto copied assignments" do
+        assignment.create_rubric(course_id: assignment.course_id)
+        course_copy = assignment.course.copy(nil)
+        assignment_copy = course_copy.assignments.first
+        expect(assignment.course_id).to_not eq(assignment_copy.course_id)
+        expect(course_copy.assignments.first.rubric.course_id).to eq(course_copy.assignments.first.course_id)
+      end
+    end
   end
 
   describe "#future?" do


### PR DESCRIPTION
### Status
**READY**

### Description

Assignment copies the rubric using the options overrides functionality, but this does not handle the course_id. This PR adds a second lambda that aligns the course_id with that of the copied assignment.

======================
Closes #3950
