### PR TITLE
3790 group regrade

### DIFF
--- a/app/assets/javascripts/angular/directives/gradebook/main.coffee
+++ b/app/assets/javascripts/angular/directives/gradebook/main.coffee
@@ -15,8 +15,7 @@
     )
 
     vm.editGrade = (grade_link) ->
-      if confirm 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
-        window.location = grade_link
+      window.location = grade_link
 
     # For sortable headers
     $scope.propertyName = 'first_name'

--- a/app/assets/javascripts/angular/directives/gradebook/main.coffee
+++ b/app/assets/javascripts/angular/directives/gradebook/main.coffee
@@ -14,7 +14,7 @@
       vm.loading = false
     )
 
-    vm.editGrade = (grade_link) ->
+    vm.showGrade = (grade_link) ->
       window.location = grade_link
 
     # For sortable headers

--- a/app/assets/javascripts/angular/templates/gradebook/main.html.haml
+++ b/app/assets/javascripts/angular/templates/gradebook/main.html.haml
@@ -25,7 +25,7 @@
           %td
             %a{"href"=>"{{student.student_link}}"} {{student.last_name}}
           %td{"ng-repeat"=>"score in student.scores"}
-            %a{"ng-click"=>"vm.editGrade(score.grade_link)", "ng-if"=>"score.grade_link"} {{score.value}}
+            %a{"ng-click"=>"vm.showGrade(score.grade_link)", "ng-if"=>"score.grade_link"} {{score.value}}
             %span{"ng-if"=>"!score.grade_link"} {{score.value}}
           %td {{student.badge_score}}
           %td {{student.total_score}}

--- a/app/controllers/assignments/groups_controller.rb
+++ b/app/controllers/assignments/groups_controller.rb
@@ -11,6 +11,9 @@ class Assignments::GroupsController < ApplicationController
     @assignment_score_levels = @assignment.assignment_score_levels.order_by_points
     @grade_next_path = path_for_next_group_grade @assignment, @group
     @rubric = @assignment.rubric if @assignment.grade_with_rubric?
+
+    grades = Grade.find_or_create_grades(@assignment.id, @group.students.pluck(:id))
+    grades.update_all(complete: false, student_visible: false)
   end
 
   private

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -48,7 +48,13 @@ module LinkHelper
     end
   end
 
-  def edit_grade_link_to(grade, options = {})
+  def edit_group_grade_link_to(assignment, group, options={})
+    confirm_message = 'These grades are about to be marked as ungraded and unavailable to the students - they won\'t be visible again until you click "Submit" - are you sure?'
+    options.merge! data: { confirm:  confirm_message }
+    link_to decorative_glyph(:edit) + "Edit Group Grades", grade_assignment_group_path(assignment, group), options
+  end
+
+  def edit_grade_link_to(grade, options={})
     return unless current_user_is_admin? || current_course.active?
     confirm_message = 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
     if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmitted?

--- a/app/views/assignments/group/_table_body.html.haml
+++ b/app/views/assignments/group/_table_body.html.haml
@@ -14,7 +14,7 @@
             = active_course_link_to "Submit", new_assignment_submission_path(@assignment, group_id: group.id), class: "button"
           - grade = group.students.first.grade_for_assignment(@assignment)
           - if grade.present? && grade.instructor_modified?
-            = active_course_link_to decorative_glyph(:edit) + "Edit Grade", grade_assignment_group_path(@assignment, group), class: "button"
+            = edit_group_grade_link_to @assignment, group, class: "button"
           - else
             = active_course_link_to decorative_glyph(:edit) + "Grade", grade_assignment_group_path(@assignment, group), class: "button"
     %td
@@ -37,7 +37,7 @@
         %tbody
           - group.students.order_by_name.each do |student|
             - grade = @assignment.grades.find_by(student_id: student.id)
-            
+
             %tr
               %td= link_to student.name, student_path(student)
               %td

--- a/app/views/grades/components/_edit_button.html.haml
+++ b/app/views/grades/components/_edit_button.html.haml
@@ -3,5 +3,5 @@
     - if grade.group.nil?
       = edit_grade_link_to grade, class: "button"
     - else
-      = link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group), class: "button"
+      = edit_group_grade_link_to grade.assignment, grade.group, class: "button"
 

--- a/app/views/info/_grades_table.haml
+++ b/app/views/info/_grades_table.haml
@@ -36,7 +36,7 @@
               %ul.button-bar
                 %li
                   - if grade.group_id.present?
-                    = active_course_link_to decorative_glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group), class: "button"
+                    = edit_group_grade_link_to assignment, grade.group, class: "button"
                   - else
                     = edit_grade_link_to grade, class: "button"
           - if current_course.active?

--- a/app/views/students/_grade_index.haml
+++ b/app/views/students/_grade_index.haml
@@ -30,7 +30,7 @@
             %ul.options-menu.dropdown-content
               - if current_user_is_admin? || current_course.active?
                 - if grade.group_id.present?
-                  %li= link_to glyph(:edit) + "Edit Grade", grade_assignment_group_path(grade.assignment, grade.group)
+                  %li= edit_group_grade_link_to grade.assignment, grade.group
                 - else
                   %li= edit_grade_link_to grade
                 %li= link_to glyph(:eye) + "See Grade", grade_path(grade)


### PR DESCRIPTION
### Status
**READY**

### Description

Extends current regrading logic to group grades. When a released group grade is reopened in the edit page, all student grades will revert to incomplete and invisible to students. An alert is attached to the edit buttons. The button now reads "Edit Group Grades".

The edit button is present on:

### The assignment show page
![screen shot 2017-12-21 at 10 06 29 am](https://user-images.githubusercontent.com/1138350/34261743-31fed236-e638-11e7-8053-9d879aa09d49.png)

### A student's grade show page (for a group grade)
![screen shot 2017-12-21 at 10 06 44 am](https://user-images.githubusercontent.com/1138350/34261744-320c2a1c-e638-11e7-808a-e0f2982f7238.png)

### The student's show page (professor's view)
![screen shot 2017-12-21 at 10 07 32 am](https://user-images.githubusercontent.com/1138350/34261745-3224ee26-e638-11e7-8a79-32f87b3cac51.png)

### The grading status page
![screen shot 2017-12-21 at 10 14 00 am](https://user-images.githubusercontent.com/1138350/34261746-3232bd58-e638-11e7-8ceb-20e13a6e5bd5.png)


### Related PRs

#3777 - reset editing grades to invisible with warning

======================
Closes #3790
