### PR TITLE
3434 Students Searchable by Email

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -20,7 +20,7 @@
               return '<li><a href="#">' + label + '</a></li>';
             },
             filter: function(item, query) {
-              return item.name.match(new RegExp(query, 'i'));
+              return item.search_string.match(new RegExp(query, 'i'));
             }
           }).on('omniselect:select', function(event, id) {
             window.location = '/students/' + id;

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -6,7 +6,7 @@ class API::StudentsController < ApplicationController
   # PUT api/students
   def index
     students = current_course.students.map do |u|
-      { name: u.formatted_long_name, id: u.id, search_string: u.searchable_name }
+      { name: u.name, id: u.id, search_string: u.searchable_name }
     end
     render json: MultiJson.dump(students)
   end

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -6,7 +6,7 @@ class API::StudentsController < ApplicationController
   # PUT api/students
   def index
     students = current_course.students.map do |u|
-      { name: u.name, id: u.id }
+      { name: u.formatted_long_name, id: u.id, search_string: u.searchable_name }
     end
     render json: MultiJson.dump(students)
   end
@@ -33,5 +33,3 @@ class API::StudentsController < ApplicationController
     @course_potential_points_for_student = current_course.total_points + @earned_badge_points
   end
 end
-
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -404,6 +404,18 @@ class User < ActiveRecord::Base
     course_memberships.where(course: course).first.last_login_at
   end
 
+  def formatted_long_name
+    if email.present?
+      "#{self.name} #{self.email}"
+    else
+      "#{self.name}"
+    end
+  end
+
+  def searchable_name
+    "#{ formatted_long_name}"
+  end
+
   private
 
   def earnable_course_badges(grade)

--- a/spec/controllers/api/students_controller_spec.rb
+++ b/spec/controllers/api/students_controller_spec.rb
@@ -12,7 +12,11 @@ describe API::StudentsController do
     describe "GET index" do
       it "returns students and ids" do
         get :index, format: :json
-        expect(JSON.parse(response.body)).to eq([{"name"=>"#{student.name}", "id"=>student.id}])
+        expect(JSON.parse(response.body)).to eq([{
+          "name"=>"#{student.name}",
+          "id"=>student.id,
+          "search_string"=>"#{student.name } #{student.email}"
+          }])
         expect(response.status).to eq(200)
       end
     end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As support staff, I occasionally wind up in situations where I know the email address of a person needing some help in GC, but no other details. It would be awesome to be able to search for users by email address.

### Related PRs
N/A


### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, if I type in an email to the "Search Learners" field, I can view results for students containing names and email addresses. If I click on one of these results, I will be taken to the student's page. 

### Impacted Areas in Application
Student Search

======================
Closes #3434 
