### PR TITLE
add student name and username to submissions export file

### DIFF
--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -4,7 +4,7 @@ class SubmissionExporter
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
         csv << [ submission.id, submission.assignment_id, submission.assignment.name,
-          submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:updated_at) ]
+          submission.student.email, submission.student.name, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:updated_at) ]
       end
     end
   end
@@ -12,6 +12,6 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment ID", "Assignment Name", "Student ID", "Group ID", "Student Comment", "Created At", "Updated At", "Score", "Grader Feedback", "Grade Last Updated"]
+    ["Submission ID", "Assignment ID", "Assignment Name", "Student Email", "Student Name", "Student ID", "Group ID", "Student Comment", "Created At", "Updated At", "Score", "Grader Feedback", "Grade Last Updated"]
   end
 end

--- a/spec/controllers/info_controller_spec.rb
+++ b/spec/controllers/info_controller_spec.rb
@@ -141,7 +141,7 @@ describe InfoController do
     describe "GET submissions export" do
       it "retrieves the submissions export download" do
         get :submissions, params: { id: course.id }, format: :csv
-        expect(response.body).to include("Submission ID,Assignment ID,Assignment Name,Student ID,Group ID,Student Comment,Created At,Updated At,Score,Grader Feedback,Grade Last Updated")
+        expect(response.body).to include("Submission ID,Assignment ID,Assignment Name,Student Email,Student Name,Student ID,Group ID,Student Comment,Created At,Updated At,Score,Grader Feedback,Grade Last Updated")
       end
     end
   end


### PR DESCRIPTION
### Status
**READY**

### Description
Adds the student name and username to the submissions export file (this was originally created for research purposes, and in making it more broadly available we didn't do a good job of reconsidering the needs)

