### PR TITLE
Copy methods with lookups for associations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -370,7 +370,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: true
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: true

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -83,18 +83,21 @@ class Assignment < ActiveRecord::Base
 
   delegate :student_weightable?, to: :assignment_type
 
-  # Default method triggered by ModelCopier + ModelAssociationCopier
-  # Primarily used when copying on a higher level; i.e. copying an entire course
-  def copy(attributes={})
-    copy_with_associations attributes, {
-      overrides: [
-        -> (copy) { copy.rubric = self.rubric.copy if self.rubric.present? },
-        -> (copy) { copy.rubric.course_id = copy.course_id if self.rubric.present? },
+  # Used by Course to copy assignments to a new course.
+  # Relies on the course copy method to manage rubrics,
+  # so that associated model ids are properly updated.
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes,
+      associations: [
+        :assignment_score_levels,
+        { assignment_files: { assignment_id: :id }}
       ]
-    }
+    )
   end
 
   # Copy a specific assignment while prepending 'Copy of' to the name
+  # Used for copying within the same course
   def copy_with_prepended_name(attributes={})
     copy_with_associations attributes, {
       prepend: { name: "Copy of " },

--- a/app/models/assignment_file.rb
+++ b/app/models/assignment_file.rb
@@ -9,8 +9,8 @@ class AssignmentFile < ActiveRecord::Base
   mount_uploader :file, AttachmentUploader
   process_in_background :file
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(attributes: attributes,
                                options: { overrides: [-> (copy) do
                                             copy.copy_s3_object_from(self.s3_object_file_key,
                                               "#{copy.file.store_dir}/#{self.mounted_filename}")

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -30,7 +30,7 @@ class AssignmentType < ActiveRecord::Base
     course.assignment_types.find_by attendance: true
   end
 
-  def copy(attributes={})
+  def copy(attributes={}, lookup_store=nil)
     ModelCopier.new(self, lookup_store).copy(attributes: attributes, associations: [:assignments])
   end
 

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -31,7 +31,7 @@ class AssignmentType < ActiveRecord::Base
   end
 
   def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes, associations: [:assignments])
+    ModelCopier.new(self, lookup_store).copy(attributes: attributes, associations: [:assignments])
   end
 
   # weights default to 0 if weightable but not weighted by the student

--- a/app/models/concerns/copyable.rb
+++ b/app/models/concerns/copyable.rb
@@ -1,9 +1,13 @@
 module Copyable
   extend ActiveSupport::Concern
 
-  def copy(attributes={})
+  def copy(attributes={}, lookup_store=nil)
+    lookup_store ||= ModelCopierLookups.new
     copy = self.dup
     copy.copy_attributes(attributes)
+    # call save so we have an id on the copy to store
+    copy.save
+    lookup_store.store(self, copy)
     copy
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -236,6 +236,7 @@ class Course < ActiveRecord::Base
                                associations: [
                                  :badges,
                                  { assignment_types: { course_id: :id }},
+                                 :rubrics,
                                  :challenges,
                                  :grade_scheme_elements
                                ] + associations,

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -50,8 +50,8 @@ class CourseMembership < ActiveRecord::Base
     course_membership.save
   end
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes.merge(score: 0))
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(attributes: attributes.merge(score: 0))
   end
 
   def recalculate_and_update_student_score

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -21,8 +21,8 @@ class Criterion < ActiveRecord::Base
 
   scope :ordered, -> { order(:order) }
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(attributes: attributes,
                                associations: [:levels],
                                options: { overrides: [
                                  ->(copy) { copy.add_default_levels = false }]})

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,7 @@
 class Event < ActiveRecord::Base
   include Copyable
   include UploadsMedia
-  
+
   validates_with OpenBeforeCloseValidator
 
   belongs_to :course
@@ -11,9 +11,10 @@ class Event < ActiveRecord::Base
   # Check to make sure the event has a name before saving
   validates_presence_of :name
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
-                               options: { prepend: { name: "Copy of "}}
-                              )
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes,
+      options: { prepend: { name: "Copy of "}}
+    )
   end
 end

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -19,10 +19,9 @@ class Level < ActiveRecord::Base
     points > criterion.meets_expectations_points
   end
 
-  def copy(attributes={})
-    # ModelCopier.new(self).copy(attributes: attributes,
-    #   associations: [{ level_badges: { level_id: :id }}])
-    ModelCopier.new(self).copy(attributes: attributes)
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(attributes: attributes,
+      associations: [{ level_badges: { level_id: :id }}])
   end
 
   # Determines if the specified student has earned this level.

--- a/app/models/level_badge.rb
+++ b/app/models/level_badge.rb
@@ -1,5 +1,5 @@
 class LevelBadge < ActiveRecord::Base
-  # include Copyable
+  include Copyable
 
   belongs_to :level
   belongs_to :badge

--- a/app/models/level_badge.rb
+++ b/app/models/level_badge.rb
@@ -5,4 +5,11 @@ class LevelBadge < ActiveRecord::Base
   belongs_to :badge
 
   validates :level_id, uniqueness: { scope: :badge_id }
+
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes,
+      options: { lookups: [:badges, :levels] }
+    )
+  end
 end

--- a/app/models/rubric.rb
+++ b/app/models/rubric.rb
@@ -20,7 +20,11 @@ class Rubric < ActiveRecord::Base
     criteria.count > 0
   end
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes, associations: [:criteria])
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes,
+      associations: [:criteria],
+      options: { lookups: [:courses, :assignments] }
+    )
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -36,9 +36,12 @@ class Team < ActiveRecord::Base
       .where("LOWER(name) = :name", name: name.downcase).first
   end
 
-  def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes.merge(challenge_grade_score: nil, average_score: 0),
-      associations: [{ team_memberships: { team_id: :id }}])
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes.merge(challenge_grade_score: nil, average_score: 0),
+      associations: [{ team_memberships: { team_id: :id }}],
+      options: { lookups: [:courses] }
+    )
   end
 
   def active_members

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -116,23 +116,10 @@ describe CoursesController do
       end
 
       it "duplicates rubrics if present" do
-        assignment_type = create(:assignment_type, course: course)
-        badge = create(:badge, course: course, name: "First")
-        assignment = create(:assignment, assignment_type: assignment_type, course: course)
-        rubric = create(:rubric, assignment: assignment, course: course)
-        criterion = create(:criterion, rubric: rubric)
-        level = create(:level, criterion: criterion)
-        level_badge = create(:level_badge, level: level, badge: badge)
-        course_2 = Course.last
-        assignment_2 = course_2.assignments.first
-        rubric_2 = assignment_2.rubric
-        criterion_2 = rubric_2.criteria.first
-        level_2 = criterion_2.levels.last
-        expect{ post :copy, params: { id: course.id }}.to change(Course, :count).by(1)
-        expect(assignment_2.rubric.present?).to eq(true)
-        expect(rubric_2.criteria.present?).to eq(true)
-        expect(criterion_2.levels.present?).to eq(true)
-        expect(level_2.level_badges.present?).to eq(true)
+        level_badge = create(:level_badge)
+        course = level_badge.level.criterion.rubric.course
+        create(:course_membership, :professor, course: course, user: admin)
+        expect{ post :copy, params: { id: course.id }}.to change(Rubric, :count).by(1)
       end
 
       it "redirects to the course edit path if the copy fails" do

--- a/spec/controllers/rubrics_controller_spec.rb
+++ b/spec/controllers/rubrics_controller_spec.rb
@@ -37,11 +37,11 @@ describe RubricsController do
           match_array(full_rubric.criteria.pluck(:max_points))
       end
 
-      # it "copies earned badges on rubric" do
-      #   create :level_badge, level: full_rubric.criteria.first.levels.first
-      #   expect{ post :copy, params: { assignment_id: new_assignment.id, rubric_id: full_rubric.id }}
-      #     .to change(LevelBadge, :count).by(1)
-      # end
+      it "copies earned badges on rubric" do
+        create :dummy_level_badge, level: full_rubric.criteria.first.levels.first
+        expect{ post :copy, params: { assignment_id: new_assignment.id, rubric_id: full_rubric.id }}
+          .to change(LevelBadge, :count).by(1)
+      end
 
       it "doesn't duplicate badges" do
         create :level_badge, level: full_rubric.criteria.first.levels.first

--- a/spec/factories/level_badge_factory.rb
+++ b/spec/factories/level_badge_factory.rb
@@ -1,6 +1,12 @@
 FactoryGirl.define do
   factory :level_badge do
-    association :level
-    association :badge
+
+    before(:create) do |lb|
+      c = create :course
+      a = create :assignment, course: c
+      r = create :rubric_with_criteria, course: c, assignment: a
+      lb.level = r.criteria.last.levels.last
+      lb.badge = create :badge, course: c
+    end
   end
 end

--- a/spec/factories/level_badge_factory.rb
+++ b/spec/factories/level_badge_factory.rb
@@ -9,4 +9,12 @@ FactoryGirl.define do
       lb.badge = create :badge, course: c
     end
   end
+
+  # for specs that need to pass a level and/or badge into a level_badge
+  # be warned that the courses will not be the same for these models,
+  # it would be best to write these tests using the level badge above
+  factory :dummy_level_badge, :class => LevelBadge do
+    association :badge
+    association :level
+  end
 end

--- a/spec/models/course_membership_spec.rb
+++ b/spec/models/course_membership_spec.rb
@@ -1,6 +1,6 @@
 describe CourseMembership do
   describe "#copy" do
-    let(:course_membership) { build :course_membership }
+    let(:course_membership) { create :course_membership }
     subject { course_membership.copy }
 
     it "makes a duplicated copy of itself" do
@@ -14,7 +14,7 @@ describe CourseMembership do
     end
 
     it "resets the values for the scores" do
-      course_membership = build_stubbed :course_membership, score: 0
+      course_membership.update(score: 1000)
       subject = course_membership.copy
       expect(subject.score).to be_zero
     end

--- a/spec/models/level_badge_spec.rb
+++ b/spec/models/level_badge_spec.rb
@@ -1,13 +1,24 @@
 describe LevelBadge do
-  # let(:level_badge) { create :level_badge }
+  let(:level_badge) { create :level_badge }
 
-  # describe "#copy" do
-  #   subject { level_badge.copy }
-  #
-  #   it "makes a duplicated copy of itself" do
-  #     expect(subject).to_not eq level_badge
-  #     expect(subject.badge_id).to eq(level_badge.badge_id)
-  #     expect(subject.level_id).to eq(level_badge.level_id)
-  #   end
-  # end
+  describe "#copy" do
+
+    it "makes a duplicated copy of itself" do
+      subject = level_badge.copy
+      expect(subject).to_not eq level_badge
+      expect(subject.badge_id).to eq(level_badge.badge_id)
+      expect(subject.level_id).to eq(level_badge.level_id)
+    end
+
+    context "when copied as part of a course copy" do
+
+      it "uses lookups to assign proper badge and level id" do
+        copied_course = level_badge.badge.course.copy(nil)
+        copy = LevelBadge.last
+        expect(copy.badge.course).to eq(copied_course)
+        expect(copy.level.criterion.rubric.course).to eq(copied_course)
+      end
+    end
+  end
 end
+

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -47,18 +47,17 @@ describe Level do
     end
   end
 
-  # describe "#copy" do
-  #   subject { level.copy }
-  #
-  #   it "duplicates the level badges for the level" do
-  #     level.save
-  #     create :level_badge, level: level
-  #     expect(subject.level_badges.size).to eq 1
-  #     expect(subject.level_badges.pluck(:badge_id)).to eq \
-  #       level.level_badges.pluck(:badge_id)
-  #     expect(LevelBadge.count).to eq(2)
-  #   end
-  # end
+  describe "#copy" do
+    it "duplicates the level badges for the level" do
+      level_badge = create :level_badge
+      level = level_badge.level
+      subject = level.copy
+      expect(subject.level_badges.size).to eq 1
+      expect(subject.level_badges.pluck(:badge_id)).to eq \
+        level.level_badges.pluck(:badge_id)
+      expect(LevelBadge.count).to eq(2)
+    end
+  end
 
   describe "updating points" do
     it "updates the meets exectations points on criterion" do

--- a/spec/models/model_copier_spec.rb
+++ b/spec/models/model_copier_spec.rb
@@ -8,21 +8,23 @@ describe ModelCopier do
   end
 
   describe "#copy" do
-    subject { described_class.new(model).copy }
+    context "with no additional params" do
+      subject { described_class.new(model).copy }
 
-    it "duplicates the model" do
-      expect(subject).to be_an_instance_of model.class
-      expect(subject.object_id).to_not eq model.object_id
-    end
+      it "duplicates the model" do
+        expect(subject).to be_an_instance_of model.class
+        expect(subject.object_id).to_not eq model.object_id
+      end
 
-    it "duplicates the attributes" do
-      model.course_number = "BLAH"
+      it "duplicates the attributes" do
+        model.course_number = "BLAH"
 
-      expect(subject.course_number).to eq "BLAH"
-    end
+        expect(subject.course_number).to eq "BLAH"
+      end
 
-    it "saves the duplicated model" do
-      expect(subject).to be_persisted
+      it "saves the duplicated model" do
+        expect(subject).to be_persisted
+      end
     end
 
     it "does not save the duplicated model if the model is not saved" do
@@ -58,11 +60,11 @@ describe ModelCopier do
     end
 
     context "with an association to copy" do
-      subject { described_class.new(model).copy associations: :badges }
 
       before(:each) { create :badge, course: model }
 
       it "copies the associations" do
+        subject = described_class.new(model).copy associations: :badges
         expect(subject.badges.count).to eq 1
         expect(subject.badges.map(&:course_id).uniq).to eq [subject.id]
       end
@@ -72,7 +74,7 @@ describe ModelCopier do
 
         before(:each) do
           assignment_type = create :assignment_type, course: model
-          create :assignment, assignment_type: assignment_type
+          create :assignment, assignment_type: assignment_type, course: model
         end
 
         it "copies the associations with the attributes" do
@@ -81,6 +83,74 @@ describe ModelCopier do
           expect(subject.assignments.map(&:course_id)).to eq [subject.id]
         end
       end
+    end
+
+    context "with lookups" do
+
+      # use level badge as an test example,
+      # since it has two associated model ids we can test.
+      let(:original) { create :level_badge }
+      let(:lookup_store) { ModelCopierLookups.new }
+
+      context "when id is found" do
+        before do
+          allow(lookup_store).to receive(:lookup_hash).and_return({
+            badges: { original.badge_id => 1234 },
+            levels: { original.level_id => 5678 }
+          })
+        end
+
+        it "copies the ids from the lookup_store" do
+          copied = described_class.new(original, lookup_store).copy options: { lookups: [:badges, :levels] }
+          expect(copied.badge_id).to eq(1234)
+          expect(copied.level_id).to eq(5678)
+        end
+      end
+
+      context "when the id is not present" do
+        it "defaults to the original id" do
+          copied = described_class.new(original, lookup_store).copy options: { lookups: [:badges, :levels] }
+          expect(copied.level_id).to eq(original.level_id)
+        end
+      end
+    end
+  end
+
+  describe ModelCopier::AssociationAttributeParser do
+    describe "#split_attributes_from_association" do
+      it "stores the attributes hash, parsed from the associations" do
+        subject = described_class.new(assignment_types: { course_id: :id, name: :name })
+        expect(subject.attributes).to be_nil
+        expect(subject.split_attributes_from_association).to eq({ course_id: :id, name: :name })
+        expect(subject.attributes).to eq({ course_id: :id, name: :name })
+      end
+    end
+
+    describe "#assign_values_to_attributes" do
+      it "pulls the attribute from the target and replaces the key in the hash" do
+        subject = described_class.new(assignment_types: { course_id: :id, name: :name })
+        subject.split_attributes_from_association
+        expect(subject.attributes).to eq({ course_id: :id, name: :name })
+        subject.assign_values_to_attributes(double :course, id: 555, name: "frootloops")
+        expect(subject.attributes).to eq(course_id: 555, name: "frootloops")
+      end
+    end
+  end
+
+  describe "ModelCopierLookups" do
+    let!(:badge) { create :badge, course: model }
+
+    it "sets a lookup when a model is copied" do
+      lookup_store = ModelCopierLookups.new
+      copied = described_class.new(model, lookup_store).copy associations: :badges
+      expect(lookup_store.lookup(:courses, model.id)).to eq copied.id
+      expect(lookup_store.lookup(:badges, badge.id)).to eq copied.badges.first.id
+    end
+
+    it "returns a hash of lookup_store from the original" do
+      lookup_store = ModelCopierLookups.new
+      copied = described_class.new(model, lookup_store).copy associations: :badges
+      expect(lookup_store.assign_values_to_attributes([:courses], badge )).to eq({course_id: copied.id})
     end
   end
 end

--- a/spec/services/creates_criterion_grade/builds_earned_level_badges_spec.rb
+++ b/spec/services/creates_criterion_grade/builds_earned_level_badges_spec.rb
@@ -11,7 +11,7 @@ describe Services::Actions::BuildsEarnedLevelBadges do
   let(:group) { create(:group, course: course, assignments: [assignment]) }
   let(:grade) { create(:grade, student: student, assignment: assignment) }
 
-  let!(:level_badge) { create :level_badge, level: criterion_grade.level, badge: badge }
+  let!(:level_badge) { create :dummy_level_badge, level: criterion_grade.level, badge: badge }
 
   let(:context) do
     {


### PR DESCRIPTION
### Status

**READY**

### Description

Uses a lookup dictionary when copying to ensure associated ids are updated to the new models.

### Impacted Areas in Application

Primary need is for when we copy a course.  Immediate bug fix is for LevelBadges.