### PR TITLE
3881 Add Team column to final grade exports

### DIFF
--- a/app/exporters/course_grade_exporter.rb
+++ b/app/exporters/course_grade_exporter.rb
@@ -18,7 +18,6 @@ class CourseGradeExporter
   end
 
   def student_data(student, course)
-    # binding.pry
     [student.first_name,
       student.last_name,
       student.email,

--- a/app/exporters/course_grade_exporter.rb
+++ b/app/exporters/course_grade_exporter.rb
@@ -13,11 +13,12 @@ class CourseGradeExporter
   private
 
   def baseline_headers
-    ["First Name", "Last Name", "Email", "Username", "Score", "Grade", "Level",
+    ["First Name", "Last Name", "Email", "Username", "Score", "Grade", "Level", "Team",
       "Earned Badge #", "GradeCraft ID", "GradeCraft Account Created", "Last Logged In At", "Auditing" ]
   end
 
   def student_data(student, course)
+    # binding.pry
     [student.first_name,
       student.last_name,
       student.email,
@@ -25,6 +26,7 @@ class CourseGradeExporter
       student.score_for_course(course),
       student.grade_letter_for_course(course),
       student.grade_level_for_course(course),
+      student.team_for_course(course).try(:name),
       student.earned_badges_for_course(course).count,
       student.id,
       student.created_at,

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -12,7 +12,7 @@
       %tbody
         %tr
           %td= link_to glyph("file-excel-o") + "Final Grades", final_grades_path(id: current_course.id, format: "csv")
-          %td First Name, Last Name, Email, Username, Score, Grade, Level, Earned Badge #, GradeCraft ID, Last Logged In, Auditing
+          %td First Name, Last Name, Email, Username, Score, Grade, Level, Team, Earned Badge #, GradeCraft ID, Last Logged In, Auditing
         %tr
           %td= link_to glyph("file-excel-o") + "Full Gradebook", gradebook_file_path(id: current_course.id, format: "csv")
           %td First Name, Last Name, Email, Username, #{ term_for :team }, Final grades for all #{ term_for :assignments }

--- a/spec/exporters/course_grade_exporter_spec.rb
+++ b/spec/exporters/course_grade_exporter_spec.rb
@@ -3,16 +3,20 @@ describe CourseGradeExporter do
   subject { CourseGradeExporter.new }
 
   describe "#final_grades_for_course(course)" do
+    let!(:team) { create :team, course: course }
 
     it "generates an empty CSV if there are no students" do
       csv = subject.final_grades_for_course(course)
-      expect(csv).to include "First Name,Last Name,Email,Username,Score,Grade,Level,Earned Badge #,GradeCraft ID,GradeCraft Account Created,Last Logged In At,Auditing"
+      expect(csv).to include "First Name,Last Name,Email,Username,Score,Grade,Level,Team,Earned Badge #,GradeCraft ID,GradeCraft Account Created,Last Logged In At,Auditing"
     end
 
     it "generates a CSV with student grades for the course" do
       @student = create(:user, first_name: "Pinky", last_name: "Alpha")
       @student_2 = create(:user, first_name: "The Brain", last_name: "Zed")
       create(:course_membership, :student, course: course, user: @student, score: 80000, auditing: true)
+      # let!(:team_membership) { create :team_membership, team: team, student: student }
+      create(:team_membership, team: team, student: @student)
+      create(:team_membership, team: team, student: @student_2)
       @students = course.students
       create(:course_membership, :student, course: course, user: @student_2, score: 120000, auditing: false)
       create(:grade_scheme_element, course: course, level: "Amazing", letter: "B-")
@@ -34,12 +38,14 @@ describe CourseGradeExporter do
       expect(csv[2][5]).to eq "B"
       expect(csv[1][6]).to eq "Amazing"
       expect(csv[2][6]).to eq "Phenomenal"
-      expect(csv[1][7]).to eq "0"
-      expect(csv[2][7]).to eq "0"
-      expect(csv[1][8]).to eq "#{@student.id}"
-      expect(csv[2][8]).to eq "#{@student_2.id}"
-      expect(csv[1][11]).to eq "Yes"
-      expect(csv[2][11]).to eq "No"
+      expect(csv[1][7]).to eq @student.team_for_course(course).name
+      expect(csv[2][7]).to eq @student_2.team_for_course(course).name
+      expect(csv[1][8]).to eq "0"
+      expect(csv[2][8]).to eq "0"
+      expect(csv[1][9]).to eq "#{@student.id}"
+      expect(csv[2][9]).to eq "#{@student_2.id}"
+      expect(csv[1][12]).to eq "Yes"
+      expect(csv[2][12]).to eq "No"
     end
   end
 end

--- a/spec/exporters/course_grade_exporter_spec.rb
+++ b/spec/exporters/course_grade_exporter_spec.rb
@@ -14,7 +14,6 @@ describe CourseGradeExporter do
       @student = create(:user, first_name: "Pinky", last_name: "Alpha")
       @student_2 = create(:user, first_name: "The Brain", last_name: "Zed")
       create(:course_membership, :student, course: course, user: @student, score: 80000, auditing: true)
-      # let!(:team_membership) { create :team_membership, team: team, student: student }
       create(:team_membership, team: team, student: @student)
       create(:team_membership, team: team, student: @student_2)
       @students = course.students

--- a/spec/features/downloading_final_grades_spec.rb
+++ b/spec/features/downloading_final_grades_spec.rb
@@ -16,7 +16,7 @@ feature "downloading final grades file" do
 
       expect(page.response_headers["Content-Type"]).to eq("text/csv")
 
-      expect(page).to have_content "First Name,Last Name,Email,Username,Score,Grade,Level,Earned Badge #,GradeCraft ID"
+      expect(page).to have_content "First Name,Last Name,Email,Username,Score,Grade,Level,Team,Earned Badge #,GradeCraft ID"
     end
   end
 end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Add 'Team' column to Final Grades Export

### Related PRs
List related PRs against other branches:

Branch | PR
------ | ------
3748 | [link](https://github.com/UM-USElab/gradecraft-development/pull/3888)
3884 | [link](https://github.com/UM-USElab/gradecraft-development/pull/3891)

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the Course Data Exports page. Download the Final Grades export. While reviewing the exported csv file, note the new column "Teams" that lists the corresponding team for each student.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Exports

======================
Closes #3881 
