### PR TITLE
3771 Add Updated At Field to Submission

### DIFF
--- a/app/views/submissions/components/_files.haml
+++ b/app/views/submissions/components/_files.haml
@@ -6,6 +6,8 @@
       %li
         = external_link_to submission_file.instructor_filename(index),
           submission_file_download_path(submission_file, index: index)
+        .span
+          = "Updated at: #{submission_file.updated_at}"
 
 
   %span.smallcaps Missing Attachments:


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Add Updated At Date to the display of Submission files for instructors.

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, view any submission that has an attached file. Take note of the Updated At field under the link to the submission file when viewing the submission.

### Impacted Areas in Application
* Submissions
* Grade

======================
Closes #3771 
