### PR TITLE
3748 Submission export additions

### DIFF
--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -3,8 +3,8 @@ class SubmissionExporter
     CSV.generate do |csv|
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
-        csv << [ submission.id, submission.assignment_id, submission.assignment.name,
-          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
+        csv << [ submission.id, submission.assignment.assignment_type.name, submission.assignment_id, submission.assignment.name,
+          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
       end
     end
   end
@@ -12,6 +12,11 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group ID", "Student Comment", "Created At", "Updated At", "Score", "Grader Feedback", "Grade Last Updated"]
+    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
+  end
+
+  def find_graded_by_name(graded_by_id)
+    return nil unless !graded_by_id.nil?
+    User.find(graded_by_id).name
   end
 end

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -29,7 +29,7 @@
           %td Assignment ID, Name, Point Total, Description, Open At, Due At, Accept Until
         %tr
           %td= link_to glyph("file-excel-o") + "#{term_for :assignment} Submissions", submissions_path(id: current_course.id, format: "csv")
-          %td Submission ID, Assignment ID, Assignment Name, Student ID, Group ID, Student Comment, Created At, Updated At, Score, Grader Feedback, Grade Last Updated
+          %td Submission ID, Assignment Type, Assignment ID, Assignment Name, Student Email, Student ID, Group Name, Student Comment, Created At, Updated At, Score, Graded By, Grader Feedback, Grade Last Updated
         - if current_course.has_badges?
           %tr
             %td


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
For the assignment submissions export, update the following:

 Switch Group ID to Group Name
 add grader name (if grade exists)
 add AssignmentType

### Related PRs

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, go to the course downloads page and download a copy of the Assignment Submissions export file (you may have to modify the link, by default is sends the file as an email). Observe the following:

Group Id heading should now read Group Name
Grader Column is added
Assignment Type column is added

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Exports

======================
Closes #3748 
