### PR TITLE
use max points in predictor

### DIFF
--- a/app/assets/javascripts/angular/services/PredictorService.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.coffee
@@ -62,7 +62,7 @@
     if includeWeights
       total = weightedPoints(assignmentType, total)
     if assignmentType.is_capped and includeCaps
-      total = if total > assignmentType.total_points then assignmentType.total_points else total
+      total = if total > assignmentType.max_points then assignmentType.max_points else total
     total
 
   assignmentsWeightedPredictedPoints = ()->
@@ -75,7 +75,7 @@
   # Total predicted points above and beyond the assignment type max points
   assignmentTypePointExcess = (assignmentType)->
     if assignmentType.is_capped
-      assignmentTypePointTotal(assignmentType, true, false, true) - assignmentType.total_points
+      assignmentTypePointTotal(assignmentType, true, false, true) - assignmentType.max_points
     else
       0
 


### PR DESCRIPTION
### Status
**READY**

### Description

This assumes assignment caps are no longer included in `total_points` sent to the predictor, and uses the `max_points` field to determine if a student has predicted more than they can earn.


======================
Closes #3857
