### PR TITLE
Don't update grade if unchanged

### DIFF
--- a/app/services/creates_grade/builds_grade.rb
+++ b/app/services/creates_grade/builds_grade.rb
@@ -9,6 +9,11 @@ module Services
       executed do |context|
         grade = Grade.find_or_create(context[:assignment].id, context[:student].id)
         update_grade_attributes grade, context[:attributes]["grade"]
+        unless grade.changed?
+          context.skip_all!("Grade did not change")
+          context[:grade] = nil
+          next context  # don't update the grade
+        end
         grade.graded_at = DateTime.now
         grade.graded_by_id = context[:graded_by_id]
         grade.full_points = context[:assignment].full_points

--- a/app/services/creates_grade/builds_grade.rb
+++ b/app/services/creates_grade/builds_grade.rb
@@ -10,8 +10,7 @@ module Services
         grade = Grade.find_or_create(context[:assignment].id, context[:student].id)
         update_grade_attributes grade, context[:attributes]["grade"]
         unless grade.changed?
-          context.skip_all!("Grade did not change")
-          context[:grade] = nil
+          context.fail!("Grade did not change", error_code: 400)
           next context  # don't update the grade
         end
         grade.graded_at = DateTime.now

--- a/app/services/shared/iterates_grade_attributes.rb
+++ b/app/services/shared/iterates_grade_attributes.rb
@@ -20,7 +20,7 @@ module Services
           if result.success?
             context.successful << result[:grade]
           else
-            context.unsuccessful << { grade: result[:grade], error: result[:message] }
+            context.unsuccessful << { grade: result[:grade], error: result[:message] } unless result.error_code == 400
           end
         end
       end

--- a/spec/services/creates_grade/builds_grade_spec.rb
+++ b/spec/services/creates_grade/builds_grade_spec.rb
@@ -54,4 +54,11 @@ describe Services::Actions::BuildsGrade do
     result = described_class.execute context
     expect(result[:grade].group_id).to eq 777
   end
+
+  it "halts the context if the grade attributes did not change" do
+    grade = create :grade, assignment: assignment, student: student
+    context[:attributes] = { "grade" => { "raw_points" => grade.raw_points } }
+    result = described_class.execute context
+    expect(result[:grade]).to be_nil
+  end
 end


### PR DESCRIPTION
### Status
IN DEVELOPMENT

### Description
Fixes issues with quick-grade where too many notifications are being sent, regardless of whether there are any grade changes or not.

Should address erroneous emails sent by quick grade for both individual as well as group-graded assignments.

======================
Closes #3812
