### PR TITLE
3647 Gradebook exports - assignments not listed in order of position

### DIFF
--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -2,10 +2,8 @@ class GradebookExporter
 
   # gradebook spreadsheet export for course
   def gradebook(course)
-    binding.pry
     CSV.generate do |csv|
       csv << gradebook_columns(course)
-      binding.pry
       course.students.order_by_name.each do |student|
         csv << student_data_for(student, course)
       end

--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -17,7 +17,13 @@ class GradebookExporter
   end
 
   def assignment_name_columns(course)
-    course.assignments.order(:assignment_type_id, :id).collect(&:name)
+    assignment_names = []
+    course.assignment_types.ordered.each do |type|
+      type.assignments.ordered.each do |assignment|
+        assignment_names << assignment.name
+      end
+    end
+    assignment_names
   end
 
   def gradebook_columns(course)

--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -17,7 +17,7 @@ class GradebookExporter
   end
 
   def assignment_name_columns(course)
-    course.assignments.super_ordered.collect(&:name)
+    course.assignments.ordered_by_position.collect(&:name)
   end
 
   def gradebook_columns(course)
@@ -40,7 +40,7 @@ class GradebookExporter
     student_data << student.earned_badge_score_for_course(course)
 
     # add the grades for the necessary assignments
-    course.assignments.super_ordered.inject(student_data) do |memo, assignment|
+    course.assignments.ordered_by_position.inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
       score = GradeProctor.new(grade).viewable? ? grade.final_points : ""
       memo << score

--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -2,8 +2,10 @@ class GradebookExporter
 
   # gradebook spreadsheet export for course
   def gradebook(course)
+    binding.pry
     CSV.generate do |csv|
       csv << gradebook_columns(course)
+      binding.pry
       course.students.order_by_name.each do |student|
         csv << student_data_for(student, course)
       end
@@ -17,7 +19,7 @@ class GradebookExporter
   end
 
   def assignment_name_columns(course)
-    course.assignments.ordered.collect(&:name)
+    course.assignments.order(:assignment_type_id, :id).collect(&:name)
   end
 
   def gradebook_columns(course)
@@ -40,7 +42,7 @@ class GradebookExporter
     student_data << student.earned_badge_score_for_course(course)
 
     # add the grades for the necessary assignments
-    course.assignments.ordered.inject(student_data) do |memo, assignment|
+    course.assignments.order(:assignment_type_id, :id).inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
       score = GradeProctor.new(grade).viewable? ? grade.final_points : ""
       memo << score

--- a/app/exporters/gradebook_exporter.rb
+++ b/app/exporters/gradebook_exporter.rb
@@ -17,13 +17,7 @@ class GradebookExporter
   end
 
   def assignment_name_columns(course)
-    assignment_names = []
-    course.assignment_types.ordered.each do |type|
-      type.assignments.ordered.each do |assignment|
-        assignment_names << assignment.name
-      end
-    end
-    assignment_names
+    course.assignments.super_ordered.collect(&:name)
   end
 
   def gradebook_columns(course)
@@ -46,7 +40,7 @@ class GradebookExporter
     student_data << student.earned_badge_score_for_course(course)
 
     # add the grades for the necessary assignments
-    course.assignments.order(:assignment_type_id, :id).inject(student_data) do |memo, assignment|
+    course.assignments.super_ordered.inject(student_data) do |memo, assignment|
       grade = assignment.grade_for_student(student)
       score = GradeProctor.new(grade).viewable? ? grade.final_points : ""
       memo << score

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -69,6 +69,13 @@ class Assignment < ActiveRecord::Base
   scope :ordered, -> { order("position ASC") }
   acts_as_list scope: :assignment_type
 
+  scope :super_ordered, -> do
+    joins("INNER JOIN assignment_types ON "\
+      "assignment_types.id = assignments.assignment_type_id")
+      .order("assignment_types.position ASC, position ASC")
+      .references(:assignment_type, :assignment)
+  end
+
   # Filtering Assignments by various date properties
   scope :with_dates, -> { where("assignments.due_at IS NOT NULL OR assignments.open_at IS NOT NULL") }
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -69,7 +69,7 @@ class Assignment < ActiveRecord::Base
   scope :ordered, -> { order("position ASC") }
   acts_as_list scope: :assignment_type
 
-  scope :super_ordered, -> do
+  scope :ordered_by_position, -> do
     joins("INNER JOIN assignment_types ON "\
       "assignment_types.id = assignments.assignment_type_id")
       .order("assignment_types.position ASC, position ASC")


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
As an instructor, when I export a gradebook, I expect the assignment columns to be in the order of their Assignment Type position and then their assignment position

### Related PRs
N/A


### Todos
- [ ] Add Tests
- [ ] Update/Add Documentation
- [ ] Update Sample Data


### Deploy Notes
None

### Gem dependencies
None.

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the course exports page. Click the "Final Grade Book" link. Open the corresponding CSV file. Verify that the assignment heading AND their corresponding student scores match what's on the assignments page in GradeCraft.

### Impacted Areas in Application
* Exports

======================
Closes #3647 
