### PR TITLE
3627 Google iFrame issue

### DIFF
--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -43,4 +43,4 @@
                   Create Rubric
 
             = active_course_link_to decorative_glyph(:calendar) + "Add to Google Calendar",
-          add_assignment_google_calendars_assignments_path(presenter.assignment), method: :post
+          add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -20,7 +20,7 @@
 %p.assignment-description.italic= "Due: #{presenter.assignment.due_at.in_time_zone(current_user.time_zone)}" if presenter.assignment.due_at?
 
 %p.assignment-description= link_to decorative_glyph(:calendar) + "Add to Google Calendar",
-  add_assignment_google_calendars_assignments_path(presenter.assignment), method: :post
+  add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
 
 - if presenter.assignment_accepting_submissions?(current_student) && !presenter.has_viewable_submission?(current_student, current_user)
   = render partial: "students/submissions", locals: { assignment: presenter.assignment }

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -9,7 +9,7 @@
           - if current_course.allows_canvas?
             = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path
           - if current_course.assignments.present?
-            = active_course_link_to decorative_glyph(:calendar) + "Add All to Google Calendar", add_assignments_google_calendars_assignments_path, method: :post
+            = active_course_link_to decorative_glyph(:calendar) + "Add All to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post
 .pageContent
   = render partial: "layouts/alerts"
 

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -26,6 +26,6 @@
               .button-container.dropdown
                 %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
                 %ul.options-menu.dropdown-content
-                  %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), method: :post
+                  %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), :target => "_parent", method: :post
                   = active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event)
                   = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure you want to delete #{event.name}?" }

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,7 +7,7 @@
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
             %li= link_to decorative_glyph(:copy) + "Copy Event ", copy_events_path(id: @event.id), method: :post
-            %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(@event), method: :post
+            %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(@event), :target => "_parent", method: :post
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -25,4 +25,4 @@
                   %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_blank", method: :post, data: { disable_with: "Adding Your Assignments..." }
+    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -25,4 +25,4 @@
                   %li #{ link_to assignment.name, assignment } due at #{ assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, method: :post, data: { disable_with: "Adding Your Assignments..." }
+    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_blank", method: :post, data: { disable_with: "Adding Your Assignments..." }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Schools that use D2L within an iFrame have a problem with authenticating against Google, specifically if authentication occurs within the same iFrame. To remedy this, make authentication outside of the iFrame.

### Related PRs
N/A


### Todos
- [ ] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As a D2L user using Gradecraft without a google authorization in the database, click any google calendar link. This should redirect you to the google authorization page. Upon authenticating, the user should return back to the application.

NOTE: When the user returns to the application after authorization, the D2L mast head will be gone, as the user will have been taken to a version of the application outside of the frame within D2L. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Google Calendar

======================
Closes #3627 
