### PR TITLE
1245 Student Created Badges

### DIFF
--- a/app/assets/javascripts/angular/directives/badges/student_badge_index.coffee
+++ b/app/assets/javascripts/angular/directives/badges/student_badge_index.coffee
@@ -21,7 +21,7 @@
   ]
 
   services = ()->
-    promises = [BadgeService.getBadges()]
+    promises = [BadgeService.getBadges(null, "accepted")]
     return $q.all(promises)
 
   {
@@ -35,4 +35,3 @@
     templateUrl: 'badges/student_index.html'
   }
 ]
-

--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -2,7 +2,7 @@
   AwardedBadgesCtrl = [()->
     vm = this
     vm.BadgeService = BadgeService
-    BadgeService.getBadges(vm.studentId)
+    BadgeService.getBadges(vm.studentId, "accepted")
 
     # Has the student currently earned this badge on this grade?
     vm.badgeIsEarnedForGrade = (badge)->
@@ -42,4 +42,3 @@
     templateUrl: 'grades/earned_badges_select.html'
   }
 ]
-

--- a/app/assets/javascripts/angular/services/BadgeService.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.coffee
@@ -30,12 +30,12 @@
   # GET index list of badges
   # for students includes predictions
   # for faculty using student id, includes badge awards and availability
-  getBadges = (studentId)->
+  getBadges = (studentId, state = null)->
     if studentId
       url = '/api/students/' + studentId + '/badges'
     else
       url = '/api/badges'
-    $http.get(url).success( (response)->
+    $http.get(url, params: {state: state}).success( (response)->
       GradeCraftAPI.loadMany(badges, response, {"include" : ['prediction']})
       _.each(badges, (badge)->
         # add earned badge count for generic predictor

--- a/app/assets/javascripts/angular/templates/badges/student_index.html.haml
+++ b/app/assets/javascripts/angular/templates/badges/student_index.html.haml
@@ -5,12 +5,12 @@
 
     .badge-index-section
       .badge-icon-container{'ng-repeat'=>'badge in vm.badges', 'ng-class'=>'{"focus-article": vm.isFocusArticle(badge)}'}
-        %a.mobile-click{:href => "badges/{{badge.id}}"}
-        .img-cropper.med-crop
-          %img{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'badge-icon unearned' : 'badge-icon')", 'ng-src'=>'{{badge.icon}}', 'ng-click'=>'vm.changeFocusArticle(badge)'}
-        %p.badge-name {{badge.name}}
-        .gold-stars{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'unearned' : 'earned')"}
-          %i.fa.fa-fw.fa-star
-            .earned-count {{badge.earned_badge_count}}
-
-  %student-panel.student-panel.badge-panel.student-flex-col{'context'=>'"badges"'}
+        .badge-icon{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'badge-icon unearned' : 'badge-icon')"}
+          %a{:href => "badges/{{badge.id}}"}
+            .img-cropper.med-crop
+              %img{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'badge-icon unearned' : 'badge-icon')", 'ng-src'=>'{{badge.icon}}', 'ng-click'=>'vm.changeFocusArticle(badge)'}
+            .gold-stars{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'unearned' : 'earned')"}
+              %i.fa.fa-fw.fa-star
+                .earned-count {{badge.earned_badge_count}}
+          %a{:href => "badges/{{badge.id}}"}
+            %p.badge-name {{badge.name}}

--- a/app/assets/stylesheets/layout/_layout.sass
+++ b/app/assets/stylesheets/layout/_layout.sass
@@ -11,7 +11,7 @@ body
 .inner-wrap
   display: flex
   flex: 1 0 auto
-  margin: 2.75rem auto 0
+  margin: 0 auto;
   max-width: 1500px
   width: 100%
   background-color: $color-white
@@ -23,13 +23,17 @@ body
 .pageContent
   padding: 0rem 1rem 1rem
   background-color: $color-white
-  @media (max-width: $media-small-max)
-    padding: 0.5rem
+  @media (max-width: $media-medium-max)
+    padding: 0.5rem 1rem
 
 .student > .mainContent
-  padding-top: 2.2rem
-  @media (max-width: $media-small-max)
-    padding-top: 0
+  margin: 0 auto
+  max-width: 1100px
+
+.student > .mainContent .pageContent
+  padding: 0 .25rem
+  @media (max-width: $media-medium-max)
+    padding: 0 1rem
 
 .box
   a, button
@@ -87,6 +91,13 @@ hr.light-grey
 
 .page-header
   padding: 0.5rem 1rem
+
+.student > .mainContent > .page-header
+  padding: 1rem .25rem
+  @media (max-width: $media-medium-max)
+    padding: 2.5rem 1rem 0
+  @media (max-width: $media-small-max)
+    padding: .5rem 1rem
 
 .collapse-toggler
   i.fa.fa-angle-double-right.fa-fw

--- a/app/assets/stylesheets/layout/_offscreen_sidebar.sass
+++ b/app/assets/stylesheets/layout/_offscreen_sidebar.sass
@@ -62,6 +62,9 @@
     .search
       display: none
 
+    .mobile-course-and-account-info
+      margin-top: 17rem
+
     .course-info-btn-mobile, .course-site
       position: relative
       cursor: pointer

--- a/app/assets/stylesheets/layout/_student_sidebar.sass
+++ b/app/assets/stylesheets/layout/_student_sidebar.sass
@@ -13,7 +13,7 @@
   width: auto
   overflow: hidden
   min-height: 100%
-  border-right: 1px solid $color-grey-6
+  
 
 .staff .student-panel
   margin-top: -2.75rem

--- a/app/assets/stylesheets/layout/_student_subnav.sass
+++ b/app/assets/stylesheets/layout/_student_subnav.sass
@@ -9,14 +9,20 @@ dl
   margin-top: 3.375rem
   max-width: 1248px
 
+.subnav-wrapper
+  background-color: $color-blue-2
+  width: 100%
+  height: 2.3rem
+  @media (max-width: $media-medium-max)
+    background-color: white
+    height: 0
+
 .sub-nav
   padding: 0.5rem 0rem
-  margin: 0
-  position: fixed
+  margin: 0 auto
   display: block
   overflow: hidden
-  width: 100%
-  max-width: 1500px
+  max-width: 1100px
   background-color: $color-blue-2
   z-index: 20
   @media (max-width: $media-small-max)

--- a/app/assets/stylesheets/layout/_topbar.sass
+++ b/app/assets/stylesheets/layout/_topbar.sass
@@ -14,7 +14,7 @@ a.site-title
   border: none
 
 .container
-  width: 100%
+  max-width: 1500px
   margin: 0 auto
 
 /* Navbar Styles */
@@ -22,10 +22,11 @@ a.site-title
   list-style-type: none
 
 .navbar
-  position: fixed
-  top: 0 !important
+  // position: fixed
+  // top: 0 !important
   z-index: 99
   height: 45px !important
+  background-color: $color-blue-1
 
 .logged-out
   .navbar
@@ -103,9 +104,12 @@ ul.subnav.logged-out
 
   .the-nav
     display: block
-    max-width: 1500px
+    max-width: 1100px
     margin: 0 auto
     font-weight: 300
+
+  .subnav-wrapper
+    background-color: $color-blue-2
 
   .the-nav .nav-pill.right
     z-index: 100
@@ -166,7 +170,7 @@ ul.subnav.logged-out
     position: absolute
     right: 0
     z-index: 20
-    margin: 0
+    margin: 0 auto
     padding: 0
     min-width: 150px
     font-size: .8rem

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -29,9 +29,14 @@
     display: none
 
 // used on the badge index for students
+.badge-index-section
+  width: 100%
+  text-align: center
+  margin-bottom: 3rem
+
 .badge-icon-container
   display: inline-block
-  margin: 1rem
+  margin: 3.5rem 1rem 1rem
   position: relative
   vertical-align: top
 
@@ -40,12 +45,19 @@
     border: 1px solid $color-yellow-1
     width: 146px
     height: 146px
+    transition: all .3s
+    &:hover
+        box-shadow: 0 0 10px $color-yellow-1
 
     &.unearned, &.unavailable
-      filter: grayscale(100%)
       border: 1px solid $color-grey-4
       background: $color-grey-6
       box-shadow: inset 2px 2px 4px $color-grey-4
+      &:hover
+        box-shadow: inset 2px 2px 4px $color-grey-4, 0 0 10px $color-yellow-1
+
+      img
+        filter: grayscale(100%)
 
     &.earned
       opacity: 1
@@ -69,6 +81,9 @@
     color: $color-black
     padding-top: .5rem
     margin: 2.5rem auto 0
+    transition: all .3s
+    &:hover
+      color: $color-blue-3
 
 
 .mobile-click
@@ -86,30 +101,60 @@
 
 // Student Badge Show Page
 .student
+  .page-header
+    display: flex
+    justify-content: space-between
+    align-items: center
+
   .badge-show-page
 
     section
       max-width: 990px
-      margin: 1rem auto
+      margin: 0
 
     .pg-header
       display: flex
       justify-content: flex-start
       align-items: center
+      @media (max-width: $media-small-max)
+        flex-direction: column
+        justify-content: center
 
-    .img-cropper
-      margin-right: 2rem
+    .badge-icon
+      &:hover
+          box-shadow: none
+      &.unearned, &.unavailable
+        box-shadow: none
+
+    .badge-icon-container
+      margin: 1rem 2rem 1rem 0
+      @media (max-width: $media-small-max)
+        margin: 1rem auto
 
     .badge-container
       display: flex
       justify-content: flex-start
+      @media (max-width: $media-small-max)
+        display: block
+
 
       .badge-stats
-        padding-right: 5rem
+        min-width: 180px
+        margin-right: 0
+        @media (max-width: $media-small-max)
+          width: 100%
+
+        .badge-stat
+          margin: 1rem 0
+
+      .badge-info
         margin: 0
 
-      .badge-description
-        margin: 0
+      .badge-info-piece
+        margin: 1rem 0
+
+    .earned-badge
+      margin: 1rem 0
 
 // staff badge show page
 .staff

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -13,8 +13,7 @@
   font-family: 'Open Sans', sans-serif
   font-weight: normal
   width: 1rem
-  margin-top: -1.35rem
-  margin-left: .8rem
+  margin: -1.35rem auto 0
   text-align: center
   color: $color-black
 
@@ -36,20 +35,41 @@
   position: relative
   vertical-align: top
 
-  .img-cropper
-    margin: 0 auto
-
   .badge-icon
-    cursor: pointer
+    border-radius: 100px
+    border: 1px solid $color-yellow-1
+    width: 146px
+    height: 146px
+
     &.unearned, &.unavailable
-      opacity: .2 !important
+      filter: grayscale(100%)
+      border: 1px solid $color-grey-4
+      background: $color-grey-6
+      box-shadow: inset 2px 2px 4px $color-grey-4
+
     &.earned
       opacity: 1
 
-  &.focus-article
-    background-color: transparentize($color-blue-3, .8)
-    @media (max-width: $media-medium-max)
-      background-color: initial
+
+  .img-cropper
+    background: white
+    border-radius: 100px
+    box-sizing: content-box
+    overflow: hidden
+    margin: .5rem auto
+    position: relative
+    top: 15px
+
+    img
+      display: block
+      object-fit: cover
+      transition: all .3s
+
+  .badge-name
+    color: $color-black
+    padding-top: .5rem
+    margin: 2.5rem auto 0
+
 
 .mobile-click
   display: none
@@ -217,8 +237,8 @@ input.media-upload-button, input.icon-upload-button
     width: 150px
     height: 150px
   &.med-crop
-    width: 80px
-    height: 80px
+    width: 100px
+    height: 100px
   &.small-crop
     width: 40px
     height: 40px

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -67,15 +67,29 @@
 // Student Badge Show Page
 .student
   .badge-show-page
-    .badge-container
-      text-align: center
 
     section
-      max-width: 720px
+      max-width: 990px
       margin: 1rem auto
 
+    .pg-header
+      display: flex
+      justify-content: flex-start
+      align-items: center
+
     .img-cropper
-      margin: 0 auto
+      margin-right: 2rem
+
+    .badge-container
+      display: flex
+      justify-content: flex-start
+
+      .badge-stats
+        padding-right: 5rem
+        margin: 0
+
+      .badge-description
+        margin: 0
 
 // staff badge show page
 .staff

--- a/app/assets/stylesheets/pages/_dashboard.sass
+++ b/app/assets/stylesheets/pages/_dashboard.sass
@@ -50,6 +50,7 @@
   width: 100%
   border: 1px solid $color-grey-6
   border-radius: 3px
+  padding: .5px
 
   .card-header
     background-color: $color-grey-7

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -19,8 +19,7 @@ class API::BadgesController < ApplicationController
       :visible_when_locked,
       :state)
 
-    return unless params[:state].present?
-      @badges = badges_by_state
+    @badges = badges_by_state if params[:state].present?
 
     if current_user_is_student?
       @student = current_student
@@ -75,8 +74,14 @@ class API::BadgesController < ApplicationController
   private
 
   def badges_by_state
-    if params[:state] == "accepted"
+    state = params[:state]
+    case state
+    when "accepted"
       @badges = @badges.accepted
+    when "proposed"
+      @badges = @badges.proposed
+    when "rejected"
+      @badges = @badges.rejected
     end
   end
 

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -1,7 +1,8 @@
 class API::BadgesController < ApplicationController
   include SortsPosition
 
-  before_action :ensure_staff?, except: [:index]
+  before_action :ensure_not_observer?, only: [:create]
+  before_action :ensure_staff?, except: [:index, :create]
 
   # GET api/badges
   def index
@@ -48,7 +49,7 @@ class API::BadgesController < ApplicationController
   end
 
   def create
-    @badge = current_course.badges.new(badge_params)
+    @badge = current_course.badges.new(badge_params.merge(user_id: current_user.id)) # I think it's a bad idea to merge here, revisit later
     if @badge.save
       render "api/badges/show", success: true, status: 201
     else
@@ -80,7 +81,8 @@ class API::BadgesController < ApplicationController
       :show_points_when_locked,
       :student_awardable,
       :visible,
-      :visible_when_locked
+      :visible_when_locked,
+      :user_id
     )
   end
 end

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -51,7 +51,6 @@ class API::BadgesController < ApplicationController
   def create
     @badge = current_course.badges.new(badge_params.merge(user_id: current_user.id)) # I think it's a bad idea to merge here, revisit later
     if current_user_is_staff?
-      binding.pry
       @badge.update_attribute(:state, "Accepted")
     end
     if @badge.save

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -16,7 +16,11 @@ class API::BadgesController < ApplicationController
       :name,
       :position,
       :visible,
-      :visible_when_locked)
+      :visible_when_locked,
+      :state)
+
+    return unless params[:state].present?
+      @badges = badges_by_state
 
     if current_user_is_student?
       @student = current_student
@@ -69,6 +73,12 @@ class API::BadgesController < ApplicationController
   end
 
   private
+
+  def badges_by_state
+    if params[:state] == "accepted"
+      @badges = @badges.accepted
+    end
+  end
 
   def badge_params
     params.require(:badge).permit(

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -1,8 +1,8 @@
 class API::BadgesController < ApplicationController
   include SortsPosition
 
-  before_action :ensure_not_observer?, only: [:create]
-  before_action :ensure_staff?, except: [:index, :create]
+  before_action :ensure_not_observer?, only: [:create, :update]
+  before_action :ensure_staff?, except: [:index, :create, :update]
 
   # GET api/badges
   def index
@@ -49,9 +49,9 @@ class API::BadgesController < ApplicationController
   end
 
   def create
-    @badge = current_course.badges.new(badge_params.merge(user_id: current_user.id)) # I think it's a bad idea to merge here, revisit later
+    @badge = current_course.badges.new(badge_params.merge(created_by: current_user.id)) # I think it's a bad idea to merge here, revisit later
     if current_user_is_staff?
-      @badge.update_attribute(:state, "Accepted")
+      @badge.update_attribute(:state, "accepted")
     end
     if @badge.save
       render "api/badges/show", success: true, status: 201

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -49,9 +49,9 @@ class API::BadgesController < ApplicationController
   end
 
   def create
-    @badge = current_course.badges.new(badge_params.merge(created_by: current_user.id)) # I think it's a bad idea to merge here, revisit later
+    @badge = current_course.badges.new(badge_params.merge(created_by: current_user.id))
     if current_user_is_staff?
-      @badge.update_attribute(:state, "accepted")
+      @badge.state = "accepted"
     end
     if @badge.save
       render "api/badges/show", success: true, status: 201
@@ -85,7 +85,7 @@ class API::BadgesController < ApplicationController
       :student_awardable,
       :visible,
       :visible_when_locked,
-      :user_id
+      :created_by
     )
   end
 end

--- a/app/controllers/api/badges_controller.rb
+++ b/app/controllers/api/badges_controller.rb
@@ -50,6 +50,10 @@ class API::BadgesController < ApplicationController
 
   def create
     @badge = current_course.badges.new(badge_params.merge(user_id: current_user.id)) # I think it's a bad idea to merge here, revisit later
+    if current_user_is_staff?
+      binding.pry
+      @badge.update_attribute(:state, "Accepted")
+    end
     if @badge.save
       render "api/badges/show", success: true, status: 201
     else

--- a/app/controllers/api/students/badges_controller.rb
+++ b/app/controllers/api/students/badges_controller.rb
@@ -19,8 +19,7 @@ class API::Students::BadgesController < ApplicationController
       :visible_when_locked).includes(:earned_badges)
     @earned_badges = current_course.earned_badges.where(student_id: @student.id)
 
-    return unless params[:state].present?
-      @badges = badges_by_state
+    @badges = badges_by_state if params[:state].present?
 
     render template: "api/badges/index"
   end
@@ -28,8 +27,14 @@ class API::Students::BadgesController < ApplicationController
   private
 
   def badges_by_state
-    if params[:state] == "accepted"
-      return @badges.accepted
+    state = params[:state]
+    case state
+    when "accepted"
+      @badges = @badges.accepted
+    when "proposed"
+      @badges = @badges.proposed
+    when "rejected"
+      @badges = @badges.rejected
     end
   end
 end

--- a/app/controllers/api/students/badges_controller.rb
+++ b/app/controllers/api/students/badges_controller.rb
@@ -18,6 +18,18 @@ class API::Students::BadgesController < ApplicationController
       :visible,
       :visible_when_locked).includes(:earned_badges)
     @earned_badges = current_course.earned_badges.where(student_id: @student.id)
+
+    return unless params[:state].present?
+      @badges = badges_by_state
+
     render template: "api/badges/index"
+  end
+
+  private
+
+  def badges_by_state
+    if params[:state] == "accepted"
+      return @badges.accepted
+    end
   end
 end

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -45,7 +45,7 @@ class BadgesController < ApplicationController
 
   def accept_proposal
     @badge = Badge.find(params[:id])
-    if @badge.update_attribute(:state, "Accepted")
+    if @badge.update_attribute(:state, "accepted")
       redirect_to badges_path, notice: "#{@badge.name} Accepted"
     else
       redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
@@ -54,7 +54,7 @@ class BadgesController < ApplicationController
 
   def reject_proposal
     @badge = Badge.find(params[:id])
-    if @badge.update_attribute(:state, "Rejected")
+    if @badge.update_attribute(:state, "rejected")
       redirect_to badges_path, notice: "#{@badge.name} Rejected"
     else
       redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,9 +1,9 @@
 class BadgesController < ApplicationController
 
   before_action :ensure_not_observer?, except: [:index, :show]
-  before_action :ensure_staff?, except: [:index, :show]
+  before_action :ensure_staff?, except: [:index, :show, :propose, :new]
   before_action :find_badge, only: [:show, :edit, :destroy]
-  before_action :use_current_course, only: [:index, :show, :new, :edit]
+  before_action :use_current_course, only: [:index, :show, :new, :propose, :edit]
 
   # GET /badges
   def index
@@ -27,6 +27,14 @@ class BadgesController < ApplicationController
 
   def new
     @badge = @course.badges.new
+  end
+
+  def propose
+    if current_user_is_staff?
+      @badge = @course.badges.new
+    else
+      @badge = @course.badges.new
+    end
   end
 
   def edit

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -10,9 +10,9 @@ class BadgesController < ApplicationController
     render Badges::IndexPresenter.build({
       title: term_for(:badges),
       badges: @course.badges.ordered,
-      accepted_badges: @course.badges.accepted,
-      rejected_badges: @course.badges.rejected,
-      proposed_badges: @course.badges.proposed,
+      # accepted_badges: @course.badges.accepted,
+      # rejected_badges: @course.badges.rejected,
+      # proposed_badges: @course.badges.proposed,
       student: current_student
     })
   end
@@ -43,19 +43,11 @@ class BadgesController < ApplicationController
       notice: "#{@name} #{term_for :badge} successfully deleted"
   end
 
-  def accept_proposal
+  def update_proposal
     @badge = Badge.find(params[:id])
-    if @badge.update_attribute(:state, "accepted")
-      redirect_to badges_path, notice: "#{@badge.name} Accepted"
-    else
-      redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
-    end
-  end
-
-  def reject_proposal
-    @badge = Badge.find(params[:id])
-    if @badge.update_attribute(:state, "rejected")
-      redirect_to badges_path, notice: "#{@badge.name} Rejected"
+    update_value = params[:update_value]
+    if @badge.update_attribute(:state, update_value)
+      redirect_to badges_path, notice: "#{@badge.name} #{update_value.capitalize}"
     else
       redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
     end

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -10,6 +10,9 @@ class BadgesController < ApplicationController
     render Badges::IndexPresenter.build({
       title: term_for(:badges),
       badges: @course.badges.ordered,
+      accepted_badges: @course.badges.accepted,
+      rejected_badges: @course.badges.rejected,
+      proposed_badges: @course.badges.proposed,
       student: current_student
     })
   end
@@ -44,6 +47,15 @@ class BadgesController < ApplicationController
     @badge = Badge.find(params[:id])
     if @badge.update_attribute(:state, "Accepted")
       redirect_to badges_path, notice: "#{@badge.name} Accepted"
+    else
+      redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
+    end
+  end
+
+  def reject_proposal
+    @badge = Badge.find(params[:id])
+    if @badge.update_attribute(:state, "Rejected")
+      redirect_to badges_path, notice: "#{@badge.name} Rejected"
     else
       redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
     end

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -29,14 +29,6 @@ class BadgesController < ApplicationController
     @badge = @course.badges.new
   end
 
-  def propose
-    if current_user_is_staff?
-      @badge = @course.badges.new
-    else
-      @badge = @course.badges.new
-    end
-  end
-
   def edit
     @badge = Badge.find(params[:id])
   end
@@ -46,6 +38,15 @@ class BadgesController < ApplicationController
     @badge.destroy
     redirect_to badges_path,
       notice: "#{@name} #{term_for :badge} successfully deleted"
+  end
+
+  def accept_proposal
+    @badge = Badge.find(params[:id])
+    if @badge.update_attribute(:state, "Accepted")
+      redirect_to badges_path, notice: "#{@badge.name} Accepted"
+    else
+      redirect_to badges_path, notice: "#{@badge.name} Something Went Wrong"
+    end
   end
 
   def export_structure

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -10,9 +10,6 @@ class BadgesController < ApplicationController
     render Badges::IndexPresenter.build({
       title: term_for(:badges),
       badges: @course.badges.ordered,
-      # accepted_badges: @course.badges.accepted,
-      # rejected_badges: @course.badges.rejected,
-      # proposed_badges: @course.badges.proposed,
       student: current_student
     })
   end

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -41,11 +41,11 @@ module LinkHelper
 
   # Conditionally renders a link_to helper based on whether the course is active
   # or not - tag allows you to optionally wrap value in html tag
-  def active_course_link_to(name = nil, options = nil, html_options = nil, tag_class = nil, &block)
+  def active_course_link_to(name = nil, options = nil, html_options = nil, tag_class = nil, content_name = "li", &block)
     return unless current_user_is_admin? || current_course.active?
-    content_tag(:li, class: tag_class) do
-      link_to name, options, html_options, &block
-    end
+    link = link_to name, options, html_options, &block
+    return link unless content_name
+    content_tag(content_name, class: tag_class) { link }
   end
 
   def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -41,11 +41,11 @@ module LinkHelper
 
   # Conditionally renders a link_to helper based on whether the course is active
   # or not - tag allows you to optionally wrap value in html tag
-  def active_course_link_to(name = nil, options = nil, html_options = nil, tag_class = nil, content_name = "li", &block)
+  def active_course_link_to(body, url, html_options={}, content_tag_class=nil, content_name="li", &block)
     return unless current_user_is_admin? || current_course.active?
-    link = link_to name, options, html_options, &block
-    return link unless content_name
-    content_tag(content_name, class: tag_class) { link }
+    link = link_to body, url, html_options, &block
+    return link if content_name.nil?
+    content_tag(content_name, class: content_tag_class) { link }
   end
 
   def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -12,6 +12,7 @@ class Badge < ActiveRecord::Base
   has_many :predicted_earned_badges, dependent: :destroy
 
   belongs_to :course
+  belongs_to :creator, class_name: "User", foreign_key: :created_by
 
   accepts_nested_attributes_for :earned_badges, allow_destroy: true, reject_if: proc { |a| a.points.blank? }
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -27,9 +27,9 @@ class Badge < ActiveRecord::Base
 
   scope :visible, -> { where(visible: true) }
   scope :ordered, -> { order("position ASC") }
-  scope :accepted, -> { where(state: "Accepted").order("position ASC") }
-  scope :rejected, -> { where(state: "Rejected").order("position ASC") }
-  scope :proposed, -> { where(state: "Proposed").order("position ASC") }
+  scope :accepted, -> { where(state: "accepted").order("position ASC") }
+  scope :rejected, -> { where(state: "rejected").order("position ASC") }
+  scope :proposed, -> { where(state: "proposed").order("position ASC") }
   scope :earned_this_week, -> { includes(:earned_badges).where("earned_badges.updated_at > ?", 7.days.ago).references(:earned_badges) }
 
   # Counting how many times a particular student has earned this badge

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -27,6 +27,9 @@ class Badge < ActiveRecord::Base
 
   scope :visible, -> { where(visible: true) }
   scope :ordered, -> { order("position ASC") }
+  scope :accepted, -> { where(state: "Accepted").order("position ASC") }
+  scope :rejected, -> { where(state: "Rejected").order("position ASC") }
+  scope :proposed, -> { where(state: "Proposed").order("position ASC") }
   scope :earned_this_week, -> { includes(:earned_badges).where("earned_badges.updated_at > ?", 7.days.ago).references(:earned_badges) }
 
   # Counting how many times a particular student has earned this badge

--- a/app/presenters/badges/index_presenter.rb
+++ b/app/presenters/badges/index_presenter.rb
@@ -8,15 +8,15 @@ class Badges::IndexPresenter < Showtime::Presenter
   end
 
   def accepted_badges
-    properties[:accepted_badges]
+    badges.accepted
   end
 
   def rejected_badges
-    properties[:rejected_badges]
+    badges.rejected
   end
 
   def proposed_badges
-    properties[:proposed_badges]
+    badges.proposed
   end
 
   def student

--- a/app/presenters/badges/index_presenter.rb
+++ b/app/presenters/badges/index_presenter.rb
@@ -7,6 +7,18 @@ class Badges::IndexPresenter < Showtime::Presenter
     properties[:badges]
   end
 
+  def accepted_badges
+    properties[:accepted_badges]
+  end
+
+  def rejected_badges
+    properties[:rejected_badges]
+  end
+
+  def proposed_badges
+    properties[:proposed_badges]
+  end
+
   def student
     properties[:student]
   end

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -1,7 +1,8 @@
 .button-container.dropdown
   %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
   %ul.options-menu.dropdown-content
-    = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)
-    = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge)
+    - if badge.state == "accepted"
+      = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)
+      = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge)
     = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge)
     = active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), data: { confirm: "Are you sure you want to delete #{badge.name}?",  method: :delete }

--- a/app/views/badges/_buttons.haml
+++ b/app/views/badges/_buttons.haml
@@ -4,5 +4,8 @@
     - if badge.state == "accepted"
       = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)
       = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge)
+    - if badge.state == "proposed"
+      = active_course_link_to decorative_glyph(:plus) + "Accept", update_proposal_badge_path(badge, update_value: "accepted"), method: :post
+      = active_course_link_to decorative_glyph(:minus) + "Reject", update_proposal_badge_path(badge, update_value: "rejected"), method: :post
     = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge)
     = active_course_link_to decorative_glyph(:trash) + "Delete", badge_path(badge), data: { confirm: "Are you sure you want to delete #{badge.name}?",  method: :delete }

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -13,7 +13,7 @@
           %ul.options-menu.dropdown-content
             - if @badge.state == "Proposed"
               = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
-              = active_course_link_to decorative_glyph(:minus) + "Deny", accept_proposal_badge_path(badge), method: :post
+              = active_course_link_to decorative_glyph(:minus) + "Deny", badge_path(badge), data: { confirm: "This will delete the proposed item. Are you sure you want to delete #{badge.name}?",  method: :delete }
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
             - if actions.include? :award

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -11,7 +11,7 @@
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
-            - if @badge.state == "Proposed"
+            - if @badge.state == "proposed"
               = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
               = active_course_link_to decorative_glyph(:minus) + "Reject", reject_proposal_badge_path(badge), method: :post
             - if actions.include? :see

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -13,7 +13,7 @@
           %ul.options-menu.dropdown-content
             - if @badge.state == "Proposed"
               = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
-              = active_course_link_to decorative_glyph(:minus) + "Deny", badge_path(badge), data: { confirm: "This will delete the proposed item. Are you sure you want to delete #{badge.name}?",  method: :delete }
+              = active_course_link_to decorative_glyph(:minus) + "Reject", reject_proposal_badge_path(badge), method: :post
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
             - if actions.include? :award

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -3,12 +3,16 @@
     %ul
       - if actions.include? :edit
         = active_course_link_to decorative_glyph(:edit) + "Edit", edit_badge_path(badge), class: "button button-edit"
+
       - if actions.include? :new
         = active_course_link_to decorative_glyph(:plus) + "New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
+
       - if !current_page?(badges_path)
         %li.dropdown
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
+            - if @badge.state == "Proposed"
+              = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
             - if actions.include? :award

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -13,6 +13,7 @@
           %ul.options-menu.dropdown-content
             - if @badge.state == "Proposed"
               = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
+              = active_course_link_to decorative_glyph(:minus) + "Deny", accept_proposal_badge_path(badge), method: :post
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
             - if actions.include? :award

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -12,8 +12,8 @@
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
             - if @badge.state == "proposed"
-              = active_course_link_to decorative_glyph(:plus) + "Accept", accept_proposal_badge_path(badge), method: :post
-              = active_course_link_to decorative_glyph(:minus) + "Reject", reject_proposal_badge_path(badge), method: :post
+              = active_course_link_to decorative_glyph(:plus) + "Accept", update_proposal_badge_path(badge, update_value: "accepted"), method: :post
+              = active_course_link_to decorative_glyph(:minus) + "Reject", update_proposal_badge_path(badge, update_value: "rejected"), method: :post
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
             - if @badge.state == "accepted"

--- a/app/views/badges/_context_menu.haml
+++ b/app/views/badges/_context_menu.haml
@@ -16,8 +16,8 @@
               = active_course_link_to decorative_glyph(:minus) + "Reject", reject_proposal_badge_path(badge), method: :post
             - if actions.include? :see
               %li= link_to decorative_glyph(:eye) + "See", badge_path(badge), class: "button button-edit"
-            - if actions.include? :award
-              = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge)
-            - if actions.include? :quick_award
-              = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)
-              = active_course_link_to decorative_glyph(:download) + "Import", badge_badges_importers_path(badge)
+            - if @badge.state == "accepted"
+              - if actions.include? :award
+                = active_course_link_to decorative_glyph(:star) + "Award", new_badge_earned_badge_path(badge_id: badge)
+              - if actions.include? :quick_award
+                = active_course_link_to decorative_glyph(:check) + "Quick Award", mass_edit_badge_earned_badges_path(badge)

--- a/app/views/badges/_index_staff.haml
+++ b/app/views/badges/_index_staff.haml
@@ -1,46 +1,20 @@
 .pageContent
   = render "layouts/alerts"
 
-  %table.badge-index-table.second-row-header
-    %thead
-      %tr
-        %th.sort-column
-        %th.badge-name-column Name
-        %th.icon-column Icon
-        %th.points-column Point Value
-        %th.lock-icon-column Locked?
-        %th.earned_column Earned
-        %th.state_column State
-        %th.button-column.options Options
+  = simple_form_for(@course)  do |f|
+    #tabs.ui-tabs.ui-widget
+      %ul.ui-tabs-nav{role: "tablist"}
+        %li
+          %a{ "href" => "#tab"} Accepted Badges
+        %li
+          %a{ "href" => "#tab2"} Proposed Badges
+        %li
+          %a{ "href" => "#tab3"} Rejected Badges
 
-    %tbody.sort-badges
-      - presenter.badges.each do |badge|
-        - if BadgeProctor.new(badge).viewable?(current_student || current_user)
-          %tr{id: "badge-#{badge.id}"}
-            %td.center.draggable
-              %i.fa.fa-arrows-v
-
-            // Badge Name
-            %td= render partial: "badges/components/name",
-                locals: { badge: badge, title: link_to(badge.name, badge_path(badge)) }
-
-            // Badge Icon
-            %td
-              .img-cropper.med-crop
-                = render partial: "badges/components/icon", locals: { badge: badge, count: 1 }
-
-            // Point Value
-            %td
-              - if current_course.valuable_badges?
-                = render partial: "badges/components/points", locals: { badge: badge }
-
-            // Lock Condition Icons
-            %td= render partial: "badges/components/hover_icons", locals: { badge: badge }
-
-            // Badge Count
-            %td= render partial: "badges/components/count", locals: { badge: badge, count: presenter.earned_badges_count(badge) }
-
-            %td= render partial: "badges/components/state", locals: { badge: badge }
-
-            // Buttons
-            %td= render partial: "badges/buttons", locals: { badge: badge }
+      #tabt1.ui-tabs-panel
+        .ui-tabs-panel#tab.active{role: "tabpanel", "aria-hidden" => false }
+          = render partial: "badges/components/badge_table", locals: { title: "accepted", badges: presenter.accepted_badges, presenter: presenter, f: f }
+        .ui-tabs-panel#tab2{role: "tabpanel", "aria-hidden" => false }
+          = render partial: "badges/components/badge_table", locals: { title: "proposed", badges: presenter.proposed_badges, presenter: presenter, f: f }
+        .ui-tabs-panel#tab3{role: "tabpanel", "aria-hidden" => false }
+          = render partial: "badges/components/badge_table", locals: { title: "rejected", badges: presenter.rejected_badges, presenter: presenter, f: f }

--- a/app/views/badges/_index_staff.haml
+++ b/app/views/badges/_index_staff.haml
@@ -10,6 +10,7 @@
         %th.points-column Point Value
         %th.lock-icon-column Locked?
         %th.earned_column Earned
+        %th.state_column State
         %th.button-column.options Options
 
     %tbody.sort-badges
@@ -38,6 +39,8 @@
 
             // Badge Count
             %td= render partial: "badges/components/count", locals: { badge: badge, count: presenter.earned_badges_count(badge) }
+
+            %td= render partial: "badges/components/state", locals: { badge: badge }
 
             // Buttons
             %td= render partial: "badges/buttons", locals: { badge: badge }

--- a/app/views/badges/_show_staff.haml
+++ b/app/views/badges/_show_staff.haml
@@ -22,11 +22,12 @@
               - if current_user_is_staff?
                 = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", :upload_id => bf.id } )
 
-    - if current_course.has_teams?
+    - if current_course.has_teams? && presenter.badge.state == "accepted"
       .team-filter
         = form_tag badge_path(presenter.badge), name: "see_team", :onchange => ("javascript: document.see_team.submit();"), :method => :get do
           %label.sr-only{:for => "team_id"}
             Select #{term_for :team}
           = select_tag :team_id, options_for_select(presenter.teams.map { |t| [t.name, t.id] }, presenter.team.try(:id)), :prompt => "– Select #{(term_for :team).titleize} –"
 
+  - if presenter.badge.state == "accepted"
     = render partial: "badges/all_students_earned_badges_table", locals: { presenter: presenter }

--- a/app/views/badges/_show_staff.haml
+++ b/app/views/badges/_show_staff.haml
@@ -4,6 +4,7 @@
   = render partial: "layouts/alerts"
 
   .badge-show-page
+    = render partial: "badges/components/created_by", locals: { badge: presenter.badge }
     .badge-container
       .img-cropper.med-crop
         = render partial: "badges/components/icon", locals: { badge: presenter.badge, count: presenter.earned_badges.count }

--- a/app/views/badges/_show_student.haml
+++ b/app/views/badges/_show_student.haml
@@ -2,34 +2,60 @@
   = render partial: "layouts/alerts"
 
   .badge-show-page
-    %section.badge-container
-      %h1.badge-title
-        = render partial: "badges/components/name", locals: { badge: presenter.badge, title: presenter.badge.name }
+    %section.pg-header
       .img-cropper.large-crop
         = render partial: "badges/components/icon", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
-      .count
-        Times Earned:
-        %span
-          = render partial: "badges/components/count", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
-        = render partial: "badges/components/hover_icons", locals: { badge: presenter.badge }
-    %section.badge-description
-      %h2 Description
-      = render partial: "badges/components/description", locals: { badge: presenter.badge, title: presenter.badge.name }
+      %h1.badge-title
+        = render partial: "badges/components/name", locals: { badge: presenter.badge, title: presenter.badge.name }
+    %section.badge-container
+      %section.badge-stats
+        .badge-stat
+          %h3.points
+            Point Value
+          %span
+          - if presenter.badge.full_points.present? && presenter.badge.full_points > 0
+            = render partial: "badges/components/points", locals: {badge: presenter.badge, points: presenter.badge.full_points }
+          - else
+            0
+        .badge-stat
+          %h3.status
+            Status
+          %span
+            = render partial: "badges/components/state", locals: {badge: presenter.badge, state: presenter.badge.state }
+        .badge.stat
+          %h3.count
+            Times Earned
+          %span
+            = render partial: "badges/components/count", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
+          = render partial: "badges/components/hover_icons", locals: { badge: presenter.badge }
+      %section.badge-description
+        %h2 Description
+        = render partial: "badges/components/description", locals: { badge: presenter.badge, title: presenter.badge.name }
 
-    - if presenter.badge.student_awardable?
-      %section.student-awardable
-        = link_to glyph(:star) + "Award", new_badge_earned_badge_path(presenter.badge), class: "button"
-        You can award this #{(term_for :badge).downcase} to another #{(term_for :student).downcase}.
-
-    - if presenter.badge.badge_files.present?
-      %p
-        %b Attachments:
+        %h2
+          Unlock Conditions
         %ul
-          - presenter.badge.badge_files.each do |bf|
-            %li
-              = link_to bf.filename, bf.url
-              - if current_user_is_staff?
-                = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", :upload_id => bf.id } )
+          %li
+            %p
+              This is an unlock condition
+          %li
+            %p
+              This is another unlock condition
 
-    %section.badges-earned
-      = render partial: "badges/student_earned_badges", locals: { presenter: presenter }
+      - if presenter.badge.student_awardable?
+        %section.student-awardable
+          = link_to glyph(:star) + "Award", new_badge_earned_badge_path(presenter.badge), class: "button"
+          You can award this #{(term_for :badge).downcase} to another #{(term_for :student).downcase}.
+
+      - if presenter.badge.badge_files.present?
+        %p
+          %b Attachments:
+          %ul
+            - presenter.badge.badge_files.each do |bf|
+              %li
+                = link_to bf.filename, bf.url
+                - if current_user_is_staff?
+                  = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", :upload_id => bf.id } )
+
+      %section.badges-earned
+        = render partial: "badges/student_earned_badges", locals: { presenter: presenter }

--- a/app/views/badges/_show_student.haml
+++ b/app/views/badges/_show_student.haml
@@ -2,9 +2,13 @@
   = render partial: "layouts/alerts"
 
   .badge-show-page
+    %a{:href => "/badges"}
+      Back to Badges
     %section.pg-header
-      .img-cropper.large-crop
-        = render partial: "badges/components/icon", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
+      .badge-icon-container
+        .badge-icon{'ng-class'=>"(badge.earned_badge_count <= 0 ? 'badge-icon unearned' : 'badge-icon')"}
+          .img-cropper.med-crop
+            = render partial: "badges/components/icon", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
       %h1.badge-title
         = render partial: "badges/components/name", locals: { badge: presenter.badge, title: presenter.badge.name }
     %section.badge-container
@@ -18,7 +22,7 @@
           - else
             0
         .badge-stat
-          %h3.status
+          %h3.badge-status
             Status
           %span
             = render partial: "badges/components/state", locals: {badge: presenter.badge, state: presenter.badge.state }
@@ -28,19 +32,24 @@
           %span
             = render partial: "badges/components/count", locals: { badge: presenter.badge, count: presenter.earned_badges.count }
           = render partial: "badges/components/hover_icons", locals: { badge: presenter.badge }
-      %section.badge-description
-        %h2 Description
-        = render partial: "badges/components/description", locals: { badge: presenter.badge, title: presenter.badge.name }
+      %section.badge-info
+        .badge-info-piece
+          %h3 Description
+          = render partial: "badges/components/description", locals: { badge: presenter.badge, title: presenter.badge.name }
 
-        %h2
-          Unlock Conditions
-        %ul
-          %li
-            %p
-              This is an unlock condition
-          %li
-            %p
-              This is another unlock condition
+        .badge-info-piece
+          %h3
+            Unlock Conditions
+          %ul
+            %li
+              %p
+                This is an unlock condition
+            %li
+              %p
+                This is another unlock condition
+
+        .badge-info-piece
+          = render partial: "badges/student_earned_badges", locals: { presenter: presenter }
 
       - if presenter.badge.student_awardable?
         %section.student-awardable
@@ -56,6 +65,3 @@
                 = link_to bf.filename, bf.url
                 - if current_user_is_staff?
                   = link_to "(Remove)", remove_uploads_path({ :model => "BadgeFile", :upload_id => bf.id } )
-
-      %section.badges-earned
-        = render partial: "badges/student_earned_badges", locals: { presenter: presenter }

--- a/app/views/badges/_student_earned_badges.haml
+++ b/app/views/badges/_student_earned_badges.haml
@@ -2,6 +2,6 @@
 - presenter.earned_badges.each do |badge|
   .earned-badge
     .earned-badge-date
-      = glyph(:calendar) + "#{l badge.created_at.in_time_zone(current_user.time_zone) }"
+      = glyph(:calendar) + "#{ badge.created_at.in_time_zone(current_user.time_zone).strftime("%B %d, %Y") }"
     .earned-badge-feedback
       = raw badge.feedback

--- a/app/views/badges/_student_earned_badges.haml
+++ b/app/views/badges/_student_earned_badges.haml
@@ -2,6 +2,6 @@
 - presenter.earned_badges.each do |badge|
   .earned-badge
     .earned-badge-date
-      = glyph(:calendar) + "#{ badge.created_at.in_time_zone(current_user.time_zone).strftime("%B %d, %Y") }"
+      = glyph(:calendar) + "#{l badge.created_at.in_time_zone(current_user.time_zone), format: :medium }"
     .earned-badge-feedback
       = raw badge.feedback

--- a/app/views/badges/_student_earned_badges.haml
+++ b/app/views/badges/_student_earned_badges.haml
@@ -1,7 +1,7 @@
+%h3 Awarded
 - presenter.earned_badges.each do |badge|
   .earned-badge
     .earned-badge-date
-      %h2 Awarded
       = glyph(:calendar) + "#{l badge.created_at.in_time_zone(current_user.time_zone) }"
     .earned-badge-feedback
       = raw badge.feedback

--- a/app/views/badges/components/_badge_table.haml
+++ b/app/views/badges/components/_badge_table.haml
@@ -1,0 +1,45 @@
+%h2.subtitle= "#{ title} "
+
+%table.badge-index-table.second-row-header
+  %thead
+    %tr
+      %th.sort-column
+      %th.badge-name-column Name
+      %th.icon-column Icon
+      %th.points-column Point Value
+      %th.lock-icon-column Locked?
+      %th.earned_column Earned
+      %th.state_column State
+      %th.button-column.options Options
+
+  %tbody.sort-badges
+    - badges.each do |badge|
+      - if BadgeProctor.new(badge).viewable?(current_student || current_user)
+        %tr{id: "badge-#{badge.id}"}
+          %td.center.draggable
+            %i.fa.fa-arrows-v
+
+          // Badge Name
+          %td= render partial: "badges/components/name",
+              locals: { badge: badge, title: link_to(badge.name, badge_path(badge)) }
+
+          // Badge Icon
+          %td
+            .img-cropper.med-crop
+              = render partial: "badges/components/icon", locals: { badge: badge, count: 1 }
+
+          // Point Value
+          %td
+            - if current_course.valuable_badges?
+              = render partial: "badges/components/points", locals: { badge: badge }
+
+          // Lock Condition Icons
+          %td= render partial: "badges/components/hover_icons", locals: { badge: badge }
+
+          // Badge Count
+          %td= render partial: "badges/components/count", locals: { badge: badge, count: presenter.earned_badges_count(badge) }
+
+          %td= render partial: "badges/components/state", locals: { badge: badge }
+
+          // Buttons
+          %td= render partial: "badges/buttons", locals: { badge: badge }

--- a/app/views/badges/components/_created_by.haml
+++ b/app/views/badges/components/_created_by.haml
@@ -1,0 +1,2 @@
+- if badge.state == "Proposed"
+  = "Proposed By: #{User.find(badge.user_id).name}"

--- a/app/views/badges/components/_created_by.haml
+++ b/app/views/badges/components/_created_by.haml
@@ -1,2 +1,2 @@
-- if badge.state == "Proposed"
-  = "Proposed By: #{User.find(badge.user_id).name}"
+- if badge.state == "proposed"
+  = "Proposed By: #{User.find(badge.created_by).name}"

--- a/app/views/badges/components/_state.haml
+++ b/app/views/badges/components/_state.haml
@@ -1,1 +1,1 @@
-= "#{badge.state}"
+= "#{badge.state.capitalize}"

--- a/app/views/badges/components/_state.haml
+++ b/app/views/badges/components/_state.haml
@@ -1,0 +1,1 @@
+= "#{badge.state}"

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,6 +1,9 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff?
+-# = render partial: "badges/student_context_menu", locals: {actions: [:new]} if current_user_is_staff?
+= render partial: "badges/student_context_menu", locals: {actions: [:new]} if current_user_is_student? || current_user_is_observer?
 
 - if current_user_is_student? || current_user_is_observer?
+  = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
   = render partial: "badges/index_student", locals: { presenter: presenter }
 
 - elsif current_user_is_staff?

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,6 +1,4 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff?
--# = render partial: "badges/student_context_menu", locals: {actions: [:new]} if current_user_is_staff?
-= render partial: "badges/student_context_menu", locals: {actions: [:new]} if current_user_is_student? || current_user_is_observer?
 
 - if current_user_is_student? || current_user_is_observer?
   = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,7 +1,7 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff?
 
 - if current_user_is_student? || current_user_is_observer?
-  = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit"
+  = active_course_link_to_unless_current decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit", content_name: nil
   = render partial: "badges/index_student", locals: { presenter: presenter }
 
 - elsif current_user_is_staff?

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,7 +1,7 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff?
 
 - if current_user_is_student? || current_user_is_observer?
-  = active_course_link_to_unless_current decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, class: "button button-edit", content_name: nil
+  = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, { class: "button button-edit" }, nil, nil
   = render partial: "badges/index_student", locals: { presenter: presenter }
 
 - elsif current_user_is_staff?

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,7 +1,10 @@
 = render partial: "badges/context_menu", locals: {actions: [:new]} if current_user_is_staff?
 
 - if current_user_is_student? || current_user_is_observer?
-  = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, { class: "button button-edit" }, nil, nil
+  .page-header
+    %h1
+      Badges
+    = active_course_link_to decorative_glyph(:plus) + "Propose New #{(term_for :badge).titleize}", new_badge_path, { class: "button button-edit" }, nil, nil
   = render partial: "badges/index_student", locals: { presenter: presenter }
 
 - elsif current_user_is_staff?

--- a/app/views/badges/new.html.haml
+++ b/app/views/badges/new.html.haml
@@ -1,2 +1,6 @@
 .pageContent
+- if current_user_is_student? || current_user_is_observer?
+  %badge-new
+
+- elsif current_user_is_staff?
   %badge-new

--- a/app/views/badges/new.html.haml
+++ b/app/views/badges/new.html.haml
@@ -1,6 +1,2 @@
 .pageContent
-- if current_user_is_student? || current_user_is_observer?
-  %badge-new
-
-- elsif current_user_is_staff?
   %badge-new

--- a/app/views/layouts/navigation/_offscreen_sidebar.haml
+++ b/app/views/layouts/navigation/_offscreen_sidebar.haml
@@ -16,14 +16,15 @@
         = render partial: "layouts/navigation/staff_subnav"
       - elsif current_user_is_observer?
         = render partial: "layouts/navigation/observer_profile_tabs"
-      %hr
-      - if presenter.has_info?
-        %a.course-info-btn-mobile
-          %h5 Course Info
-          = glyph("chevron-down")
-        %ul.course-info
-          = render partial: "layouts/navigation/class_info"
+      .mobile-course-and-account-info
         %hr
-      %ul.account-info
-        = render partial: "layouts/navigation/account_info"
+        - if presenter.has_info?
+          %a.course-info-btn-mobile
+            %h5 Course Info
+            = glyph("chevron-down")
+          %ul.course-info
+            = render partial: "layouts/navigation/class_info"
+          %hr
+        %ul.account-info
+          = render partial: "layouts/navigation/account_info"
       %hr

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -1,18 +1,18 @@
-%ul{class: ("#{nav_class}" if local_assigns[:nav_class])}
-  %h5 Navigation
-  %li{class: ("active" if current_page?(dashboard_path)) }
-    = link_to_unless_current "Dashboard", dashboard_path
-  %li{class: ("active" if current_page?(assignments_path)) }
-    = link_to_unless_current "#{term_for :assignments}", assignments_path
-  - if current_course.grade_scheme_elements.present?
-    %li{class: ("active" if current_page?(syllabus_path)) }
-      = link_to_unless_current "Syllabus", syllabus_path
-  - if current_course.show_grade_predictor?
+.subnav-wrapper
+  %ul{class: ("#{nav_class}" if local_assigns[:nav_class])}
+    %h5 Navigation
+    %li{class: ("active" if current_page?(dashboard_path)) }
+      = link_to_unless_current "Dashboard", dashboard_path
+    %li{class: ("active" if current_page?(assignments_path)) }
+      = link_to_unless_current "#{term_for :assignments}", assignments_path
+    - if current_course.grade_scheme_elements.present?
+      %li{class: ("active" if current_page?(syllabus_path)) }
+        = link_to_unless_current "Syllabus", syllabus_path
     %li{class: ("active" if current_page?(predictor_path)) }
-      = link_to_unless_current "#{term_for :grade_predictor}", predictor_path
-  - if current_course.has_badges?
-    %li{class: ("active" if current_page?(badges_path)) }
-      = link_to_unless_current "#{term_for :badges}", badges_path
-  - if current_course.teams_visible? || current_course.has_in_team_leaderboards? || current_course.has_team_challenges?
-    %li{class: ("active" if current_page?(teams_path)) }
-      = link_to_unless_current "#{term_for :teams}", teams_path
+      = link_to_unless_current "Grade Predictor", predictor_path
+    - if current_course.has_badges?
+      %li{class: ("active" if current_page?(badges_path)) }
+        = link_to_unless_current "#{term_for :badges}", badges_path
+    - if current_course.teams_visible? || current_course.has_in_team_leaderboards? || current_course.has_team_challenges?
+      %li{class: ("active" if current_page?(teams_path)) }
+        = link_to_unless_current "#{term_for :teams}", teams_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
       long: "%d %B, %Y %H:%M"
       sortable: "%m%d%H%M%S"
       short: "%D"
+      medium: "%B %d, %Y"
     pm: pm
   simple_form:
     placeholders:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Rails.application.routes.draw do
   resources :badges, except: [:update, :create] do
     get "export_structure", on: :collection
     post "accept_proposal", on: :member
+    post "reject_proposal", on: :member
     resources :earned_badges do
       get :mass_edit, on: :collection
       post :mass_earn, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,7 +153,7 @@ Rails.application.routes.draw do
   #5. Badges
   resources :badges, except: [:update, :create] do
     get "export_structure", on: :collection
-    get "propose", on: :collection
+    post "accept_proposal", on: :member
     resources :earned_badges do
       get :mass_edit, on: :collection
       post :mass_earn, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
   #5. Badges
   resources :badges, except: [:update, :create] do
     get "export_structure", on: :collection
+    get "propose", on: :collection
     resources :earned_badges do
       get :mass_edit, on: :collection
       post :mass_earn, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,8 +153,7 @@ Rails.application.routes.draw do
   #5. Badges
   resources :badges, except: [:update, :create] do
     get "export_structure", on: :collection
-    post "accept_proposal", on: :member
-    post "reject_proposal", on: :member
+    post "update_proposal", on: :member
     resources :earned_badges do
       get :mass_edit, on: :collection
       post :mass_earn, on: :collection

--- a/db/migrate/20170912142741_add_state_and_created_by_to_badges.rb
+++ b/db/migrate/20170912142741_add_state_and_created_by_to_badges.rb
@@ -1,0 +1,4 @@
+class AddStateAndCreatedByToBadges < ActiveRecord::Migration[5.0]
+  def change
+  end
+end

--- a/db/migrate/20170912142741_add_state_and_created_by_to_badges.rb
+++ b/db/migrate/20170912142741_add_state_and_created_by_to_badges.rb
@@ -1,4 +1,0 @@
-class AddStateAndCreatedByToBadges < ActiveRecord::Migration[5.0]
-  def change
-  end
-end

--- a/db/migrate/20170914130647_add_state_and_created_by_to_badges.rb
+++ b/db/migrate/20170914130647_add_state_and_created_by_to_badges.rb
@@ -1,0 +1,7 @@
+class AddStateAndCreatedByToBadges < ActiveRecord::Migration[5.0]
+  def change
+    add_column :badges, :state, :string, null: false, default: "proposed"
+    add_column :badges, :created_by, :integer, null: true, default: false
+    add_index :badges, :created_by
+  end
+end

--- a/db/samples/badges.rb
+++ b/db/samples/badges.rb
@@ -20,7 +20,7 @@
     visible: false,
     can_earn_multiple_times: false,
     student_awardable: false,
-    user_id: 3
+    created_by: 3
   },
   assign_samples: false, # assign earned badges on init
   unlock_condition: false,

--- a/db/samples/badges.rb
+++ b/db/samples/badges.rb
@@ -20,6 +20,7 @@
     visible: false,
     can_earn_multiple_times: false,
     student_awardable: false,
+    user_id: 3
   },
   assign_samples: false, # assign earned badges on init
   unlock_condition: false,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,8 +165,9 @@ ActiveRecord::Schema.define(version: 20171012154015) do
     t.boolean  "show_points_when_locked",      default: true
     t.boolean  "show_description_when_locked", default: true,       null: false
     t.boolean  "student_awardable",            default: false,      null: false
-    t.string   "state",                        default: "Proposed", null: false
-    t.integer  "user_id",                                           null: false
+    t.string   "state",                        default: "proposed", null: false
+    t.integer  "created_by",                   default: 0
+    t.index ["created_by"], name: "index_badges_on_created_by", using: :btree
   end
 
   create_table "challenge_files", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -150,21 +150,23 @@ ActiveRecord::Schema.define(version: 20171012154015) do
   end
 
   create_table "badges", force: :cascade do |t|
-    t.string   "name",                                         null: false
+    t.string   "name",                                              null: false
     t.text     "description"
     t.integer  "full_points",                  default: 0
-    t.integer  "course_id",                                    null: false
+    t.integer  "course_id",                                         null: false
     t.string   "icon"
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
-    t.boolean  "visible",                      default: true,  null: false
-    t.boolean  "can_earn_multiple_times",      default: true,  null: false
-    t.integer  "position",                                     null: false
-    t.boolean  "visible_when_locked",          default: true,  null: false
-    t.boolean  "show_name_when_locked",        default: true,  null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
+    t.boolean  "visible",                      default: true,       null: false
+    t.boolean  "can_earn_multiple_times",      default: true,       null: false
+    t.integer  "position",                                          null: false
+    t.boolean  "visible_when_locked",          default: true,       null: false
+    t.boolean  "show_name_when_locked",        default: true,       null: false
     t.boolean  "show_points_when_locked",      default: true
-    t.boolean  "show_description_when_locked", default: true,  null: false
-    t.boolean  "student_awardable",            default: false, null: false
+    t.boolean  "show_description_when_locked", default: true,       null: false
+    t.boolean  "student_awardable",            default: false,      null: false
+    t.string   "state",                        default: "Proposed", null: false
+    t.integer  "user_id",                                           null: false
   end
 
   create_table "challenge_files", force: :cascade do |t|

--- a/spec/controllers/api/badges_controller_spec.rb
+++ b/spec/controllers/api/badges_controller_spec.rb
@@ -5,6 +5,8 @@ describe API::BadgesController do
   let(:student) { build(:user, courses: [course], role: :student) }
   let(:professor) { build(:user, courses: [course], role: :professor) }
   let(:badge) { create(:badge, course: course) }
+  let(:badge_accepted) { create(:badge, course: course, state: "accepted") }
+  let(:badge_rejected) { create(:badge, course: course, state: "rejected") }
 
   context "as professor" do
     before do
@@ -13,16 +15,30 @@ describe API::BadgesController do
       allow(controller).to receive(:current_user).and_return(professor)
     end
 
-
     describe "GET index" do
       it "assigns badges, no student, and no call to update" do
         badge
         get :index, format: :json
         predictor_badge_attributes.each do |attr|
+          # binding.pry
           expect(assigns(:badges)[0][attr]).to eq(badge[attr])
         end
         expect(assigns(:student)).to be_nil
         expect(assigns(:allow_updates)).to be_falsey
+      end
+
+      it "grabs accepted, proposed, rejected badges" do
+        badge
+        badge_accepted
+        badge_rejected
+        get :index, params: { state: "accepted", format: :json }
+        expect(assigns(:badges)).to eq([badge_accepted])
+
+        get :index, params: { state: "rejected", format: :json }
+        expect(assigns(:badges)).to eq([badge_rejected])
+
+        get :index, params: { state: "proposed", format: :json }
+        expect(assigns(:badges)).to eq([badge])
       end
     end
 

--- a/spec/controllers/api/students/badges_controller_spec.rb
+++ b/spec/controllers/api/students/badges_controller_spec.rb
@@ -1,6 +1,8 @@
 describe API::Students::BadgesController do
   let(:course) { build :course }
-  let(:badge) { create :badge }
+  let(:badge) { create :badge, course: course }
+  let(:badge_accepted) { create(:badge, course: course, state: "accepted") }
+  let(:badge_rejected) { create(:badge, course: course, state: "rejected") }
   let(:student) { create(:course_membership, :student, course: course).user}
   let(:professor) { create(:course_membership, :professor, course: course).user }
 
@@ -29,6 +31,29 @@ describe API::Students::BadgesController do
           student: student, course: course, student_visible: true)
         get :index, format: :json, params: { student_id: student.id }
         expect(assigns(:earned_badges)).to eq([earned_badge])
+      end
+
+      it "grabs accepted, proposed, rejected badges" do
+        earned_badge = create(
+          :earned_badge, badge: badge,
+          student: student, course: course, student_visible: true)
+
+        earned_badge_accepted = create(
+        :earned_badge, badge: badge_accepted,
+        student: student, course: course, student_visible: true)
+
+        earned_badge_rejected = create(
+          :earned_badge, badge: badge_rejected,
+          student: student, course: course, student_visible: true)
+
+        get :index, params: { student_id: student.id, state: "accepted" }, format: :json
+        expect(assigns(:badges)).to eq([badge_accepted])
+
+        get :index, params: { student_id: student.id, state: "rejected" }, format: :json
+        expect(assigns(:badges)).to eq([badge_rejected])
+
+        get :index, params: { student_id: student.id, state: "proposed" }, format: :json
+        expect(assigns(:badges)).to eq([badge])
       end
     end
   end

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -46,6 +46,22 @@ describe BadgesController do
       end
     end
 
+    describe "POST accept_proposal" do
+      it "accepts the proposed badge" do
+        another_badge = create :badge, course: course
+        post :accept_proposal, params: { id: another_badge }
+        expect(another_badge.reload.state).to eq "accepted"
+      end
+    end
+
+    describe "POST reject_proposal" do
+      it "reject the proposed badge" do
+        another_badge = create :badge, course: course
+        post :reject_proposal, params: { id: another_badge }
+        expect(another_badge.reload.state).to eq "rejected"
+      end
+    end
+
     describe "GET export_structure" do
       it "retrieves the export_structure download" do
         get :export_structure, params: { id: course.id }, format: :csv

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -46,18 +46,16 @@ describe BadgesController do
       end
     end
 
-    describe "POST accept_proposal" do
-      it "accepts the proposed badge" do
+    describe "POST update_proposal" do
+      it "updates the proposed badge to accepted" do
         another_badge = create :badge, course: course
-        post :accept_proposal, params: { id: another_badge }
+        post :update_proposal, params: { id: another_badge, update_value: "accepted" }
         expect(another_badge.reload.state).to eq "accepted"
       end
-    end
 
-    describe "POST reject_proposal" do
-      it "reject the proposed badge" do
+      it "updates the proposed badge to rejected" do
         another_badge = create :badge, course: course
-        post :reject_proposal, params: { id: another_badge }
+        post :update_proposal, params: { id: another_badge, update_value: "rejected" }
         expect(another_badge.reload.state).to eq "rejected"
       end
     end

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -57,16 +57,6 @@ describe BadgesController do
   context "as student" do
     before(:each) { login_user(student) }
 
-    describe "protected routes" do
-      [
-        :new
-      ].each do |route|
-          it "#{route} redirects to root" do
-            expect(get route).to redirect_to(:root)
-          end
-        end
-    end
-
     describe "protected routes requiring id in params" do
       [
         :edit,

--- a/spec/features/awarding_a_badge_spec.rb
+++ b/spec/features/awarding_a_badge_spec.rb
@@ -1,7 +1,7 @@
-feature "awarding a badge" do
+feature "awarding a badge", focus: true do
   context "as a professor" do
     let(:professor) { create :user, courses: [course], role: :professor }
-    let!(:badge) { create :badge, name: "Fancy Badge", course: course}
+    let!(:badge) { create :badge, name: "Fancy Badge", course: course, state: "accepted"}
     let!(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
 
     before(:each) do

--- a/spec/features/awarding_a_badge_spec.rb
+++ b/spec/features/awarding_a_badge_spec.rb
@@ -1,4 +1,4 @@
-feature "awarding a badge", focus: true do
+feature "awarding a badge" do
   context "as a professor" do
     let(:professor) { create :user, courses: [course], role: :professor }
     let!(:badge) { create :badge, name: "Fancy Badge", course: course, state: "accepted"}

--- a/spec/features/awarding_many_earned_badges_at_once_spec.rb
+++ b/spec/features/awarding_many_earned_badges_at_once_spec.rb
@@ -1,7 +1,7 @@
 feature "awarding many earned badges at once" do
   context "as a professor" do
     let(:professor) { create :user, courses: [course], role: :professor }
-    let!(:badge) { create :badge, name: "Fancy Badge", course: course}
+    let!(:badge) { create :badge, name: "Fancy Badge", course: course, state: "accepted"}
     let!(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
     let!(:student_2) { build :user, first_name: "Ron", last_name: "Weasley", courses: [course], role: :student }
 

--- a/spec/features/editing_an_awarded_badge_spec.rb
+++ b/spec/features/editing_an_awarded_badge_spec.rb
@@ -1,7 +1,7 @@
 feature "editing an awarded a badge" do
   context "as a professor" do
     let(:professor) { create :user, courses: [course], role: :professor }
-    let!(:badge) { create :badge, name: "Fancy Badge", course: course}
+    let!(:badge) { create :badge, name: "Fancy Badge", course: course, state: "accepted"}
     let(:student) { build :user, first_name: "Hermione", last_name: "Granger", courses: [course], role: :student }
     let(:student_2) { build :user, first_name: "Ron", last_name: "Weasley", courses: [course], role: :student }
     let!(:earned_badge) { create :earned_badge, badge: badge, student: student}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,23 @@
+/*
+Errno::ENOENT: No such file or directory @ rb_sysopen - style.scss
+
+Backtrace:
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:454:in `read'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:454:in `update_stylesheet'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:215:in `block in update_stylesheets'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:209:in `each'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:209:in `update_stylesheets'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin/compiler.rb:294:in `watch'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/plugin.rb:109:in `method_missing'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/exec/sass_scss.rb:360:in `watch_or_update'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/exec/sass_scss.rb:51:in `process_result'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/exec/base.rb:52:in `parse'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/lib/sass/exec/base.rb:19:in `parse!'
+/Users/Nathan/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/sass-3.5.2/bin/sass:13:in `<top (required)>'
+/Users/Nathan/.rbenv/versions/2.2.2/bin/sass:23:in `load'
+/Users/Nathan/.rbenv/versions/2.2.2/bin/sass:23:in `<main>'
+*/
+body:before {
+  white-space: pre;
+  font-family: monospace;
+  content: "Errno::ENOENT: No such file or directory @ rb_sysopen - style.scss"; }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As a student
I should be able to 'propose' badges,
Including setting their names, graphics, and descriptions.

As an instructor
I should be notified that there are student-created badges to review
And be able to edit their elements before approving or rejecting

The badge should retain info regarding who created it, and if they were created by a student
This should be highlighted in the interface to both students and instructors.

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
YES

### Steps to Test or Reproduce
As a student, navigate to the modified 'Badges' page. I will see a new button "Propose Badge". Clicking on the button will take me to the New Badge Form where I can submit a new badge to the instructor of the course.

As an instructor, when I navigate to the 'Badges' page, I will now see 3 tabs: 'Accepted', 'Proposed', and 'Rejected'. By navigating to the show page of one of the proposed badges I will be able to see who submitted the proposed badge. I will also be able to Accept of Reject the badge by using the Options Gear on the show page. Accepting or Rejecting will move it to the appropriate tab on the instructor badges page.

By default, when an instructor creates a badge, it will be set to 'Accepted'

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Badges

======================
Closes #1245