### PR TITLE
3683 Allow Instructors to rename Grade Predictor

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -25,5 +25,5 @@
         Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}
       %text.description
-        Predicted Final Grade:
+        Predicted Final Outcome:
         {{predictedGradeLevel()}}

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -205,7 +205,7 @@ class CoursesController < ApplicationController
       :max_weights_per_assignment_type, :assignments,
       :accepts_submissions, :tagline, :office, :phone, :has_paid,
       :class_email, :twitter_handle, :twitter_hashtag, :location, :office_hours,
-      :meeting_times, :assignment_term, :challenge_term, :badge_term, :gameful_philosophy,
+      :meeting_times, :assignment_term, :challenge_term, :grade_predictor_term, :badge_term, :gameful_philosophy,
       :team_score_average, :has_team_challenges, :team_leader_term,
       :max_assignment_types_weighted, :full_points, :has_in_team_leaderboards,
       :grade_scheme_elements_attributes, :add_team_score_to_student, :status,

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,7 +83,7 @@ class Course < ActiveRecord::Base
   accepts_nested_attributes_for :grade_scheme_elements, allow_destroy: true
 
   validates_presence_of :name, :course_number, :student_term, :team_term, :group_term,
-    :team_leader_term, :group_term, :weight_term, :badge_term, :assignment_term, :challenge_term
+    :team_leader_term, :group_term, :weight_term, :badge_term, :assignment_term, :challenge_term, :grade_predictor_term
 
   validates_numericality_of :total_weights, :max_weights_per_assignment_type,
     :max_assignment_types_weighted, less_than_or_equal_to: 999999999, greater_than: 0, if: lambda { self.has_multipliers? }, message: "must be set to greater than 0 for the Multipliers feature to work properly."

--- a/app/views/analytics/students.html.haml
+++ b/app/views/analytics/students.html.haml
@@ -20,7 +20,7 @@
 
   / Students who have not predicted any grades for this course
   %h3.bold Non-predictors
-  .italic.small= "#{term_for :students} who have not yet used the grade predictor"
+  .italic.small= "#{term_for :students} who have not yet used the #{term_for :grade_predictor}"
   %table.dynatable
     %thead
       %tr

--- a/app/views/challenges/_form.html.haml
+++ b/app/views/challenges/_form.html.haml
@@ -33,7 +33,7 @@
   %section.form-section
     %h2.form-title Grade Levels
     .challenge-score-levels
-      %p.hint Example: You could create three levels to produce a quick grading scheme for just this #{term_for :challenge} - Complete (5000 points), Finalist (7000 points), and Winner (10,000 points). These levels will then show in the quick grade, and when students are setting goals in the grade predictor.
+      %p.hint Example: You could create three levels to produce a quick grading scheme for just this #{term_for :challenge} - Complete (5000 points), Finalist (7000 points), and Winner (10,000 points). These levels will then show in the quick grade, and when students are setting goals in the #{term_for :grade_predictor}.
       %script(id="challenge-score-level-template" type="text/x-template")
         %fieldset.challenge-score-level
           = f.simple_fields_for :challenge_score_levels, ChallengeScoreLevel.new, class: "form-inline", child_index: "child_index" do |slf|

--- a/app/views/courses/_custom_terms.haml
+++ b/app/views/courses/_custom_terms.haml
@@ -33,3 +33,7 @@
   .form-flex-row
     .form-item
       = f.input :challenge_term, label: "Section Assignment", hint: "What would you like to call these section assignments? Quests, Boss Battles, Challenges..."
+
+  .form-flex-row
+    .form-item
+      = f.input :grade_predictor_term, label: "Grade Predictor", hint: "What would you like to call the Grade Predictor? Crystal Ball, Weather Forecast, Ouija Board..."

--- a/app/views/courses/_custom_terms.haml
+++ b/app/views/courses/_custom_terms.haml
@@ -7,11 +7,16 @@
       = f.input :student_term, label: "Student", hint: "What will you call your user? Student, Learner, Player..."
 
     .form-item.col-50
-      = f.input :assignment_term, label: "Assignment", hint: "Would you like to call assignments something else?"
+      = f.input :group_term, label: "Group", hint: "What will these groups be called?"
 
   .form-flex-row
+    .form-item
+      = f.input :grade_predictor_term, label: "Grade Predictor", hint: "What would you like to call the Grade Predictor? Crystal Ball, Weather Forecast, Ouija Board..."
+
+%section.form-section
+  .form-flex-row
     .form-item.col-50
-      = f.input :group_term, label: "Group", hint: "What will these groups be called?"
+      = f.input :assignment_term, label: "Assignment", hint: "Would you like to call assignments something else?"
 
     .form-item.col-50
       = f.input :badge_term, label: "Badge", hint: "Would you like to call badges something else?"
@@ -23,6 +28,7 @@
     .form-item.col-50
       = f.input :fail_term, label: "Fail", hint: "What would you like to call failure for a pass/fail assignment?"
 
+%section.form-section
   .form-flex-row
     .form-item.col-50
       = f.input :team_term, label: "Section", hint: "What will you call these? Team, House, Section..."
@@ -33,7 +39,3 @@
   .form-flex-row
     .form-item
       = f.input :challenge_term, label: "Section Assignment", hint: "What would you like to call these section assignments? Quests, Boss Battles, Challenges..."
-
-  .form-flex-row
-    .form-item
-      = f.input :grade_predictor_term, label: "Grade Predictor", hint: "What would you like to call the Grade Predictor? Crystal Ball, Weather Forecast, Ouija Board..."

--- a/app/views/info/dashboard/modules/_dashboard_assignment_weights.haml
+++ b/app/views/info/dashboard/modules/_dashboard_assignment_weights.haml
@@ -30,4 +30,4 @@
     .clear
     - if current_course.assignment_weight_open? && current_user_is_student?
       %p= link_to "Edit My Choices", predictor_path, class: "button"
-      %i Set your #{term_for :weight} choices in the grade predictor to have them automatically update your grade
+      %i Set your #{term_for :weight} choices in the #{term_for :grade_predictor} to have them automatically update your grade

--- a/app/views/info/dashboard/modules/_dashboard_avatar.haml
+++ b/app/views/info/dashboard/modules/_dashboard_avatar.haml
@@ -7,7 +7,7 @@
   .card-body
     - if current_student.predictions_for_course?(current_course) == false
       .small
-        .alert-box.alert Has not yet used the grade predictor
+        .alert-box.alert Has not yet used the #{term_for :grade_predictor}
     .module-section
       - if current_student.avatar_file_name.present?
         %img.img-rounded{:src => current_student.avatar_file_name, width: 100, height: 100 }

--- a/app/views/info/dashboard/modules/_dashboard_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_grading_scheme.haml
@@ -1,5 +1,5 @@
 .card-header
-  %h2 Course Progress
+  %h2 Your Progress
 .card-body
   - if current_student.present?
     = render partial: "info/dashboard/modules/dashboard_student_grading_scheme", locals: { presenter: presenter }

--- a/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
+++ b/app/views/info/dashboard/modules/_dashboard_to_do_list_items.haml
@@ -36,5 +36,5 @@
           %img{src: "/images/no-predicted-assignments.svg", alt:"", class:"empty-state-graphic"}
         %p.empty-state-text
           You have not predicted any #{(term_for :assignment).downcase.pluralize}! Check out the
-          = link_to "grade predictor", predictor_path
+          = link_to "#{term_for :grade_predictor}", predictor_path
           to add #{(term_for :assignment).downcase.pluralize} to this planner.

--- a/app/views/info/staff_onboarding/_staff_onboarding_slide2.haml
+++ b/app/views/info/staff_onboarding/_staff_onboarding_slide2.haml
@@ -6,5 +6,5 @@
       %h2 What is GradeCraft?
       %ul
         %li Supports personalized learning through assessment choice
-        %li The Grade Predictor promotes student agency by enabling them to make choices and set goals
+        %li The #{term_for :grade_predictor} promotes student agency by enabling them to make choices and set goals
         %li Analytics displays help students keep track of how they're doing

--- a/app/views/info/student_onboarding/_student_onboarding_slide5.haml
+++ b/app/views/info/student_onboarding/_student_onboarding_slide5.haml
@@ -1,10 +1,10 @@
 .modal-slide
   .modal-slide-top
-    %img.modal-slide-image.large-image.centered{src: "/images/onboarding-slide-5.png", alt: "Grade predictor example"}
+    %img.modal-slide-image.large-image.centered{src: "/images/onboarding-slide-5.png", alt: "#{term_for :grade_predictor} example"}
   .modal-slide-bottom
     .modal-slide-text
       %h2 Plan your grade
-      %p Plan out variable assignment pathways with Grade Predictor and use it to maximize your freedom of choice. Achieve the goals you want on your terms.
+      %p Plan out variable assignment pathways with #{term_for :grade_predictor} and use it to maximize your freedom of choice. Achieve the goals you want on your terms.
       -# - if !presenter.has_course_specific_features?
       -#   .modal-action-wrapper
       -#     %button#modal-action{type: 'submit', 'aria-label': 'close'} Let's Go!

--- a/app/views/layouts/navigation/_observer_profile_tabs.haml
+++ b/app/views/layouts/navigation/_observer_profile_tabs.haml
@@ -7,7 +7,7 @@
       = link_to_unless_current "Syllabus", syllabus_path
   %li{class: ("active" if current_page?(predictor_path)) }
     - if current_user_is_admin? || current_course.active?
-      = link_to_unless_current "Grade Predictor", predictor_path
+      = link_to_unless_current "#{term_for :grade_predictor}", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -48,7 +48,7 @@
 %h5 Course Setup
 %li= link_to_unless_current decorative_glyph(:cog) + "Course Settings", edit_course_path(current_course)
 %li= link_to_unless_current decorative_glyph(:check) + "#{ term_for :assignment } Settings", settings_assignments_path
-%li= link_to_unless_current decorative_glyph(:tasks) + "Grade Predictor Preview", predictor_path
+%li= link_to_unless_current decorative_glyph(:tasks) + "#{ term_for :grade_predictor } Preview", predictor_path
 %li= link_to_unless_current decorative_glyph("level-up") + "Grading Scheme", grade_scheme_elements_path
 %li= link_to_unless_current decorative_glyph(:university) + "My Courses", courses_path
 

--- a/app/views/layouts/navigation/_student_profile_tabs.haml
+++ b/app/views/layouts/navigation/_student_profile_tabs.haml
@@ -8,7 +8,7 @@
     %li{class: ("active" if current_page?(syllabus_path)) }
       = link_to_unless_current "Syllabus", syllabus_path
   %li{class: ("active" if current_page?(predictor_path)) }
-    = link_to_unless_current "Grade Predictor", predictor_path
+    = link_to_unless_current "#{term_for :grade_predictor}", predictor_path
   - if current_course.has_badges?
     %li{class: ("active" if current_page?(badges_path)) }
       = link_to_unless_current "#{term_for :badges}", badges_path

--- a/app/views/notification_mailer/challenge_grade_released.html.haml
+++ b/app/views/notification_mailer/challenge_grade_released.html.haml
@@ -9,5 +9,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "grade predictor", predictor_url
+    = link_to "#{term_for :grade_predictor}", predictor_url
 %hr/

--- a/app/views/notification_mailer/challenge_grade_released.text.haml
+++ b/app/views/notification_mailer/challenge_grade_released.text.haml
@@ -2,7 +2,7 @@ Dear #{ @student.first_name },
 
 You can now view the grade for your #{ @course.challenge_term.downcase } "#{ @challenge.name }" in course #{ @course.name }.
 
-Don't forget to update your plan for the semester by checking your grade predictor here: 
+Don't forget to update your plan for the semester by checking your #{term_for :grade_predictor} here: 
 
 = predictor_url
 

--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -13,5 +13,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "grade predictor", predictor_url
+    = link_to "#{term_for :grade_predictor}", predictor_url
 %hr/

--- a/app/views/notification_mailer/grade_released.text.haml
+++ b/app/views/notification_mailer/grade_released.text.haml
@@ -4,7 +4,7 @@ You can now view the grade for your #{ @course.assignment_term.downcase } "#{ @a
 
 Visit #{ assignment_url(@assignment) } to view your results.
 
-Don't forget to update your plan for the semester by checking your grade predictor here: 
+Don't forget to update your plan for the semester by checking your #{term_for :grade_predictor} here: 
 
 = predictor_url
 

--- a/app/views/notification_mailer/successful_submission.html.haml
+++ b/app/views/notification_mailer/successful_submission.html.haml
@@ -6,5 +6,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "#{term_for :grade_predictor}", predictor_url
+    = link_to "#{ @course.grade_predictor_term }", predictor_url
 %hr/

--- a/app/views/notification_mailer/successful_submission.html.haml
+++ b/app/views/notification_mailer/successful_submission.html.haml
@@ -6,5 +6,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "grade predictor", predictor_url
+    = link_to "#{term_for :grade_predictor}", predictor_url
 %hr/

--- a/app/views/notification_mailer/successful_submission.text.haml
+++ b/app/views/notification_mailer/successful_submission.text.haml
@@ -2,7 +2,7 @@ Dear #{ @user.first_name },
 
 You successfully submitted your work for #{ @assignment.name } on #{ @submission.submitted_at }.
 
-Don't forget to update your plan for the semester by checking your #{ term_for :grade_predictor} here: 
+Don't forget to update your plan for the semester by checking your #{ @course.grade_predictor_term } here: 
 
 = predictor_url
 

--- a/app/views/notification_mailer/successful_submission.text.haml
+++ b/app/views/notification_mailer/successful_submission.text.haml
@@ -2,7 +2,7 @@ Dear #{ @user.first_name },
 
 You successfully submitted your work for #{ @assignment.name } on #{ @submission.submitted_at }.
 
-Don't forget to update your plan for the semester by checking your grade predictor here: 
+Don't forget to update your plan for the semester by checking your #{ term_for :grade_predictor} here: 
 
 = predictor_url
 

--- a/app/views/notification_mailer/updated_submission.html.haml
+++ b/app/views/notification_mailer/updated_submission.html.haml
@@ -6,5 +6,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "#{term_for :grade_predictor}", predictor_url
+    = link_to "#{ @course.grade_predictor_term }", predictor_url
 %hr/

--- a/app/views/notification_mailer/updated_submission.html.haml
+++ b/app/views/notification_mailer/updated_submission.html.haml
@@ -6,5 +6,5 @@
 %p{:align => "center"}
   Don't forget to update your plan for the semester by checking your
   = succeed "." do
-    = link_to "grade predictor", predictor_url
+    = link_to "#{term_for :grade_predictor}", predictor_url
 %hr/

--- a/app/views/pages/_student_features.haml
+++ b/app/views/pages/_student_features.haml
@@ -1,10 +1,10 @@
 %section.feature-section.double-height-feature-section.white
-  %h2.center Grade Predictor
+  %h2.center #{term_for :grade_predictor}
   .image-container
-    .center= image_tag "GradePredictor.png", class: "center-image", alt: "Grade predictor"
+    .center= image_tag "GradePredictor.png", class: "center-image", alt: "#{term_for :grade_predictor}"
   %h4.center Plan your progress through the course!
   .whole
-    %p.center The grade predictor allows students to plan what assignments they will complete in order to achieve the grade they would like. With often many more assignments available to choose from, planning becomes essential to student progress. Give your students autonomy over their own learning.
+    %p.center The #{term_for :grade_predictor} allows students to plan what assignments they will complete in order to achieve the grade they would like. With often many more assignments available to choose from, planning becomes essential to student progress. Give your students autonomy over their own learning.
 
 %section.feature-section.alternate-white
   .half.text

--- a/db/migrate/20171006182839_add_grade_predictor_term_to_courses_table.rb
+++ b/db/migrate/20171006182839_add_grade_predictor_term_to_courses_table.rb
@@ -1,0 +1,5 @@
+class AddGradePredictorTermToCoursesTable < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :grade_predictor_term, :string, null: false, default: "Grade Predictor"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005150420) do
+ActiveRecord::Schema.define(version: 20171006182839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -330,6 +330,7 @@ ActiveRecord::Schema.define(version: 20171005150420) do
     t.boolean  "published",                                               default: false,                        null: false
     t.integer  "institution_id"
     t.text     "dashboard_message"
+    t.string   "grade_predictor_term",                                    default: "Grade Predictor",            null: false
     t.index ["institution_id"], name: "index_courses_on_institution_id", using: :btree
   end
 

--- a/lib/course_terms.rb
+++ b/lib/course_terms.rb
@@ -6,6 +6,7 @@ module CourseTerms
   def term_for(key, fallback = nil)
     case key.downcase.to_sym
     when :student then current_course.student_term.to_s.singularize
+    when :grade_predictor then current_course.grade_predictor_term.to_s.singularize  
     when :weight, :assignment, :badge, :team, :team_leader, :group
       current_course.send("#{key}_term").to_s.singularize
     when :pass, :fail

--- a/spec/mailers/notification_mailer/student_submissions_spec.rb
+++ b/spec/mailers/notification_mailer/student_submissions_spec.rb
@@ -21,7 +21,7 @@ describe NotificationMailer do
 
   let(:submission) { create(:submission, course: course, student: student, assignment: assignment) }
   let(:student) { create(:user) }
-  let(:course) { create(:course, assignment_term: "whifflebox") }
+  let(:course) { create(:course, assignment_term: "whifflebox", grade_predictor_term: "crystal ball") }
   let(:assignment) { create(:assignment) }
 
   describe "#successful_submission" do


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
This should be on the "Advanced settings" panel.

### Related PRs
N/A


### Todos
- [ ] Add Tests

### Deploy Notes
Migrations for adding 'grade_predictor_term' to 'courses' table.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, I can navigate to course settings, advanced settings, and I can change the term used for Grade Predictor. This will change all uses of the term 'Grade Predictor' to whatever I wish.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Course Settings

======================
Closes #3683 
