### PR TITLE
3884 add submissions count

### DIFF
--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -5,7 +5,7 @@ class AssignmentExporter
       course.assignments.each do |assignment|
         csv << [ assignment.id, assignment.name, assignment.full_points,
           assignment.description, assignment.open_at, assignment.due_at,
-          assignment.accepts_submissions_until, assignment.submissions.count  ]
+          assignment.accepts_submissions_until, assignment.submissions.submitted.count  ]
       end
     end
   end

--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -14,6 +14,6 @@ class AssignmentExporter
 
   def baseline_headers
     ["Assignment ID", "Name", "Point Total", "Description", "Open At",
-      "Due At", "Accept Until", "Submissions Total" ]
+      "Due At", "Accept Until", "Submissions Count" ]
   end
 end

--- a/app/exporters/assignment_exporter.rb
+++ b/app/exporters/assignment_exporter.rb
@@ -5,7 +5,7 @@ class AssignmentExporter
       course.assignments.each do |assignment|
         csv << [ assignment.id, assignment.name, assignment.full_points,
           assignment.description, assignment.open_at, assignment.due_at,
-          assignment.accepts_submissions_until  ]
+          assignment.accepts_submissions_until, assignment.submissions.count  ]
       end
     end
   end
@@ -14,6 +14,6 @@ class AssignmentExporter
 
   def baseline_headers
     ["Assignment ID", "Name", "Point Total", "Description", "Open At",
-      "Due At", "Accept Until" ]
+      "Due At", "Accept Until", "Submissions Total" ]
   end
 end

--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -3,8 +3,8 @@ class SubmissionExporter
     CSV.generate do |csv|
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
-        csv << [ submission.id, submission.assignment.assignment_type.name, submission.assignment_id, submission.assignment.name,
-          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
+        csv << [ submission.id, submission.assignment_id, submission.assignment.name,
+          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
       end
     end
   end
@@ -12,11 +12,6 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
-  end
-
-  def find_graded_by_name(graded_by_id)
-    return nil unless !graded_by_id.nil?
-    User.find(graded_by_id).name
+    ["Submission ID", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group ID", "Student Comment", "Created At", "Updated At", "Score", "Grader Feedback", "Grade Last Updated"]
   end
 end

--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -3,8 +3,8 @@ class SubmissionExporter
     CSV.generate do |csv|
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
-        csv << [ submission.id, submission.assignment_id, submission.assignment.name,
-          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
+        csv << [ submission.id, submission.assignment.assignment_type.name, submission.assignment_id, submission.assignment.name,
+          submission.student.email, submission.student_id, submission.group_id, submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
       end
     end
   end
@@ -12,6 +12,11 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group ID", "Student Comment", "Created At", "Updated At", "Score", "Grader Feedback", "Grade Last Updated"]
+    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
+  end
+
+  def find_graded_by_name(graded_by_id)
+    return nil unless !graded_by_id.nil?
+    User.find(graded_by_id).name
   end
 end

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -26,7 +26,7 @@
           %td First Name, Last Name, Email, Username, #{ term_for :team }, Raw and capped scores for all #{ term_for :assignment_types }
         %tr
           %td= link_to glyph("file-excel-o") + "#{term_for :assignment} Structure", export_structure_assignments_path(id: current_course.id, format: "csv")
-          %td Assignment ID, Name, Point Total, Description, Open At, Due At, Accept Until
+          %td Assignment ID, Name, Point Total, Description, Open At, Due At, Accept Until, Submission Count
         %tr
           %td= link_to glyph("file-excel-o") + "#{term_for :assignment} Submissions", submissions_path(id: current_course.id, format: "csv")
           %td Submission ID, Assignment ID, Assignment Name, Student ID, Group ID, Student Comment, Created At, Updated At, Score, Grader Feedback, Grade Last Updated

--- a/spec/exporters/assignment_exporter_spec.rb
+++ b/spec/exporters/assignment_exporter_spec.rb
@@ -6,7 +6,7 @@ describe AssignmentExporter do
   describe "#export(course)" do
     it "generates an empty CSV if there are no assignments" do
       csv = subject.export(course)
-      expect(csv).to eq "Assignment ID,Name,Point Total,Description,Open At,Due At,Accept Until,Submissions Total\n"
+      expect(csv).to eq "Assignment ID,Name,Point Total,Description,Open At,Due At,Accept Until,Submissions Count\n"
     end
 
     it "generates a csv of assignments if present" do
@@ -21,7 +21,7 @@ describe AssignmentExporter do
       expect(csv[1][4]).to eq assignment.open_at
       expect(csv[1][5]).to eq assignment.due_at
       expect(csv[1][6]).to eq assignment.accepts_submissions_until
-      expect(csv[1][7]).to eq "#{assignment.submissions.count}"
+      expect(csv[1][7]).to eq "#{assignment.submissions.submitted.count}"
     end
   end
 end

--- a/spec/exporters/assignment_exporter_spec.rb
+++ b/spec/exporters/assignment_exporter_spec.rb
@@ -6,7 +6,7 @@ describe AssignmentExporter do
   describe "#export(course)" do
     it "generates an empty CSV if there are no assignments" do
       csv = subject.export(course)
-      expect(csv).to eq "Assignment ID,Name,Point Total,Description,Open At,Due At,Accept Until\n"
+      expect(csv).to eq "Assignment ID,Name,Point Total,Description,Open At,Due At,Accept Until,Submissions Total\n"
     end
 
     it "generates a csv of assignments if present" do
@@ -21,6 +21,7 @@ describe AssignmentExporter do
       expect(csv[1][4]).to eq assignment.open_at
       expect(csv[1][5]).to eq assignment.due_at
       expect(csv[1][6]).to eq assignment.accepts_submissions_until
+      expect(csv[1][7]).to eq "#{assignment.submissions.count}"
     end
   end
 end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Add submission totals to the Assignment Structure file export

### Related PRs
List related PRs against other branches:

branch | PR
------ | ------
#3748  | [link](https://github.com/UM-USElab/gradecraft-development/pull/3888)

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the course exports page. Select the Assignment Structure link and download the export file. Observe the new column at the end "Submission Totals". The data underneath should correspond with the number of submissions for that assignment. Assignments that do not accept submissions will show '0'.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Exports

======================
Closes #3884 
