### PR TITLE
fix total earned points in predictor when counting top grades

### DIFF
--- a/app/controllers/api/assignment_types_controller.rb
+++ b/app/controllers/api/assignment_types_controller.rb
@@ -21,6 +21,7 @@ class API::AssignmentTypesController < ApplicationController
         :description,
         :student_weightable,
         :position,
+        :top_grades_counted,
         :updated_at
       )
   end

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -114,7 +114,13 @@ class AssignmentType < ActiveRecord::Base
   end
 
   def final_points_for_student(student)
-    grades_for(student).pluck("final_points").sum || 0
+    if self.count_only_top_grades?
+      grades_for(student)
+        .order_by_highest_score
+        .first(top_grades_counted).sum(&:final_points) || 0
+    else
+      grades_for(student).sum(&:final_points) || 0
+    end
   end
 
   # Calculating what the total highest points for the type is for a student

--- a/app/views/api/assignment_types/index.json.jbuilder
+++ b/app/views/api/assignment_types/index.json.jbuilder
@@ -2,10 +2,11 @@ json.data @assignment_types do |assignment_type|
   json.type "assignment types"
   json.id assignment_type.id.to_s
   json.attributes do
-    json.merge! assignment_type.attributes
-    json.total_points assignment_type.total_points_for_settings
-    json.is_capped assignment_type.is_capped?
-    json.max_points assignment_type.max_points
+    json.merge!                   assignment_type.attributes
+    json.total_points             assignment_type.total_points_for_settings
+    json.is_capped                assignment_type.is_capped?
+    json.max_points               assignment_type.max_points
+    json.count_only_top_grades    assignment_type.count_only_top_grades?
     json.summed_assignment_points assignment_type.summed_assignment_points
 
     if @student.present?

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -251,6 +251,15 @@ describe AssignmentType do
       grade = create(:student_visible_grade, student: student, raw_points: 100, adjustment_points: -42, assignment: assignment)
       expect(assignment_type.final_points_for_student(student)).to eq(58)
     end
+
+    it "accounts for presence of top_grades_counted" do
+      assignment_type.top_grades_counted = 1
+      assignment = create(:assignment, course: course, assignment_type: assignment_type)
+      grade = create(:student_visible_grade, student: student, raw_points: 200, assignment: assignment)
+      assignment_2 = create(:assignment, course: course, assignment_type: assignment_type)
+      grade_2 = create(:student_visible_grade, student: student, raw_points: 100, assignment: assignment_2)
+      expect(assignment_type.final_points_for_student(student)).to eq(200)
+    end
   end
 
   describe "#summed_highest_scores_for(student)" do


### PR DESCRIPTION
### Status
**READY**

### Description

The "Total Earned" bar in the predictor graph is calculated from assignment type totals from the back end. These totals need to take `count_only_top_grades?` into account

This PR also adds this to the json sent to the predictor, but it is not yet implemented in the predictions.

### Steps to Test or Reproduce

As a professor:
update "Count Highest Grades" for an AT.
Click "recalculate all grades" in the dashboard.
As a student:
Verify that the "Your Points: xxx" in the dashboard has updated.
Verify that the "Total Earned" bar in the predictor has updated.
These two number should be the same (although I suspect there are other conditions which through them off)