### PR TITLE
Fix bug in challenge grade levels

### DIFF
--- a/app/views/challenges/_show_student.haml
+++ b/app/views/challenges/_show_student.haml
@@ -24,7 +24,7 @@
         %td= points challenge_grade.final_points if (challenge_grade && ChallengeGradeProctor.new(challenge_grade).viewable?)
         - if @challenge.has_levels?
           %td
-            = @challenge.grade_level(grade) if challenge_grade
+            = @challenge.challenge_grade_level(challenge_grade) if challenge_grade
         %td
           - if team == current_student.team_for_course(current_course) && challenge_grade
             = link_to glyph(:eye) + "See Grade Details", challenge_grade_path(challenge_grade.id), class: 'button'


### PR DESCRIPTION
### Status
READY

### Description
This PR addresses a bug in the `challenges/_show_student` view, where it appears that there the grade is not defined and the `grade_level` method on the Challenge model was refactored at some point to be named `challenge_grade_level`.

### Steps to Test or Reproduce
Create a challenge with score levels. Grade a team and attempt to view your grade as a student. Prior to the fix, you would get an error.

### Impacted Areas in Application
Viewing challenge grades for a student on a challenge with score levels

======================
Closes #3696 
