### PR TITLE
Resolve course on copied memberships

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -117,7 +117,7 @@ class Course < ActiveRecord::Base
 
   def copy(copy_type, attributes={})
     assoc = copy_type != "with_students" ? [] : [:course_memberships, :teams]
-    result = CopyValidator.new.validate self, overrides: assoc
+    result = CopyValidator.new.validate self, associations: assoc
     raise CopyValidationError.new(result.details, "Failed to copy #{self.name} due to validation errors") if result.has_errors
 
     if copy_type != "with_students"

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -51,7 +51,10 @@ class CourseMembership < ActiveRecord::Base
   end
 
   def copy(attributes={}, lookup_store=nil)
-    ModelCopier.new(self, lookup_store).copy(attributes: attributes.merge(score: 0))
+    ModelCopier.new(self, lookup_store).copy(
+      attributes: attributes.merge(score: 0),
+      options: { lookups: [:courses] }
+    )
   end
 
   def recalculate_and_update_student_score


### PR DESCRIPTION
### Status
**READY**

### Description
At some point, a change must have been introduced where we now needed to perform a lookup on the copied `course_id`, so that the copied course membership reflects accurately and does not violate a duplicate ID constraint.

### Steps to Test or Reproduce
Ensure that courses can be properly copied with students.

### Impacted Areas in Application
Course copy with students

======================
Closes #3953
