### PR TITLE
3649 group submissions on grading status

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,4 +1,6 @@
 class InfoController < ApplicationController
+  include SubmissionsHelper
+
   helper_method :sort_column, :sort_direction, :predictions
 
   before_action :ensure_not_observer?, except: [:predictor, :syllabus]
@@ -35,9 +37,9 @@ class InfoController < ApplicationController
   # Displaying ungraded submissions, and existing grades by status
   def grading_status
     grades = current_course.grades.for_active_students.instructor_modified
-    submissions = current_course.submissions.submitted.by_active_students.includes(:assignment, :grade, :student, :group, :submission_files)
-    @ungraded_submissions_by_assignment = submissions.ungraded
-    @resubmissions_by_assignment = submissions.resubmitted
+    submissions = current_course.submissions.submitted.includes(:assignment, :grade, :student, :group, :submission_files)
+    @ungraded_submissions_by_assignment = active_individual_and_group_submissions(submissions.ungraded)
+    @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
     @in_progress_grades_by_assignment = grades.in_progress
     @ready_for_release_grades_by_assignment = grades.ready_for_release
   end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -24,6 +24,6 @@ module SubmissionsHelper
   end
 
   def active_individual_and_group_submissions(submissions)
-    submissions.by_active_individual_students + submissions.by_active_grouped_students
+    submissions.by_active_individual_students + Submission.by_active_grouped_students(submissions)
   end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,7 +1,7 @@
 module SubmissionsHelper
   def resubmission_count_for(course)
     Rails.cache.fetch(resubmission_count_cache_key(course)) do
-      course.submissions.submitted.by_active_students.resubmitted.count
+      active_individual_and_group_submissions(course.submissions.submitted.resubmitted).count
     end
   end
 
@@ -12,14 +12,18 @@ module SubmissionsHelper
   def ungraded_submissions_count_for(course, include_drafts=false)
     Rails.cache.fetch(ungraded_submissions_count_cache_key(course)) do
       if include_drafts
-        course.submissions.by_active_students.ungraded.count
+        active_individual_and_group_submissions(course.submissions.ungraded).count
       else
-        course.submissions.submitted.by_active_students.ungraded.count
+        active_individual_and_group_submissions(course.submissions.submitted.ungraded).count
       end
     end
   end
 
   def ungraded_submissions_count_cache_key(course)
     "#{course.cache_key}/ungraded_submissions_count"
+  end
+
+  def active_individual_and_group_submissions(submissions)
+    submissions.by_active_individual_students + submissions.by_active_grouped_students
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,12 +28,16 @@ class Submission < ActiveRecord::Base
       "grades.student_id = submissions.student_id)")
   end
 
-  scope :by_active_students, -> do
-    joins("INNER JOIN course_memberships ON "\
-      "course_memberships.course_id = submissions.course_id AND "\
-      "course_memberships.user_id = submissions.student_id")
-      .where("course_memberships.active = true")
-      .references(:course_membership, :submission)
+  scope :by_active_individual_students, -> do
+    individual
+      .joins(student: :course_memberships)
+      .where(student: { course_memberships: { active: true }})
+  end
+
+  scope :by_active_grouped_students, -> do
+    where.not(group_id: nil)
+      .joins(group: { students: :course_memberships })
+      .where(group: { students: { course_memberships: { active: true }}})
   end
 
   scope :ungraded, -> do
@@ -55,6 +59,7 @@ class Submission < ActiveRecord::Base
   scope :for_assignment_and_group, ->(assignment_id, group_id) { where(assignment_id: assignment_id, group_id: group_id) }
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :with_group, -> { where "group_id is not null" }
+  scope :individual, -> { where(group_id: nil) }
 
   before_validation :cache_associations
 
@@ -69,7 +74,7 @@ class Submission < ActiveRecord::Base
   multiple_files :submission_files
 
   def self.submitted_this_week(assignment_type)
-    assignment_type.submissions.submitted.by_active_students.where("submissions.submitted_at > ? ", 7.days.ago)
+    assignment_type.submissions.submitted.where("submissions.submitted_at > ? ", 7.days.ago)
   end
 
   def graded_at

--- a/app/views/api/courses/one_week_analytics.json.jbuilder
+++ b/app/views/api/courses/one_week_analytics.json.jbuilder
@@ -20,7 +20,7 @@ if current_user_is_staff?
   json.faculty_data do
     json.submissions_this_week current_course.submitted_assignment_types_this_week do |at|
       json.assignment_type at.name
-      json.count Submission.submitted_this_week(at).count
+      json.count active_individual_and_group_submissions(Submission.submitted_this_week(at)).count
     end
 
     json.badges_this_week current_course.badges.earned_this_week do |badge|

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -24,6 +24,8 @@
               = link_to team.name, team if student.present? && team.present?
         - elsif assignment.has_groups?
           %td= link_to group.try(:name), group_path(group)
+          - if course.has_teams?
+            %td
         %td= l submission.submitted_at.in_time_zone(current_user.time_zone)
         %td.hidden= l submission.submitted_at, format: :sortable
         %td

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -111,6 +111,18 @@ describe Submission do
     expect expect(submission.errors.size).to eq(0)
   end
 
+  describe ".by_active_grouped_students" do
+    let(:group) { create :group }
+    let(:group_submission) { create :group_submission, group: group, course: group.course }
+    let(:submissions) { Submission.where(id: group_submission) }
+
+    it "returns the submission as long as there is at least one active student in the group" do
+      group.students.first.course_memberships.each { |cm| cm.update(active: false) }
+      expect(Submission.by_active_grouped_students(submissions)).to eq \
+        [group_submission]
+    end
+  end
+
   describe ".for_course" do
     it "returns all submissions for a specific course" do
       course = create(:course)


### PR DESCRIPTION
### Status
READY

### Description
This PR addresses missing group submissions on the grade status page. The issue is due to an oversight in the underlying Submission scope, `by_active_students`.

### Steps to Test or Reproduce
Create a group submission and ensure that it shows on the grade status page in all of the various statuses possible (e.g. In progress, Resubmitted, etc.)

### Impacted Areas in Application
Grade status

======================
Closes #3649 
