### PR TITLE
When copying a course, level badges reference the badges in the original course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -91,6 +91,7 @@ class CoursesController < ApplicationController
         duplicated.course_memberships.create(user: current_user, role: current_role)
       end
       duplicated.recalculate_student_scores unless duplicated.student_count.zero?
+      Services::ResolvesCopiedLevelBadges.for_course course # some sort of service to resolve badges ids by matching on attributes
       session[:course_id] = duplicated.id
       redirect_to edit_course_path(duplicated.id), flash: {
         notice: "#{@course.name} successfully copied"


### PR DESCRIPTION
### Status
NOT READY

### Description
When copying a course, assignments with rubrics and level badges are copied but level badges refer to the original badge in the original course.

### Steps to Test or Reproduce
Copy a course that has an assignment with rubrics + level badges. The level badges on the copied course for the copied rubric should be invalid due to the badge ids referencing the wrong badge.

### Impacted Areas in Application
Course copy

======================
Closes #[ISSUE NUMBER]
