### PR TITLE
3682 Allow instructor to hide grade predictor at course level

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -198,7 +198,7 @@ class CoursesController < ApplicationController
       :semester, :year, :has_badges, :has_teams,
       :team_term, :student_term, :section_leader_term, :group_term, :lti_uid,
       :user_id, :course_id, :course_rules, :dashboard_message, :syllabus, :has_multipliers,
-      :has_character_names, :has_team_roles, :has_character_profiles, :show_analytics,
+      :has_character_names, :has_team_roles, :has_character_profiles, :show_analytics, :show_grade_predictor,
       :total_weights, :weights_close_at, :has_public_badges,
       :assignment_weight_type, :has_submissions, :teams_visible,
       :weight_term, :fail_term, :pass_term, :time_zone,

--- a/app/views/courses/_basic_settings.haml
+++ b/app/views/courses/_basic_settings.haml
@@ -52,6 +52,13 @@
 
       .form-card
         .form-card-header
+          = f.label :show_grade_predictor, "Grade Predictor"
+          = f.check_box :show_grade_predictor, {class: "feature-checkbox"}
+        .form-card-body
+          .feature-description{id: "showGradePredictor"}  Show Grade Predictor.
+
+      .form-card
+        .form-card-header
           = f.label :has_multipliers, "Multipliers"
           = f.check_box :has_multipliers, {class: "feature-checkbox has-settings-menu"}
         .form-card-body

--- a/db/migrate/20171012154015_add_show_grade_predictor_to_courses.rb
+++ b/db/migrate/20171012154015_add_show_grade_predictor_to_courses.rb
@@ -1,0 +1,5 @@
+class AddShowGradePredictorToCourses < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :show_grade_predictor, :boolean, null: true, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005150420) do
+ActiveRecord::Schema.define(version: 20171012154015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -330,6 +330,9 @@ ActiveRecord::Schema.define(version: 20171005150420) do
     t.boolean  "published",                                               default: false,                        null: false
     t.integer  "institution_id"
     t.text     "dashboard_message"
+    t.string   "grade_predictor_term",                                    default: "Grade Predictor",            null: false
+    t.boolean  "shows_grade_predictor",                                   default: true
+    t.boolean  "show_grade_predictor",                                    default: true
     t.index ["institution_id"], name: "index_courses_on_institution_id", using: :btree
   end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor, some courses aren't appropriate for the Grade Predictor - they should be able to turn it off as a page for both the instructor and student sides

This should be displayed as a "Feature" box on the Course Settings pane

### Related PRs
N/A

### Todos
- [ ] Add Tests
- [ ] Finish Logic

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
- [ ] Coming Soon

### Impacted Areas in Application
* Grade Predictor

======================
Closes #3682 
