### PR TITLE
Ignore breadcrumb_trail

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -45,3 +45,4 @@ exclude_paths:
 - assets/**/*
 - app/mailer_previews/*
 - doc/*
+- app/models/breadcrumb_trail.rb


### PR DESCRIPTION
### Status
READY

### Description
Codeclimate should probably ignore breadcrumb_trail.rb, since it will just be terrible by design.
