### PR TITLE
Assignment copy fix

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -114,7 +114,6 @@ class Assignment < ActiveRecord::Base
           -> (copy) do
             copy_files copy
             copy.rubric = self.rubric.copy if self.rubric.present?
-            copy.rubric.course_id = copy.course_id if self.rubric.present?
           end
         ]
       }


### PR DESCRIPTION
### Status
READY

### Description
Recently the way that assignment files were being copied when an assignment was copied was changed so that they actually copied in S3 and didn't just point to the same file.

An unintended side-effect of changing some of this logic was that it broke assignment copy within courses.

This PR fixes that and cleans up some of the logic. It also resets the position on the copy to `nil`, so that there are no duplicated values and the copied assignment appears at the bottom of the assignment list.

### Steps to Test or Reproduce
Copy a specific assignment on a course. Ensure that the assignment shows at the bottom of the assignment list and that files and rubrics are copied.

### Impacted Areas in Application
Assignment copy

======================
Closes #3902
