### PR TITLE
Don't allow course publishing if unpaid and app

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -118,6 +118,7 @@ class CoursesController < ApplicationController
 
   def publish
     authorize! :update, @course
+    authorize! :publish, @course
     @course.update(published: true)
     redirect_to dashboard_path, flash: {
       success: "This course has been published"

--- a/app/models/abilities/course_ability.rb
+++ b/app/models/abilities/course_ability.rb
@@ -8,6 +8,10 @@ module CourseAbility
       CourseProctor.new(course).updatable? user
     end
 
+    can :publish, Course do |course|
+      CourseProctor.new(course).publishable? user
+    end
+
     can :destroy, Course do |course|
       CourseProctor.new(course).destroyable? user
     end

--- a/app/proctors/course_proctor.rb
+++ b/app/proctors/course_proctor.rb
@@ -18,6 +18,13 @@ class CourseProctor
     user.is_staff?(course) || user.is_admin?(course)
   end
 
+  # Defines whether the user has the ability to publish the course
+  def publishable?(user)
+    return true unless Rails.env.beta?
+    return true if user.is_admin? @course
+    @course.has_paid?
+  end
+
   def destroyable?(user)
     return false if course.nil? || user.nil?
     user.is_admin?(course)

--- a/app/views/layouts/_course_publication.haml
+++ b/app/views/layouts/_course_publication.haml
@@ -1,5 +1,8 @@
 -# Top banner for faculty on all pages until a course is published
 - if !current_course.published
   .unpublished-course-notification
-    This Course is Currently Unpublished
-    %span.publish-button= link_to glyph(:rocket) + "Publish", publish_course_path(current_course), method: :put
+    - if CourseProctor.new(current_course).publishable? current_user
+      This Course is Currently Unpublished
+      %span.publish-button= link_to glyph(:rocket) + "Publish", publish_course_path(current_course), method: :put
+    - else
+      This Course Must Be Paid Before It Can Be Published

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -227,6 +227,13 @@ describe CoursesController do
       end
     end
 
+    describe "PUT publish" do
+      it "does not allow publishing if the environment is app and the course is unpaid" do
+        stub_env "beta"
+        expect{ post :publish, params: { id: course.id } }.to raise_error CanCan::AccessDenied
+      end
+    end
+
     describe "protected routes" do
       it "redirect to root" do
         [


### PR DESCRIPTION
### Status
READY

### Description
Adds a method to CourseProctor called `publishable?` to control whether the publish course button is visible. 

Course should not be publishable if the environment is app and the course is unpaid, unless the current user is an admin.

### Impacted Areas in Application
Course Publish

======================
Closes #3871
