### PR TITLE
Submissions after accept until

### DIFF
--- a/app/controllers/api/assignments/submissions_controller.rb
+++ b/app/controllers/api/assignments/submissions_controller.rb
@@ -31,6 +31,7 @@ class API::Assignments::SubmissionsController < ApplicationController
     end
   end
 
+  # For updating draft submissions only, does not allow submitting
   # PUT api/assignments/:assignment_id/submissions/:id
   def update
     assignment = Assignment.find(params[:assignment_id])

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -61,9 +61,11 @@ class SubmissionsController < ApplicationController
     respond_to do |format|
       if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) && Services::DeletesSubmissionDraftContent.for(submission).success?
         submission.check_and_set_late_status! unless submission.will_be_resubmitted?
-        path = @assignment.has_groups? ? { group_id: submission.group_id } :
-          { student_id: submission.student_id }
-        redirect_to = assignment_submission_path(@assignment, submission, path)
+        
+        redirect_to = assignment_submission_path @assignment,
+          submission,
+          @assignment.has_groups? ? { group_id: submission.group_id } : { student_id: submission.student_id }
+
         if current_user_is_student?
           send_notification(submission.id, submission_was_draft) if @assignment.is_individual?
           redirect_to = assignment_path(@assignment, anchor: "tabt1")

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,8 +3,11 @@ require_relative "../services/deletes_submission_draft_content"
 class SubmissionsController < ApplicationController
   before_action :ensure_not_observer?
   before_action :ensure_staff?, only: [:show, :destroy]
+  before_action :find_assignment
+  before_action :ensure_assignment_open?, except: [:show, :destroy], unless: proc { current_user_is_staff? }
   before_action :save_referer, only: [:new, :edit]
 
+  # GET /assignments/:assignment_id/submissions/:id
   def show
     @submission = Submission.find(params[:id])
     @grade = @submission.grade
@@ -13,25 +16,25 @@ class SubmissionsController < ApplicationController
     render :show, locals: { presenter: presenter }
   end
 
+  # GET /assignments/:assignment_id/submissions/new
   def new
-    @assignment = current_course.assignments.find(params[:assignment_id])
     presenter = Submissions::NewPresenter.new(base_presenter_attrs)
     render :new, presenter.render_options
   end
 
+  # POST /assignments/:assignment_id/submissions
   def create
-    assignment = current_course.assignments.find(params[:assignment_id])
-    submission = assignment.submissions.new(submission_params.merge(submitted_at: DateTime.now))
+    submission = @assignment.submissions.new(submission_params.merge(submitted_at: DateTime.now))
 
     if submission.save
       submission.check_and_set_late_status!
-      redirect_to = (session.delete(:return_to) || assignment_path(assignment))
+      redirect_to = (session.delete(:return_to) || assignment_path(@assignment))
       if current_user_is_student?
-        NotificationMailer.successful_submission(submission.id).deliver_now if assignment.is_individual?
-        redirect_to = assignment_path(assignment, anchor: "tabt1")
+        NotificationMailer.successful_submission(submission.id).deliver_now if @assignment.is_individual?
+        redirect_to = assignment_path(@assignment, anchor: "tabt1")
       end
       # rubocop:disable AndOr
-      redirect_to redirect_to, notice: "#{assignment.name} was successfully submitted." and return
+      redirect_to redirect_to, notice: "#{@assignment.name} was successfully submitted." and return
     end
     render :new, Submissions::NewPresenter.build(assignment_id: params[:assignment_id],
                                               submission: submission,
@@ -41,32 +44,32 @@ class SubmissionsController < ApplicationController
                                               view_context: view_context)
   end
 
+  # GET /assignments/:assignment_id/submissions/:id/edit
   def edit
-    @assignment = current_course.assignments.find(params[:assignment_id])
     presenter = Submissions::EditPresenter.new(presenter_attrs_with_id)
-    ensure_editable presenter.submission, @assignment or return
+    ensure_editable? presenter.submission, @assignment or return
     authorize! :update, presenter.submission
     render :edit, locals: { presenter: presenter }
   end
 
+  # PUT /assignments/:assignment_id/submissions/:id
   def update
-    assignment = current_course.assignments.find(params[:assignment_id])
-    submission = assignment.submissions.find(params[:id])
-    ensure_editable submission, assignment or return
+    submission = @assignment.submissions.find(params[:id])
+    ensure_editable? submission, @assignment or return
 
     submission_was_draft = submission.unsubmitted?
     respond_to do |format|
       if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) && Services::DeletesSubmissionDraftContent.for(submission).success?
         submission.check_and_set_late_status! unless submission.will_be_resubmitted?
-        path = assignment.has_groups? ? { group_id: submission.group_id } :
+        path = @assignment.has_groups? ? { group_id: submission.group_id } :
           { student_id: submission.student_id }
-        redirect_to = assignment_submission_path(assignment, submission, path)
+        redirect_to = assignment_submission_path(@assignment, submission, path)
         if current_user_is_student?
-          send_notification(submission.id, submission_was_draft) if assignment.is_individual?
-          redirect_to = assignment_path(assignment, anchor: "tabt1")
+          send_notification(submission.id, submission_was_draft) if @assignment.is_individual?
+          redirect_to = assignment_path(@assignment, anchor: "tabt1")
         end
-        format.html { redirect_to redirect_to, notice: "Your changes for #{assignment.name} were successfully submitted." }
-        format.json { render json: assignment, status: :created, location: assignment }
+        format.html { redirect_to redirect_to, notice: "Your changes for #{@assignment.name} were successfully submitted." }
+        format.json { render json: @assignment, status: :created, location: @assignment }
       else
         format.html do
           render :edit, Submissions::EditPresenter.build(id: params[:id],
@@ -81,13 +84,29 @@ class SubmissionsController < ApplicationController
     end
   end
 
+  # DELETE /assignments/:assignment_id/submissions/:id
   def destroy
-    assignment = current_course.assignments.find(params[:assignment_id])
-    assignment.submissions.find(params[:id]).destroy
-    redirect_to assignment_path(assignment, notice: "Submission deleted")
+    @assignment.submissions.find(params[:id]).destroy
+    redirect_to assignment_path(@assignment, notice: "Submission deleted")
   end
 
   private
+
+  def find_assignment
+    @assignment = current_course.assignments.find params[:assignment_id]
+  end
+
+  def ensure_assignment_open?
+    redirect_to assignment_path(@assignment), alert: "The assignment is no longer open for submissions" \
+      unless @assignment.open?
+  end
+
+  def ensure_editable?(submission, assignment)
+    redirect_to assignment_path(assignment, anchor: "tabt1"),
+      notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released." \
+      and return if !SubmissionProctor.new(submission).open_for_editing? assignment, current_user
+    return true
+  end
 
   def send_notification(submission_id, submission_was_draft)
     if submission_was_draft
@@ -95,13 +114,6 @@ class SubmissionsController < ApplicationController
     else
       NotificationMailer.updated_submission(submission_id).deliver_now
     end
-  end
-
-  def ensure_editable(submission, assignment)
-    redirect_to assignment_path(assignment, anchor: "tabt1"),
-      notice: "We're sorry, this assignment is currently being graded. You cannot change your submission again until your grade has been released." \
-      and return if !SubmissionProctor.new(submission).open_for_editing? assignment, current_user
-    return true
   end
 
   def presenter_attrs_with_id

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -1,38 +1,29 @@
 describe SubmissionsController do
-  let(:course) { create(:course) }
-  let(:assignment) { create(:assignment, course: course) }
-  let(:student) { create(:course_membership, :student, course: course).user }
-  let(:professor) { create(:course_membership, :professor, course: course).user }
-  let(:submission) { create(:submission, assignment: assignment, course: course, student: student) }
+  let(:course) { build :course }
+  let(:assignment) { create :assignment, course: course }
+  let(:student) { build :user, courses: [course], role: :student }
+  let(:submission) { create :submission, assignment: assignment, course: course, student: student }
 
   before(:each) { allow(controller).to receive(:current_course).and_return course }
 
   context "as a professor" do
+    let(:professor) { build :user, courses: [course], role: :professor }
 
-    before(:each) do
-      login_user(professor)
-    end
+    before(:each) { login_user professor }
 
     describe "GET show" do
-      let(:ability) { Object.new.extend(CanCan::Ability) }
-      let(:make_request) { get :show, params: { id: submission.id, assignment_id: submission.assignment_id }}
-      let(:presenter) { double(presenter_class, submission: submission).as_null_object }
-      let(:presenter_class) { Submissions::ShowPresenter }
-
-      before do
-        allow_any_instance_of(Submissions::ShowPresenter).to receive(:submission)
-          .and_return submission
-      end
+      let(:ability) { instance_double "CanCan::Ability", authorize!: true }
+      let(:make_request) { get :show, params: { id: submission.id, assignment_id: submission.assignment_id } }
+      let(:presenter) { instance_double "Submissions::ShowPresenter", submission: submission }
 
       before(:each) do
-        ability.can :read, submission
         allow_any_instance_of(described_class)
           .to receive_messages(
             current_ability: ability,
             presenter: presenter,
             presenter_attrs_with_id: { some: "attrs", id: 5 }
           )
-        allow(presenter_class).to receive(:new) { presenter }
+        allow(Submissions::ShowPresenter).to receive(:new).and_return presenter
       end
 
       it "returns the submission show page" do
@@ -40,16 +31,13 @@ describe SubmissionsController do
         expect(assigns(:assignment)).to eq assignment
         expect(response).to render_template(:show)
       end
-
-      it "builds a show presenter with the presenter attrs" do
-        expect(presenter_class).to receive(:new).with({ some: "attrs", id: 5 })
-        make_request
-      end
     end
 
     describe "GET new" do
       let(:make_request) { get :new, params: { assignment_id: submission.assignment_id }}
-      let(:presenter_class) { Submissions::NewPresenter }
+      let(:presenter) { instance_double "Submissions::NewPresenter", submission: submission, render_options: {} }
+
+      before(:each) { allow(Submissions::NewPresenter).to receive(:new).and_return presenter }
 
       it "returns the submission new page" do
         make_request
@@ -148,7 +136,7 @@ describe SubmissionsController do
     end
 
     describe "GET destroy" do
-      let!(:submission) { create(:submission, assignment: assignment, student: student, course: course) }
+      let!(:submission) { create :submission, assignment: assignment, student: student, course: course }
 
       it "assigns the assignment" do
         delete :destroy, params: { id: submission.id, assignment_id: assignment.id }
@@ -164,9 +152,7 @@ describe SubmissionsController do
   context "as a student" do
     let(:delivery) { double(:email, deliver_now: nil) }
 
-    before do
-      login_user(student)
-    end
+    before { login_user student }
 
     describe "GET edit" do
       it "redirects if the assignment is closed" do
@@ -272,7 +258,7 @@ describe SubmissionsController do
 
       context "with an individual assignment" do
         it "sends a successful email if the submission was a draft" do
-          empty_submission = create(:draft_submission, assignment: assignment, student: student)
+          empty_submission = create :draft_submission, assignment: assignment, student: student
           submission_params = { course_id: course, assignment_id: assignment.id, student_id: student }
           expect(delivery).to receive(:deliver_now)
           expect(NotificationMailer).to \
@@ -291,8 +277,8 @@ describe SubmissionsController do
       end
 
       context "with a group assignment" do
-        let(:group_assignment) { create(:group_assignment, course: course) }
-        let(:group_submission) { create(:group_submission, assignment: group_assignment) }
+        let(:group_assignment) { create :group_assignment, course: course }
+        let(:group_submission) { create :group_submission, assignment: group_assignment }
 
         it "does not send any emails" do
           params = attributes_for(:submission).merge({ assignment_id: group_assignment.id })
@@ -303,13 +289,13 @@ describe SubmissionsController do
       end
     end
 
-    describe "protected routes requiring id in params" do
-      [
-        :show,
-        :destroy
-      ].each do |route|
-        it "#{route} redirects to root" do
-          expect(get route, params: { assignment_id: 1, id: "1" }).to redirect_to(:root)
+    describe "protected routes" do
+      it "redirect with a status 302" do
+        [
+          -> { get :show, params: { assignment_id: 1, id: 1 } },
+          -> { get :destroy, params: { assignment_id: 1, id: 1 } }
+        ].each do |protected_route|
+          expect(protected_route.call).to have_http_status :redirect
         end
       end
     end
@@ -348,36 +334,21 @@ describe SubmissionsController do
   end
 
   context "as an observer" do
-    let(:observer) { create(:user, courses: [course], role: :observer) }
+    let(:observer) { build_stubbed :user, courses: [course], role: :observer }
 
-    before(:each) { login_user(observer) }
+    before(:each) { login_user observer }
 
-    describe "protected routes not requiring id in params" do
-      params = { assignment_id: "1" }
-      routes = [
-        { action: :create, request_method: :post },
-        { action: :new, request_method: :get }
-      ]
-      routes.each do |route|
-        it "#{route[:request_method]} :#{route[:action]} redirects to assignments index" do
-          expect(eval("#{route[:request_method]} :#{route[:action]}, params: #{params}")).to \
-            redirect_to(assignments_path)
-        end
-      end
-    end
-
-    describe "protected routes requiring id in params" do
-      params = { assignment_id: "1", id: "1" }
-      routes = [
-        { action: :edit, request_method: :get },
-        { action: :show, request_method: :get },
-        { action: :update, request_method: :post },
-        { action: :destroy, request_method: :get }
-      ]
-      routes.each do |route|
-        it "#{route[:request_method]} :#{route[:action]} redirects to redirects to assignments index" do
-          expect(eval("#{route[:request_method]} :#{route[:action]}, params: #{params}")).to \
-            redirect_to(assignments_path)
+    describe "protected routes" do
+      it "redirect with a status 302" do
+        [
+          -> { get :new, params: { assignment_id: 1 } },
+          -> { post :create, params: { assignment_id: 1 } },
+          -> { get :edit, params: { assignment_id: 1, id: 1 } },
+          -> { get :show, params: { assignment_id: 1, id: 1 } },
+          -> { post :update, params: { assignment_id: 1, id: 1 } },
+          -> { get :destroy, params: { assignment_id: 1, id: 1 } }
+        ].each do |protected_route|
+          expect(protected_route.call).to have_http_status :redirect
         end
       end
     end

--- a/spec/factories/assignment_factory.rb
+++ b/spec/factories/assignment_factory.rb
@@ -44,5 +44,9 @@ FactoryGirl.define do
     trait :pass_fail do
       pass_fail true
     end
+
+    trait :closed do
+      open_at Faker::Date.forward(3)
+    end
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
As reported by Evan, it was possible for a student to submit an assignment even though the due date and accept until date were in the past.

This PR restricts the modification or creation of submissions on the controller itself (for methods `new`, `create`, `edit`, and `update`) and returns an error if the assignment is not open.

### Steps to Test or Reproduce

### Impacted Areas in Application
Submissions

======================
Closes #3943 
