### PR TITLE
Fix for gradebook export points using raw_points

### DIFF
--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -40,7 +40,7 @@ class GradebookExporter
     # TODO: improve the performance here
     course.assignments.ordered.inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
-      score = GradeProctor.new(grade).viewable? ? grade.raw_points : ""
+      score = GradeProctor.new(grade).viewable? ? grade.final_points : ""
       memo << score
       memo
     end


### PR DESCRIPTION
### Status
READY

### Description
The gradebook export for a course returns `raw_points` instead of `final_points`, which does not represent the adjusted value you typically would see in Gradecraft.

### Impacted Areas in Application
Gradebook export

======================
Closes #3699 
