### PR TITLE
Remove default production credentials

### DIFF
--- a/app/assets/javascripts/angular/main.coffee
+++ b/app/assets/javascripts/angular/main.coffee
@@ -31,10 +31,10 @@
 
 @gradecraft.config(['RollbarProvider', (RollbarProvider) ->
   RollbarProvider.init({
-    accessToken: "9d4d1ff5420b4c9a82eef7d0f9b8f3dd"
+    accessToken: "POST_CLIENT_ITEM_ACCESS_TOKEN"
     captureUncaught: true
     payload:
-      environment: 'production'
+      environment: 'local'
   })
 ])
 

--- a/app/views/layouts/help/_rollbar.haml
+++ b/app/views/layouts/help/_rollbar.haml
@@ -1,10 +1,10 @@
 <script>
 var _rollbarConfig = {
-accessToken: "9d4d1ff5420b4c9a82eef7d0f9b8f3dd",
+accessToken: "POST_CLIENT_ITEM_ACCESS_TOKEN",
 captureUncaught: true,
 captureUnhandledRejections: true,
 payload: {
-environment: "production"
+environment: "local"
 }
 };
 // Rollbar Snippet


### PR DESCRIPTION
### Status
READY

### Description

Remove the public key so that when developing features and testing locally, exceptions are not propagated to Rollbar.
