### PR TITLE
handle locked badges on grading page

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -10,7 +10,8 @@
 
     # Can the badge be awarded or unawarded for this grade?
     vm.badgeIsActionable = (badge)->
-      badge.available_for_student || vm.badgeIsEarnedForGrade(badge)
+      !badge.is_locked &&
+      (badge.available_for_student || vm.badgeIsEarnedForGrade(badge))
 
     # Can the badge be awarded for this grade?
     vm.badgeIsAwardable = (badge)->


### PR DESCRIPTION
### Status
**READY**

### Description

Mark badges that are locked for a student as unable to be awarded on the Grading page (the same as badges that they've earned if they can't be awarded more than once)

<img width="316" alt="screen shot 2018-04-04 at 3 37 04 pm" src="https://user-images.githubusercontent.com/1138350/38330252-110216e6-381e-11e8-81ea-8ece2b52adec.png">


======================
Closes #3752
