### PR TITLE
3821 copy unlocks

### DIFF
--- a/app/controllers/api/copy_logs_controller.rb
+++ b/app/controllers/api/copy_logs_controller.rb
@@ -1,0 +1,13 @@
+class API::CopyLogsController < ApplicationController
+  before_action :ensure_admin?
+
+  # GET /api/courses/:course_id/copy_log
+  def show
+    course = Course.find(params[:course_id])
+    if course.copy_log.present?
+      render json: { log: course.copy_log.to_hash }
+    else
+      render json: { message: "no copy log for this course"}
+    end
+  end
+end

--- a/app/controllers/api/unlock_conditions_controller.rb
+++ b/app/controllers/api/unlock_conditions_controller.rb
@@ -22,6 +22,7 @@ class API::UnlockConditionsController < ApplicationController
   # POST /api/unlock_conditions
   def create
     @unlock_condition = UnlockCondition.new(unlock_condition_params)
+    @unlock_condition.course = @course
     if @unlock_condition.save
       render "api/unlock_conditions/show", status: 201
     else

--- a/app/models/copy_log.rb
+++ b/app/models/copy_log.rb
@@ -1,0 +1,14 @@
+class CopyLog < ActiveRecord::Base
+  belongs_to :course
+
+  validates_presence_of :course
+  validates_presence_of :log
+
+  def to_hash
+    eval self.log
+  end
+
+  def parse_log(hash_log)
+    self.log = hash_log.to_s
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -79,6 +79,8 @@ class Course < ActiveRecord::Base
     c.has_many :providers, as: :providee
     c.has_many :learning_objective_categories
     c.has_many :learning_objectives
+    c.has_many :unlock_conditions
+    c.has_one  :copy_log
   end
 
   has_many :users, through: :course_memberships

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -130,7 +130,7 @@ class Course < ActiveRecord::Base
     allows_learning_objectives? && has_learning_objectives?
   end
 
-  def log_copy(lookups)
+  def save_copy_logs(lookups)
     copy_log = CopyLog.new(course: self)
     copy_log.parse_log(lookups.lookup_hash)
     copy_log.save

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -130,6 +130,12 @@ class Course < ActiveRecord::Base
     allows_learning_objectives? && has_learning_objectives?
   end
 
+  def log_copy(lookups)
+    copy_log = CopyLog.new(course: self)
+    copy_log.parse_log(lookups.lookup_hash)
+    copy_log.save
+  end
+
   def linked?(provider)
     self.linked_courses.where(provider: provider).exists?
   end
@@ -243,6 +249,9 @@ class Course < ActiveRecord::Base
                                  :challenges,
                                  :grade_scheme_elements
                                ] + associations,
+                               cross_references: [
+                                 :unlock_conditions
+                               ],
                                options: {
                                  prepend: { name: "Copy of " },
                                  overrides: [-> (copy) { copy_syllabus copy }]

--- a/app/models/model_copier.rb
+++ b/app/models/model_copier.rb
@@ -164,9 +164,18 @@ class ModelCopierLookups
 
       # :courses => :course_id
       id_key = "#{class_type.to_s.singularize}_id".to_sym
+      id_type = "#{class_type.to_s.singularize}_type".to_sym
 
       if original.respond_to?(id_key) && lookup_has_key?(class_type, original.send(id_key))
         h[id_key] = lookup(class_type, original.send(id_key))
+
+      # handle polymorphic relationships
+      # In order for this to work for unlock conditions, they have to be run after all other
+      # models have been copied -- If badges can be conditions for assigment and assignment for badges,
+      # we have to copy all the models first, then go back and lookup the associations.
+      # TODO: add course_id to conditions, and then copy them last from the course copy.
+      elsif original.respond_to?(id_type) && lookup_has_type?(original.send(id_type), original.send(id_key))
+        h[id_key] = lookup(original.send(id_type), original.send(id_key))
       end
       h
     end

--- a/app/models/model_copier.rb
+++ b/app/models/model_copier.rb
@@ -19,7 +19,7 @@ class ModelCopier
     # copy associations that cross-reference other models, and need to
     # be run after all associations have already been copied.
     copy_associations options.delete(:cross_references) {[]}, attributes
-    copied.log_copy(lookup_store) if copied.respond_to?(:log_copy)
+    copied.save_copy_logs(lookup_store) if copied.respond_to?(:save_copy_logs)
     copied
   end
 
@@ -174,10 +174,6 @@ class ModelCopierLookups
         h[id_key] = lookup(class_type, original.send(id_key))
 
       # handle polymorphic relationships
-      # In order for this to work for unlock conditions, they have to be run after all other
-      # models have been copied -- If badges can be conditions for assigment and assignment for badges,
-      # we have to copy all the models first, then go back and lookup the associations.
-      # TODO: add course_id to conditions, and then copy them last from the course copy.
       elsif original.respond_to?(id_type) && lookup_has_key?(original.send(id_type).underscore.pluralize.to_sym, original.send(id_key))
         h[id_key] = lookup(original.send(id_type).underscore.pluralize.to_sym, original.send(id_key))
       end

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -1,4 +1,6 @@
 class UnlockCondition < ActiveRecord::Base
+  include Copyable
+
   belongs_to :course
   belongs_to :unlockable, polymorphic: true
   belongs_to :condition, polymorphic: true
@@ -62,6 +64,13 @@ class UnlockCondition < ActiveRecord::Base
       unlocked_count += 1 if self.is_complete?(student)
     end
     return unlocked_count
+  end
+
+  def copy(attributes={}, lookup_store=nil)
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes,
+      options: { lookups: [:courses, :unlockables, :conditions] }
+    )
   end
 
   protected

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -1,9 +1,12 @@
 class UnlockCondition < ActiveRecord::Base
+  belongs_to :course
   belongs_to :unlockable, polymorphic: true
   belongs_to :condition, polymorphic: true
 
   validates_presence_of :condition_id, :condition_type, :condition_state
   validates_associated :unlockable
+  # TODO: add course validation once rake task is run
+  # validates_presence_of :course
 
   # Returning the name of whatever badge or assignment has been identified as
   # the condition

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -7,7 +7,7 @@ class UnlockCondition < ActiveRecord::Base
 
   validates_presence_of :condition_id, :condition_type, :condition_state
   validates_associated :unlockable
-  # TODO: add course validation once rake task is run
+  # TODO: add course validation after rake task is run
   # validates_presence_of :course
 
   # Returning the name of whatever badge or assignment has been identified as

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -439,6 +439,7 @@ Rails.application.routes.draw do
     resources :challenges, only: :index
 
     resources :courses, only: [:index] do
+      resource :copy_log, only: [:show]
       collection do
         get "analytics"
         get "one_week_analytics", to: "courses#one_week_analytics"

--- a/db/migrate/20180124191846_create_copy_logs.rb
+++ b/db/migrate/20180124191846_create_copy_logs.rb
@@ -1,0 +1,8 @@
+class CreateCopyLogs < ActiveRecord::Migration[5.0]
+  def change
+    create_table :copy_logs do |t|
+      t.text :log
+      t.integer :course_id
+    end
+  end
+end

--- a/db/migrate/20180124191846_create_copy_logs.rb
+++ b/db/migrate/20180124191846_create_copy_logs.rb
@@ -3,6 +3,7 @@ class CreateCopyLogs < ActiveRecord::Migration[5.0]
     create_table :copy_logs do |t|
       t.text :log
       t.integer :course_id
+      t.timestamps
     end
   end
 end

--- a/db/migrate/20180124194117_add_course_id_to_unlock_conditions.rb
+++ b/db/migrate/20180124194117_add_course_id_to_unlock_conditions.rb
@@ -1,0 +1,6 @@
+class AddCourseIdToUnlockConditions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :unlock_conditions, :course_id, :integer
+    add_index :unlock_conditions, :course_id
+  end
+end

--- a/db/samples.rb
+++ b/db/samples.rb
@@ -21,6 +21,7 @@ def add_unlock_conditions(model, config, course_config)
     config[:unlock_attributes][:condition_type] == "Badge"
 
     model.unlock_conditions.create! do |uc|
+      uc.course = model.course
       if config[:unlock_attributes][:condition_type] == "Assignment"
         uc.condition =
           course_config[:assignments][config[:unlock_attributes][:condition]]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -238,8 +238,10 @@ ActiveRecord::Schema.define(version: 20180215211948) do
   end
 
   create_table "copy_logs", force: :cascade do |t|
-    t.text    "log"
-    t.integer "course_id"
+    t.text     "log"
+    t.integer  "course_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "course_analytics_exports", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -237,6 +237,11 @@ ActiveRecord::Schema.define(version: 20180215211948) do
     t.index ["course_id"], name: "index_challenges_on_course_id", using: :btree
   end
 
+  create_table "copy_logs", force: :cascade do |t|
+    t.text    "log"
+    t.integer "course_id"
+  end
+
   create_table "course_analytics_exports", force: :cascade do |t|
     t.integer  "course_id",                             null: false
     t.integer  "owner_id",                              null: false
@@ -856,6 +861,8 @@ ActiveRecord::Schema.define(version: 20180215211948) do
     t.datetime "condition_date"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "course_id"
+    t.index ["course_id"], name: "index_unlock_conditions_on_course_id", using: :btree
     t.index ["condition_id", "condition_type"], name: "index_unlock_conditions_on_condition_id_and_condition_type", using: :btree
     t.index ["unlockable_id", "unlockable_type"], name: "index_unlock_conditions_on_unlockable_id_and_unlockable_type", using: :btree
   end

--- a/lib/tasks/unlock_conditions.rake
+++ b/lib/tasks/unlock_conditions.rake
@@ -1,0 +1,12 @@
+namespace :unlocks do
+  desc "Updates course id on unlocks created before belongs_to course was added"
+  task add_course_ids: :environment do
+    UnlockCondition.find_each(batch_size: 500) do |uc|
+      next if uc.course.present?
+      # unlockable should be limited to badge and assignment
+      # both of which have a course_id
+      uc.course_id = uc.unlockable.course_id
+      puts "updated condition #{uc.id}" if uc.save
+    end
+  end
+end

--- a/spec/controllers/api/unlock_conditions_controller_spec.rb
+++ b/spec/controllers/api/unlock_conditions_controller_spec.rb
@@ -1,8 +1,9 @@
 describe API::UnlockConditionsController do
-  let!(:student)  { create(:course_membership, :student).user }
-  let(:professor) { create(:course_membership, :professor).user }
-  let(:assignment) { create :assignment }
-  let(:badge) { create :badge }
+  let(:course) { create :course }
+  let(:student) { create(:course_membership, :student, course: course).user }
+  let(:professor) { create(:course_membership, :professor, course: course).user }
+  let(:assignment) { create :assignment, course: course }
+  let(:badge) { create :badge, course: course }
 
   context "as a professor" do
     before do
@@ -30,7 +31,7 @@ describe API::UnlockConditionsController do
     end
 
     describe "POST create" do
-      it "creates a new unlock_condition" do
+      it "creates a new unlock condition" do
         expect{ post :create,
                 params: { unlock_condition:
                   { unlockable_id: assignment.id,
@@ -40,6 +41,19 @@ describe API::UnlockConditionsController do
                     condition_state: "Earned"
                   }
                 }, format: :json }.to change(UnlockCondition, :count).by(1)
+      end
+
+      it "assigns the unlock condition to the current course" do
+        post :create,
+          params: { unlock_condition:
+            { unlockable_id: assignment.id,
+              unlockable_type: "Assignment",
+              condition_id: badge.id,
+              condition_type: "Badge",
+              condition_state: "Earned"
+            }
+          }, format: :json
+        expect(UnlockCondition.first.course_id).to eq(course.id)
       end
     end
 

--- a/spec/factories/copy_log_factory.rb
+++ b/spec/factories/copy_log_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :copy_log do
+    association :course
+    log "{:courses=>{\"1\"=>\"2\"}}"
+  end
+end

--- a/spec/factories/copy_log_factory.rb
+++ b/spec/factories/copy_log_factory.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :copy_log do
     association :course
-    log "{:courses=>{\"1\"=>\"2\"}}"
+    log "{:courses=>{1=>2}}"
   end
 end

--- a/spec/models/copy_log_spec.rb
+++ b/spec/models/copy_log_spec.rb
@@ -1,0 +1,29 @@
+describe CopyLog do
+  let(:course) { build :course }
+  subject { build :copy_log, course: course }
+
+  it "is invalid without a log" do
+    subject.log = nil
+    expect(subject).to_not be_valid
+    expect(subject.errors[:log]).to include "can't be blank"
+  end
+
+  it "is invalid without course" do
+    subject.course = nil
+    expect(subject).to_not be_valid
+    expect(subject.errors[:course]).to include "can't be blank"
+  end
+
+  describe "to_hash" do
+    it "converts the log back to a hash" do
+      expect(subject.to_hash).to eq({courses: {"1"=>"2"}})
+    end
+  end
+
+  describe "parse_log" do
+    it "stores the log hash as a string" do
+      subject.parse_log({courses: {"2"=>"3"}})
+      expect(subject.log).to eq("{:courses=>{\"2\"=>\"3\"}}")
+    end
+  end
+end

--- a/spec/models/copy_log_spec.rb
+++ b/spec/models/copy_log_spec.rb
@@ -16,14 +16,14 @@ describe CopyLog do
 
   describe "to_hash" do
     it "converts the log back to a hash" do
-      expect(subject.to_hash).to eq({courses: {"1"=>"2"}})
+      expect(subject.to_hash).to eq({courses: {1=>2}})
     end
   end
 
   describe "parse_log" do
     it "stores the log hash as a string" do
-      subject.parse_log({courses: {"2"=>"3"}})
-      expect(subject.log).to eq("{:courses=>{\"2\"=>\"3\"}}")
+      subject.parse_log({courses: {2=>3}})
+      expect(subject.log).to eq("{:courses=>{2=>3}}")
     end
   end
 end

--- a/spec/models/model_copier_spec.rb
+++ b/spec/models/model_copier_spec.rb
@@ -25,6 +25,10 @@ describe ModelCopier do
       it "saves the duplicated model" do
         expect(subject).to be_persisted
       end
+
+      it "saves a copy log if the model is a course" do
+        expect(subject.copy_log).to be_an_instance_of(CopyLog)
+      end
     end
 
     it "does not save the duplicated model if the model is not saved" do


### PR DESCRIPTION
### Status
**READY**

### Description

Part III of fixing the course copy bugs.

This PR builds upon the lookup store and file copy work, and brings in copying for conditions.

A final copy procedure has been added, called `:cross_references`, which acts like associations, but copies after all associations have been copied. This assures that the copy_log is full of all references.

It also adds a check for polymorphic relationships, so if the reference is not found in the lookup, the model is checked for a reference type.

It also saves the final copy log as a model, for debugging purposes. Currently only available in the console, this could also be made accessible via the api.

### Related PRs

#3794
#3798


### Deploy Notes

This rake task must be run before copying will work:

`bundle exec rake conditions:add_course_ids

### Migrations
YES

======================
Closes #3821
