### PR TITLE
Possible fix to check trial create for environment

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable AndOr
 class UserSessionsController < ApplicationController
 
   before_action :ensure_staff?, only: [:impersonate_student]
@@ -10,6 +11,7 @@ class UserSessionsController < ApplicationController
   end
 
   def instructors
+    redirect_back_or_default and return if Rails.env.production?
     @user = User.new
   end
 

--- a/app/views/layouts/navigation/_public_nav.haml
+++ b/app/views/layouts/navigation/_public_nav.haml
@@ -1,4 +1,5 @@
-%li= link_to "Free Trial", instructors_user_sessions_path
+- if !Rails.env.production?
+  %li= link_to "Free Trial", instructors_user_sessions_path
 
 %li
   = link_to_unless_current "Features", features_path do |name|


### PR DESCRIPTION
### Status
READY

### Description
See issue for background. I traced back how this might be happening and it seems that the user received an activation email that pointed them to the umich domain for activation. The only way I can see this happening is if they were somehow able to get to the create a free trial page while on the umich domain.

I wasn't able to figure out exactly where the origin of this happening might be, but I did find one partial view where it wasn't protected when the environment was production. I added two extra checks to ensure that this isn't possible in the future.

### Impacted Areas in Application
Create free trial

======================
Closes #3689 
