### PR TITLE
3685 instructors edit passwords

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -120,7 +120,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     up = user_params
-    if up[:password].blank? && up[:password_confirmation].blank?
+    if (up[:password].blank? && up[:password_confirmation].blank?) || !UserProctor.new(@user).can_update_password?(current_user, current_course)
       up.delete(:password)
       up.delete(:password_confirmation)
     end

--- a/app/proctors/user_proctor.rb
+++ b/app/proctors/user_proctor.rb
@@ -1,0 +1,14 @@
+class UserProctor
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def can_update_password?(proxy, course)
+    return false if user.kerberos_uid.present? || !user.persisted?
+    return true if proxy.is_admin? course
+    return false unless proxy.is_professor? course
+    Rails.env.beta? && course.institution.try(:institution_type) == "K-12"
+  end
+end

--- a/app/views/users/_gradecraft_user_form.html.haml
+++ b/app/views/users/_gradecraft_user_form.html.haml
@@ -10,7 +10,7 @@
     .form-item
       = f.label :email
       = f.text_field :email, "aria-required": "true"
-    - if ! @user.kerberos_uid.present? && @user.persisted? && current_user_is_admin?
+    - if UserProctor.new(@user).can_update_password? current_user, current_course
       .form-item
         = f.label :password
         = f.password_field :password, as: :password

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -56,11 +56,13 @@ describe UsersController do
           expect(user.activation_state).to eq "pending"
         end
       end
+    end
 
+    describe "PUT update" do
       it "updates an existing user" do
         user
         params = { first_name: "Jonathan" }
-        post :update, params: { id: user.id, user: params }
+        put :update, params: { id: user.id, user: params }
         expect(user.reload.first_name).to eq "Jonathan"
       end
     end
@@ -115,6 +117,12 @@ describe UsersController do
                                         }
                                 }
         expect(flash[:alert]).to include "already exists for"
+      end
+
+      it "deletes the password params if the user is not permitted to change it" do
+        user_params = { password: "password", password_confirmation: "password" }
+        allow(UserProctor).to receive(:new).with(user).and_return instance_double("UserProctor", can_update_password?: false)
+        expect{ put :update, params: { id: user.id, user: user_params } }.to_not change { user.reload.crypted_password }
       end
     end
 

--- a/spec/factories/institution_factory.rb
+++ b/spec/factories/institution_factory.rb
@@ -6,5 +6,17 @@ FactoryGirl.define do
     trait :without_site_license do
       has_site_license false
     end
+
+    trait :k_12 do
+      institution_type "K-12"
+    end
+
+    trait :higher_ed do
+      institution_type "Higher Education"
+    end
+
+    trait :other do
+      institution_type "Other"
+    end
   end
 end

--- a/spec/proctors/user_proctor_spec.rb
+++ b/spec/proctors/user_proctor_spec.rb
@@ -1,0 +1,38 @@
+describe UserProctor do
+  let(:user) { build_stubbed :user }
+  let(:subject) { described_class.new user }
+
+  describe "#can_update_password?" do
+    let(:course) { build_stubbed :course }
+    let(:proxy) { build_stubbed :user, courses: [course] }
+
+    it "returns false if the user has a kerberos password" do
+      user.kerberos_uid = Faker::Internet.unique.user_name
+      expect(subject.can_update_password? proxy, course).to eq false
+    end
+
+    it "returns false if the user has not been persisted" do
+      expect(subject.can_update_password? proxy, course).to eq false
+    end
+
+    context "as an admin" do
+      let(:proxy) { build_stubbed :user, courses: [course], role: :admin }
+
+      it "returns true" do
+        expect(subject.can_update_password? proxy, course).to eq true
+      end
+    end
+
+    context "as an instructor" do
+      let(:user) { create :user }
+      let(:institution) { build_stubbed :institution, :k_12 }
+      let(:proxy) { build_stubbed :user, courses: [course], role: :professor }
+
+      it "returns true if the environment is beta and the linked institution is K-12" do
+        allow(Rails).to receive(:env).and_return ActiveSupport::StringInquirer.new("beta")
+        course.institution = institution
+        expect(subject.can_update_password? proxy, course).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Status
READY

### Description
As a instructor on app.gradecraft.com, if my course has been linked to an institution of type "K-12", I now have the ability to change a student's password.

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
Deploy this to app and link any given course to the properly typed institution. Ensure that the password fields show and that it is possible to update it on a student's behalf.

### Impacted Areas in Application
User update form

======================
Closes #3685 
