### PR TITLE
Bug fix for has_google_access

### DIFF
--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -41,6 +41,6 @@
                   Edit Rubric
                 - else
                   Create Rubric
-                - if presenter.course.institution.has_google_access?
+                - if presenter.course.institution.try(:has_google_access)
                   = active_course_link_to decorative_glyph(:calendar) + "Add to Google Calendar",
                     add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -19,7 +19,7 @@
 %p.assignment-description.italic= "Opens: #{l presenter.assignment.open_at.in_time_zone(current_user.time_zone)}" if presenter.assignment.open_at?
 %p.assignment-description.italic= "Due: #{l presenter.assignment.due_at.in_time_zone(current_user.time_zone)}" if presenter.assignment.due_at?
 
-- if presenter.course.institution.has_google_access?
+- if presenter.course.institution.try(:has_google_access)
   %p.assignment-description= link_to decorative_glyph(:calendar) + "Add to Google Calendar",
     add_assignment_google_calendars_assignments_path(presenter.assignment), :target => "_parent",  method: :post
 

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -8,7 +8,7 @@
         %ul.options-menu.dropdown-content
           - if current_course.allows_canvas?
             = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path
-          - if current_course.assignments.present? && current_course.institution.has_google_access?
+          - if current_course.assignments.present? && current_course.institution.try(:has_google_access)
             = active_course_link_to decorative_glyph(:calendar) + "Add All to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -30,7 +30,7 @@
               .button-container.dropdown
                 %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
                 %ul.options-menu.dropdown-content
-                  - if event.course.institution.has_google_access?
+                  - if event.course.institution.try(:has_google_access)
                     %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(event), :target => "_parent", method: :post
                   = active_course_link_to decorative_glyph(:edit) + "Edit", edit_event_path(event)
                   = active_course_link_to decorative_glyph(:trash) + "Delete", event, :method => :delete, data: { :confirm => "Are you sure you want to delete #{event.name}?" }

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -7,7 +7,7 @@
           %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
           %ul.options-menu.dropdown-content
             %li= link_to decorative_glyph(:copy) + "Copy Event ", copy_events_path(id: @event.id), method: :post
-            - if @event.course.institution.has_google_access?
+            - if @event.course.institution.try(:has_google_access)
               %li= link_to decorative_glyph(:calendar) + "Add to Google Calendar ", add_event_google_calendars_events_path(@event), :target => "_parent", method: :post
 
 .pageContent

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -30,5 +30,5 @@
                   %li #{ link_to assignment.name, assignment } due at #{ l assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    - if presenter.course.institution.has_google_access
+    - if presenter.course.institution.try(:has_google_access)
       = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
GC returns server error if a specific course isn't tied to any institution. Instead, do .try(:has_google_access)

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
3616 | [link](https://github.com/UM-USElab/gradecraft-development/pull/3675)

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the calendar events page, if the course does have an institution and has google access is set to true, a link to add to google calendar should be present. If the course is not tied to an institution OR has_google_access is set to false, links will not be present.

### Impacted Areas in Application
* Events
* Assignments 

======================
Closes #3694
