### PR TITLE
Route user accordingly based on current course role

### DIFF
--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -10,6 +10,7 @@ class InfoController < ApplicationController
   before_action :find_students,
     only: [:earned_badges, :multiplier_choices, :final_grades_for_course ]
   before_action :use_current_course, only: [:earned_badges, :per_assign, :multiplier_choices, :gradebook]
+  before_action :ensure_current_course_role?, only: :dashboard
 
   # Displays student and instructor dashboard
   def dashboard
@@ -131,6 +132,14 @@ class InfoController < ApplicationController
       @students = current_course.students_being_graded_by_team(@team).order_by_name
     else
       @students = current_course.students_being_graded.order_by_name
+    end
+  end
+
+  def ensure_current_course_role?
+    if current_user.role(current_course).nil?
+      next_course = current_user.course_memberships.first.try(:course)
+      return redirect_to change_course_path(next_course) unless next_course.nil?
+      redirect_to errors_path status_code: 401, error_type: "without_course_membership"
     end
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
If a user's role in the `current_course` is somehow revoked, then when they try to log into GC they will be stuck on the 500 error page unless they know how to change their course context.

This PR ensures that if you are trying to get to the dashboard, you will be routed according to one of two ways if you no longer have access to the `current_course`:

1. If you belong to any other courses, your `current_course` will change to the first course that you have access to.

2. If you don't belong to any other courses, then you will be redirected to the error page stating that you have no course memberships.

======================
Closes #3806

  