### PR TITLE
3642 Added email to search results column

### DIFF
--- a/app/assets/javascripts/angular/templates/user/search/results.html.haml
+++ b/app/assets/javascripts/angular/templates/user/search/results.html.haml
@@ -4,6 +4,7 @@
       %th Id
       %th First Name
       %th Last Name
+      %th Email
       %th Courses
       %th Role
       %th Score
@@ -15,6 +16,7 @@
       %td {{ user.id }}
       %td {{ user.first_name }}
       %td {{ user.last_name }}
+      %td {{ user.email }}
       %td{"ng-bind-html"=>"course_name_with_link(user)"}
       %td{"ng-bind-html"=>"course_membership_attribute_for(user, 'role')"}
       %td{"ng-bind-html"=>"course_membership_attribute_for(user, 'score')"}

--- a/app/views/api/users/search.json.jbuilder
+++ b/app/views/api/users/search.json.jbuilder
@@ -7,6 +7,7 @@ json.data do
       json.id                         user.id.to_s
       json.first_name                 user.first_name
       json.last_name                  user.last_name
+      json.email                      user.email
       json.course_memberships user.course_memberships.map {
         |cm| { course_id: cm.course.id,
                course_name: cm.course.formatted_long_name,


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an admin user, when I search for someone, it would be really helpful to have a column in the table where I can see their email address for contact purposes.

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an admin, navigate to the Search Users tab, search any user by any convention necessary, and view their email in the search results.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Search Users page

======================
Closes #3642 
