### PR TITLE
Fix issue caused by condition_value being nil

### DIFF
--- a/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
+++ b/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
@@ -57,8 +57,12 @@
   %select(ng-model="condition.condition_state" ng-change="updateCondition()")
     %option(ng-repeat="state in assignmentTypeStates"  ng-selected="state == condition.condition_state" value="{{state}}")
       {{state}}
-  %label(ng-if="condition.condition_state == 'Assignments Completed'") Number of {{termFor("assignments")}}
-  %label(ng-if="condition.condition_state != 'Assignments Completed'") Amount
+  %label(ng-if="condition.condition_state == 'Assignments Completed'")
+    Number of {{termFor("assignments")}}
+    %span.required-label(ng-if="condition.condition_value == null") *required
+  %label(ng-if="condition.condition_state != 'Assignments Completed'")
+    Amount
+    %span.required-label(ng-if="condition.condition_value == null") *required
   %input(ng-model="condition.condition_value" gc-number-input ng-change="updateCondition()")
   %label Completed By Date
   %input(id="{{datePickerId(condition)}}" ng-model="condition.condition_date" gc-date-time-input ng-change="updateCondition()")

--- a/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
+++ b/app/assets/javascripts/angular/templates/unlock_conditions/unlock_condition.html.haml
@@ -1,7 +1,7 @@
 .unlock-condition-requirement(ng-class='{"valid" : conditionIsValid(condition)}')
   %label Requirement
   %select(ng-model="condition.condition_type" name="condition_type" ng-change="changeConditionType(condition)")
-    %option(ng-repeat="type in conditionTypes" ng-selected="conditionsTypeTranslation(type) == termFor(condition.condition_type)" value="{{conditionsTypeTranslation(type)}}")
+    %option(ng-repeat="type in conditionTypes" ng-selected="conditionsTypeTranslation(type) == condition.condition_type" value="{{conditionsTypeTranslation(type)}}")
       {{termFor(type)}}
 
 .unlock-condition-parameters(ng-if="condition.condition_type=='Assignment'")

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -57,6 +57,12 @@ class UnlockCondition < ActiveRecord::Base
     return unlocked_count
   end
 
+  protected
+
+  def condition_value
+    self[:condition_value] || 0
+  end
+
   private
 
   def condition_state_do

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -685,7 +685,7 @@ describe UnlockCondition do
       subject = create(:unlock_condition, condition_id: course.id, condition_type: "Course", condition_state: "Earned",
         unlockable_id: unlockable_assignment.id, unlockable_type: "Assignment", condition_value: 10)
       expect(subject.requirements_completed_sentence).to \
-        eq("Earned #{ subject.condition_value } points in this course")
+        eq("Earned 10 points in this course")
     end
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
In response to Rollbar issue [2445](https://rollbar.com/gradecraft/gradecraft-development/items/2445/), it appears that there is a nil comparison failure at line 122 in the UnlockCondition model.

Per the stack trace, line 122 seems to refer to the following line in `#check_assignments_completed_condition`:

```
assignment_completed_count >= condition_value
``` 

As observed in Evan's case of Sophomore Honors course - course 295, the `condition_value` is null.

The simple fix to this is to override the accessor method for `condition_value` such that 0 is returned if null. The better solution is probably to update the field with a migration and a rake task so that the field is non-nullable and defaults to 0.

This PR addresses the former.

### Migrations
NO

### Steps to Test or Reproduce


======================
Closes #3640
