### PR TITLE
Show all badges instead of at most two

### DIFF
--- a/app/views/rubrics/components/_level_badges.haml
+++ b/app/views/rubrics/components/_level_badges.haml
@@ -1,5 +1,5 @@
 %ul.badge-row
   - level.level_badges.each_with_index do |level_badge, index|
-    - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level) && index < 2
+    - if BadgeProctor.new(level_badge.badge).viewable?(current_user, level: level)
       .level-badge-image
         %img{src: level_badge.badge.try(:icon), alt: level_badge.badge.try(:name), title: level_badge.badge.try(:name), class: "level_badge" }


### PR DESCRIPTION
### Status
READY

### Description
When viewing a rubric, show all available and earned badges instead of just two.

======================
Closes #3706 
