### PR TITLE
Replace updated_at with graded_at

### DIFF
--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -4,7 +4,7 @@ class SubmissionExporter
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
         csv << [ submission.id, submission.assignment_id, submission.assignment.name,
-          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:updated_at) ]
+          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
       end
     end
   end


### PR DESCRIPTION
### Status
IN DEVELOPMENT

### Description
In looking at the Talent Gateway Online Community Submissions export, I notice that there's a large group of grades that have been updated within minutes of each other that were originally created in 2016.

In the export, the column in question is the one marked "Grade Last Updated". In its current state, it reflects the grade `updated_at` field which can update for any reason.

This PR changes that field so that it reflects the `graded_at` field on the grade, which should be more accurate.

### Impacted Areas in Application
CSV submission export

======================
Closes #3824
