### PR TITLE
3588 Activate All Students per Course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -139,9 +139,9 @@ class CoursesController < ApplicationController
       student.activate!
     end
     if total != 1
-      redirect_to session[:return_to] || dashboard_path, notice: "#{total} students have been activated!" and return
+      redirect_to session[:return_to] || students_path, notice: "#{total} #{(term_for :student).downcase}(s) have been activated!" and return
     else
-      redirect_to session[:return_to] || dashboard_path, notice: "#{total} student has been activated!" and return
+      redirect_to session[:return_to] || students_path, notice: "#{total} #{t(term_for :student).downcase}(s) has been activated!" and return
     end
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -132,17 +132,16 @@ class CoursesController < ApplicationController
   end
 
   def activate_all_students
-    if course = current_user.courses.where(id: params[:id]).first
-      students = User.accounts_not_activated(course)
-      total = students.count
-      students.each do |student|
-        student.activate!
-      end
-      if total != 1
-        redirect_to session[:return_to] || dashboard_path, notice: "#{total} students have been activated!" and return
-      else
-        redirect_to session[:return_to] || dashboard_path, notice: "#{total} student has been activated!" and return
-      end
+    course = current_user.courses.where(id: params[:id]).first
+    students = User.accounts_not_activated(course)
+    total = students.count
+    students.each do |student|
+      student.activate!
+    end
+    if total != 1
+      redirect_to session[:return_to] || dashboard_path, notice: "#{total} students have been activated!" and return
+    else
+      redirect_to session[:return_to] || dashboard_path, notice: "#{total} student has been activated!" and return
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ class User < ActiveRecord::Base
 
   scope :order_by_name, -> { order("last_name, first_name ASC") }
 
+  scope :accounts_not_activated, ->(course_id) { includes(:course_memberships).where(course_memberships: { course_id: course_id }, activation_state: 'pending')}
+
   mount_uploader :avatar_file_name, AvatarUploader
 
   has_many :authorizations, class_name: "UserAuthorization", dependent: :destroy

--- a/app/views/courses/index.html.haml
+++ b/app/views/courses/index.html.haml
@@ -55,3 +55,4 @@
                   %li= link_to decorative_glyph(:edit) + "Edit", edit_course_path(course)
                   %li= link_to decorative_glyph(:copy) + "Copy", copy_courses_path(id: course.id), :method => :copy
                   %li= link_to decorative_glyph(:copy) + "Copy + Students", copy_courses_path(id: course.id, copy_type: "with_students"), :method => :copy
+                  %li= link_to decorative_glyph(:copy) + "Activate All Students", activate_all_students_courses_path(id: course.id), :method => :post

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,7 @@ Rails.application.routes.draw do
     post :recalculate_student_scores, on: :member
     put :publish, on: :member
     put :unpublish, on: :member
+    post :activate_all_students, on: :collection
     get :badges, on: :member
     get :change, on: :member
     get :new_external, on: :collection

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -184,6 +184,25 @@ describe CoursesController do
       end
     end
 
+    describe "POST activate_all_students" do
+      let(:unactivated_user) { create(:user)}
+      it "activates the user" do
+        post :activate_all_students, params:{id: course.id}
+        expect(unactivated_user.activated?).to eq true
+      end
+
+      it "redirects to referer url if present" do
+        request.env["HTTP_REFERER"] = "http://some-referer.com"
+        post :activate_all_students, params:{id: course.id}
+        expect(response).to redirect_to("http://some-referer.com")
+      end
+
+      it "redirects to dashboard if referer url is not present" do
+        post :activate_all_students, params:{id: course.id}
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
     describe "POST recalculate_student_scores" do
       it "is a protected route" do
         expect(post :recalculate_student_scores, params: { id: course.id.to_s }).to \
@@ -258,7 +277,8 @@ describe CoursesController do
     describe "protected routes requiring id in params" do
       [
         :edit,
-        :update
+        :update,
+        :activate_all_students
       ].each do |route|
         it "#{route} redirects to root" do
           expect(get route, params: { id: "1" }).to redirect_to(:root)

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -197,9 +197,9 @@ describe CoursesController do
         expect(response).to redirect_to("http://some-referer.com")
       end
 
-      it "redirects to dashboard if referer url is not present" do
+      it "redirects to students_path if referer url is not present" do
         post :activate_all_students, params:{id: course.id}
-        expect(response).to redirect_to(dashboard_path)
+        expect(response).to redirect_to(students_path)
       end
     end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an admin user, occasionally we hit a space where students have accounts that need to be activated. We should add a button that allows an admin user to do this from within the interface.

### Related PRs
N/A


### Todos
- [x] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Create a single new user or multiple new users for a single course who has/have not been activated. Navigate to 'My Courses'. In the drop-down options per course, notice the new "Activate All Students" option. Selecting this will loop through the not-yet-activated students in a course and activate their account (not to be confused with activating their course membership). You will notice an alert at the top of the page when the process is complete.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Courses
* Users

======================
Closes #3588 
