### PR TITLE
Fix visibility bug on outcome progress

### DIFF
--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -39,10 +39,10 @@ class LearningObjective < ActiveRecord::Base
 
   def grade_outcome_progress_for(cumulative_outcome, include_details)
     outcomes = observed_outcomes(cumulative_outcome)
+    return "Not Started" if outcomes.empty?
     return "Failed" if outcomes.any? { |o| o.learning_objective_level.failed? }
 
     proficient_outcomes = observed_outcomes(cumulative_outcome, true)
-    return "Not Started" if proficient_outcomes.empty?
     proficient_outcomes.count < count_to_achieve ? in_progress_str(proficient_outcomes.count, count_to_achieve, include_details) : "Completed"
   end
 

--- a/app/models/learning_objective_cumulative_outcome.rb
+++ b/app/models/learning_objective_cumulative_outcome.rb
@@ -10,8 +10,4 @@ class LearningObjectiveCumulativeOutcome < ActiveRecord::Base
     message: "should be unique per learning objective" }
 
   scope :for_user, -> (user_id) { where user_id: user_id }
-
-  def failed?
-    observed_outcomes.any? { |o| o.learning_objective_level.failed? }
-  end
 end

--- a/spec/factories/learning_objective_observed_outcome_factory.rb
+++ b/spec/factories/learning_objective_observed_outcome_factory.rb
@@ -5,14 +5,8 @@ FactoryGirl.define do
     assessed_at { Faker::Date.backward(60) }
     comments { Faker::Hipster.sentence }
 
-    factory :learning_objective_observed_outcome_grade do
-      transient do
-        student_visible_grade true
-      end
-
-      grade do
-        create :grade, student_visible: student_visible_grade
-      end
+    factory :student_visible_observed_outcome do
+      association :grade, factory: :student_visible_grade
     end
   end
 end

--- a/spec/models/learning_objective_observed_outcome_spec.rb
+++ b/spec/models/learning_objective_observed_outcome_spec.rb
@@ -1,6 +1,6 @@
 describe LearningObjectiveObservedOutcome do
   describe "validations" do
-    let(:outcome) { build_stubbed :learning_objective_observed_outcome_grade }
+    let(:outcome) { build_stubbed :learning_objective_observed_outcome }
 
     it "require an assessed at date" do
       outcome.assessed_at = nil


### PR DESCRIPTION
### Status
READY

### Description
A condition was observed where if an existing grade was edited and the visibility was set back to false, an instructor could assess for a failed objective level and have it autosave without having submitted the grade yet. The student in this case would then see that they failed, even though the grade was not yet visible.

### Impacted Areas in Application
Learning Objectives

======================
Closes #3919
