### PR TITLE
Unlock conditions

### DIFF
--- a/app/models/concerns/unlockable_condition.rb
+++ b/app/models/concerns/unlockable_condition.rb
@@ -3,8 +3,7 @@ module UnlockableCondition
 
   included do
     has_many :unlock_conditions, as: :unlockable, dependent: :destroy
-    has_many :unlock_keys, class_name: "UnlockCondition",
-      foreign_key: :condition_id, dependent: :destroy
+    has_many :unlock_keys, as: :condition, dependent: :destroy
     has_many :unlock_states, as: :unlockable, dependent: :destroy
 
     accepts_nested_attributes_for :unlock_conditions, allow_destroy: true,

--- a/app/models/concerns/unlockable_condition.rb
+++ b/app/models/concerns/unlockable_condition.rb
@@ -3,7 +3,8 @@ module UnlockableCondition
 
   included do
     has_many :unlock_conditions, as: :unlockable, dependent: :destroy
-    has_many :unlock_keys, as: :condition, dependent: :destroy
+    has_many :unlock_keys, class_name: "UnlockCondition",
+      as: :condition, dependent: :destroy
     has_many :unlock_states, as: :unlockable, dependent: :destroy
 
     accepts_nested_attributes_for :unlock_conditions, allow_destroy: true,


### PR DESCRIPTION
### Status
**READY**

### Description
This fixes a bug where Unlock Keys would occasionally display the wrong associated Unlockable. This was happening because of how the polymorphic association was specified in the UnlockableCondition module - namely it was looking for the right associated condition_id, but not always the right associated condition_type. By updating the way the `has_many` association was written, this issue appears to be addressed. 

======================
Closes #3749 
