### PR TITLE
Use formatted long name instead of just name

### DIFF
--- a/app/views/api/users/search.json.jbuilder
+++ b/app/views/api/users/search.json.jbuilder
@@ -9,7 +9,7 @@ json.data do
       json.last_name                  user.last_name
       json.course_memberships user.course_memberships.map {
         |cm| { course_id: cm.course.id,
-               course_name: cm.course.name,
+               course_name: cm.course.formatted_long_name,
                role: term_for(cm.role, cm.role.capitalize),
                score: cm.role == "student" ? cm.score : nil }.compact
       }


### PR DESCRIPTION
### Status
READY

### Description
Use the `formatted_long_name` instead of just the `name` for the Course when searching for users so that we can more uniquely identify courses for different semesters/terms.

======================
Closes #3668
