### PR TITLE
3723 duplicate score level bug

### DIFF
--- a/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
+++ b/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
@@ -38,10 +38,11 @@ angular.module('helpers').factory('DebounceQueue', ['$timeout', ($timeout)->
 
   # Use this on Submit to run all remaining events,
   # to assure that no delayed updates are missed.
-  # NOTE: any create events will have to be canceled manually
-  # on call, or they will sit in the queue and trigger
-  # a second call on submit, resulting in duplicate models.
-  # see AssignmentService._updateScoreLevel for an example
+  # NOTE: Events should be canceled by the functions that
+  # they trigger on call, or they will sit in the queue and trigger
+  # a second call on submit, possibly resulting in duplicate models.
+  # see AssignmentService for an example of using runAllEvents, and
+  # cancelling events from the _update* methods
   runAllEvents = ()->
     _.each(queueStore, (queueItem) ->
       if queueItem != null

--- a/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
+++ b/app/assets/javascripts/angular/helpers/debounceQueue.js.coffee
@@ -34,11 +34,19 @@ angular.module('helpers').factory('DebounceQueue', ['$timeout', ($timeout)->
     storeId = type + id
     return false if !queueStore[storeId]
     $timeout.cancel(queueStore[storeId].promise)
+    queueStore[storeId] = null
 
+  # Use this on Submit to run all remaining events,
+  # to assure that no delayed updates are missed.
+  # NOTE: any create events will have to be canceled manually
+  # on call, or they will sit in the queue and trigger
+  # a second call on submit, resulting in duplicate models.
+  # see AssignmentService._updateScoreLevel for an example
   runAllEvents = ()->
     _.each(queueStore, (queueItem) ->
-      $timeout.cancel(queueItem.promise)
-      queueItem.event.apply(null, queueItem.args)
+      if queueItem != null
+        $timeout.cancel(queueItem.promise)
+        queueItem.event.apply(null, queueItem.args)
     )
 
   return {

--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -164,8 +164,10 @@
           GradeCraftAPI.logResponse(response)
       )
 
-
   _updateScoreLevel = (assignmentId, scoreLevel)->
+    # delete associated event, so it is not retriggered on submit
+    DebounceQueue.cancelEvent("scoreLevels", scoreLevel.id || 0)
+
     params = { "assignment_score_levels_attributes" :
       [{ "id" : scoreLevel.id, "points" : scoreLevel.points, "name" : scoreLevel.name }]
     }

--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -137,8 +137,6 @@
   _updateAssignment = (id)->
     assignment = _.find(assignments, {id: id})
     if assignment && ValidateDates(assignment).valid
-      # delete associated event, so it is not retriggered on submit
-      DebounceQueue.cancelEvent("assignments", id)
       $http.put("/api/assignments/#{id}", assignment: assignment).then(
         (response) ->
           angular.copy(response.data.data.attributes, assignment)
@@ -167,9 +165,6 @@
       )
 
   _updateScoreLevel = (assignmentId, scoreLevel)->
-    # delete associated event, so it is not retriggered on submit
-    DebounceQueue.cancelEvent("scoreLevels", scoreLevel.id || 0)
-
     params = { "assignment_score_levels_attributes" :
       [{ "id" : scoreLevel.id, "points" : scoreLevel.points, "name" : scoreLevel.name }]
     }

--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -137,6 +137,8 @@
   _updateAssignment = (id)->
     assignment = _.find(assignments, {id: id})
     if assignment && ValidateDates(assignment).valid
+      # delete associated event, so it is not retriggered on submit
+      DebounceQueue.cancelEvent("assignments", id)
       $http.put("/api/assignments/#{id}", assignment: assignment).then(
         (response) ->
           angular.copy(response.data.data.attributes, assignment)


### PR DESCRIPTION
### Status
READY

### Description

Fixes a bug where the last score level added was duplicated on submit. This exposes a limitation to the debounce queue `runAllEvents` method: timeouts that have been triggered will stay in the `queueStore` and be retriggered on submit.  For updates this is a performance issue, and for creates this will result in duplicate models.

The solution proposed here is to cancel the events form the timed-out method before making the http call.

======================
Closes #3723
