### PR TITLE
add assignment description to submission show page

### DIFF
--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -12,6 +12,9 @@
     #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
       .ui-tabs-panel#submission.active{role: "tabpanel", "aria-hidden" => false}
         = render partial: "layouts/alerts"
+
+        = render partial: "submissions/assignment_guidelines", locals: { assignment: presenter.assignment }
+
         = render partial: "submissions/submission_content", locals: { presenter: presenter }
       .ui-tabs-panel#history{role: "tabpanel", "aria-hidden" => false}
         = history_timeline presenter.submission_grade_history


### PR DESCRIPTION
### Status
**READY (pending build)**

### Description
Laurie's asked us to add the assignment description to the submission show page. 

### Migrations
NO

### Steps to Test or Reproduce
Navigate to the grading status page and click "See Submission" - confirm that you can see the assignment description at the top of the page 

1. 

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Submission show page 