### PR TITLE
Reset multiplier-related fields if unused

### DIFF
--- a/app/assets/javascripts/angular/templates/predictor/main.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/main.html.haml
@@ -21,8 +21,6 @@
           .predictor-title-right-span
             Weights are Closed for This Course
 
-
-
     %predictor-section-assignment-types
 
     %predictor-section-badges

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -6,6 +6,8 @@ class Course < ActiveRecord::Base
   include Analytics::CourseAnalytics
   include S3Manager::Copying
 
+  # Callbacks
+  before_validation :reset_weight_fields_if_unused
   before_create :mark_umich_as_paid
   after_create :create_admin_memberships
 
@@ -229,6 +231,16 @@ class Course < ActiveRecord::Base
   end
 
   private
+
+  # If not using multipliers, reset the related columns
+  def reset_weight_fields_if_unused
+    return if self.has_multipliers?
+
+    self.assign_attributes total_weights: nil,
+      weights_close_at: nil,
+      max_weights_per_assignment_type: nil,
+      max_assignment_types_weighted: nil
+  end
 
   def create_admin_memberships
     User.where(admin: true).each do |admin|

--- a/spec/factories/course_factory.rb
+++ b/spec/factories/course_factory.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
     published true
 
     factory :course_with_weighting do
+      has_multipliers true
       total_weights 6
       max_weights_per_assignment_type 4
       max_assignment_types_weighted 2
@@ -24,6 +25,10 @@ FactoryGirl.define do
     trait :uses_learning_objectives do
       allows_learning_objectives true
       has_learning_objectives true
+    end
+
+    trait :has_multipliers do
+      has_multipliers true
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -8,6 +8,17 @@ describe Course do
       allow(Rails).to receive(:env) { "production".inquiry }
       expect { subject.save }.to change(subject, :has_paid)
     end
+
+    it "resets the weights-oriented attributes if multipliers are't being used" do
+      subject.assign_attributes has_multipliers: false,
+        total_weights: 3,
+        max_weights_per_assignment_type: 2,
+        max_assignment_types_weighted: 1
+      subject.run_callbacks :validation
+      expect(subject).to have_attributes(total_weights: nil,
+        max_weights_per_assignment_type: nil,
+        max_assignment_types_weighted: nil)
+    end
   end
 
   describe "validations" do
@@ -565,15 +576,15 @@ describe Course do
   end
 
   describe "#assignment_weight_spent_for_student(student)" do
+    subject { create :course_with_weighting, total_weights: 4 }
+
     it "returns false if the student has not yet spent enough weights" do
-      subject.total_weights = 4
       student = create(:user, courses: [subject], role: :student)
       assignment_weight_1 = create(:assignment_type_weight, student: student, course: subject, weight: 2)
       expect(subject.assignment_weight_spent_for_student(student)).to eq(false)
     end
 
     it "returns true if the student has spent enough weights" do
-      subject.total_weights = 4
       student = create(:user, courses: [subject], role: :student)
       assignment_weight_1 = create(:assignment_type_weight, student: student, course: subject, weight: 2)
       assignment_weight_2 = create(:assignment_type_weight, student: student, course: subject, weight: 2)

--- a/spec/views/api/assignment_types/index_spec.rb
+++ b/spec/views/api/assignment_types/index_spec.rb
@@ -1,12 +1,12 @@
 describe "api/assignment_types/index" do
 
   before(:all) do
-    @course = create(:course,
+    @course = create(:course, :has_multipliers,
       assignment_term: "mission",
       total_weights: 6,
       weights_close_at: Time.now,
       max_weights_per_assignment_type: 4,
-      max_assignment_types_weighted: 2,
+      max_assignment_types_weighted: 2
     )
     assignment_type = create(:assignment_type, course: @course, student_weightable: true, has_max_points: true, max_points: 1234)
     @assignment_types = [assignment_type]


### PR DESCRIPTION
### Status
READY

### Description
This PR clears out the `total_weights`, `weights_close_at`, `max_weights_per_assignment_type`, and `max_assignment_types_weighted` fields if the `has_multipliers` value changes to false via a callback on the Course model.

======================
Closes #3892
