### PR TITLE
groups try final points

### DIFF
--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -45,7 +45,7 @@
                   - if @assignment.pass_fail? && grade.pass_fail_status.present?
                     = term_for grade.pass_fail_status
                   - else
-                    = points grade.final_points
+                    = points grade.try(:final_points)
 
               - if @assignment.student_weightable?
                 %td


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes a bug where group grades don't necessarily have final points, but they are appearing in the table. We'll need to continue to investigate the data structure once this is merged. It's possible that something isn't updating properly on group grades. 
