### PR TITLE
Allow student impersonation on unpublished course

### DIFF
--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -2,7 +2,7 @@
   / Display errors and notifications
   = render partial: "layouts/navigation/student_profile_tabs", locals: {nav_class: 'sub-nav'}
   %main.mainContent#main-content{role: "main"}
-    - if current_course.published
+    - if current_course.published || impersonating?
       .page-header
         %h1.pagetitle= title
       -# = render partial: "info/student_onboarding", locals:  { presenter: Info::DashboardCourseRulesPresenter.new(course: current_course, current_user: current_student) }


### PR DESCRIPTION
### Status
READY

### Description
Allows you to impersonate any student in an unpublished course. As a future feature, we should allow student impersonation without specificity of which student.

Closes #3476
Relates to #3722  
