### PR TITLE
Fix attachments being hidden, media not loading

### DIFF
--- a/app/assets/javascripts/angular/templates/assignments/media_uploader.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/media_uploader.html.haml
@@ -12,7 +12,7 @@
       %button.remove-unlock-condition(ng-click="removeMedia()")
         %i.fa.fa-fw.fa-times
 
-.form-item{"ng-if"=>"hideAttachments === true"}
+.form-item{"ng-if"=>"!hideAttachments"}
   %label
     Attachments
     %input.file-upload-button(type="file" multiple="true" assignment-file-upload="assignmentFiles" assignment-id="assignment.id")

--- a/app/views/api/attendance/_assignment.json.jbuilder
+++ b/app/views/api/attendance/_assignment.json.jbuilder
@@ -11,4 +11,5 @@ json.attributes do
   json.name assignment.name
   json.pass_fail assignment.pass_fail
   json.updated_at assignment.updated_at
+  json.media assignment.media.url
 end


### PR DESCRIPTION
### Status
READY

### Description
Two bugs:

1. Attached media images were not being loaded from the attendance events mass edit page
2. Attachment button was no longer visible on the assignment edit page

======================
Closes #3883
