### PR TITLE
Update admin attribute on user model

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -17,6 +17,9 @@ namespace :users do
       fail "ERROR: username not found (\"#{ENV['username']}\")"
     end
 
+    user.update admin: true
+    puts "Updated admin attribute for future courses"
+
     Course.find_each(batch_size: 500) do |course|
       membership = CourseMembership.find_or_create_by course: course, user: user
       membership.role = 'admin'


### PR DESCRIPTION
### Status
READY

### Description
Makes a small tweak to the `users:make_admin_on_all_courses` task so that it also updates the `admin` attribute on the user model to `true`.

Purpose is to automatically make the user an admin on all future courses that are created as well.

Run as usual by executing the following command in the Gradecraft directory (**not** in console):
```
bundle exec rails users:make_admin_on_all_courses username=jonathoy
```