### PR TITLE
3899 simplify resubmissions

### DIFF
--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -1,3 +1,5 @@
+require_relative "../../../services/creates_or_updates_submission"
+
 class API::Assignments::SubmissionsController < ApplicationController
   before_action :ensure_student?
 
@@ -24,7 +26,9 @@ class API::Assignments::SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     @submission = assignment.submissions.new merged_submission_params(assignment)
 
-    if @submission.save
+    if @submission.save #Put Service call here
+      binding.pry
+      Services::CreatesOrUpdatesSubmission.create_or_update_submission assignment @submission
       render "api/assignments/submissions/submission", status: 201
     else
       render "api/assignments/submissions/errors", status: 500
@@ -38,7 +42,10 @@ class API::Assignments::SubmissionsController < ApplicationController
     @submission = assignment.submissions.find_by_id(params[:id])
 
     if @submission.present?
-      if @submission.update_attributes submission_params
+      binding.pry
+      if @submission.update_attributes submission_params #Put service call here
+        Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
+
         render "api/assignments/submissions/submission", status: 200
       else
         render "api/assignments/submissions/errors", status: 500

--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -1,5 +1,3 @@
-require_relative "../../../services/creates_or_updates_submission"
-
 class API::Assignments::SubmissionsController < ApplicationController
   before_action :ensure_student?
 

--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -26,9 +26,8 @@ class API::Assignments::SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     @submission = assignment.submissions.new merged_submission_params(assignment)
 
-    result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submission
+    result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
     if result.success?
-      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
       render "api/assignments/submissions/submission", status: 201
     else
       render "api/assignments/submissions/errors", status: 500

--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -26,7 +26,8 @@ class API::Assignments::SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     @submission = assignment.submissions.new merged_submission_params(assignment)
 
-    if @submission.save #Put Service call here
+    result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submission
+    if result.success?
       Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
       render "api/assignments/submissions/submission", status: 201
     else

--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -26,8 +26,7 @@ class API::Assignments::SubmissionsController < ApplicationController
     assignment = Assignment.find(params[:assignment_id])
     @submission = assignment.submissions.new merged_submission_params(assignment)
 
-    result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
-    if result.success?
+    if @submission.save
       render "api/assignments/submissions/submission", status: 201
     else
       render "api/assignments/submissions/errors", status: 500
@@ -41,9 +40,7 @@ class API::Assignments::SubmissionsController < ApplicationController
     @submission = assignment.submissions.find_by_id(params[:id])
 
     if @submission.present?
-      if @submission.update_attributes submission_params #Put service call here
-        Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
-
+      if @submission.update_attributes submission_params
         render "api/assignments/submissions/submission", status: 200
       else
         render "api/assignments/submissions/errors", status: 500

--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -27,8 +27,7 @@ class API::Assignments::SubmissionsController < ApplicationController
     @submission = assignment.submissions.new merged_submission_params(assignment)
 
     if @submission.save #Put Service call here
-      binding.pry
-      Services::CreatesOrUpdatesSubmission.create_or_update_submission assignment @submission
+      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
       render "api/assignments/submissions/submission", status: 201
     else
       render "api/assignments/submissions/errors", status: 500
@@ -42,7 +41,6 @@ class API::Assignments::SubmissionsController < ApplicationController
     @submission = assignment.submissions.find_by_id(params[:id])
 
     if @submission.present?
-      binding.pry
       if @submission.update_attributes submission_params #Put service call here
         Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, @submission
 

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -41,7 +41,6 @@ class InfoController < ApplicationController
     submissions = current_course.submissions.submitted.includes(:assignment, :grade, :student, :group, :submission_files)
     @ungraded_submissions_by_assignment = active_individual_and_group_submissions(submissions.ungraded)
     @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
-    # @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmission?)
     @in_progress_grades_by_assignment = grades.in_progress
     @ready_for_release_grades_by_assignment = grades.includes(:assignment, :student, :group).ready_for_release
   end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -40,7 +40,8 @@ class InfoController < ApplicationController
     grades = current_course.grades.for_active_students.instructor_modified
     submissions = current_course.submissions.submitted.includes(:assignment, :grade, :student, :group, :submission_files)
     @ungraded_submissions_by_assignment = active_individual_and_group_submissions(submissions.ungraded)
-    @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
+    # @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
+    @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmission?)
     @in_progress_grades_by_assignment = grades.in_progress
     @ready_for_release_grades_by_assignment = grades.includes(:assignment, :student, :group).ready_for_release
   end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -40,8 +40,8 @@ class InfoController < ApplicationController
     grades = current_course.grades.for_active_students.instructor_modified
     submissions = current_course.submissions.submitted.includes(:assignment, :grade, :student, :group, :submission_files)
     @ungraded_submissions_by_assignment = active_individual_and_group_submissions(submissions.ungraded)
-    # @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
-    @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmission?)
+    @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmitted)
+    # @resubmissions_by_assignment = active_individual_and_group_submissions(submissions.resubmission?)
     @in_progress_grades_by_assignment = grades.in_progress
     @ready_for_release_grades_by_assignment = grades.includes(:assignment, :student, :group).ready_for_release
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -41,7 +41,7 @@ class SubmissionsController < ApplicationController
     # rubocop:disable AndOr
     redirect_to redirect_to, notice: "#{assignment.name} was successfully submitted." and return
 
-    # end
+    end
     render :new, Submissions::NewPresenter.build(assignment_id: params[:assignment_id],
                                               submission: submission,
                                               student: submission.student,

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -39,10 +39,7 @@ class SubmissionsController < ApplicationController
       # rubocop:disable AndOr
       redirect_to redirect_to, notice: "#{@assignment.name} was successfully submitted." and return
     end
-    # rubocop:disable AndOr
-    redirect_to redirect_to, notice: "#{assignment.name} was successfully submitted." and return
 
-    end
     render :new, Submissions::NewPresenter.build(assignment_id: params[:assignment_id],
                                               submission: submission,
                                               student: submission.student,

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -27,8 +27,9 @@ class SubmissionsController < ApplicationController
   def create
     submission = @assignment.submissions.new(submission_params.merge(submitted_at: DateTime.now))
 
-    if submission.save
-      Services::CreatesOrUpdatesSubmission.create_or_update_submission assignment @submission
+    result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission @assignment, submission
+    if result.success?
+
       submission.check_and_set_late_status!
       redirect_to = (session.delete(:return_to) || assignment_path(@assignment))
       if current_user_is_student?

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -38,6 +38,10 @@ class SubmissionsController < ApplicationController
       # rubocop:disable AndOr
       redirect_to redirect_to, notice: "#{@assignment.name} was successfully submitted." and return
     end
+    # rubocop:disable AndOr
+    redirect_to redirect_to, notice: "#{assignment.name} was successfully submitted." and return
+
+    # end
     render :new, Submissions::NewPresenter.build(assignment_id: params[:assignment_id],
                                               submission: submission,
                                               student: submission.student,
@@ -49,14 +53,7 @@ class SubmissionsController < ApplicationController
   # GET /assignments/:assignment_id/submissions/:id/edit
   def edit
     presenter = Submissions::EditPresenter.new(presenter_attrs_with_id)
-<<<<<<< HEAD
     ensure_editable? presenter.submission, @assignment or return
-=======
-    ensure_editable presenter.submission, @assignment or return
-    if
-      presenter.submission.resubmission = true
-    end
->>>>>>> 3899 Simplify Resubmissions initial commit
     authorize! :update, presenter.submission
     render :edit, locals: { presenter: presenter }
   end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -63,7 +63,10 @@ class SubmissionsController < ApplicationController
 
     submission_was_draft = submission.unsubmitted?
     respond_to do |format|
-      if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) && Services::DeletesSubmissionDraftContent.for(submission).success?
+      submission.update_attributes(submission_params.merge(submitted_at: DateTime.now))
+      result = Services::CreatesOrUpdatesSubmission.creates_or_updates_submission @assignment, submission
+
+      if result.success? && Services::DeletesSubmissionDraftContent.for(submission).success?
         submission.check_and_set_late_status! unless submission.will_be_resubmitted?
 
         redirect_to = assignment_submission_path @assignment,

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -57,7 +57,8 @@ module LinkHelper
   def edit_grade_link_to(grade, options={})
     return unless current_user_is_admin? || current_course.active?
     confirm_message = 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
-    if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmitted?
+    # if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmitted?
+    if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmission?
       options.merge! data: { confirm:  confirm_message }
       link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), options
     elsif grade.student_visible?

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -57,7 +57,6 @@ module LinkHelper
   def edit_grade_link_to(grade, options={})
     return unless current_user_is_admin? || current_course.active?
     confirm_message = 'This grade is about to be marked as ungraded and unavailable to the student - it won\'t be visible again until you click "Submit" - are you sure?'
-    # if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmitted?
     if grade.assignment.accepts_submissions? && grade.submission && grade.submission.resubmission?
       options.merge! data: { confirm:  confirm_message }
       link_to decorative_glyph(:edit) + "Re-grade", edit_grade_path(grade), options

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,6 +1,5 @@
 module SubmissionsHelper
   def resubmission_count_for(course)
-    active_individual_and_group_submissions(course.submissions.resubmitted).count
     Rails.cache.fetch(resubmission_count_cache_key(course)) do
       active_individual_and_group_submissions(course.submissions.resubmitted).count
     end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -2,6 +2,7 @@ module SubmissionsHelper
   def resubmission_count_for(course)
     Rails.cache.fetch(resubmission_count_cache_key(course)) do
       active_individual_and_group_submissions(course.submissions.submitted.resubmitted).count
+      # active_individual_and_group_submissions(course.submissions.submitted.resubmission?).count
     end
   end
 

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,8 +1,8 @@
 module SubmissionsHelper
   def resubmission_count_for(course)
+    active_individual_and_group_submissions(course.submissions.resubmitted).count
     Rails.cache.fetch(resubmission_count_cache_key(course)) do
-      active_individual_and_group_submissions(course.submissions.submitted.resubmitted).count
-      # active_individual_and_group_submissions(course.submissions.submitted.resubmission?).count
+      active_individual_and_group_submissions(course.submissions.resubmitted).count
     end
   end
 

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -8,7 +8,8 @@ module GradeStatus
     scope :not_released, -> { where(instructor_modified: true, student_visible: false)}
     scope :ready_for_release, -> { where(instructor_modified: true, complete: true, student_visible: false)}
     scope :student_visible, ->  { where(student_visible: true) }
-    scope :complete, -> { where(student_visible: true, complete: true) }
+    # Needs validation to ensure that a grade cannot be complete but invisible to student
+    # scope :complete, -> { where(student_visible: true, complete: true) }
   end
 
   def in_progress?

--- a/app/models/concerns/grade_status.rb
+++ b/app/models/concerns/grade_status.rb
@@ -8,6 +8,7 @@ module GradeStatus
     scope :not_released, -> { where(instructor_modified: true, student_visible: false)}
     scope :ready_for_release, -> { where(instructor_modified: true, complete: true, student_visible: false)}
     scope :student_visible, ->  { where(student_visible: true) }
+    scope :complete, -> { where(student_visible: true, complete: true) }
   end
 
   def in_progress?

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -57,6 +57,7 @@ class Grade < ActiveRecord::Base
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }
   scope :not_nil, -> { where.not(score: nil)}
+  scope :for_group, ->(assignment, group) { where(assignment_id: assignment.id, group_id: group.id) }
 
   scope :for_active_students, -> do
     joins("INNER JOIN course_memberships ON "\

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -39,26 +39,6 @@ class Submission < ActiveRecord::Base
     .where.not(id: with_grade.where(grades: { instructor_modified: true }))
   end
 
-  # def submission_grade
-  #   if assignment.has_groups?
-  #     group.grade_for_assignment assignment if group.present?
-  #   else
-  #     student.grade_for_assignment assignment if student.present?
-  #   end
-  # end
-
-  # def resubmitted?
-  #   submission_grade && submission_grade.student_visible? &&
-  #   !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
-  # end
-
-  # scope :resubmitted, -> {
-  #   includes(:grade, :assignment)
-  #   .where("grades.student_visible = true")
-  #   .where("grades.graded_at < submitted_at")
-  #   .references(:grade, :assignment)
-  # }
-
   scope :order_by_submitted, -> { order("submitted_at ASC") }
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -39,6 +39,19 @@ class Submission < ActiveRecord::Base
     .where.not(id: with_grade.where(grades: { instructor_modified: true }))
   end
 
+  # def submission_grade
+  #   if assignment.has_groups?
+  #     group.grade_for_assignment assignment if group.present?
+  #   else
+  #     student.grade_for_assignment assignment if student.present?
+  #   end
+  # end
+
+  # def resubmitted?
+  #   submission_grade && submission_grade.student_visible? &&
+  #   !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
+  # end
+
   scope :resubmitted, -> {
     includes(:grade, :assignment)
     .where("grades.student_visible = true")
@@ -108,10 +121,10 @@ class Submission < ActiveRecord::Base
 
   # this is transitive so that once it is graded again, then
   # it will no longer be resubmitted
-  def resubmitted?
-    submission_grade && submission_grade.student_visible? &&
-    !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
-  end
+  # def resubmitted?
+  #   submission_grade && submission_grade.student_visible? &&
+  #   !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
+  # end
 
   # Getting the name of the student who submitted the work
   def name

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -29,10 +29,10 @@ class Submission < ActiveRecord::Base
   end
 
   scope :by_active_individual_students, -> do
-    individual
-      .joins(student: :course_memberships)
-      .where(student: { course_memberships: { active: true }})
-  end
+      individual
+        .includes(student: :course_memberships)
+        .where(student: { course_memberships: { active: true }})
+    end
 
   scope :ungraded, -> do
     includes(:assignment, :group, :student)
@@ -52,12 +52,12 @@ class Submission < ActiveRecord::Base
   #   !graded_at.nil? && !submitted_at.nil? && graded_at < submitted_at
   # end
 
-  scope :resubmitted, -> {
-    includes(:grade, :assignment)
-    .where("grades.student_visible = true")
-    .where("grades.graded_at < submitted_at")
-    .references(:grade, :assignment)
-  }
+  # scope :resubmitted, -> {
+  #   includes(:grade, :assignment)
+  #   .where("grades.student_visible = true")
+  #   .where("grades.graded_at < submitted_at")
+  #   .references(:grade, :assignment)
+  # }
 
   scope :order_by_submitted, -> { order("submitted_at ASC") }
   scope :for_course, ->(course) { where(course_id: course.id) }
@@ -67,6 +67,7 @@ class Submission < ActiveRecord::Base
   scope :submitted, -> { where.not(submitted_at: nil) }
   scope :with_group, -> { where "group_id is not null" }
   scope :individual, -> { where(group_id: nil) }
+  scope :resubmitted, -> { where(resubmission: true) }
 
   before_validation :cache_associations
 

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -127,7 +127,8 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def submission_resubmitted?(submission)
-    submission.nil? ? false : submission.resubmitted?
+    # submission.nil? ? false : submission.resubmitted?
+    submission.nil? ? false : submission.resubmission?
   end
 
   def new_assignment?

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -127,7 +127,6 @@ class Assignments::Presenter < Showtime::Presenter
   end
 
   def submission_resubmitted?(submission)
-    # submission.nil? ? false : submission.resubmitted?
     submission.nil? ? false : submission.resubmission?
   end
 

--- a/app/services/creates_or_updates_submission.rb
+++ b/app/services/creates_or_updates_submission.rb
@@ -1,0 +1,18 @@
+require "light-service"
+require_relative "creates_or_updates_submission/updates_submission_params"
+require_relative "creates_or_updates_submission/updates_resubmission_flag"
+
+module Services
+  class CreatesOrUpdatesSubmission
+    extend LightService::Organizer
+
+    def self.creates_or_updates_submission(assignment, submission)
+      binding.pry
+      with(assignment: assignment, submission: submission)
+        .reduce(
+          Actions::UpdateSubmissionParams,
+          Actions::UpdatesResubmissionFlag
+        )
+    end
+  end
+end

--- a/app/services/creates_or_updates_submission.rb
+++ b/app/services/creates_or_updates_submission.rb
@@ -7,7 +7,6 @@ module Services
     extend LightService::Organizer
 
     def self.creates_or_updates_submission(assignment, submission)
-      binding.pry
       with(assignment: assignment, submission: submission)
         .reduce(
           Actions::UpdateSubmissionParams,

--- a/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
+++ b/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
@@ -1,0 +1,25 @@
+module Services
+  module Actions
+    class UpdatesResubmissionFlag
+      extend LightService::Action
+
+      expects :assignment, :submission
+
+      executed do |context|
+        assignment = context[:assignment]
+        submission = context[:submission]
+        submission.resubmission = true if find_grade(assignment, submission)
+        submission.save
+
+      end
+
+      private
+
+      def self.find_grade(assignment, submission)
+        return true if Grade.where(assignment_id: assignment.id, student_id: submission.student_id)
+        return false
+      end
+
+    end
+  end
+end

--- a/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
+++ b/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
@@ -16,14 +16,14 @@ module Services
 
       def self.find_individual_grade(assignment, submission)
         if assignment.nil? == false && submission.student_id.nil? == false
-          return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).complete.empty?
+          return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).student_visible.empty?
         end
         return false
       end
 
       def self.find_group_grade(assignment, submission)
         if assignment.nil? == false && submission.group.nil? == false
-          return true if !Grade.for_group(assignment, submission.group).complete.empty?
+          return true if !Grade.for_group(assignment, submission.group).student_visible.empty?
         end
         return false
       end

--- a/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
+++ b/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
@@ -16,7 +16,7 @@ module Services
       private
 
       def self.find_grade(assignment, submission)
-        return true if Grade.where(assignment_id: assignment.id, student_id: submission.student_id)
+        return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).empty?
         return false
       end
 

--- a/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
+++ b/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
@@ -8,15 +8,23 @@ module Services
       executed do |context|
         assignment = context[:assignment]
         submission = context[:submission]
-        submission.resubmission = true if find_grade(assignment, submission)
+        submission.resubmission = true if find_individual_grade(assignment, submission) || find_group_grade(assignment, submission)
         submission.save
-
       end
 
       private
 
-      def self.find_grade(assignment, submission)
-        return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).empty?
+      def self.find_individual_grade(assignment, submission)
+        if assignment.nil? == false && submission.student_id.nil? == false
+          return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).complete.empty?
+        end
+        return false
+      end
+
+      def self.find_group_grade(assignment, submission)
+        if assignment.nil? == false && submission.group.nil? == false
+          return true if !Grade.for_group(assignment, submission.group).complete.empty?
+        end
         return false
       end
 

--- a/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
+++ b/app/services/creates_or_updates_submission/updates_resubmission_flag.rb
@@ -8,24 +8,17 @@ module Services
       executed do |context|
         assignment = context[:assignment]
         submission = context[:submission]
-        submission.resubmission = true if find_individual_grade(assignment, submission) || find_group_grade(assignment, submission)
-        submission.save
+        submission.update(resubmission: true) if current_grade_exists?(assignment, submission)
       end
 
       private
 
-      def self.find_individual_grade(assignment, submission)
-        if assignment.nil? == false && submission.student_id.nil? == false
-          return true if !Grade.where(assignment_id: assignment.id, student_id: submission.student_id).student_visible.empty?
+      def self.current_grade_exists?(assignment, submission)
+        if assignment.is_individual?
+          Grade.where(assignment_id: assignment.id, student_id: submission.student_id).student_visible.present?
+        else
+          Grade.for_group(assignment, submission.group).student_visible.present?
         end
-        return false
-      end
-
-      def self.find_group_grade(assignment, submission)
-        if assignment.nil? == false && submission.group.nil? == false
-          return true if !Grade.for_group(assignment, submission.group).student_visible.empty?
-        end
-        return false
       end
 
     end

--- a/app/services/creates_or_updates_submission/updates_submission_params.rb
+++ b/app/services/creates_or_updates_submission/updates_submission_params.rb
@@ -10,7 +10,7 @@ module Services
         submission = context[:submission]
 
         context.fail_with_rollback!("The submission is invalid and cannot be saved") \
-          unless submission.save!
+          unless submission.save
 
       end
     end

--- a/app/services/creates_or_updates_submission/updates_submission_params.rb
+++ b/app/services/creates_or_updates_submission/updates_submission_params.rb
@@ -9,7 +9,8 @@ module Services
         assignment = context[:assignment]
         submission = context[:submission]
 
-        submission.save!
+        context.fail_with_rollback!("The submission is invalid and cannot be saved") \
+          unless submission.save!
 
       end
     end

--- a/app/services/creates_or_updates_submission/updates_submission_params.rb
+++ b/app/services/creates_or_updates_submission/updates_submission_params.rb
@@ -1,0 +1,17 @@
+module Services
+  module Actions
+    class UpdateSubmissionParams
+      extend LightService::Action
+
+      expects :assignment, :submission
+
+      executed do |context|
+        assignment = context[:assignment]
+        submission = context[:submission]
+
+        submission.save!
+
+      end
+    end
+  end
+end

--- a/app/views/submissions/components/_dates_and_state.haml
+++ b/app/views/submissions/components/_dates_and_state.haml
@@ -1,7 +1,7 @@
 %p
   - if presenter.submission.present? && presenter.submission.submitted_at?
     %span.smallcaps Submitted:
-    %span.submission-date= l presenter.submission.submitted_at.in_time_zone(current_user.time_zone) 
+    %span.submission-date= l presenter.submission.submitted_at.in_time_zone(current_user.time_zone)
 
   // Late alert if submitted after due date
   - if presenter.submission.late?
@@ -9,5 +9,6 @@
       %i.fa.fa-fw.fa-clock-o
       %span.icon-text LATE
 
-  - if presenter.submission.resubmitted?
+  -# - if presenter.submission.resubmitted?
+  - if presenter.submission.resubmission?
     %span.label.alert Resubmitted!

--- a/app/views/submissions/components/_dates_and_state.haml
+++ b/app/views/submissions/components/_dates_and_state.haml
@@ -9,6 +9,5 @@
       %i.fa.fa-fw.fa-clock-o
       %span.icon-text LATE
 
-  -# - if presenter.submission.resubmitted?
   - if presenter.submission.resubmission?
     %span.label.alert Resubmitted!

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,7 +10,8 @@ Rails.application.configure do
     :address => "gcmailcatcher",
     :port => 25,
   }
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.active_support.deprecation = :notify
   config.assets.compile = ["1", "yes", "true", "on"].include?(ENV["GC_ASSETS_COMPILE"] || "0" )

--- a/db/migrate/20180307150401_add_boolean_resubmission_field.rb
+++ b/db/migrate/20180307150401_add_boolean_resubmission_field.rb
@@ -1,0 +1,5 @@
+class AddBooleanResubmissionField < ActiveRecord::Migration[5.0]
+  def change
+    add_column :submissions, :resubmission, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215211948) do
+ActiveRecord::Schema.define(version: 20180307150401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -793,6 +793,7 @@ ActiveRecord::Schema.define(version: 20180215211948) do
     t.datetime "submitted_at"
     t.boolean  "late",               default: false, null: false
     t.text     "text_comment_draft"
+    t.boolean  "resubmission",       default: false, null: false
     t.index ["assignment_id", "group_id"], name: "index_submissions_on_assignment_id_and_group_id", unique: true, using: :btree
     t.index ["assignment_id", "student_id"], name: "index_submissions_on_assignment_id_and_student_id", unique: true, using: :btree
     t.index ["assignment_id"], name: "index_submissions_on_assignment_id", using: :btree
@@ -864,8 +865,8 @@ ActiveRecord::Schema.define(version: 20180215211948) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "course_id"
-    t.index ["course_id"], name: "index_unlock_conditions_on_course_id", using: :btree
     t.index ["condition_id", "condition_type"], name: "index_unlock_conditions_on_condition_id_and_condition_type", using: :btree
+    t.index ["course_id"], name: "index_unlock_conditions_on_course_id", using: :btree
     t.index ["unlockable_id", "unlockable_type"], name: "index_unlock_conditions_on_unlockable_id_and_unlockable_type", using: :btree
   end
 

--- a/spec/features/viewing_submissions_spec.rb
+++ b/spec/features/viewing_submissions_spec.rb
@@ -21,7 +21,7 @@ feature "viewing submissions" do
         student: student, raw_points: 10000, student_visible: true,
         graded_at: DateTime.now
       submission.update_attributes link: "http://example.org",
-        submitted_at: DateTime.now
+        submitted_at: DateTime.now, resubmission: true
       visit assignment_path assignment
 
       within ".pageContent" do
@@ -39,7 +39,7 @@ feature "viewing submissions" do
         student: student, raw_points: 10000, student_visible: true,
         graded_at: DateTime.now
       submission.update_attributes link: "http://example.org",
-        submitted_at: DateTime.now
+        submitted_at: DateTime.now, resubmission: true
       visit assignment_submission_path assignment, submission
     end
 

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -2,11 +2,12 @@ describe SubmissionsHelper do
   let(:course) { create :course }
 
   describe "#resubmission_count_for" do
+    let!(:assignment) { create(:assignment) }
     let!(:student) { create(:course_membership, :student, course: course, active: true).user }
-    let!(:grade) { create :student_visible_grade, course: course, student_id: student.id, submission: submission,
+    let!(:grade) { create :student_visible_grade, course: course, student_id: student.id, assignment_id: assignment.id, submission: submission,
                    graded_at: 1.day.ago
                  }
-    let!(:submission) { create :submission, student_id: student.id, course: course, submitted_at: DateTime.now }
+    let!(:submission) { create :submission, student_id: student.id, assignment_id: assignment.id, course: course, resubmission: true, submitted_at: DateTime.now }
 
     it "returns the number of resubmitted submissions" do
       expect(resubmission_count_for(course)).to eq 1

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -169,6 +169,26 @@ describe Submission do
     end
   end
 
+  describe ".resubmitted" do
+    before { Submission.destroy_all }
+
+    it "returns only submissions where resubmitted is true" do
+      submitted_submission = create(:submission, assignment: assignment, student: student)
+      grade = create(:student_visible_grade, assignment: assignment, student: student)
+      grade.graded_at = grade.created_at
+      grade.save!
+      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submitted_submission
+
+      expect(Submission.resubmitted).to eq [submitted_submission]
+    end
+
+    it "returns only submissions where resubmitted is true" do
+      submitted_submission = create(:submission, assignment: assignment, student: student)
+
+      expect(Submission.resubmitted).to eq []
+    end
+  end
+
   describe "#submission_files_attributes=" do
     it "supports multiple file uploads" do
       file_attribute_1 = fixture_file "test_file.txt", "txt"
@@ -343,32 +363,32 @@ describe Submission do
     end
   end
 
-  describe "#resubmitted?" do
-    it "returns false if it has no grade" do
-      expect(submission).to_not be_resubmitted
-    end
-
-    it "returns true if grade was graded before it was submitted" do
-      create :grade, student_visible: true, student: student, submission: submission,
-        assignment: assignment, graded_at: DateTime.now
-      submission.update_attributes submitted_at: DateTime.now
-      expect(submission).to be_resubmitted
-    end
-
-    it "returns false if the grade was graded after it was submitted" do
-      submission.submitted_at = DateTime.now
-      submission.save
-      create :grade, student_visible: true, submission: submission,
-        assignment: submission.assignment, graded_at: DateTime.now
-      expect(submission).to_not be_resubmitted
-    end
-
-    it "returns false if it was not graded" do
-      create :grade, student_visible: true, submission: submission,
-        assignment: submission.assignment
-      expect(submission).to_not be_resubmitted
-    end
-  end
+  # describe "#resubmitted?" do
+  #   it "returns false if it has no grade" do
+  #     expect(submission).to_not be_resubmitted
+  #   end
+  #
+  #   it "returns true if grade was graded before it was submitted" do
+  #     create :grade, student_visible: true, student: student, submission: submission,
+  #       assignment: assignment, graded_at: DateTime.now
+  #     submission.update_attributes submitted_at: DateTime.now
+  #     expect(submission).to be_resubmitted
+  #   end
+  #
+  #   it "returns false if the grade was graded after it was submitted" do
+  #     submission.submitted_at = DateTime.now
+  #     submission.save
+  #     create :grade, student_visible: true, submission: submission,
+  #       assignment: submission.assignment, graded_at: DateTime.now
+  #     expect(submission).to_not be_resubmitted
+  #   end
+  #
+  #   it "returns false if it was not graded" do
+  #     create :grade, student_visible: true, submission: submission,
+  #       assignment: submission.assignment
+  #     expect(submission).to_not be_resubmitted
+  #   end
+  # end
 
   describe "#name" do
     it "returns the student's name" do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -294,9 +294,9 @@ describe Submission do
 
   describe ".resubmitted" do
     it "returns the submissions that have been submitted after they were graded" do
-      grade = create(:student_visible_grade, submission: submission, graded_at: 1.day.ago)
+      grade = create(:student_visible_grade, assignment: assignment, submission: submission, student: student, graded_at: 1.day.ago)
       submission.submitted_at = DateTime.now
-      submission.save
+      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submission
       expect(Submission.resubmitted).to eq [submission]
     end
 
@@ -323,16 +323,16 @@ describe Submission do
     end
 
     it "returns one submission for a group resubmissions" do
-      submission = build(:group_submission)
+      submission = build(:group_submission, assignment: assignment)
       student1 = create(:user)
       student2 = create(:user)
       group = create(:group, assignments: [submission.assignment])
       group.students << [student1, student2]
-      grade1 = create(:student_visible_grade, submission: submission, student: student1, graded_at: 1.day.ago)
-      grade2 = create(:student_visible_grade, submission: submission, student: student2, graded_at: 1.day.ago)
+      grade1 = create(:student_visible_grade, assignment: assignment, student: student1, group: group, graded_at: 1.day.ago)
+      grade2 = create(:student_visible_grade, assignment: assignment, student: student2, group: group, graded_at: 1.day.ago)
       submission.submitted_at = DateTime.now
       submission.group_id = group.id
-      submission.save
+      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submission
       expect(Submission.resubmitted).to eq [submission]
     end
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,6 +1,7 @@
 describe Submission do
   let(:course) { build_stubbed(:course) }
   let(:assignment) { create(:assignment) }
+  let(:group_assignment) { create(:assignment) }
   let(:student) { create(:course_membership, :student, course: course, active: true).user }
   let(:submission) { create(:submission, course: course, assignment: assignment, student: student) }
 
@@ -323,16 +324,17 @@ describe Submission do
     end
 
     it "returns one submission for a group resubmissions" do
-      submission = build(:group_submission, assignment: assignment)
+      group_assignment = build(:assignment, grade_scope: "Group")
+      submission = build(:group_submission, assignment: group_assignment)
       student1 = create(:user)
       student2 = create(:user)
       group = create(:group, assignments: [submission.assignment])
       group.students << [student1, student2]
-      grade1 = create(:student_visible_grade, assignment: assignment, student: student1, group: group, graded_at: 1.day.ago)
-      grade2 = create(:student_visible_grade, assignment: assignment, student: student2, group: group, graded_at: 1.day.ago)
+      grade1 = create(:student_visible_grade, assignment: group_assignment, student: student1, group: group, graded_at: 1.day.ago)
+      grade2 = create(:student_visible_grade, assignment: group_assignment, student: student2, group: group, graded_at: 1.day.ago)
       submission.submitted_at = DateTime.now
       submission.group_id = group.id
-      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission assignment, submission
+      Services::CreatesOrUpdatesSubmission.creates_or_updates_submission group_assignment, submission
       expect(Submission.resubmitted).to eq [submission]
     end
   end

--- a/spec/services/creates_or_updates_submission/updates_resubmission_flag_spec.rb
+++ b/spec/services/creates_or_updates_submission/updates_resubmission_flag_spec.rb
@@ -1,0 +1,28 @@
+describe Services::Actions::UpdatesResubmissionFlag do
+  let!(:course) { create :course }
+  let!(:student) { create(:course_membership, :student, course: course).user }
+  let!(:assignment) { create :assignment }
+  let!(:submission) { create :submission, assignment_id: assignment.id, student_id: student.id, resubmission: false }
+  let!(:grade) { create :grade, student_id: student.id, assignment_id: assignment.id, student_visible: true }
+
+  it "flips the resubmission flag if individual grade exists" do
+    expect { described_class.execute assignment: assignment, submission: submission}.to \
+      change { Submission.resubmitted.count }
+  end
+
+  it "flips the resubmission flag if group grade exists" do
+    group_assignment = build(:assignment, grade_scope: "Group")
+    group_submission = build(:group_submission, assignment: group_assignment)
+    student1 = create(:user)
+    student2 = create(:user)
+    group = create(:group, assignments: [submission.assignment])
+    group.students << [student1, student2]
+    grade1 = create(:student_visible_grade, assignment: group_assignment, student: student1, group: group, graded_at: 1.day.ago)
+    grade2 = create(:student_visible_grade, assignment: group_assignment, student: student2, group: group, graded_at: 1.day.ago)
+    group_submission.submitted_at = DateTime.now
+    group_submission.group_id = group.id
+    expect { described_class.execute assignment: group_assignment, submission: group_submission}.to \
+      change { Submission.resubmitted.count }
+  end
+
+end

--- a/spec/services/creates_or_updates_submission/updates_submission_params_spec.rb
+++ b/spec/services/creates_or_updates_submission/updates_submission_params_spec.rb
@@ -1,4 +1,4 @@
-describe Services::Actions::UpdateSubmissionParams, focus: true do
+describe Services::Actions::UpdateSubmissionParams do
   let!(:course) { create :course }
   let!(:student) { create(:course_membership, :student, course: course).user }
   let!(:assignment) { create :assignment }

--- a/spec/services/creates_or_updates_submission/updates_submission_params_spec.rb
+++ b/spec/services/creates_or_updates_submission/updates_submission_params_spec.rb
@@ -1,0 +1,14 @@
+describe Services::Actions::UpdateSubmissionParams, focus: true do
+  let!(:course) { create :course }
+  let!(:student) { create(:course_membership, :student, course: course).user }
+  let!(:assignment) { create :assignment }
+  let!(:submission) { create :submission, assignment_id: assignment.id, student_id: student.id, resubmission: false }
+  let!(:grade) { create :grade, student_id: student.id, assignment_id: assignment.id, student_visible: true }
+
+  it "saves the submission" do
+    new_submission = build(:submission, assignment: assignment)
+    expect { described_class.execute assignment: assignment, submission: new_submission }.to \
+      change { Submission.count }
+  end
+
+end

--- a/spec/services/creates_or_updates_submission_spec.rb
+++ b/spec/services/creates_or_updates_submission_spec.rb
@@ -1,0 +1,16 @@
+describe Services::CreatesOrUpdatesSubmission do
+  let(:assignment) { create :assignment }
+  let(:submission) { create :submission }
+
+  describe ".creates_or_updates_submission" do
+    it "updates the resubmission flag" do
+      expect(Services::Actions::UpdateSubmissionParams).to receive(:execute).and_call_original
+      described_class.creates_or_updates_submission assignment, submission
+    end
+
+    it "updates the existing submission" do
+      expect(Services::Actions::UpdateSubmissionParams).to receive(:execute).and_call_original
+      described_class.creates_or_updates_submission assignment, submission
+    end
+  end
+end


### PR DESCRIPTION
### Status
**READY**

### Description
_Expected Behavior_
As an instructor, when I create an assignment that accepts submissions and resubmissions, it won't matter if a student has submitted before or not, once the assignment has been graded the first time then every thing submitted afterwards will be considered a resubmission. This will be reflected on the Grading Status page.

_Actual Behavior_
As an instructor, when I create an assignment that accepts submissions and resubmissions, a scope and method are in place to look for a submission and a grade in order for a submission to be considered a resubmission.

### Related PRs
N/A


### Todos
- [x] Add Tests


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
YES

### Steps to Test or Reproduce
1. Have an instructor create an assignment that accepts submissions
2. Have a student start the submission process but not complete it.
3. Have the instructor grade the assignment as a non-submission
4. Have the student receive their grade and attempt to resubmit.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Submissions

======================
Closes #3899 
