### PR TITLE
3738 reset editing grades to invisible with warning

### DIFF
--- a/app/assets/javascripts/angular/directives/gradebook/main.coffee
+++ b/app/assets/javascripts/angular/directives/gradebook/main.coffee
@@ -14,6 +14,10 @@
       vm.loading = false
     )
 
+    vm.editGrade = (grade_link) ->
+      if confirm 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
+        window.location = grade_link
+
     # For sortable headers
     $scope.propertyName = 'first_name'
     $scope.reverse = false

--- a/app/assets/javascripts/angular/services/GradeService.coffee
+++ b/app/assets/javascripts/angular/services/GradeService.coffee
@@ -177,10 +177,10 @@
 
   # Final "Submit Grade" actions, includes cleanup and redirect, background jobs
   submitGrade = (returnURL=null)->
+    return false unless confirm _confirmMessage()
+
     modelGrade.student_visible =  modelGrade.submit_as_student_visible
     modelGrade.complete =  modelGrade.submit_as_complete
-
-    return false unless confirm _confirmMessage()
 
     return queueUpdateGrade(true, returnURL, true) unless isRubricGraded
 

--- a/app/assets/javascripts/angular/templates/gradebook/main.html.haml
+++ b/app/assets/javascripts/angular/templates/gradebook/main.html.haml
@@ -25,7 +25,7 @@
           %td
             %a{"href"=>"{{student.student_link}}"} {{student.last_name}}
           %td{"ng-repeat"=>"score in student.scores"}
-            %a{"href"=>"{{score.grade_link}}", "ng-if"=>"score.grade_link"} {{score.value}}
+            %a{"ng-click"=>"vm.editGrade(score.grade_link)", "ng-if"=>"score.grade_link"} {{score.value}}
             %span{"ng-if"=>"!score.grade_link"} {{score.value}}
           %td {{student.badge_score}}
           %td {{student.total_score}}

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -26,6 +26,8 @@ class GradesController < ApplicationController
   # GET /grades/:id/edit
   def edit
     @grade = Grade.find params[:id]
+    @grade.update(complete: false, student_visible: false) if
+      @grade.complete? || @grade.student_visible?
     @submission = @grade.student.submission_for_assignment(@grade.assignment)
     @team = Team.find(params[:team_id]) if params[:team_id]
     if request.referer && request.referer.match(grading_status_path)

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -48,6 +48,20 @@ module LinkHelper
     end
   end
 
+  def edit_grade_link_to(grade, options = {})
+    return unless current_user_is_admin? || current_course.active?
+    confirm_message = 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
+    if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmitted?
+      options.merge! data: { confirm:  confirm_message }
+      link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), options
+    elsif grade.student_visible?
+      options.merge! data: { confirm:  confirm_message }
+      link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), options
+    else
+      link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), options
+    end
+  end
+
   def active_course_link_to_unless_current(name, options = {}, html_options = {}, &block)
     link_to_unless_current name, options, html_options, &block if current_user_is_admin? || current_course.active?
   end

--- a/app/views/assignments/grades/index.html.haml
+++ b/app/views/assignments/grades/index.html.haml
@@ -13,6 +13,9 @@
         .left
           %h5.bold= "#{points grade_for_assignment.score} / #{points presenter.assignment.full_points} points "
         - if current_user_is_admin? || current_course.active?
+          -# delete this route entirely and all associated partials,
+          -# or fix and change to edit_grade_link_to presenter.grade_for_assignment
+          -# see Github issue #3751
           .right= link_to "Edit #{student.first_name}'s Grade", edit_grade_path(presenter.grade_for_assignment), class: "button"
         %br
         %br

--- a/app/views/assignments/individual/_table_body.html.haml
+++ b/app/views/assignments/individual/_table_body.html.haml
@@ -61,12 +61,7 @@
       .table-menu
         %ul
           - if grade.instructor_modified?
-            - if presenter.assignment.accepts_submissions? && presenter.submission_resubmitted?(student_submission)
-              %li
-                = link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), class: "button danger"
-            - else
-              %li
-                = link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
+            %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade), class: "button"
           - else
             - if presenter.assignment.is_unlockable? && !presenter.assignment.is_unlocked_for_student?(student)
               = active_course_link_to decorative_glyph("unlock-alt") + "Unlock", manually_unlock_unlock_state_path(student_id: student.id, assignment_id: presenter.assignment.id), :method => :post, class: "button"
@@ -82,7 +77,9 @@
                     /* Submission present - allow instructor to see it, and identify if it's a new submission or a resubmission. */
                     %li= link_to decorative_glyph(:paperclip) + "See Submission", assignment_submission_path(presenter.assignment, student_submission.id)
                 - if grade.instructor_modified?
-                  %li= link_to decorative_glyph(:eye) + "See Grade", grade_path(grade)
+                  %li
+                    = edit_grade_link_to grade
+
                   = active_course_link_to decorative_glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure you want to delete #{student.name}'s grade for #{presenter.assignment.name}?", method: :delete }
 
     %td

--- a/app/views/grades/components/_edit_button.html.haml
+++ b/app/views/grades/components/_edit_button.html.haml
@@ -1,7 +1,7 @@
-- if grade.group.nil?
-  - path = edit_grade_path(grade)
-- else
-  - path = grade_assignment_group_path(grade.assignment, grade.group)
-
 - if current_course.active? || current_user_is_admin?
-  = link_to glyph(:edit) + "Edit Grade", path, class: "button"
+  %div
+    - if grade.group.nil?
+      = edit_grade_link_to grade, class: "button"
+    - else
+      = link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group), class: "button"
+

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -38,7 +38,7 @@
                   - if grade.group_id.present?
                     = active_course_link_to decorative_glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group), class: "button"
                   - else
-                    = active_course_link_to decorative_glyph(:edit) + "Edit Grade", edit_grade_path(grade), class: "button"
+                    = edit_grade_link_to grade, class: "button"
           - if current_course.active?
             %td
               .center

--- a/app/views/info/_submissions_table.haml
+++ b/app/views/info/_submissions_table.haml
@@ -32,6 +32,10 @@
           .right
             %ul.button-bar
               - if assignment.is_individual?
-                = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
+                - grade = assignment.grade_for_student student
+                - if grade.present?
+                  = edit_grade_link_to grade, class: "button"
+                - else
+                  = active_course_link_to decorative_glyph(:check) + "Grade", assignment_student_grade_path(assignment, student), method: :post, class: "button"
               - elsif assignment.has_groups?
                 = active_course_link_to decorative_glyph(:check) + "Grade", grade_assignment_group_path(assignment, group), class: "button"

--- a/app/views/info/grading_status.html.haml
+++ b/app/views/info/grading_status.html.haml
@@ -29,7 +29,7 @@
           %i.fa.fa-chevron-circle-right.fa-fw
           Ungraded Submissions
       .collapse-hidden{role: "tabpanel"}
-        = render partial: "submissions_table", locals: { submission_type: "ungraded", submissions_by_assignment: @ungraded_submissions_by_assignment, course: current_course }
+        = render partial: "info/submissions_table", locals: { submission_type: "ungraded", submissions_by_assignment: @ungraded_submissions_by_assignment, course: current_course }
 
   - if @in_progress_grades_by_assignment.present?
     .collapseSection{id: "in_progress", role: "tablist"}
@@ -38,7 +38,7 @@
           %i.fa.fa-chevron-circle-right.fa-fw
           In Progress Grades
       .collapse-hidden{role: "tabpanel"}
-        = render partial: "grades_table", locals: { grade_type: "in_progress", grades_by_assignment: @in_progress_grades_by_assignment, course: current_course }
+        = render partial: "info/grades_table", locals: { grade_type: "in_progress", grades_by_assignment: @in_progress_grades_by_assignment, course: current_course }
 
   - if @ready_for_release_grades_by_assignment.present?
     .collapseSection{id: "unreleased", role: "tablist"}
@@ -47,7 +47,7 @@
           %i.fa.fa-chevron-circle-right.fa-fw
           Ready For Release Grades
       .collapse-hidden{role: "tabpanel"}
-        = render partial: "grades_table", locals: { grade_type: "unreleased", grades_by_assignment: @ready_for_release_grades_by_assignment, course: current_course }
+        = render partial: "info/grades_table", locals: { grade_type: "unreleased", grades_by_assignment: @ready_for_release_grades_by_assignment, course: current_course }
 
   - if @resubmissions_by_assignment.present?
     .collapseSection{id: "resubmissions", role: "tablist"}
@@ -56,4 +56,4 @@
           %i.fa.fa-chevron-circle-right.fa-fw
           Resubmissions
       .collapse-hidden{role: "tabpanel"}
-        = render partial: "submissions_table", locals: { submission_type: "resubmissions", submissions_by_assignment: @resubmissions_by_assignment, course: current_course }
+        = render partial: "info/submissions_table", locals: { submission_type: "resubmissions", submissions_by_assignment: @resubmissions_by_assignment, course: current_course }

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -36,5 +36,6 @@
             .button-container.dropdown
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
-                = active_course_link_to decorative_glyph(:edit) + "Edit", edit_grade_path(grade), class: "button"
+                %li
+                  = edit_grade_link_to grade, class: "button"
                 = active_course_link_to decorative_glyph(:trash) + "Delete", grade_path(grade), class: "button", data: { confirm: "Are you sure you want to delete #{grade.student.name}'s grade for #{grade.assignment.name}?", method: :delete }

--- a/app/views/students/_grade_index.haml
+++ b/app/views/students/_grade_index.haml
@@ -32,6 +32,6 @@
                 - if grade.group_id.present?
                   %li= link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group)
                 - else
-                  %li= link_to glyph(:edit) + "Edit Grade", edit_grade_path(grade)
+                  %li= edit_grade_link_to grade
                 %li= link_to glyph(:eye) + "See Grade", grade_path(grade)
                 %li= link_to glyph(:trash) + "Delete Grade", grade_path(grade), data: { confirm: "Are you sure you want to delete #{grade.student.name}'s grade for #{grade.assignment.name}?" }

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -24,4 +24,4 @@
       .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_assignment_weights"
 
 .pageContent
-  = render partial: "grade_index", locals: { presenter: presenter }
+  = render partial: "students/grade_index", locals: { presenter: presenter }

--- a/app/views/submissions/_buttons.haml
+++ b/app/views/submissions/_buttons.haml
@@ -8,8 +8,11 @@
         = active_course_link_to decorative_glyph(:trash) + "Delete Submission",
           assignment_submission_path(assignment: presenter.assignment, submission: presenter.submission ), class: "button button-edit",
           data: { confirm: "Are you sure you want to delete #{presenter.student.name}'s submission for #{presenter.assignment.name}?", method: :delete }
-        = active_course_link_to decorative_glyph(:check) + "Grade",
-          assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
+        - if presenter.grade
+          = edit_grade_link_to presenter.grade, class: "button"
+        - else
+          = active_course_link_to decorative_glyph(:check) + "Grade",
+            assignment_student_grade_path(presenter.assignment, presenter.student), class: "button button-edit", method: :post
 - elsif presenter.assignment.has_groups?
   - content_for :context_menu do
     .context-menu

--- a/spec/controllers/grades_controller_spec.rb
+++ b/spec/controllers/grades_controller_spec.rb
@@ -47,6 +47,13 @@ describe GradesController do
         expect(assigns(:submission)).to eq(submission)
       end
 
+      it "sets the grade to incomplete and not student visible before load" do
+        grade.update(complete: true, student_visible: true)
+        get :edit, params: { id: grade.id }
+        expect(assigns(:grade).complete).to be_falsey
+        expect(assigns(:grade).student_visible).to be_falsey
+      end
+
       describe "on submit" do
         it "redirects to the assignment show page by default" do
           get :edit, params: { id: grade.id }


### PR DESCRIPTION
### Status
**READY (but see todos)**

### Description

Sets any grade about to be edited to incomplete and invisible to students, and adds an alert message to all edit buttons that the grade will be affected.

Pages with edit links and confirm messages:

  * student show page
  * grading status page
  * grade show page
  * submission show page
  * grade review page
  * gradebook page
  * assignment show page

Additional changes:
  * on Assignment show page, UX enhancements switching SEE and EDIT button placement
  * In Angular: move confirm message to top of submit function (submit-cancel visibility bug)

### Related PRs

This is in place of, and closes PR #3744
There is an obsolete(?) routes not updated, further described in #3751 

### Todos

- [x] Address #3751 and either remove comment or update edit button
- [ ] This does not address group grades (separate ticket?)

======================
Closes #3738
