### PR TITLE
3344 predictor gse locks

### DIFF
--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -18,6 +18,9 @@
       scope.lockedPointsPredicted = ()->
         PredictorService.lockedPointsPredicted()
 
+      scope.lockedGradeSchemeElementsPresent = ()->
+        PredictorService.lockedGradeSchemeElementsPresent()
+
       scope.predictedGradeLevel = ()->
         PredictorService.predictedGradeLevel()
 
@@ -116,8 +119,6 @@
           .attr("transform", ()->
             "translate(" + padding + "," + (65) + ")"
           ).call(d3.axisBottom(scale))
-
-
 
       # Calculetes width for Earned Points (green) bar
       scope.svgEarnedBarWidth = ()->

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -50,6 +50,20 @@
         else
           return position + alignWithTickMark
 
+      # Indicate Locked Grade Scheme elements by coloring them red
+      scope.pinColor = (gse)->
+        if gse.is_locked
+          "#D1495B" #red for locked GSE
+        else
+          "000000" #black
+
+      scope.pinTextColor = (gse)->
+        if gse.is_locked
+          "#D1495B" #red
+        else
+          "#68A127" #green
+
+
       # Loads the grade points values and corresponding grade levels name/letter-grade into the predictor graph
       # Renders D3 object
       scope.renderGradeLevelGraph = ()->
@@ -64,19 +78,20 @@
                   d3.select(".grade_scheme-label-" + gse.lowest_points).style("visibility", "visible")
                   d3.select(".grade_scheme-pointer-" + gse.lowest_points)
                     .attr("transform","scale(4) translate(-1.5,-3)")
-                    .attr("fill", "#68A127")
+                    .attr("fill", (gse)-> scope.pinTextColor(gse))
                 )
                 .on("mouseout", (gse)->
                   d3.select(".grade_scheme-label-" + gse.lowest_points).style("visibility", "hidden")
                   d3.select(".grade_scheme-pointer-" + gse.lowest_points)
                     .attr("transform","scale(2) translate(-1.5,0)")
-                    .attr("fill", "black")
+                    .attr("fill", (gse)-> scope.pinColor(gse))
                 )
         g.append("path")
           .attr("d", "M3,2.492c0,1.392-1.5,4.48-1.5,4.48S0,3.884,0,2.492c0-1.392,0.671-2.52,1.5-2.52S3,1.101,3,2.492z")
           .attr("class",(gse)-> "grade_scheme-pointer-" + gse.lowest_points)
           # move the pins over so the point is on the right value
           .attr("transform","scale(2) translate(-1.5,0)")
+          .attr("fill", (gse)-> scope.pinColor(gse))
         txt = d3.select("#svg-grade-level-text").selectAll('g').data(PredictorService.gradeSchemeElements).enter()
                 .append('g')
                 .attr("class", (gse)->
@@ -93,7 +108,7 @@
               angular.element(".grade_scheme-label-" + gse.lowest_points)[0].getBBox().width + (padding * 2)
             )
           .attr("height", 22)
-          .attr("fill","#68A127")
+          .attr("fill", (gse)-> scope.pinTextColor(gse))
         txt.attr("transform", (gse)->
           "translate(" + scope.gradeLevelPosition(scale,gse.lowest_points,stats.width,padding) + "," + 0 + ")")
         graph = d3.select("svg").append("g")

--- a/app/assets/javascripts/angular/directives/predictor/graph.coffee
+++ b/app/assets/javascripts/angular/directives/predictor/graph.coffee
@@ -40,7 +40,7 @@
 
       # Don't let the hover boxes with grades info fall off the right side
       scope.gradeLevelPosition = (scale,lowRange,width,padding)->
-        alignWithTickMark = 8
+        alignWithTickMark = 3.5
         position = scale(lowRange)
         textWidth = angular.element(".grade_scheme-label-" + lowRange)[0].getBBox().width
         if position < padding
@@ -63,13 +63,13 @@
                 .on("mouseover", (gse)->
                   d3.select(".grade_scheme-label-" + gse.lowest_points).style("visibility", "visible")
                   d3.select(".grade_scheme-pointer-" + gse.lowest_points)
-                    .attr("transform","scale(4) translate(-.5,-3)")
+                    .attr("transform","scale(4) translate(-1.5,-3)")
                     .attr("fill", "#68A127")
                 )
                 .on("mouseout", (gse)->
                   d3.select(".grade_scheme-label-" + gse.lowest_points).style("visibility", "hidden")
                   d3.select(".grade_scheme-pointer-" + gse.lowest_points)
-                    .attr("transform","scale(2) translate(0,0)")
+                    .attr("transform","scale(2) translate(-1.5,0)")
                     .attr("fill", "black")
                 )
         g.append("path")

--- a/app/assets/javascripts/angular/services/PredictorService.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.coffee
@@ -160,6 +160,10 @@
     subset = _.where(assignments, {is_locked: true})
     total = AssignmentService.assignmentsSubsetPredictedPoints(subset)
 
+  lockedGradeSchemeElementsPresent = ()->
+    debugger
+    _.where(assignments, {is_locked: true})
+
   # Total points actually earned to date
   allPointsEarned = ()->
     total = 0

--- a/app/assets/javascripts/angular/services/PredictorService.coffee
+++ b/app/assets/javascripts/angular/services/PredictorService.coffee
@@ -161,8 +161,7 @@
     total = AssignmentService.assignmentsSubsetPredictedPoints(subset)
 
   lockedGradeSchemeElementsPresent = ()->
-    debugger
-    _.where(assignments, {is_locked: true})
+    _.where(gradeSchemeElements, {is_locked: true}).length > 0
 
   # Total points actually earned to date
   allPointsEarned = ()->
@@ -214,6 +213,7 @@
       postPredictedArticle: postPredictedArticle
       allPointsPredicted: allPointsPredicted
       lockedPointsPredicted: lockedPointsPredicted
+      lockedGradeSchemeElementsPresent: lockedGradeSchemeElementsPresent
       allPointsEarned: allPointsEarned
       predictedGradeLevel: predictedGradeLevel
 

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -26,7 +26,7 @@
     %g{"ng-if"=>"lockedGradeSchemeElementsPresent()",  "id" => "svg-gse-locked-key", "transform" => "translate(320,120)"}
       %path.key{"d"=>"M3,2.492c0,1.392-1.5,4.48-1.5,4.48S0,3.884,0,2.492c0-1.392,0.671-2.52,1.5-2.52S3,1.101,3,2.492z", "transform"=>"scale(2) translate(5,1)"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Open Sans"}
-        Locked Grade Scheme Element
+        Locked Grade Level
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}
       %text.description
         Predicted Final Outcome:

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -23,6 +23,10 @@
       %rect.key{"width"=>"20", "height"=>"20", "mask"=>"url(#mask-stripe)"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Open Sans"}
         Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
+    %g{"ng-if"=>"true",  "id" => "svg-gse-locked-key", "transform" => "translate(300,120)"}
+      %rect.key{"width"=>"20", "height"=>"20"}
+      %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Open Sans"}
+        Locked Grade Scheme Element
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}
       %text.description
         Predicted Final Outcome:

--- a/app/assets/javascripts/angular/templates/predictor/graph.html.haml
+++ b/app/assets/javascripts/angular/templates/predictor/graph.html.haml
@@ -23,8 +23,8 @@
       %rect.key{"width"=>"20", "height"=>"20", "mask"=>"url(#mask-stripe)"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Open Sans"}
         Predicted Points that are Locked: {{lockedPointsPredicted() | number}}
-    %g{"ng-if"=>"true",  "id" => "svg-gse-locked-key", "transform" => "translate(300,120)"}
-      %rect.key{"width"=>"20", "height"=>"20"}
+    %g{"ng-if"=>"lockedGradeSchemeElementsPresent()",  "id" => "svg-gse-locked-key", "transform" => "translate(320,120)"}
+      %path.key{"d"=>"M3,2.492c0,1.392-1.5,4.48-1.5,4.48S0,3.884,0,2.492c0-1.392,0.671-2.52,1.5-2.52S3,1.101,3,2.492z", "transform"=>"scale(2) translate(5,1)"}
       %text.description{"x"=>"22", "y"=>"16", "font-family"=>"Open Sans"}
         Locked Grade Scheme Element
     %g{"id" => "svg-predicted-grade", "transform" => "translate(10,165)"}

--- a/app/assets/stylesheets/pages/_predictor.sass
+++ b/app/assets/stylesheets/pages/_predictor.sass
@@ -93,6 +93,11 @@ $card-margin-1 : 3px
       fill: $color-blue-3
       width: 20px
       height: 20px
+  #svg-gse-locked-key
+    .key
+      fill: $color-red-1
+      width: 20px
+      height: 20px
   #svg-predicted-grade
     font-size: $predictor-font-size-3
     font-weight: bold

--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -7,6 +7,9 @@ class API::GradeSchemeElementsController < ApplicationController
   # GET /api/grade_scheme_elements
   def index
     assign_for_index
+    if current_user_is_student?
+      @student = current_student
+    end
   end
 
   # POST /api/grade_scheme_elements

--- a/app/views/api/grade_scheme_elements/index.json.jbuilder
+++ b/app/views/api/grade_scheme_elements/index.json.jbuilder
@@ -4,6 +4,9 @@ json.data @grade_scheme_elements do |gse|
   json.attributes do
     json.merge! gse.attributes
     json.name gse.name
+    if @student.present?
+      json.locked gse.is_unlockable? && gse.is_unlocked_for_student(@student)
+    end
   end
 end
 

--- a/app/views/api/grade_scheme_elements/index.json.jbuilder
+++ b/app/views/api/grade_scheme_elements/index.json.jbuilder
@@ -5,7 +5,7 @@ json.data @grade_scheme_elements do |gse|
     json.merge! gse.attributes
     json.name gse.name
     if @student.present?
-      json.locked gse.is_unlockable? && gse.is_unlocked_for_student(@student)
+      json.locked gse.is_unlockable? && !gse.is_unlocked_for_student?(@student)
     end
   end
 end

--- a/app/views/api/grade_scheme_elements/index.json.jbuilder
+++ b/app/views/api/grade_scheme_elements/index.json.jbuilder
@@ -5,7 +5,7 @@ json.data @grade_scheme_elements do |gse|
     json.merge! gse.attributes
     json.name gse.name
     if @student.present?
-      json.locked gse.is_unlockable? && !gse.is_unlocked_for_student?(@student)
+      json.is_locked gse.is_unlockable? && !gse.is_unlocked_for_student?(@student)
     end
   end
 end


### PR DESCRIPTION
### Status
**READY**

### Description

If a Grade Scheme Element is Locked for a student in a course, it will show up as a red pointer in the predictor to alert the student.

<img width="764" alt="screen shot 2018-03-14 at 11 03 02 am" src="https://user-images.githubusercontent.com/1138350/37419021-ebea2ed8-2789-11e8-966b-17bd70dafad9.png">
<img width="774" alt="screen shot 2018-03-14 at 11 03 10 am" src="https://user-images.githubusercontent.com/1138350/37419022-ec081c86-2789-11e8-9794-cea8c2fc680c.png">

Similar to other unlocks, if there are no locked GSEs affecting the student's grade, the additional keys do not appear under the graph:

<img width="942" alt="screen shot 2018-03-22 at 9 41 51 am" src="https://user-images.githubusercontent.com/1138350/37773934-4f62978a-2db5-11e8-9d84-1b2691fe75a8.png">

### Additions

Fixes a bug with the placement of pinpoints after blur on a GSE hover.

#### Caveats

The graph itself has not changed -- It seemed like the layers of information would become too dense if we try and add yet another color or overlay. Lacking a graphical mockup of a viable solution, I have left this work for later, on the chance that we have the resources and user feedback that indicates it would be worth the effort.

I can imagine a number of other enhancements, for instance better mobile styling, or a lock icon included somewhere within the graph, but these all would take quite a lot of effort to implement within the svg element. They would have to be thoroughly planned before execution, and should be assigned their own ticket.

### Steps to Test or Reproduce
1) Add a lock to a Grade scheme element that is closed for a student, and view the predictor as that student.
2) The key description should only show when there is a locked GSE present.

### Impacted Areas in Application
Predictor, unlocks

======================
Closes #3344 

