### PR TITLE
Changed style to Delete Announcements

### DIFF
--- a/app/views/announcements/_list.html.haml
+++ b/app/views/announcements/_list.html.haml
@@ -22,4 +22,4 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
                 %li
-                  = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announement #{announcement.title}?", method: :delete }
+                  = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announcement #{announcement.title}?", method: :delete }

--- a/app/views/announcements/_list.html.haml
+++ b/app/views/announcements/_list.html.haml
@@ -21,4 +21,5 @@
             .button-container.dropdown
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
-                = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announement #{announcement.title}?", method: :delete }
+                %li
+                  = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announement #{announcement.title}?", method: :delete }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Fixed style to Delete Announcement by making it a list item.

### Related PRs
branch | PR
------ | ------
3656 Delete Announcement | [link](https://github.com/UM-USElab/gradecraft-development/pull/3704)


### Todos
N/A

### Deploy Notes
N/A

### Gem dependencies
- ADDED | REMOVED [gem_name](link)

### Migrations
NO

### Steps to Test or Reproduce
N/A

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Announcements

======================
Closes #3656
