### PR TITLE
Reduce Possibility for Duplicate Course Copy Requests

### DIFF
--- a/app/views/courses/_admin_table.haml
+++ b/app/views/courses/_admin_table.haml
@@ -57,6 +57,6 @@
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
               %ul.options-menu.dropdown-content
                 %li= link_to decorative_glyph(:edit) + "Edit", edit_course_path(course)
-                %li= link_to decorative_glyph(:copy) + "Copy", copy_courses_path(id: course.id), :method => :copy
-                %li= link_to decorative_glyph(:copy) + "Copy + Students", copy_courses_path(id: course.id, copy_type: "with_students"), :method => :copy
+                %li= link_to decorative_glyph(:copy) + "Copy", copy_courses_path(id: course.id), data: { disable_with: "Copying..." }, :method => :copy
+                %li= link_to decorative_glyph(:copy) + "Copy + Students", copy_courses_path(id: course.id, copy_type: "with_students"), data: { disable_with: "Copying..." }, :method => :copy
                 %li= link_to glyph(:trash) + "Delete", course, id: "course-id-#{course.id}", data: { confirm: "This will delete #{course.name} - are you sure?" }, :method => :delete

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -51,6 +51,11 @@ describe Course do
       expect{ subject }.to raise_error CopyValidationError
     end
 
+    it "creates only one copy" do
+      course
+      expect{ subject }.to change(Course, :count).by 1
+    end
+
     it "makes a duplicated copy of itself" do
       expect(subject).to_not eq course
     end


### PR DESCRIPTION
### Status
READY

### Description
Not really an big issue, but there is the possibility that you can click on the course copy button one too many times by accident and therefore create multiple copies.

This PR proposes the use of `disable_with` on the link, so as to disable multiple clicks in the browser using the unobtrusive Javascript driver and some built-in Rails magic.

Closes #3920