### PR TITLE
Fix presenter bug where group_id wasn't provided

### DIFF
--- a/app/views/grades/show.html.haml
+++ b/app/views/grades/show.html.haml
@@ -17,7 +17,7 @@
         %h2 The Submission
         = render partial: "submissions/submission_content",
             locals: { presenter: Submissions::ShowPresenter.new(id: presenter.submission_for_assignment(@grade.student).id,
-              assignment_id: @grade.assignment_id, course: current_course) }
+              assignment_id: @grade.assignment_id, course: current_course, group_id: @grade.group_id) }
         = history_timeline presenter.submission_grade_history(@grade.student)
         %hr.dotted
 


### PR DESCRIPTION
### Status
READY

### Description
A bug would occur when attempting to edit or resubmit an existing submission, if the assignment was group-graded. See original issue for details on how to replicate. The fix for this was to include the `group_id`.

======================
Closes #3660 
