### PR TITLE
Submissions export background

### DIFF
--- a/app/background_jobs/submission_export_job.rb
+++ b/app/background_jobs/submission_export_job.rb
@@ -1,0 +1,4 @@
+class SubmissionExportJob < ResqueJob::Base
+  @queue = :submission_exporter
+  @performer_class = SubmissionExportPerformer
+end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -111,9 +111,11 @@ class InfoController < ApplicationController
 
   def submissions
     course = current_user.courses.find_by(id: params[:id])
-    respond_to do |format|
-      format.csv { send_data SubmissionExporter.new.export(course), filename: "#{ course.name } Submissions - #{ Date.today }.csv" }
-    end
+    @submission_export_job = SubmissionExportJob.new(user_id: current_user.id, course_id: course.id, filename: "#{ course.name } Submissions Export - #{ Date.today }.csv")
+    @submission_export_job.enqueue
+
+    flash[:notice]="Your request to export submissions from course \"#{ course.name }\" is currently being processed. We will email you the data shortly."
+    redirect_back_or_default
   end
 
   private

--- a/app/mailers/exports_mailer.rb
+++ b/app/mailers/exports_mailer.rb
@@ -5,6 +5,12 @@ class ExportsMailer < ApplicationMailer
   # need for building the secure download method on success emails
   add_template_helper(SecureTokenHelper)
 
+  def submission_export(course, user, filename, csv_data)
+    set_export_ivars(course, user)
+    attachments["#{ course.name } Submissions - #{ Date.today }.csv"] = csv_attachment(csv_data)
+    send_export_email "Submission export for #{ course.name } is attached"
+  end
+
   def submissions_export_started(professor, assignment)
     mail_submissions_export("is being created", professor, assignment)
   end

--- a/app/performers/submission_export_performer.rb
+++ b/app/performers/submission_export_performer.rb
@@ -1,0 +1,55 @@
+class SubmissionExportPerformer < ResqueJob::Performer
+  def setup
+    @user = fetch_user
+    @course = fetch_course
+    @filename = @attrs[:filename]
+  end
+
+  # perform() attributes assigned to @attrs in the ResqueJob::Base class
+  def do_the_work
+    if @course.present? && @user.present?
+      require_success(fetch_csv_messages, max_result_size: 250) do
+       fetch_csv_data(@course)
+     end
+
+      require_success(notification_messages, max_result_size: 200) do
+        notify_submission_export # the result of this block determines the outcome
+      end
+    end
+  end
+
+  protected
+
+  def fetch_user
+    User.find @attrs[:user_id]
+  end
+
+  # TODO: speed this up by condensing the CSV generator into a single query
+  def fetch_course # TODO: add specs for includes
+    Course.find @attrs[:course_id]
+  end
+
+  def fetch_csv_data(course)
+    @csv_data = SubmissionExporter.new.export(course)
+  end
+
+  def notify_submission_export
+    ExportsMailer
+      .submission_export(@course, @user, @filename, @csv_data)
+      .deliver_now
+  end
+
+  def fetch_csv_messages
+    {
+      success: "Successfully fetched submission data for course ##{@course.id}.",
+      failure: "Failed to fetch submission data for course ##{@course.id}."
+    }
+  end
+
+  def notification_messages
+    {
+      success: "Submission export notification mailer was successfully delivered.",
+      failure: "Submission export notification mailer was not delivered."
+    }
+  end
+end

--- a/app/views/exports_mailer/submission_export.html.haml
+++ b/app/views/exports_mailer/submission_export.html.haml
@@ -1,0 +1,5 @@
+%h2{ :align => "center" }
+  %strong Dear #{ @user.first_name },
+
+%p{ :align => "center" }
+  The submission export you have requested for #{ @course.name } is attached.

--- a/app/views/exports_mailer/submission_export.text.haml
+++ b/app/views/exports_mailer/submission_export.text.haml
@@ -1,0 +1,7 @@
+Dear #{@user.first_name},
+
+The submission export you requested for #{@course.name} is attached.
+
+Thanks,
+
+GradeCraft


### PR DESCRIPTION
### Status
**READY**

### Description
This PR refactors the submission export file process to leverage a background job and a mailer and prevent a user from being unable to export due to an overly large file. 

This may be a pattern we should just employ for all file exports.
