### PR TITLE
Fix bugs in assignment import process

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentImporterService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentImporterService.coffee
@@ -37,6 +37,7 @@
     _.each(assignmentRows, (row) ->
       row.selected_due_date = new Date(row.formatted_due_date) if row.formatted_due_date?
       row.hasInvalidDueDate = !row.selected_due_date?
+      true
     )
 
   _clearArrays = (arrays...) ->

--- a/app/importers/assignment_importers/csv_assignment_importer.rb
+++ b/app/importers/assignment_importers/csv_assignment_importer.rb
@@ -58,10 +58,11 @@ class CSVAssignmentImporter
 
   def find_or_create_assignment_type(row, course)
     if row[:selected_assignment_type].nil?
+      assignment_type_id = matching_assignment_type_id course.assignment_types, row[:assignment_type]
       # If assignment type exists but one was not selected, the record is invalid
-      if assignment_type_exists? course.assignment_types, row[:assignment_type]
-        append_unsuccessful row.to_h, "Assignment type exists, but no selection was made"
-        return nil
+      if assignment_type_id.present?
+        # Automatically resolve type id if the name matches
+        assignment_type_id
       else
         type = course.assignment_types.create name: row[:assignment_type]
         if type.persisted?
@@ -81,8 +82,8 @@ class CSVAssignmentImporter
     end
   end
 
-  def assignment_type_exists?(assignment_types, imported_type)
-    !parsed_assignment_type_id(assignment_types, imported_type).nil?
+  def matching_assignment_type_id(assignment_types, imported_type)
+    parsed_assignment_type_id assignment_types, imported_type
   end
 
   class AssignmentRow

--- a/spec/importers/assignment_importers/csv_assignment_importer_spec.rb
+++ b/spec/importers/assignment_importers/csv_assignment_importer_spec.rb
@@ -14,7 +14,6 @@ describe CSVAssignmentImporter do
 
   describe "#import" do
     let(:course) { create :course }
-    let!(:assignment_type) { create :assignment_type, name: "Grading Settings", course: course }
     let(:assignment_rows) do
       subject.as_assignment_rows(file).map do |row|
         {
@@ -29,24 +28,23 @@ describe CSVAssignmentImporter do
 
     before(:each) do
       allow(subject).to receive(:current_course).and_return course
-      assignment_rows.last.merge! selected_assignment_type: assignment_type.id
     end
 
     it "creates the assignment type if it does not exist" do
       expect{ subject.import assignment_rows, course }.to \
-        change{ AssignmentType.count }.by 2
+        change{ AssignmentType.count }.by 3
     end
 
     it "creates the assignments" do
       expect{ subject.import assignment_rows, course }.to \
-        change{ Assignment.count }.by 3
+        change{ Assignment.count }.by 4
     end
 
     it "logs the successful and the unsuccessful rows" do
       subject.import assignment_rows, course
 
-      expect(subject.successful.count).to eq 3
-      expect(subject.unsuccessful.count).to eq 1
+      expect(subject.successful.count).to eq 4
+      expect(subject.unsuccessful.count).to be_zero
     end
 
     it "sets the assignment attributes" do


### PR DESCRIPTION
### Status
READY (Pending Codeship build)

### Description
First observed issue is due to an unintended side-effect. Coffeescript automatically returns the result of the last line in a function. Using the example CSV that was provided by Evan, it was determined a variable assignment was inadvertently returning false which caused the `_.each` loop to break.

Second observed issue was the result of subsequent assignments being marked as invalid, if a matching assignment type was previously created in the batch.

======================
Closes #3803
