### PR TITLE
3656 Allow Instructor to delete announcement

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -37,9 +37,11 @@ class AnnouncementsController < ApplicationController
 
   # DELETE /announcements/:id
   def destroy
-    announcement = current_course.announcements.find(params[:id])
-    announcement.destroy
-    redirect_to announcements_url, notice: "Announcement #{announcement.title} successfully deleted"
+    @announcement = Announcement.find params[:id]
+    authorize! :destroy, @announcement
+    @title = @announcement.title
+    @announcement.destroy
+    redirect_to announcements_url, notice: "Announcement #{@title} successfully deleted"
   end
 
   private

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -35,6 +35,13 @@ class AnnouncementsController < ApplicationController
     render :new
   end
 
+  # DELETE /announcements/:id
+  def destroy
+    announcement = current_course.announcements.find(params[:id])
+    announcement.destroy
+    redirect_to announcements_url, notice: "Announcement #{announcement.title} successfully deleted"
+  end
+
   private
 
   def announcement_params

--- a/app/models/abilities/announcement_ability.rb
+++ b/app/models/abilities/announcement_ability.rb
@@ -7,12 +7,12 @@ module AnnouncementAbility
           announcement.course.users.include?(user)))
     end
 
-    can :create, Announcement do |announcement|
+    can [:create, :destroy], Announcement do |announcement|
       announcement.course.nil? || (announcement.course == course &&
         user.is_staff?(announcement.course))
     end
 
-    can [:destroy, :update], Announcement, course_id: course.id,
+    can :update, Announcement, course_id: course.id,
       author_id: user.id
   end
 end

--- a/app/views/announcements/_list.html.haml
+++ b/app/views/announcements/_list.html.haml
@@ -7,6 +7,7 @@
       %th Sent
       - if current_user.is_staff?(current_course)
         %th Read
+      %th.button-column.options Options
   %tbody
     - cache multi_cache_key :announcements, current_course do
       - @announcements.each do |announcement|
@@ -16,3 +17,8 @@
           %td= l announcement.created_at.in_time_zone(current_user.time_zone)
           - if current_user.is_staff?(current_course)
             %td= "#{announcement.read_count} / #{announcement.course.students.count}"
+          %td
+            .button-container.dropdown
+              %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
+              %ul.options-menu.dropdown-content
+                = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announement #{announcement.title}?", method: :delete }

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -3,7 +3,6 @@
     .context-menu
       %ul
         %li= link_to decorative_glyph(:plus) + 'New Announcement', new_announcement_path, class: "button button-edit"
-        %li= link_to decorative_glyph(:minus) + 'Delete Announcement', announcement_path(@announcement), class: "button button-edit", data: {confirm: "Are you sure you want to delete Announement #{@announcement.title}?", method: :delete }
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -3,6 +3,7 @@
     .context-menu
       %ul
         %li= link_to decorative_glyph(:plus) + 'New Announcement', new_announcement_path, class: "button button-edit"
+        %li= link_to decorative_glyph(:minus) + 'Delete Announcement', announcement_path(@announcement), class: "button button-edit", data: {confirm: "Are you sure you want to delete Announement #{@announcement.title}?", method: :delete }
 
 .pageContent
   = render partial: "layouts/alerts"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   post "analytics_events/tab_select_event"
 
   #2. Announcements
-  resources :announcements, except: [:destroy, :edit, :update]
+  resources :announcements, except: [:edit, :update]
 
   #3. Assignments, Submissions, Grades
   namespace :assignments do

--- a/spec/controllers/announcements_controller_spec.rb
+++ b/spec/controllers/announcements_controller_spec.rb
@@ -3,7 +3,7 @@ describe AnnouncementsController do
   let(:student) { create(:course_membership, :student, course: course).user }
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let(:announcement) { create :announcement, course: course }
-  
+
   context "as a student" do
     before(:each) do
       login_user(student)
@@ -26,6 +26,13 @@ describe AnnouncementsController do
       it "should not allow a student to create an announcement" do
         expect { post :create, params: { announcement:
                                          { title: "New Tour", body: "Test" }}}.to \
+          raise_error CanCan::AccessDenied
+      end
+    end
+
+    describe "DELETE destroy" do
+      it "should not allow a student to destroy an announcement" do
+        expect{ delete :destroy, params: { id: announcement.id }}.to \
           raise_error CanCan::AccessDenied
       end
     end
@@ -76,6 +83,21 @@ describe AnnouncementsController do
           expect {
             post :create, params: { announcement: { title: "New Tour", body: body }}
           }.to change  { ActionMailer::Base.deliveries.count }.by 2
+        end
+      end
+
+      describe "DELETE destroy" do
+        it "removes the announcement and announcement states entirely" do
+          announcement
+          expect{
+            delete :destroy, params: { id: announcement.id }
+          }.to change{Announcement.count}.by(-1)
+        end
+
+        it "redirects to the announcements page" do
+          announcement
+          expect(delete :destroy, params: { id: announcement.id }).to \
+            redirect_to(announcements_path)
         end
       end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
This should also delete all associated announcement states

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the show page of an announcement. Click the, "Delete Announcement" button in the top right corner. Upon confirmation, this will not only delete the announcement, but the corresponding announcement states. Finally, user is redirected to the announcements index page with a message that the announcement was deleted.

### Impacted Areas in Application
* Announcements 

======================
Closes #3656 
