### PR TITLE
Add copy validation

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -55,9 +55,13 @@ class AssignmentsController < ApplicationController
   # Duplicate an assignment - important for super repetitive items like
   # attendance and reading reactions
   def copy
-    assignment = current_course.assignments.find(params[:id])
-    duplicated = assignment.copy_with_prepended_name
-    redirect_to edit_assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
+    begin
+      assignment = current_course.assignments.find(params[:id])
+      duplicated = assignment.copy_with_prepended_name
+      redirect_to edit_assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
+    rescue InvalidAssociationError => e
+      render json: { message: e.message, details: e.details }, status: :internal_server_error
+    end
   end
 
   def destroy

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -59,7 +59,7 @@ class AssignmentsController < ApplicationController
       assignment = current_course.assignments.find(params[:id])
       duplicated = assignment.copy_with_prepended_name
       redirect_to edit_assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
-    rescue InvalidAssociationError => e
+    rescue CopyValidationError => e
       render json: { message: e.message, details: e.details }, status: :internal_server_error
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -104,7 +104,7 @@ class CoursesController < ApplicationController
           alert: "#{@course.name} was not successfully copied"
         }
       end
-    rescue InvalidAssociationError => e
+    rescue CopyValidationError => e
       render json: { message: e.message, details: e.details }, status: :internal_server_error
     end
   end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -86,20 +86,26 @@ class CoursesController < ApplicationController
 
   def copy
     authorize! :read, @course
-    duplicated = @course.copy(params[:copy_type])
-    if duplicated.save
-      if !current_user_is_admin? && current_user.role(duplicated).nil?
-        duplicated.course_memberships.create(user: current_user, role: current_role)
+
+    begin
+      duplicated = @course.copy(params[:copy_type])
+
+      if duplicated.save
+        if !current_user_is_admin? && current_user.role(duplicated).nil?
+          duplicated.course_memberships.create(user: current_user, role: current_role)
+        end
+        duplicated.recalculate_student_scores unless duplicated.student_count.zero?
+        session[:course_id] = duplicated.id
+        redirect_to edit_course_path(duplicated.id), flash: {
+          notice: "#{@course.name} successfully copied"
+        }
+      else
+        redirect_to courses_path, flash: {
+          alert: "#{@course.name} was not successfully copied"
+        }
       end
-      duplicated.recalculate_student_scores unless duplicated.student_count.zero?
-      session[:course_id] = duplicated.id
-      redirect_to edit_course_path(duplicated.id), flash: {
-        notice: "#{@course.name} successfully copied"
-      }
-    else
-      redirect_to courses_path, flash: {
-        alert: "#{@course.name} was not successfully copied"
-      }
+    rescue InvalidAssociationError => e
+      redirect_to courses_path, flash: { error: "Failed to copy course.\nOne or more associations were invalid on #{@course.name}" } and return
     end
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -105,7 +105,7 @@ class CoursesController < ApplicationController
         }
       end
     rescue InvalidAssociationError => e
-      redirect_to courses_path, flash: { error: "Failed to copy course.\nOne or more associations were invalid on #{@course.name}" } and return
+      render json: { message: e.message, details: e.details }, status: :internal_server_error
     end
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -106,7 +106,7 @@ class Assignment < ActiveRecord::Base
   # Used for copying within the same course
   def copy_with_prepended_name(attributes={})
     result = CopyValidator.new.validate(self, lookup_key: :assignments, associations: [:rubric])
-    raise InvalidAssociationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
+    raise CopyValidationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
 
     ModelCopier.new(self).copy(
       attributes: attributes.merge(position: nil),

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -105,6 +105,9 @@ class Assignment < ActiveRecord::Base
   # Copy a specific assignment while prepending 'Copy of' to the name
   # Used for copying within the same course
   def copy_with_prepended_name(attributes={})
+    result = CopyValidator.new.validate(self, lookup_key: :assignments, associations: [:rubric])
+    raise InvalidAssociationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
+
     ModelCopier.new(self).copy(
       attributes: attributes.merge(position: nil),
       associations: [:assignment_score_levels],

--- a/app/models/concerns/copyable.rb
+++ b/app/models/concerns/copyable.rb
@@ -1,5 +1,7 @@
 require_relative "../copy_validator"
 
+# NOTE: If at any point we add additional associations for copying, the
+# validation schema needs to be updated in the CopyValidator class
 module Copyable
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/copyable.rb
+++ b/app/models/concerns/copyable.rb
@@ -1,3 +1,5 @@
+require_relative "../copy_validator"
+
 module Copyable
   extend ActiveSupport::Concern
 

--- a/app/models/copy_validator.rb
+++ b/app/models/copy_validator.rb
@@ -21,7 +21,7 @@ class CopyValidator
   # model: the model to validate
   # lookup_key: should match the key as specified in COPY_ASSOCIATIONS hash, e.g. criteria as opposed to criterion
   # options: hash containing either
-  #   - lookup_key: a custom key as defined in the COPY_ASSOCIATIONS constant
+  #   - lookup_key: a custom key (symbol) as defined in the COPY_ASSOCIATIONS constant
   #   - associations: any additional associations that are being copied and need validating
   def validate(model, options={})
     lookup_key = options.delete(:lookup_key) || model_type_as_symbol(model.class.name)
@@ -44,8 +44,15 @@ class CopyValidator
 
   def validate_associations(model, associations)
     associations.each do |a|
-      model.send(a).each do |am|
-        validate(am, { lookup_key: a })
+      assoc = model.send(a)
+      next if assoc.nil?
+
+      if assoc.is_a? Enumerable
+        assoc.each do |am|
+          validate(am, { lookup_key: a })
+        end
+      else
+        validate(assoc, { lookup_key: a })
       end
     end
   end

--- a/app/models/copy_validator.rb
+++ b/app/models/copy_validator.rb
@@ -1,0 +1,92 @@
+class CopyValidator
+  # The definitive structure for which associations are copied and should be validated
+  # Has to be manually updated for now each time an association is added to the copy
+  # process
+  COPY_ASSOCIATIONS ||= {
+    course: [:badges, :assignment_types, :rubrics, :challenges, :grade_scheme_elements],
+    assignment_types: [:assignments],
+    assignments: [:assignment_score_levels],
+    rubric: [:criteria],
+    criteria: [:levels],
+    levels: [:level_badges]
+  }.freeze
+
+  attr_accessor :details, :has_errors
+
+  def initialize
+    @details = {}
+    @has_errors = false
+  end
+
+  # model: the model to validate
+  # lookup_key: should match the key as specified in COPY_ASSOCIATIONS hash, e.g. criteria as opposed to criterion
+  # options: hash containing either
+  #   - lookup_key: a custom key as defined in the COPY_ASSOCIATIONS constant
+  #   - associations: any additional associations that are being copied and need validating
+  def validate(model, options={})
+    lookup_key = options.delete(:lookup_key) || model_type_as_symbol(model.class.name)
+    additional_associations = options.delete(:associations)
+
+    associations = COPY_ASSOCIATIONS[lookup_key]
+    associations << additional_associations unless additional_associations.blank?
+
+    validate_model model
+    validate_associations model, associations.flatten unless associations.blank?
+
+    self
+  end
+
+  private
+
+  def validate_model(model)
+    append_result(model_type_as_symbol(model.class.name.pluralize), result_hash(model))
+  end
+
+  def validate_associations(model, associations)
+    associations.each do |a|
+      model.send(a).each do |am|
+        validate(am, { lookup_key: a })
+      end
+    end
+  end
+
+  def result_hash(model)
+    errors = model.errors.full_messages unless model.valid?
+    CopyValidatorResult.new(model_type_as_symbol(model.class.name), model.id, model.valid?, errors).to_h
+  end
+
+  def append_result(model_name, validation)
+    @has_errors = true unless validation[:valid]
+
+    if @details[model_name].present?
+      @details[model_name] << validation
+    else
+      @details[model_name] = [validation]
+    end
+  end
+
+  def model_type_as_symbol(name)
+    name.underscore.to_sym
+  end
+end
+
+class CopyValidatorResult
+  attr_reader :type, :id, :valid, :errors
+
+  def initialize(type, id, valid, errors)
+    @type, @id, @valid, @errors = type, id, valid, errors
+  end
+
+  def to_h
+    self.instance_values.symbolize_keys
+  end
+end
+
+class InvalidAssociationError < StandardError
+  attr_reader :details
+
+  def initialize(details, msg="One or more associations were invalid")
+    @details = details
+    super(msg)
+  end
+end

--- a/app/models/copy_validator.rb
+++ b/app/models/copy_validator.rb
@@ -2,7 +2,7 @@ class CopyValidator
   # The definitive structure for which associations are copied and should be validated
   # Has to be manually updated for now each time an association is added to the copy
   # process
-  COPY_ASSOCIATIONS ||= {
+  COPY_ASSOCIATIONS = {
     course: [:badges, :assignment_types, :rubrics, :challenges, :grade_scheme_elements],
     assignment_types: [:assignments],
     assignments: [:assignment_score_levels],
@@ -27,7 +27,7 @@ class CopyValidator
     lookup_key = options.delete(:lookup_key) || model_type_as_symbol(model.class.name)
     additional_associations = options.delete(:associations)
 
-    associations = COPY_ASSOCIATIONS[lookup_key]
+    associations = COPY_ASSOCIATIONS[lookup_key].clone
     associations << additional_associations unless additional_associations.blank?
 
     validate_model model

--- a/app/models/copy_validator.rb
+++ b/app/models/copy_validator.rb
@@ -74,7 +74,10 @@ class CopyValidatorResult
   attr_reader :type, :id, :valid, :errors
 
   def initialize(type, id, valid, errors)
-    @type, @id, @valid, @errors = type, id, valid, errors
+    @type = type
+    @id = id
+    @valid = valid
+    @errors = errors
   end
 
   def to_h

--- a/app/models/copy_validator.rb
+++ b/app/models/copy_validator.rb
@@ -27,7 +27,7 @@ class CopyValidator
     lookup_key = options.delete(:lookup_key) || model_type_as_symbol(model.class.name)
     additional_associations = options.delete(:associations)
 
-    associations = COPY_ASSOCIATIONS[lookup_key].clone
+    associations = COPY_ASSOCIATIONS[lookup_key].try(:clone)
     associations << additional_associations unless additional_associations.blank?
 
     validate_model model

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -118,7 +118,7 @@ class Course < ActiveRecord::Base
   def copy(copy_type, attributes={})
     assoc = copy_type != "with_students" ? [] : [:course_memberships, :teams]
     result = CopyValidator.new.validate self, overrides: assoc
-    raise InvalidAssociationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
+    raise CopyValidationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
 
     if copy_type != "with_students"
       copy_with_associations(attributes.merge(lti_uid: nil, status: true), assoc)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -118,7 +118,7 @@ class Course < ActiveRecord::Base
   def copy(copy_type, attributes={})
     assoc = copy_type != "with_students" ? [] : [:course_memberships, :teams]
     result = CopyValidator.new.validate self, overrides: assoc
-    raise InvalidAssociationError.new(result) if result.has_errors
+    raise InvalidAssociationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
 
     if copy_type != "with_students"
       copy_with_associations(attributes.merge(lti_uid: nil, status: true), assoc)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -32,7 +32,7 @@ describe AssignmentsController do
 
     describe "POST copy" do
       it "returns an error if there are validation errors" do
-        allow_any_instance_of(Assignment).to receive(:copy_with_prepended_name).and_raise InvalidAssociationError, {}
+        allow_any_instance_of(Assignment).to receive(:copy_with_prepended_name).and_raise CopyValidationError, {}
         post :copy, params: { id: assignment.id }
         expect(response).to have_http_status :internal_server_error
       end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -18,7 +18,6 @@ describe AssignmentsController do
     describe "GET settings" do
       it "returns title and assignments" do
         get :settings
-        # TODO: confirm multiple assignments are chronological and alphabetical
         expect(assigns(:assignment_types)).to eq([assignment_type])
         expect(response).to render_template(:settings)
       end
@@ -61,8 +60,6 @@ describe AssignmentsController do
         expect(duplicated.rubric).to_not be_nil
         expect(duplicated.rubric.criteria.first.name).to eq "Rubric 1"
         expect(duplicated.rubric.criteria.first.levels.first.name).to eq "Full Credit"
-        # expect(duplicated.rubric.criteria.first.levels.first.level_badges.count).to \
-        #   eq 1
       end
 
       it "redirects to the edit page for the duplicated assignment" do

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -32,6 +32,12 @@ describe AssignmentsController do
     end
 
     describe "POST copy" do
+      it "returns an error if there are validation errors" do
+        allow_any_instance_of(Assignment).to receive(:copy_with_prepended_name).and_raise InvalidAssociationError, {}
+        post :copy, params: { id: assignment.id }
+        expect(response).to have_http_status :internal_server_error
+      end
+
       it "duplicates an assignment" do
         post :copy, params: { id: assignment.id }
         expect expect(course.assignments.count).to eq(2)

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -72,7 +72,7 @@ describe CoursesController do
 
     describe "POST copy" do
       it "returns an error if there are validation errors" do
-        allow_any_instance_of(Course).to receive(:copy).and_raise InvalidAssociationError, {}
+        allow_any_instance_of(Course).to receive(:copy).and_raise CopyValidationError, {}
         post :copy, params: { id: course.id }
         expect(response).to have_http_status :internal_server_error
       end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -74,7 +74,7 @@ describe CoursesController do
       it "returns an error if there are validation errors" do
         allow_any_instance_of(Course).to receive(:copy).and_raise InvalidAssociationError, {}
         post :copy, params: { id: course.id }
-        expect(response).to redirect_to courses_path
+        expect(response).to have_http_status :internal_server_error
       end
 
       it "creates a duplicate course" do

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -71,6 +71,12 @@ describe CoursesController do
     end
 
     describe "POST copy" do
+      it "returns an error if there are validation errors" do
+        allow_any_instance_of(Course).to receive(:copy).and_raise InvalidAssociationError, {}
+        post :copy, params: { id: course.id }
+        expect(response).to redirect_to courses_path
+      end
+
       it "creates a duplicate course" do
         expect{ post :copy, params: { id: course.id }}.to change(Course, :count).by(1)
       end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -297,7 +297,7 @@ describe Assignment do
       result = double(has_errors: true, details: { message: "Blah blah" })
       validator = instance_double("CopyValidator", validate: result)
       allow(CopyValidator).to receive(:new).and_return validator
-      expect{ subject }.to raise_error InvalidAssociationError
+      expect{ subject }.to raise_error CopyValidationError
     end
 
     it "prepends the name with 'Copy of'" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -293,6 +293,13 @@ describe Assignment do
     let(:assignment) { build :assignment }
     subject { assignment.copy_with_prepended_name }
 
+    it "raises an error if the validation fails" do
+      result = double(has_errors: true, details: { message: "Blah blah" })
+      validator = instance_double("CopyValidator", validate: result)
+      allow(CopyValidator).to receive(:new).and_return validator
+      expect{ subject }.to raise_error InvalidAssociationError
+    end
+
     it "prepends the name with 'Copy of'" do
       assignment.name = "Table of elements"
       expect(subject.name).to eq "Copy of Table of elements"
@@ -310,7 +317,7 @@ describe Assignment do
 
     it "copies the assignment score levels" do
       assignment.save
-      assignment.assignment_score_levels.create
+      create :assignment_score_level, assignment: assignment
       expect(subject.assignment_score_levels.size).to eq 1
       expect(subject.assignment_score_levels.map(&:assignment_id)).to eq [subject.id]
     end

--- a/spec/models/copy_validator_spec.rb
+++ b/spec/models/copy_validator_spec.rb
@@ -17,6 +17,20 @@ describe CopyValidator do
       expect(result.details[:grade_scheme_elements].length).to eq 3
     end
 
+    it "checks validation on any additional associations" do
+      assignment = assignments.first
+      assignment.update_columns max_group_size: -1
+      create :rubric_with_criteria, assignment: assignment, course: course
+
+      result = subject.validate assignment, lookup_key: :assignments, associations: [:rubric]
+
+      expect(result.has_errors).to eq true
+      expect(result.details[:assignments].length).to eq 1
+      expect(result.details[:rubrics].length).to eq 1
+      expect(result.details[:criteria].length).to eq assignment.rubric.criteria.length
+      expect(result.details[:levels].length).to eq assignment.rubric.criteria.sum(&:levels).length
+    end
+
     it "returns information regarding whether a model is valid or not" do
       assignment_type.update_columns max_points: -1
       assignment_type.valid?

--- a/spec/models/copy_validator_spec.rb
+++ b/spec/models/copy_validator_spec.rb
@@ -1,5 +1,5 @@
 describe CopyValidator do
-  subject { described_class.new }
+  let(:subject) { described_class.new }
 
   let(:course) { create :course }
   let!(:assignment_type) { create :assignment_type, course: course }

--- a/spec/models/copy_validator_spec.rb
+++ b/spec/models/copy_validator_spec.rb
@@ -1,13 +1,16 @@
 describe CopyValidator do
   let(:subject) { described_class.new }
-
   let(:course) { create :course }
-  let!(:assignment_type) { create :assignment_type, course: course }
-  let!(:assignments) { create_list :assignment, 2, course: course, assignment_type: assignment_type }
-  let!(:grade_scheme_elements) { create_list :grade_scheme_element, 3, course: course }
 
   describe "#validate" do
+    let(:assignment_type) { create :assignment_type, course: course }
+    let(:assignments) { create_list :assignment, 2, course: course, assignment_type: assignment_type }
+    let(:grade_scheme_elements) { create_list :grade_scheme_element, 3, course: course }
+
     it "checks validation against all associated models" do
+      assignments
+      grade_scheme_elements
+
       result = subject.validate course
 
       expect(result.has_errors).to eq false
@@ -22,7 +25,7 @@ describe CopyValidator do
       assignment.update_columns max_group_size: -1
       create :rubric_with_criteria, assignment: assignment, course: course
 
-      result = subject.validate assignment, lookup_key: :assignments, associations: [:rubric]
+      result = subject.validate assignment.reload, lookup_key: :assignments, associations: [:rubric]
 
       expect(result.has_errors).to eq true
       expect(result.details[:assignments].length).to eq 1
@@ -32,9 +35,10 @@ describe CopyValidator do
     end
 
     it "returns information regarding whether a model is valid or not" do
-      assignment_type.update_columns max_points: -1
+      assignment_type.update_columns top_grades_counted: -1
       assignment_type.valid?
-      result = subject.validate course
+
+      result = subject.validate course.reload
 
       expect(result.has_errors).to eq true
       expect(result.details[:assignment_types]).to include type: :assignment_type,

--- a/spec/models/copy_validator_spec.rb
+++ b/spec/models/copy_validator_spec.rb
@@ -1,0 +1,43 @@
+describe CopyValidator do
+  subject { described_class.new }
+
+  let(:course) { create :course }
+  let!(:assignment_type) { create :assignment_type, course: course }
+  let!(:assignments) { create_list :assignment, 2, course: course, assignment_type: assignment_type }
+  let!(:grade_scheme_elements) { create_list :grade_scheme_element, 3, course: course }
+
+  describe "#validate" do
+    it "checks validation against all associated models" do
+      result = subject.validate course
+
+      expect(result.has_errors).to eq false
+      expect(result.details[:courses].length).to eq 1
+      expect(result.details[:assignment_types].length).to eq 1
+      expect(result.details[:assignments].length).to eq 2
+      expect(result.details[:grade_scheme_elements].length).to eq 3
+    end
+
+    it "returns information regarding whether a model is valid or not" do
+      assignment_type.update_columns max_points: -1
+      assignment_type.valid?
+      result = subject.validate course
+
+      expect(result.has_errors).to eq true
+      expect(result.details[:assignment_types]).to include type: :assignment_type,
+        id: assignment_type.id, valid: false, errors: assignment_type.reload.errors.full_messages
+    end
+  end
+end
+
+describe CopyValidatorResult do
+  describe "#to_h" do
+    subject { described_class.new :course, 1, false, errors.full_messages }
+
+    let(:errors) { double(full_messages: ["Course is fake!"]) }
+
+    it "returns a hash for the provided attributes" do
+      expect(subject.to_h).to be_a Hash
+      expect(subject.to_h).to include type: :course, id: 1, valid: false, errors: errors.full_messages
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -41,8 +41,15 @@ describe Course do
   end
 
   describe "#copy" do
-    let(:course) { create :course }
     subject { course.copy nil }
+    let(:course) { create :course }
+
+    it "throws an exception if validation fails" do
+      result = double(has_errors: true)
+      validator = instance_double("CopyValidator", validate: result)
+      allow(CopyValidator).to receive(:new).and_return validator
+      expect{ subject }.to raise_error InvalidAssociationError
+    end
 
     it "makes a duplicated copy of itself" do
       expect(subject).to_not eq course
@@ -97,8 +104,8 @@ describe Course do
   end
 
   describe "#copy with students" do
-    let!(:student) { create(:course_membership, :student, course: subject).user }
     subject { create :course }
+    let!(:student) { create(:course_membership, :student, course: subject).user }
 
     it "turns off the create_admin_memberships callback" do
       expect_any_instance_of(Course).to_not receive(:create_admin_memberships)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -48,7 +48,7 @@ describe Course do
       result = double(has_errors: true, details: { message: "Blah blah" })
       validator = instance_double("CopyValidator", validate: result)
       allow(CopyValidator).to receive(:new).and_return validator
-      expect{ subject }.to raise_error InvalidAssociationError
+      expect{ subject }.to raise_error CopyValidationError
     end
 
     it "makes a duplicated copy of itself" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -45,7 +45,7 @@ describe Course do
     let(:course) { create :course }
 
     it "throws an exception if validation fails" do
-      result = double(has_errors: true)
+      result = double(has_errors: true, details: { message: "Blah blah" })
       validator = instance_double("CopyValidator", validate: result)
       allow(CopyValidator).to receive(:new).and_return validator
       expect{ subject }.to raise_error InvalidAssociationError


### PR DESCRIPTION
### Status
READY

### Description
Prior to copying a course **or** assignment, all associations about to be copied should be validated so that we don't end up with incorrectly linked models when save is called in the `ModelCopier`.

**Caveat: The validation process in this PR relies on the copy associations being defined in the `COPY_ASSOCIATIONS` hash. If we want to copy additional associations in the future, this needs to be updated as needed.**

### Migrations
NO

### Steps to Test or Reproduce
Force one or more model errors (possible via `update_columns`) and attempt to do a copy. The process should fail and you should receive a raw JSON response which displays some error validation results.

Download a JSON prettifier for your browser if you don't have one!

### Impacted Areas in Application
Course copy
Assignment copy

======================
Closes #3889 
