### PR TITLE
3659 Added Instition Type to Institution

### DIFF
--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -38,7 +38,7 @@ class InstitutionsController < ApplicationController
   private
 
   def institution_params
-    params.require(:institution).permit :name, :has_site_license,
+    params.require(:institution).permit :name, :has_site_license, :institution_type,
       providers_attributes: [:id, :name, :base_url, :providee_id, :consumer_key,
         :consumer_secret, :consumer_secret_confirmation]
   end

--- a/app/views/institutions/components/_form.haml
+++ b/app/views/institutions/components/_form.haml
@@ -6,6 +6,9 @@
     .form-item
       = f.label :has_site_license
       = f.check_box :has_site_license
+    .form-item
+      = f.label :institution_type, "Institution Type"
+      = f.select :institution_type, [["K-12"], ["Higher Education"], ["Other"]]
 
   %section.form-section
     %h2.form-title= "Canvas Credentials"

--- a/app/views/institutions/index.html.haml
+++ b/app/views/institutions/index.html.haml
@@ -12,12 +12,14 @@
       %tr
         %th{scope: "col"} Name
         %th{scope: "col"} Has Site License?
+        %th{scope: "col"} Type
         %th.options{scope: "col", "data-dynatable-no-sort": "true"} Options
     %tbody
       - @institutions.each do |institution|
         %tr
           %td= institution.name
           %td= institution.has_site_license? ? "Yes" : "No"
+          %td= institution.institution_type
           %td.center
             .button-container.dropdown
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")

--- a/db/migrate/20171002182206_add_institution_type.rb
+++ b/db/migrate/20171002182206_add_institution_type.rb
@@ -1,0 +1,5 @@
+class AddInstitutionType < ActiveRecord::Migration[5.0]
+  def change
+    add_column :institutions, :institution_type, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170805193014) do
+ActiveRecord::Schema.define(version: 20171002182206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -516,6 +516,7 @@ ActiveRecord::Schema.define(version: 20170805193014) do
   create_table "institutions", force: :cascade do |t|
     t.string  "name",                             null: false
     t.boolean "has_site_license", default: false, null: false
+    t.string  "institution_type"
     t.index ["name"], name: "index_institutions_on_name", using: :btree
   end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an admin user, I want to be able to identify that an institution is either K-12, Higher Ed, or "Other"

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
Added institution_type field to institutions table

### Gem dependencies
N/A

### Migrations
YES

### Steps to Test or Reproduce
As an admin, I can now edit an institution on the edit institution page to include the institution type as "K-12", "Higher Education", or "Other". Furthermore, this status will now be displayed on the institutions index page.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Institutions

======================
Closes #3659 
