### PR TITLE
Only set the submission_id on the grade if not nil

### DIFF
--- a/app/services/creates_grade/associates_submission_with_grade.rb
+++ b/app/services/creates_grade/associates_submission_with_grade.rb
@@ -17,7 +17,7 @@ module Services
           s = Submission.find_by(assignment_id: assignment.id,
                                  student_id: student.id)
         end
-        context[:grade].submission_id = s.nil? ? nil : s.id
+        context[:grade].submission_id = s.id unless s.nil?
       end
     end
   end

--- a/spec/services/creates_grade/associates_submission_with_grade_spec.rb
+++ b/spec/services/creates_grade/associates_submission_with_grade_spec.rb
@@ -38,9 +38,10 @@ describe Services::Actions::AssociatesSubmissionWithGrade do
       expect(result[:grade].submission_id).to eq submission.id
     end
 
-    it "adds nil as submission_id if no submission is found" do
+    it "does not reset the submission_id if no submission is found" do
+      grade.submission_id = 1234
       result = described_class.execute context
-      expect(result[:grade].submission_id).to be_nil
+      expect(result[:grade].submission_id).to eq 1234
     end
   end
 


### PR DESCRIPTION
### Status
HOLD

### Description
Observation as reported by Evan:

From the assignment show page, there appear to be three resubmissions. However, from the grading status page there is only one for that assignment. The two places differ because they are based off of two different resubmission methods on the Submission model.

Essentially, one of the grades had a `submission_id` that was correctly set and the other two had a `submission_id` of `nil`, even though a submission existed for the user + assignment.

I wasn't able to reproduce this locally, but I know that the assigning of the `submission_id` to the grade happens in the `AssociatesSubmissionWithGrade` service. For this PR, I changed the last line in that action to only update the `submission_id` if it is not `nil`.

======================
Closes #[ISSUE NUMBER]
