### PR TITLE
Prepend 'Copy of' unless copying course

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -55,7 +55,7 @@ class AssignmentsController < ApplicationController
   # attendance and reading reactions
   def copy
     assignment = current_course.assignments.find(params[:id])
-    duplicated = assignment.copy
+    duplicated = assignment.copy_with_prepended_name
     redirect_to edit_assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
   end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -280,8 +280,18 @@ describe Assignment do
   end
 
   describe "#copy" do
-    let(:assignment) { build :assignment }
+    let(:assignment) { build_stubbed :assignment }
     subject { assignment.copy }
+
+    it "preserves the original assignment name" do
+      assignment.name = "Table of elements"
+      expect(subject.name).to eq "Table of elements"
+    end
+  end
+
+  describe "#copy_with_prepended_name" do
+    let(:assignment) { build :assignment }
+    subject { assignment.copy_with_prepended_name }
 
     it "prepends the name with 'Copy of'" do
       assignment.name = "Table of elements"


### PR DESCRIPTION
### Status
READY (Pending Codeship build)

### Description
This PR addresses the scenario where we only want to prepend assignments with 'Copy of' if they are copying a specific one. If they are copying an entire course and the assignments are being copied as an association, they should retain their original names.

### Steps to Test or Reproduce
Perform a course copy and ensure that the assignments are copied with their original names. Check that if you copy an individual assignment, the name is prepended with 'Copy of'

### Impacted Areas in Application
Course copy

======================
Closes #2711 
