### PR TITLE
api assignment index order includes assignment type

### DIFF
--- a/app/assets/javascripts/angular/services/StudentPanelService.coffee
+++ b/app/assets/javascripts/angular/services/StudentPanelService.coffee
@@ -1,5 +1,4 @@
-# Manages state for the student side panel. Only in place on the Predictor Page
-# for now, but built to accomodate side panels on other pages.
+# Manages state for the student side panel.
 
 @gradecraft.factory 'StudentPanelService', [ 'GradeCraftAPI', (GradeCraftAPI)->
 

--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -5,7 +5,7 @@ class API::AssignmentsController < ApplicationController
 
   # GET api/assignments
   def index
-    @assignments = current_course.assignments.ordered
+    @assignments = current_course.assignments.joins(:assignment_type).order("assignments.position").order("assignment_types.position")
 
     if current_user_is_student?
       @student = current_student

--- a/spec/controllers/api/assignments_controller_spec.rb
+++ b/spec/controllers/api/assignments_controller_spec.rb
@@ -24,6 +24,21 @@ describe API::AssignmentsController do
         expect(assigns :grades).to be_nil
         expect(response).to render_template(:index)
       end
+
+      describe "ordered by position" do
+        it "orders primarily by postions and secondarily by assignment type position" do
+          assignment.assignment_type.update(position: 2)
+          at2 = create :assignment_type, position: 1, course: course
+
+          a2 = create :assignment, position: 1, assignment_type: at2, course: course
+          a3 = create :assignment, position: 1, assignment_type: assignment.assignment_type, course: course
+          a4 = create :assignment, position: 2, assignment_type: at2, course: course
+          assignment.update(position: 5)
+          get :index, format: :json
+          expect(assigns(:assignments).pluck(:position)).to eq([1,1,2,5])
+          expect(assigns(:assignments).pluck(:id)).to eq([a2.id, a3.id, a4.id, assignment.id])
+        end
+      end
     end
 
     describe "GET show" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -214,6 +214,15 @@ describe Assignment do
     end
   end
 
+  describe "ordered by position" do
+    it "sets the order by the position" do
+      a1 = create :assignment, position: 2
+      a2 = create :assignment, position: 1
+      expect(Assignment.all.ordered.first).to eq(a2)
+      expect(Assignment.all.ordered.last).to eq(a1)
+    end
+  end
+
   describe "#min_group_size" do
     it "sets the default min group size at 2" do
       expect(subject.min_group_size).to eq(1)


### PR DESCRIPTION
### Status
**READY**

### Description
Adds an order to assignment types in the api index list that orders secondarily on assignment type.
This assures that the assignment which is first, and which is pulled as the default into the student side informational panel, is the first one in the predictor.

Note: this join could be included in the scope on the model, but since I didn't see the need for it on any other page, I moved it into the controller action.

======================
Closes #3677
