### PR TITLE
Production Fixes

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,6 +5,7 @@ class Course < ActiveRecord::Base
   include UnlockableCondition
   include Analytics::CourseAnalytics
 
+  before_create :mark_umich_as_paid
   after_create :create_admin_memberships
 
   # Note: we are setting the role scopes as instance methods,
@@ -211,6 +212,10 @@ class Course < ActiveRecord::Base
     User.where(admin: true).each do |admin|
       CourseMembership.create course_id: self.id, user_id: admin.id, role: "admin"
     end
+  end
+
+  def mark_umich_as_paid
+    self.has_paid = true if Rails.env.production?
   end
 
   def copy_with_associations(attributes, associations)

--- a/app/models/level.rb
+++ b/app/models/level.rb
@@ -20,8 +20,9 @@ class Level < ActiveRecord::Base
   end
 
   def copy(attributes={})
-    ModelCopier.new(self).copy(attributes: attributes,
-      associations: [{ level_badges: { level_id: :id }}])
+    # ModelCopier.new(self).copy(attributes: attributes,
+    #   associations: [{ level_badges: { level_id: :id }}])
+    ModelCopier.new(self).copy(attributes: attributes)
   end
 
   # Determines if the specified student has earned this level.

--- a/app/models/level_badge.rb
+++ b/app/models/level_badge.rb
@@ -1,5 +1,5 @@
 class LevelBadge < ActiveRecord::Base
-  include Copyable
+  # include Copyable
 
   belongs_to :level
   belongs_to :badge

--- a/app/views/assignment_types/_form.html.haml
+++ b/app/views/assignment_types/_form.html.haml
@@ -27,13 +27,13 @@
         If you fill this in, students will not be able to earn more than this amount.
       = f.text_field :max_points, data: {autonumeric: true, "m-dec" => "0"}
 
-    .form-item
-      / Do only X number of highest grades count?
-      = f.label :top_grades_counted, :label => "Count Highest Grades"
-      -# .form-hint{id: "assignment_type_top_grades_counted"}
-      = tooltip("count-highest-hint", "info-circle", placement: "right") do
-        Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here.
-      = f.input :top_grades_counted, input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }, label: false
+    -# .form-item
+    -#   / Do only X number of highest grades count?
+    -#   = f.label :top_grades_counted, :label => "Count Highest Grades"
+    -#   -# .form-hint{id: "assignment_type_top_grades_counted"}
+    -#   = tooltip("count-highest-hint", "info-circle", placement: "right") do
+    -#     Do you want to only count the highest grades from this category towards a student's grade? Specify the number of grades to count here.
+    -#   = f.input :top_grades_counted, input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }, label: false
 
     - if current_course.has_multipliers?
       .form-item

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -55,8 +55,8 @@ describe AssignmentsController do
         expect(duplicated.rubric).to_not be_nil
         expect(duplicated.rubric.criteria.first.name).to eq "Rubric 1"
         expect(duplicated.rubric.criteria.first.levels.first.name).to eq "Full Credit"
-        expect(duplicated.rubric.criteria.first.levels.first.level_badges.count).to \
-          eq 1
+        # expect(duplicated.rubric.criteria.first.levels.first.level_badges.count).to \
+        #   eq 1
       end
 
       it "redirects to the edit page for the duplicated assignment" do

--- a/spec/controllers/rubrics_controller_spec.rb
+++ b/spec/controllers/rubrics_controller_spec.rb
@@ -44,11 +44,11 @@ describe RubricsController do
           match_array(full_rubric.criteria.pluck(:max_points))
       end
 
-      it "copies earned badges on rubric" do
-        create :level_badge, level: full_rubric.criteria.first.levels.first
-        expect{ post :copy, params: { assignment_id: new_assignment.id, rubric_id: full_rubric.id }}
-          .to change(LevelBadge, :count).by(1)
-      end
+      # it "copies earned badges on rubric" do
+      #   create :level_badge, level: full_rubric.criteria.first.levels.first
+      #   expect{ post :copy, params: { assignment_id: new_assignment.id, rubric_id: full_rubric.id }}
+      #     .to change(LevelBadge, :count).by(1)
+      # end
 
       it "doesn't duplicate badges" do
         create :level_badge, level: full_rubric.criteria.first.levels.first

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -3,6 +3,13 @@ describe Course do
   let(:staff_membership) { create :course_membership, :staff, course: subject,
                                   instructor_of_record: true }
 
+  describe "callbacks" do
+    it "sets has paid to true if the env is umich" do
+      allow(Rails).to receive(:env) { "production".inquiry }
+      expect { subject.save }.to change(subject, :has_paid)
+    end
+  end
+
   describe "validations" do
     it "requires a name" do
       subject.name = nil

--- a/spec/models/level_badge_spec.rb
+++ b/spec/models/level_badge_spec.rb
@@ -1,13 +1,13 @@
 describe LevelBadge do
-  let(:level_badge) { create :level_badge }
+  # let(:level_badge) { create :level_badge }
 
-  describe "#copy" do
-    subject { level_badge.copy }
-
-    it "makes a duplicated copy of itself" do
-      expect(subject).to_not eq level_badge
-      expect(subject.badge_id).to eq(level_badge.badge_id)
-      expect(subject.level_id).to eq(level_badge.level_id)
-    end
-  end
+  # describe "#copy" do
+  #   subject { level_badge.copy }
+  #
+  #   it "makes a duplicated copy of itself" do
+  #     expect(subject).to_not eq level_badge
+  #     expect(subject.badge_id).to eq(level_badge.badge_id)
+  #     expect(subject.level_id).to eq(level_badge.level_id)
+  #   end
+  # end
 end

--- a/spec/models/level_spec.rb
+++ b/spec/models/level_spec.rb
@@ -47,18 +47,18 @@ describe Level do
     end
   end
 
-  describe "#copy" do
-    subject { level.copy }
-
-    it "duplicates the level badges for the level" do
-      level.save
-      create :level_badge, level: level
-      expect(subject.level_badges.size).to eq 1
-      expect(subject.level_badges.pluck(:badge_id)).to eq \
-        level.level_badges.pluck(:badge_id)
-      expect(LevelBadge.count).to eq(2)
-    end
-  end
+  # describe "#copy" do
+  #   subject { level.copy }
+  #
+  #   it "duplicates the level badges for the level" do
+  #     level.save
+  #     create :level_badge, level: level
+  #     expect(subject.level_badges.size).to eq 1
+  #     expect(subject.level_badges.pluck(:badge_id)).to eq \
+  #       level.level_badges.pluck(:badge_id)
+  #     expect(LevelBadge.count).to eq(2)
+  #   end
+  # end
 
   describe "updating points" do
     it "updates the meets exectations points on criterion" do


### PR DESCRIPTION
### Status
READY (Pending Codeship Build)

### Description
This PR temporarily addresses a few issues:

1. Temporarily disable level badges from being copied when a course is copied, to prevent errant data.
2. Disable x highest grades, since it is an incomplete feature
3. If the course is on umich, on create, automatically set `has_paid` to true