### PR TITLE
3726 Add announcement read table

### DIFF
--- a/app/views/announcements/_state_table.haml
+++ b/app/views/announcements/_state_table.haml
@@ -2,10 +2,11 @@
   %thead
     %tr
       %th Student
-      %th State
-      - @announcement
+      %th{scope: "col", :"data-dynatable-sorts" => "date"} Read?
+      %th.hidden Date
   %tbody
   - @announcement.course.students.each do |student|
     %tr
       %td= link_to student.name, student_path(student)
-      %td= @announcement.read?(student) ? "Read" : "Unread"
+      %td= l @announcement.states.for_user(student).first.try(:created_at).in_time_zone(current_user.time_zone) if @announcement.read?(student)
+      %td= l @announcement.states.for_user(student).first.try(:created_at), format: :sortable if @announcement.read?(student)

--- a/app/views/announcements/_state_table.haml
+++ b/app/views/announcements/_state_table.haml
@@ -1,0 +1,11 @@
+%table.announcement-states.dynatable
+  %thead
+    %tr
+      %th Student
+      %th State
+      - @announcement
+  %tbody
+  - @announcement.course.students.each do |student|
+    %tr
+      %td= link_to student.name, student_path(student)
+      %td= @announcement.read?(student) ? "Read" : "Unread"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -19,4 +19,5 @@
     %strong Message:
     = @announcement.body.html_safe
 
-  = render partial: "state_table"
+  - if current_user_is_staff?
+    = render partial: "state_table"

--- a/app/views/announcements/show.html.haml
+++ b/app/views/announcements/show.html.haml
@@ -18,3 +18,5 @@
   %p
     %strong Message:
     = @announcement.body.html_safe
+
+  = render partial: "state_table"


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an Instructor, I want to be able to see not only how many have read an announcement, but who individually has read the announcement.

### Related PRs
N/A

### Todos
N/A

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, create a new announcement. As a student, view the announcement, as an instructor, go into the announcement's show page and I will be able to view a table of students with a corresponding status regarding whether they have read the announcement or not.

### Impacted Areas in Application
* Announcements

======================
Closes #3726 
