### PR TITLE
Fix erroneous pass fail status from being logged

### DIFF
--- a/app/views/assignments/_self_log_form.html.haml
+++ b/app/views/assignments/_self_log_form.html.haml
@@ -5,7 +5,7 @@
       = f.select :raw_points, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.points] }, :prompt => "Select your outcome"
       = f.submit "Submit", class: "button success"
     - elsif assignment.pass_fail?
-      = f.select :pass_fail_status, [current_course.pass_term, current_course.fail_term], prompt: "Select your outcome"
+      = f.select :pass_fail_status, [[term_for(:pass), "Pass"], [term_for(:fail), "Fail"]], prompt: "Select your outcome"
       = f.submit "Submit", class: "button success"
     - else
       = f.submit "I have completed this #{term_for :assignment}", class: "button success"


### PR DESCRIPTION
### Status
READY

### Description
There's a bug on the page where you can self-log your grade on a pass/fail type assignment if the course has custom terms for "Pass" or "Fail".

Instead of persisting the app-recognized string, it will store the custom term instead.

======================
Closes #3779
