### PR TITLE
hide announcement delete button

### DIFF
--- a/app/views/announcements/_list.html.haml
+++ b/app/views/announcements/_list.html.haml
@@ -8,7 +8,7 @@
       %th.hidden Sent Date
       - if current_user.is_staff?(current_course)
         %th Read
-      %th.button-column.options Options
+        %th.button-column.options Options
   %tbody
     - cache multi_cache_key :announcements, current_course do
       - @announcements.each do |announcement|
@@ -19,9 +19,9 @@
           %td= l announcement.created_at, format: :sortable
           - if current_user.is_staff?(current_course)
             %td= "#{announcement.read_count} / #{announcement.course.students.count}"
-          %td
-            .button-container.dropdown
-              %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
-              %ul.options-menu.dropdown-content
-                %li
-                  = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announcement #{announcement.title}?", method: :delete }
+            %td
+              .button-container.dropdown
+                %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
+                %ul.options-menu.dropdown-content
+                  %li
+                    = link_to decorative_glyph(:trash) + 'Delete Announcement', announcement_path(announcement), data: {confirm: "Are you sure you want to delete Announcement #{announcement.title}?", method: :delete }


### PR DESCRIPTION
### Status
**READY**

### Description
Students can't delete announcements, so we should hide the buttons from their view

