### PR TITLE
show auditors on the assignment grading page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,13 @@ class User < ActiveRecord::Base
       query
     end
 
+    def active_students_for_course(course, team=nil)
+      user_ids = CourseMembership.where(course: course, role: "student", active: true).pluck(:user_id)
+      query = User.where(id: user_ids)
+      query = query.students_in_team(team.id, user_ids) if team
+      query
+    end
+
     def students_being_graded_for_course(course, team=nil)
       user_ids = CourseMembership.where(course: course, role: "student", auditing: false, active: true).pluck(:user_id)
       query = User.where(id: user_ids)

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -167,7 +167,7 @@ class Assignments::Presenter < Showtime::Presenter
 
   def students
     @students ||= AssignmentStudentCollection.new(User
-      .students_being_graded_for_course(course, team)
+      .active_students_for_course(course, team)
       .order_by_name, self)
   end
 

--- a/spec/presenters/assignments/presenter_spec.rb
+++ b/spec/presenters/assignments/presenter_spec.rb
@@ -92,7 +92,7 @@ describe Assignments::Presenter do
 
     it "returns the students that are attached to the course" do
       allow(course).to receive(:teams).and_return double(:relation, find_by: team)
-      allow(User).to receive(:students_being_graded_for_course).and_return double(:collection, order_by_name: [student])
+      allow(User).to receive(:active_students_for_course).and_return double(:collection, order_by_name: [student])
       expect(subject.students.class).to eq Assignments::Presenter::AssignmentStudentCollection
     end
   end


### PR DESCRIPTION
### Status
**READY**

### Description
Instructors should still be able to grade auditors. This fixes the bug Barry encountered where the assignment page showed him a grade count but there didn't appear to be grades in place. 

