### PR TITLE
2933 Return an alert is a course membership already exists

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,7 +74,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    if check_params
+    if user_exists
       result = Services::CreatesOrUpdatesUser.create_or_update user_params, current_course,
         params[:send_welcome] == "1"
       @user = result[:user]
@@ -257,7 +257,7 @@ class UsersController < ApplicationController
 
   private
 
-  def check_params
+  def user_exists
     if User.find_by_insensitive_email(params["user"]["email"]).nil?
       return true
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,8 +100,20 @@ class UsersController < ApplicationController
       CourseMembershipBuilder.new(current_user).build_for(@user)
       render :new
     else
-      redirect_to students_path, alert: "#{term_for :student} #{params["user"]["first_name"]}
-        #{params["user"]["last_name"]} with email #{params["user"]["email"]} already exists for #{current_course.name}!"
+      if @user.is_student?(current_course)
+        redirect_to students_path,
+          # rubocop:disable AndOr
+          alert: "#{term_for :student} #{params["user"]["first_name"]}
+            #{params["user"]["last_name"]} with email #{params["user"]["email"]} already exists for #{current_course.name}!" and return
+      elsif @user.is_staff?(current_course)
+        redirect_to staff_index_path,
+          alert: "Staff Member #{params["user"]["first_name"]}
+          #{params["user"]["last_name"]} with email #{params["user"]["email"]} already exists for #{current_course.name}!" and return
+      elsif @user.is_observer?(current_course)
+        redirect_to observers_path,
+          alert: "Observer #{params["user"]["first_name"]}
+          #{params["user"]["last_name"]} with email #{params["user"]["email"]} already exists for #{current_course.name}!" and return
+      end
     end
   end
 

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -35,12 +35,12 @@ class CSVStudentImporter
         end
 
         if check_user(user, team, course)
-          append_unsuccessful row, "Unable to import this #{term_for :student}, they have already been added to the course"
+          append_unsuccessful row, "Unable to import this user, they have already been added to the course"
           next
         end
 
         unless Services::CreatesCourseMembership.create(user, course).success?
-          append_unsuccessful row, "Unable to add this #{term_for :student} to the course"
+          append_unsuccessful row, "Unable to add this user to the course"
           next
         end
 

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -34,7 +34,7 @@ class CSVStudentImporter
           next
         end
 
-        if !user.course_memberships.where(course_id: course.id).first.nil? && user.course_memberships.where(course_id: course.id).first.try(:team).try(:name) == team
+        if check_user(user, team, course)
           append_unsuccessful row, "Unable to create course membership for student, course membership already exists"
           next
         end
@@ -62,6 +62,22 @@ class CSVStudentImporter
     return if row.team_name.blank?
     team = Team.find_by_course_and_name course.id, row.team_name
     team ||= Team.create course_id: course.id, name: row.team_name
+  end
+
+  def check_user(user, team, course)
+    if team.nil?
+      if !user.course_memberships.where(course_id: course.id).first.nil?
+        return true
+      else
+        return false
+      end
+    else
+      if !user.course_memberships.where(course_id: course.id).first.nil? && !user.team_memberships.where(team_id: team.id).empty?
+        return true
+      else
+        return false
+      end
+    end
   end
 
   def strip_whitespace(row)

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -66,17 +66,11 @@ class CSVStudentImporter
 
   def check_user(user, team, course)
     if team.nil?
-      if !user.course_memberships.where(course_id: course.id).first.nil?
-        return true
-      else
-        return false
-      end
+      return false unless !user.course_memberships.where(course_id: course.id).first.nil?
+      return true
     else
-      if !user.course_memberships.where(course_id: course.id).first.nil? && !user.team_memberships.where(team_id: team.id).empty?
-        return true
-      else
-        return false
-      end
+      return false unless !user.course_memberships.where(course_id: course.id).first.nil? && !user.team_memberships.where(team_id: team.id).empty?
+      return true
     end
   end
 

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -35,12 +35,12 @@ class CSVStudentImporter
         end
 
         if check_user(user, team, course)
-          append_unsuccessful row, "Unable to create course membership for student, course membership already exists"
+          append_unsuccessful row, "Unable to import this #{term_for :student}, they have already been added to the course"
           next
         end
 
         unless Services::CreatesCourseMembership.create(user, course).success?
-          append_unsuccessful row, "Unable to create course membership for student"
+          append_unsuccessful row, "Unable to add this #{term_for :student} to the course"
           next
         end
 

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -34,6 +34,11 @@ class CSVStudentImporter
           next
         end
 
+        if !user.course_memberships.where(course_id: course.id).first.nil?
+          append_unsuccessful row, "Unable to create course membership for student, course membership already exists"
+          next
+        end
+
         unless Services::CreatesCourseMembership.create(user, course).success?
           append_unsuccessful row, "Unable to create course membership for student"
           next

--- a/app/importers/user_importers/csv_student_importer.rb
+++ b/app/importers/user_importers/csv_student_importer.rb
@@ -34,7 +34,7 @@ class CSVStudentImporter
           next
         end
 
-        if !user.course_memberships.where(course_id: course.id).first.nil?
+        if !user.course_memberships.where(course_id: course.id).first.nil? && user.course_memberships.where(course_id: course.id).first.try(:team).try(:name) == team
           append_unsuccessful row, "Unable to create course membership for student, course membership already exists"
           next
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -63,8 +63,42 @@ describe UsersController do
         post :update, params: { id: user.id, user: params }
         expect(user.reload.first_name).to eq "Jonathan"
       end
-
     end
+
+    context "calling create" do
+
+      it "creates a new staff member", focus: true do
+        post :create, params: { user: { first_name: "Bob",
+                  last_name: "Ross",
+                  email: "bob.ross@mailinator.com",
+                  course_memberships_attributes: { "0": {course_id: course.id,
+                                                       role: "professor",
+                                                       auditing: "0"}
+                                                  }
+                                        }
+                                }
+        expect(response).to redirect_to(staff_index_path)
+      end
+
+      it "creates a new observer", focus: true do
+        post :create, params: { user: { first_name: "Bob",
+                  last_name: "Ross",
+                  email: "bob.ross@mailinator.com",
+                  course_memberships_attributes: { "0": {course_id: course.id,
+                                                       role: "observer",
+                                                       auditing: "0"}
+                                                  }
+                                        }
+                                }
+        expect(response).to redirect_to(observers_path)
+      end
+
+      # it "returns an error for duplication if the user already exists" do
+      #
+      # end
+    end
+
+
 
     # We used to allow instructors to delete users, but no longer (admins only)
     describe "GET destroy" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -93,12 +93,30 @@ describe UsersController do
         expect(response).to redirect_to(observers_path)
       end
 
-      # it "returns an error for duplication if the user already exists" do
-      #
-      # end
+      let(:user) { create(:user, first_name: "Bob", last_name: "Ross", email: "bob.ross@mailinator.com", courses: [course]) }
+
+      it "returns an error for duplication if the user already exists" do
+        post :create, params: { user: { first_name: "Bob",
+                  last_name: "Ross",
+                  email: "bob.ross@mailinator.com",
+                  course_memberships_attributes: { "0": {course_id: course.id,
+                                                       role: "student",
+                                                       auditing: "0"}
+                                                  }
+                                        }
+                                }
+        post :create, params: { user: { first_name: "Bob",
+                  last_name: "Ross",
+                  email: "bob.ross@mailinator.com",
+                  course_memberships_attributes: { "0": {course_id: course.id,
+                                                       role: "student",
+                                                       auditing: "0"}
+                                                  }
+                                        }
+                                }
+        expect(flash[:alert]).to include "already exists for"
+      end
     end
-
-
 
     # We used to allow instructors to delete users, but no longer (admins only)
     describe "GET destroy" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -67,7 +67,7 @@ describe UsersController do
 
     context "calling create" do
 
-      it "creates a new staff member", focus: true do
+      it "creates a new staff member" do
         post :create, params: { user: { first_name: "Bob",
                   last_name: "Ross",
                   email: "bob.ross@mailinator.com",
@@ -80,7 +80,7 @@ describe UsersController do
         expect(response).to redirect_to(staff_index_path)
       end
 
-      it "creates a new observer", focus: true do
+      it "creates a new observer" do
         post :create, params: { user: { first_name: "Bob",
                   last_name: "Ross",
                   email: "bob.ross@mailinator.com",

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -2,4 +2,3 @@ First Name,Last Name,Username,Email,Team Name
   leading,trailing  ,whitespace, whitespace@example.com , ,
 Robert,Plant,csv_robert,csv_robert@example.com,
 Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin
-Bob,Ross,bob_ross,bob_ross@example.com,

--- a/spec/fixtures/files/users.csv
+++ b/spec/fixtures/files/users.csv
@@ -2,3 +2,4 @@ First Name,Last Name,Username,Email,Team Name
   leading,trailing  ,whitespace, whitespace@example.com , ,
 Robert,Plant,csv_robert,csv_robert@example.com,
 Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin
+Bob,Ross,bob_ross,bob_ross@example.com,

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -62,7 +62,7 @@ describe CSVStudentImporter do
           subject.import course
           result = subject.import course
           expect(result.unsuccessful).to include({data: "Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin\n",
-            errors: "Unable to create course membership for student, course membership already exists"})
+            errors: "Unable to import this user, they have already been added to the course"})
         end
 
         it "creates the team and adds the student if the team does not exist" do

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -1,4 +1,4 @@
-describe CSVStudentImporter do
+describe CSVStudentImporter, focus: true do
   before(:all) { User.destroy_all }
 
   describe "#import" do
@@ -59,10 +59,11 @@ describe CSVStudentImporter do
         end
 
         it "appends unsuccessful if a course membership already exists for user and there is no change to team" do
-          create :user, first_name: "Bob", last_name: "Ross", email: "bob_ross@example.com",
-            username: "bob_ross", password: "blah", courses: [course], role: :student
+          # create :user, first_name: "Jimmy", last_name: "Page", email: "csv_jimmy@example.com",
+          #   username: "jimmy", password: "blah", courses: [course], role: :student, team: team
+          subject.import course
           result = subject.import course
-          expect(result.unsuccessful).to include({data: "Bob,Ross,bob_ross,bob_ross@example.com,\n",
+          expect(result.unsuccessful).to include({data: "Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin\n",
             errors: "Unable to create course membership for student, course membership already exists"})
         end
 

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -1,4 +1,4 @@
-describe CSVStudentImporter, focus: true do
+describe CSVStudentImporter do
   before(:all) { User.destroy_all }
 
   describe "#import" do

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -58,6 +58,14 @@ describe CSVStudentImporter do
           expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
+        it "appends unsuccessful if a course membership already exists for user and there is no change to team" do
+          create :user, first_name: "Bob", last_name: "Ross", email: "bob_ross@example.com",
+            username: "bob_ross", password: "blah", courses: [course], role: :student
+          result = subject.import course
+          expect(result.unsuccessful).to include({data: "Bob,Ross,bob_ross,bob_ross@example.com,\n",
+            errors: "Unable to create course membership for student, course membership already exists"})
+        end
+
         it "creates the team and adds the student if the team does not exist" do
           Team.unscoped.last.destroy
           subject.import course

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -59,8 +59,6 @@ describe CSVStudentImporter do
         end
 
         it "appends unsuccessful if a course membership already exists for user and there is no change to team" do
-          # create :user, first_name: "Jimmy", last_name: "Page", email: "csv_jimmy@example.com",
-          #   username: "jimmy", password: "blah", courses: [course], role: :student, team: team
           subject.import course
           result = subject.import course
           expect(result.unsuccessful).to include({data: "Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin\n",


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
If a user tries to create a new course_membership for someone, but that person is already enrolled in the course, we should respond with an alert message: 'First-Name Last-Name is already enrolled in this course site" rather than a server error

### Related PRs
N/A


### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an admin, navigate to the students page and add a new student that already exists in the course. I should return to the user page with an alert that the user already exists in said course.

However, if I navigate to a second course where the student does not have a course membership, I should still be able to add that student.

### Impacted Areas in Application
* Students

======================
Closes #2933 
