### PR TITLE
3616 Disable Google Calendar at Institution Level

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -38,7 +38,7 @@ class InstitutionsController < ApplicationController
   private
 
   def institution_params
-    params.require(:institution).permit :name, :has_site_license, :institution_type,
+    params.require(:institution).permit :name, :has_site_license, :institution_type, :has_google_access,
       providers_attributes: [:id, :name, :base_url, :providee_id, :consumer_key,
         :consumer_secret, :consumer_secret_confirmation]
   end

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -41,6 +41,6 @@
                   Edit Rubric
                 - else
                   Create Rubric
-
-            = active_course_link_to decorative_glyph(:calendar) + "Add to Google Calendar",
-          add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
+                - if presenter.course.institution.has_google_access?
+                  = active_course_link_to decorative_glyph(:calendar) + "Add to Google Calendar",
+                add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -43,4 +43,4 @@
                   Create Rubric
                 - if presenter.course.institution.has_google_access?
                   = active_course_link_to decorative_glyph(:calendar) + "Add to Google Calendar",
-                add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
+                    add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -19,8 +19,9 @@
 %p.assignment-description.italic= "Opens: #{l presenter.assignment.open_at.in_time_zone(current_user.time_zone)}" if presenter.assignment.open_at?
 %p.assignment-description.italic= "Due: #{l presenter.assignment.due_at.in_time_zone(current_user.time_zone)}" if presenter.assignment.due_at?
 
-%p.assignment-description= link_to decorative_glyph(:calendar) + "Add to Google Calendar",
-  add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
+- if presenter.course.institution.has_google_access?
+  %p.assignment-description= link_to decorative_glyph(:calendar) + "Add to Google Calendar",
+    add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
 
 - if presenter.assignment_accepting_submissions?(current_student) && !presenter.has_viewable_submission?(current_student, current_user)
   = render partial: "students/submissions", locals: { assignment: presenter.assignment }

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -8,7 +8,7 @@
         %ul.options-menu.dropdown-content
           - if current_course.allows_canvas?
             = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path
-          - if current_course.assignments.present?
+          - if current_course.assignments.present? && current_course.institution.has_google_access?
             = active_course_link_to decorative_glyph(:calendar) + "Add All to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -30,6 +30,7 @@
               .button-container.dropdown
                 %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
                 %ul.options-menu.dropdown-content
-                  %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), :target => "_parent", method: :post
+                  - if event.course.institution.has_google_access?
+                    %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), :target => "_parent", method: :post
                   = active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event)
                   = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure you want to delete #{event.name}?" }

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,7 +7,8 @@
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
             %li= link_to decorative_glyph(:copy) + "Copy Event ", copy_events_path(id: @event.id), method: :post
-            %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(@event), :target => "_parent", method: :post
+            - if @event.course.institution.has_google_access?
+              %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(@event), :target => "_parent", method: :post
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -30,4 +30,5 @@
                   %li #{ link_to assignment.name, assignment } due at #{ l assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }
+    - if presenter.course.institution.has_google_access
+      = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/app/views/institutions/components/_form.haml
+++ b/app/views/institutions/components/_form.haml
@@ -9,6 +9,10 @@
     .form-item
       = f.label :institution_type, "Institution Type"
       = f.select :institution_type, [["K-12"], ["Higher Education"], ["Other"]]
+    .form-item
+      = f.label :has_google_access
+      = f.check_box :has_google_access
+
 
   %section.form-section
     %h2.form-title= "Canvas Credentials"

--- a/db/migrate/20170929130612_add_google_access_to_institution.rb
+++ b/db/migrate/20170929130612_add_google_access_to_institution.rb
@@ -1,0 +1,5 @@
+class AddGoogleAccessToInstitution < ActiveRecord::Migration[5.0]
+  def change
+    add_column :institutions, :has_google_access, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20171005150420_add_google_access_to_institution.rb
+++ b/db/migrate/20171005150420_add_google_access_to_institution.rb
@@ -1,5 +1,5 @@
 class AddGoogleAccessToInstitution < ActiveRecord::Migration[5.0]
   def change
-    add_column :institutions, :has_google_access, :boolean, null: false, default: false
+    add_column :institutions, :has_google_access, :boolean, null: false, default: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< 83dcbc9a16d1961cae5001e2f6091256ee219494
 ActiveRecord::Schema.define(version: 20171002182206) do
+=======
+ActiveRecord::Schema.define(version: 20171005150420) do
+>>>>>>> Made has_google_access default to true
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -514,10 +518,10 @@ ActiveRecord::Schema.define(version: 20171002182206) do
   end
 
   create_table "institutions", force: :cascade do |t|
-    t.string  "name",                             null: false
-    t.boolean "has_site_license", default: false, null: false
+    t.string  "name",                              null: false
+    t.boolean "has_site_license",  default: false, null: false
     t.string  "institution_type"
-    t.boolean "has_google_access", default: false, null: false
+    t.boolean "has_google_access", default: true,  null: false
     t.index ["name"], name: "index_institutions_on_name", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< 83dcbc9a16d1961cae5001e2f6091256ee219494
-ActiveRecord::Schema.define(version: 20171002182206) do
-=======
 ActiveRecord::Schema.define(version: 20171005150420) do
->>>>>>> Made has_google_access default to true
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -517,6 +517,7 @@ ActiveRecord::Schema.define(version: 20171002182206) do
     t.string  "name",                             null: false
     t.boolean "has_site_license", default: false, null: false
     t.string  "institution_type"
+    t.boolean "has_google_access", default: false, null: false
     t.index ["name"], name: "index_institutions_on_name", using: :btree
   end
 

--- a/spec/features/creating_a_new_event_spec.rb
+++ b/spec/features/creating_a_new_event_spec.rb
@@ -1,6 +1,7 @@
 feature "creating a new event" do
   context "as a professor" do
-    let(:course) { build :course }
+    let!(:institution) { create :institution }
+    let(:course) { build :course, institution: institution }
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
 

--- a/spec/features/deleting_an_event_spec.rb
+++ b/spec/features/deleting_an_event_spec.rb
@@ -1,6 +1,7 @@
 feature "deleting an event" do
   context "as a professor" do
-    let(:course) { build :course }
+    let!(:institution) { create :institution }
+    let(:course) { build :course, institution: institution }
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
     let!(:event) { create :event, course: course, name: "Event Name", due_at: Date.today }

--- a/spec/features/editing_an_event_spec.rb
+++ b/spec/features/editing_an_event_spec.rb
@@ -1,6 +1,7 @@
 feature "editing an event" do
   context "as a professor" do
-    let(:course) { build :course}
+    let!(:institution) { create :institution }
+    let(:course) { build :course, institution: institution }
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
     let!(:event) { create :event, course: course, name: "Event Name", due_at: Date.today }

--- a/spec/features/editing_submissions_spec.rb
+++ b/spec/features/editing_submissions_spec.rb
@@ -1,5 +1,7 @@
 feature "editing submissions" do
   context "as a student" do
+    let!(:institution) { create :institution }
+    let(:course) { build :course, institution: institution }
     let(:assignment) { build :assignment, accepts_submissions: true, resubmissions_allowed: true, course: membership.course }
     let(:membership) { create :course_membership, :student, user: student }
     let!(:student) { create :user }

--- a/spec/features/editing_submissions_spec.rb
+++ b/spec/features/editing_submissions_spec.rb
@@ -1,13 +1,12 @@
 feature "editing submissions" do
   context "as a student" do
     let!(:institution) { create :institution }
-    let(:course) { build :course, institution: institution }
-    let(:assignment) { build :assignment, accepts_submissions: true, resubmissions_allowed: true, course: membership.course }
-    let(:membership) { create :course_membership, :student, user: student }
-    let!(:student) { create :user }
+    let(:course) { create :course, institution: institution }
+    let(:assignment) { create :assignment, accepts_submissions: true, resubmissions_allowed: true, course: course }
+    let(:student) { create :user, courses: [course], role: :student }
 
     let!(:submission) do
-      create :submission, course: membership.course, assignment: assignment, student: student, link: "http://ai.umich.edu"
+      create :submission, course: course, assignment: assignment, student: student, link: "http://ai.umich.edu"
     end
     let!(:grade) { create :grade, student_visible: true, student: student, submission: submission, assignment: assignment }
 

--- a/spec/features/viewing_submission_history_spec.rb
+++ b/spec/features/viewing_submission_history_spec.rb
@@ -1,18 +1,16 @@
 feature "viewing submission history" do
-  let!(:submission) do
-    create :submission, course: membership.course, assignment: assignment, student: student
-  end
-  let(:assignment) do
-    create :assignment, accepts_submissions: true, course: membership.course
-  end
-  let(:membership) { create :course_membership, :student, user: student }
-  let(:student) { create :user }
-
   before { PaperTrail.enabled = true }
+  let!(:institution) { create :institution }
+  let(:course) { create :course, institution: institution }
+  let(:assignment) { create :assignment, accepts_submissions: true, course: course }
+  let!(:submission) do
+    create :submission, course: course, assignment: assignment, student: student
+  end
+  let(:student) { create :user, courses: [course], role: :student }
 
   context "as a professor" do
     let(:professor) { create :user }
-    let!(:professor_membership) { create :course_membership, :professor, user: professor, course: membership.course }
+    let!(:professor_membership) { create :course_membership, :professor, user: professor, course: course }
 
     before { login_as professor }
 

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -1,4 +1,4 @@
-feature "viewing submissions", focus: true do
+feature "viewing submissions" do
   let!(:institution) { create :institution }
   let(:course) { create :course, institution: institution }
   let(:assignment) { create :assignment, accepts_submissions: true, course: course }

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -1,13 +1,13 @@
-feature "viewing submissions" do
-  let(:assignment) { build :assignment, accepts_submissions: true, course: membership.course }
+feature "viewing submissions", focus: true do
+  let!(:institution) { create :institution }
+  let(:course) { create :course, institution: institution }
+  let(:assignment) { create :assignment, accepts_submissions: true, course: course }
   let!(:submission) do
-    create :submission, course: membership.course, assignment: assignment, student: student
+    create :submission, course: course, assignment: assignment, student: student
   end
-  let(:student) { create :user }
+  let(:student) { create :user, courses: [course], role: :student }
 
   context "as a student" do
-    let(:membership) { create :course_membership, :student, user: student }
-
     before { login_as student }
 
     scenario "allows an editable submission if it's before the due date" do
@@ -31,8 +31,7 @@ feature "viewing submissions" do
   end
 
   context "as a professor" do
-    let(:membership) { create :course_membership, :professor, user: professor }
-    let(:professor) { create :user }
+    let(:professor) { create :user, courses: [course], role: :professor }
 
     before do
       login_as professor

--- a/spec/views/assignments/_index_staff_spec.rb
+++ b/spec/views/assignments/_index_staff_spec.rb
@@ -3,7 +3,8 @@ include CourseTerms
 describe "assignments/_index_staff" do
 
   before(:all) do
-    @course = create(:course)
+    @institution = create(:institution)
+    @course = create(:course, institution: @institution)
     @assignment_type_1 = create(:assignment_type, course: @course, max_points: 1000)
     @assignment_type_2 = create(:assignment_type, course: @course, max_points: 2000)
     @assignment_1 = create(:assignment, assignment_type: @assignment_type_1, full_points: 500)

--- a/spec/views/grades/show_spec.rb
+++ b/spec/views/grades/show_spec.rb
@@ -2,7 +2,8 @@ describe "grades/show" do
   let(:presenter) { Assignments::Presenter.new({ assignment: @assignment, course: @course }) }
 
   before(:each) do
-    @course = create(:course)
+    @institution = create(:institution)
+    @course = create(:course, institution: @institution)
     @assignment = create(:assignment)
     @course.assignments << @assignment
     student = create(:user, courses: [@course], role: :student)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an admin user (only) I want to be able to set at the Institution level whether or not the school has Google Calendar integration. If an associated school does not, then we should not show the Google integration buttons in the interface, to either students or staff.

### Related PRs
N/A


### Todos
- [ ] Add Tests

### Deploy Notes
Added has_google_access column to Institution table.

### Gem dependencies
N/A

### Migrations
YES

### Steps to Test or Reproduce
As an admin, navigate to the institutions page and click uncheck the checkbox for Has Google Access. Checking and unchecking the box will toggle toggle the Google Calendar links in the following areas:
Instructor/Events
Student/Events
Instructor/Assignments
Student/Assignments
Student/Dashboard

### Impacted Areas in Application
* Assignments
* Events
* Dashboards

======================
Closes #3616 
