### PR TITLE
3865 weights closed bugfix

### DIFF
--- a/app/assets/javascripts/angular/directives/weights/weights.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights.coffee
@@ -1,3 +1,6 @@
+# This directive was explicitly for the /assignment_type_weights index page,
+# which is not currently an active route, and can probably be removed.
+# all student weighting currently is faciliated through the predictor.
 @gradecraft.directive 'assignmentTypeWeights', ['$q', 'AssignmentTypeService', ($q, AssignmentTypeService) ->
   WeightsCtrl = [()->
     vm = this
@@ -32,4 +35,3 @@
     templateUrl: 'weights/assignment_type_weights.html'
   }
 ]
-

--- a/app/assets/javascripts/angular/directives/weights/weights_coin_widget.coffee
+++ b/app/assets/javascripts/angular/directives/weights/weights_coin_widget.coffee
@@ -26,12 +26,11 @@
 
       scope.weightsOpen = ()->
         AssignmentTypeService.weights.open
+
       scope.weightsAvailableForArticle = ()->
         AssignmentTypeService.weightsAvailableForArticle(@article)
 
       scope.hasWeights = ()->
         @article.student_weight > 0
-
-
   }
 ]

--- a/app/assets/javascripts/angular/services/AssignmentTypeService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentTypeService.coffee
@@ -64,7 +64,7 @@
       GradeCraftAPI.setTermFor("weights", res.meta.term_for_weights)
       update.weights = res.meta.update_weights
       weights.open = !res.meta.weights_close_at ||
-        Date.parse(res.meta.weights_close_at) >= Date.now()
+        new Date(res.meta.weights_close_at) >= Date.now()
       weights.total_weights = res.meta.total_weights
       weights.weights_close_at = res.meta.weights_close_at
       weights.max_weights_per_assignment_type = res.meta.max_weights_per_assignment_type

--- a/app/assets/javascripts/angular/templates/predictor/main.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/main.html.haml
@@ -17,6 +17,11 @@
             .coin-stack
               .coin{'ng-repeat' => 'coin in vm.predictorService.unusedWeightsRange()'}
               .coin-stack-count {{vm.predictorService.unusedWeightsRange().length}}
+        .predictor-section-title-predicted-points{'ng-if'=>'!vm.predictorService.weightsAvailable()'}
+          .predictor-title-right-span
+            Weights are Closed for This Course
+
+
 
     %predictor-section-assignment-types
 

--- a/app/assets/javascripts/angular/templates/weights/coins.html.haml
+++ b/app/assets/javascripts/angular/templates/weights/coins.html.haml
@@ -8,9 +8,12 @@
       .coin-stack-count {{article.student_weight}}
       %i.coin-remove-icon.fa.fa-fw.fa-times
 
-  .no-coins-slot{{'ng-if' => '! hasWeights() && !weightsAvailableForArticle()'}} no {{termFor("weights")}}
+  .no-coins-slot{{'ng-if' => '!hasWeights() && !weightsAvailableForArticle()'}} no {{termFor("weights")}}
 
 .coins{{'ng-if'=>'!weightsOpen()'}}
-  .coin-stack
-    .coin-non-interactive{{'ng-repeat' => 'coin in usedWeightsRange()'}}
+  .coin-stack{{'ng-if' => 'article.student_weight'}}
+    .coin.coin--non-interactive{{'ng-repeat'=>'coin in coinBackStackRange()'}}
+    .coin.coin--non-interactive
+      .coin-stack-count {{article.student_weight}}
 
+  .no-coins-slot{{'ng-if' => '!article.student_weight'}} no {{termFor("weights")}}

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -233,18 +233,16 @@ $card-margin-1 : 3px
       color: $color-orange-1
       left: -10px
       top: 1px
-    &:hover .coin-stack-count
-      visibility: hidden
-  .coin, .coin-non-interactive, .coin-slot
+  .coin, .coin-slot
     float: right
     width: 20px
     height: 20px
     border-radius: 50%
   .coin
     margin: 3px 0 0 -15px
-  .coin-non-interactive, .coin-slot
+  .coin-slot
     margin: 2px 0 0 2px
-  .coin, .coin-non-interactive
+  .coin
     background-color: $color-yellow-1
     border: 2px solid $color-orange-1
     @include transition(all, .5s, ease-out)
@@ -253,6 +251,12 @@ $card-margin-1 : 3px
     margin: 1px 0 0 -2px
   .coin:hover
     background-color: $color-orange-1
+    .coin-stack-count
+      visibility: hidden
+  .coin.coin--non-interactive:hover
+    background-color: $color-yellow-1
+    .coin-stack-count
+      visibility: visible
   .coin:hover .coin-remove-icon
     visibility: visible
   .coin-slot

--- a/app/views/courses/_basic_settings.haml
+++ b/app/views/courses/_basic_settings.haml
@@ -107,7 +107,7 @@
         .advanced-settings-card
           %a.button-close= glyph(:times)
           = f.input :total_weights, :label => "How many multipliers do #{term_for :students} have to allocate?", input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }
-          = f.input :weights_close_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @assignment.try(:open_at) }, :label => "What date must they make this decision by?"
+          = f.input :weights_close_at, as: :string, :include_blank => true, :input_html => { class: "datetimepicker", :value => @course.try(:weights_close_at) }, :label => "What date must they make this decision by?"
           = f.input :max_weights_per_assignment_type, input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }
           = f.input :max_assignment_types_weighted, input_html: { data: { autonumeric: true, "m-dec" => "0" }, type: "text" }, :label => "Is there a maximum number of assignment types they can weight?"
           = f.input :weight_term, {:label => "What do you want to call these weights/multipliers?"}


### PR DESCRIPTION
### Status
**READY**

### Description

Fixes bugs with the display of weights in conjunction with a weights close at date.

  * Fixes the display of the date, when it exists, in the course setup form
  * Fixes the predictor to correctly parse the closing date
  * Fixes the predictor display of coins when the date has passed
  * Fixes the predictor display of no coins when the date has passed
  * Adds a note on the top bar if the weights are closed for the course

![screen shot 2018-02-14 at 3 18 18 pm](https://user-images.githubusercontent.com/1138350/36226313-778ac54c-119b-11e8-99a4-4a06553a5191.png)


======================
Closes #3865
