### PR TITLE
Change condition for which model callback happens

### DIFF
--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -4,7 +4,7 @@ class AssignmentType < ActiveRecord::Base
 
   acts_as_list scope: :course
 
-  before_save :zero_max_points_if_unused
+  before_validation :zero_max_points_if_unused
 
   belongs_to :course
   has_many :assignments, -> { order("position ASC") }, dependent: :destroy

--- a/spec/models/assignment_type_spec.rb
+++ b/spec/models/assignment_type_spec.rb
@@ -21,6 +21,7 @@ describe AssignmentType do
 
     it "is only valid with positive max points" do
       subject.max_points = -1000
+      subject.has_max_points = true
       expect(subject).to be_invalid
     end
 


### PR DESCRIPTION
### Status
READY

### Description
Improves a callback to address an edge case which was possible prior to the addition of a max points validation on the assignment type model.

The original purpose of the callback is to set the `max_points` value back to `nil` any time the value for `has_max_points` is set to false, since there are currently still places in the app that will compare against the value if it exists.

Without the change proposed in this PR, the callback would never occur for older data scenarios (e.g. where `{ has_max_points: false, max_points: 0 }`) because the model would be considered invalid before save.
