### PR TITLE
Don't clear out uploader media

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -335,7 +335,6 @@ class Assignment < ActiveRecord::Base
 
   # Copy assignment media
   def copy_media(copy)
-    copy.update(media: nil, remove_media: true)
     remote_upload(copy, self, "media", media.url)
   end
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -67,7 +67,6 @@ class Badge < ActiveRecord::Base
 
   # Copy badge icon
   def copy_icon(copy)
-    copy.update(icon: nil, remove_icon: true)
     remote_upload(copy, self, "icon", icon.url)
   end
 

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -75,7 +75,6 @@ class Challenge < ActiveRecord::Base
 
   # Copy assignment media
   def copy_media(copy)
-    copy.update(media: nil, remove_media: true)
     remote_upload(copy, self, "media", media.url)
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
Removes added lines that were meant to clear out the uploader media on the copy model prior to copying the actual media in S3.

Due to a bug in Carrierwave, the mounted uploader retains a reference to the original model instead of the copy and this in turn causes issues.

======================
Interim solution to #3952 
