### PR TITLE
Zero out max_points if unused

### DIFF
--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -4,6 +4,8 @@ class AssignmentType < ActiveRecord::Base
 
   acts_as_list scope: :course
 
+  before_save :zero_max_points_if_unused
+
   belongs_to :course
   has_many :assignments, -> { order("position ASC") }, dependent: :destroy
   has_many :submissions, through: :assignments
@@ -138,5 +140,11 @@ class AssignmentType < ActiveRecord::Base
     score = score_for_student(student)
     return max_points if is_capped? && score > max_points
     score
+  end
+
+  private
+
+  def zero_max_points_if_unused
+    self.max_points = nil unless self.has_max_points?
   end
 end

--- a/spec/factories/assignment_type_factory.rb
+++ b/spec/factories/assignment_type_factory.rb
@@ -2,5 +2,10 @@ FactoryGirl.define do
   factory :assignment_type do
     name { Faker::Lorem.word }
     course { create(:course) }
+
+    trait :has_max_points do
+      has_max_points true
+      max_points { Faker::Number.number(5) }
+    end
   end
 end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -23,7 +23,7 @@ describe Assignment do
     end
 
     it "is invalid with points greater than assignment type cap" do
-      subject.assignment_type.update(max_points: 1000)
+      subject.assignment_type.update(max_points: 1000, has_max_points: true)
       subject.full_points = 2000
       expect(subject).to_not be_valid
       expect(subject.errors[:base]).to include "The full points for the assignment must be less than the cap for the whole assignment type."

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -30,6 +30,15 @@ describe AssignmentType do
     end
   end
 
+  describe "callbacks" do
+    let(:subject) { build :assignment_type, max_points: 1337, has_max_points: false }
+
+    it "clears out the max points value if they aren't being used" do
+      subject.save
+      expect(subject.reload.max_points).to be_nil
+    end
+  end
+
   describe "#copy" do
     subject { assignment_type.copy }
 


### PR DESCRIPTION
### Status
READY (Pending Codeship build)

### Description
See original issue for details.

### Steps to Test or Reproduce
From assignment edit form,

1. Check Maximum Points? box
2. Set a value for the Maximum Points Possible input field
3. Save. The point possible value should reset to zero.

### Impacted Areas in Application
Assignment types, assignments

======================
Closes #3860
