### PR TITLE
Fix typo in safe params 🐛

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -99,7 +99,7 @@ class API::AssignmentsController < ApplicationController
       :hide_analytics,
       :media,
       :min_group_size,
-      :max_group_sie,
+      :max_group_size,
       :name,
       :open_at,
       :pass_fail,


### PR DESCRIPTION
### Status
READY

### Description
On a group-graded assignment, the max group size value does not persist on the assignment edit form.

This is due to a typo in the strong params hash.

======================
Closes #3666 
