### PR TITLE
Filter out inactive enrollments, non-graded

### DIFF
--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -369,6 +369,8 @@ module ActiveLMS
       handle_exceptions(exception_handler) do
         grades = []
         params = { assignment_ids: assignment_ids,
+                   enrollment_state: "active",
+                   workflow_state: "graded",
                    student_ids: "all",
                    include: ["assignment", "course", "user", "submission_comments"],
                    per_page: options.delete(:per_page) || 25 }.merge(options)

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -205,6 +205,8 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
         .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
                        "include" => ["assignment", "course", "user", "submission_comments"],
                        "per_page" => 25,
+                       "enrollment_state" => "active",
+                       "workflow_state" => "graded",
                        "access_token" => access_token })
     end
     subject { described_class.new access_token }
@@ -228,7 +230,10 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
             "https://canvas.instructure.com/api/v1/courses/123/students/submissions")
           .with(query: { "assignment_ids" => assignment_ids, "student_ids" => "all",
                          "include" => ["assignment", "course", "user", "submission_comments"],
-                         "per_page" => 5, "test" => true,
+                         "per_page" => 5,
+                         "enrollment_state" => "active",
+                         "workflow_state" => "graded",
+                         "test" => true,
                          "access_token" => access_token })
           .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
         result = subject.grades(123, assignment_ids, nil, nil, { per_page: 5, test: true })


### PR DESCRIPTION
### Status
READY

### Description
Observed behavior: if there are grades (submissions in Canvas) that are returned via the API that are by inactive users, the grade import process will fail in Gradecraft. This is due to the fact that a additional lookup is performed on the user in order to fetch their primary email address.

For some reason, the Canvas API returns a 403 Unauthorized if you try to view a user's profile and the user is inactive.

The solution implemented in this PR is to add additional parameters to the grade query so as to filter out these errant and unwanted records.

For this PR, I have also added an additional parameter to filter on "graded" submissions.

### Impacted Areas in Application
Canvas grade import

======================
Closes #3792
