### PR TITLE
allow score level creation with zero points

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -180,7 +180,7 @@
     )
 
   queueUpdateScoreLevel = (assignmentId, scoreLevel)->
-    return false if !scoreLevel.points || !scoreLevel.name
+    return false if scoreLevel.points == null || !scoreLevel.name
     # use "creating" to avoid creating more than one with params
     return if scoreLevel.creating
     scoreLevel.creating = true if !scoreLevel.id


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes the call to update score levels to only reject null, but still allow score levels with zero points.


======================
Closes #3687 
