### PR TITLE
fix to the missing badge term, hide description if locked

### DIFF
--- a/app/controllers/earned_badges_controller.rb
+++ b/app/controllers/earned_badges_controller.rb
@@ -8,7 +8,7 @@ class EarnedBadgesController < ApplicationController
   before_action :ensure_staff?, except: [:new, :create]
   before_action :find_badge
   before_action :find_earned_badge, only: [:show, :edit, :update, :destroy ]
-  before_action :use_current_course, only: [:show, :new, :edit, :mass_edit ]
+  before_action :use_current_course, only: [:show, :new, :edit, :mass_edit, :create, :update ]
 
   def index
     redirect_to badge_path(@badge)

--- a/app/models/concerns/unlockable_condition.rb
+++ b/app/models/concerns/unlockable_condition.rb
@@ -13,7 +13,7 @@ module UnlockableCondition
 
   def unlock!(student)
     unlocked = self.unlock_condition_count_to_meet == self.unlock_condition_count_met_for(student)
-    unlock_state = unlock_states.where(student_id: student.id).first if unlocked
+    unlock_state = unlock_states.where(student_id: student.id).first
     unlock_state ||= unlock_states.build(student_id: student.id,
                                          unlockable_id: self.id,
                                          unlockable_type: self.class)

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -28,20 +28,12 @@
 - if presenter.student_logged?(current_user)
   = render partial: "assignments/self_log_form", locals: { student: current_student, assignment: presenter.assignment }
 
-
-- if presenter.assignment.assignment_files.present?
-  %h3.uppercase Downloads
-  %ul
-  - presenter.assignment.assignment_files.each do |af|
-    %li= link_to af.filename, af.url
-
 - if current_user_is_staff? && presenter.assignment.grades.instructor_modified.any?
   %h3.uppercase Downloads
   %p= link_to glyph(:download) + "Download Grades", export_assignment_grades_path(presenter.assignment, format: :csv)
 
   - if presenter.grade_with_rubric? && presenter.grades.present?
     .clear= link_to glyph(:download) + "Download Rubric Grades", export_earned_levels_assignment_grades_path(presenter.assignment, format: :csv)
-
 
 - if current_student.present?
   - @group = current_student.group_for_assignment(presenter.assignment)
@@ -57,8 +49,8 @@
 
   - if presenter.assignment.is_unlockable?
     - if presenter.assignment.is_unlocked_for_student?(current_student)
-      %h3.uppercase #{glyph(:lock)} This #{term_for :assignment} has been Unlocked
-      .italic To achieve this you:
+      %h3.uppercase #{glyph(:unlock)} This #{term_for :assignment} has been Unlocked!
+      %p.italic To achieve this you:
       %ul
         - presenter.assignment.unlock_conditions.each do |condition|
           %li
@@ -99,6 +91,12 @@
         %li= key.key_description_sentence
 
 - if presenter.assignment_has_viewable_description?(current_user)
+  - if presenter.assignment.assignment_files.present?
+    %h3.uppercase Downloads
+    %ul
+      - presenter.assignment.assignment_files.each do |af|
+        %li= link_to af.filename, af.url
+
   %h3.uppercase Guidelines:
   = raw sanitize_external_links presenter.assignment.description
 


### PR DESCRIPTION
### Status
**In Development**

### Description
This PR fixes a bug where file downloads were visible even if the description was locked, it fixes a bug where the current course wasn't being passed to the badge create and update methods for proper rendering of validation errors, it submits a first pass for fixing the bug of too many unlock states created

### Todos
- [ ] Add Tests
- [ ] Update/Add Documentation

### Deploy Notes
Need to delete extraneous `UnlockStates`

### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Unlock State awarding
* Display of locked descriptions
* Earned Badge awarding

======================
Closes #3585 
