### PR TITLE
3899-2 Fix Resubmission Bug

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -28,8 +28,10 @@ class SubmissionsController < ApplicationController
 
     if submission.save
       submission.check_and_set_late_status!
-      grade = find_grade(@assignment, submission)
-      grade.update(submission_id: submission.id) unless grade.nil?
+      grades = find_grades(@assignment, submission)
+      grades.each do |grade|
+        grade.update(submission_id: submission.id) unless grade.nil?
+      end
       redirect_to = (session.delete(:return_to) || assignment_path(@assignment))
       if current_user_is_student?
         NotificationMailer.successful_submission(submission.id).deliver_now if @assignment.is_individual?
@@ -96,11 +98,11 @@ class SubmissionsController < ApplicationController
 
   private
 
-  def find_grade(assignment, submission)
+  def find_grades(assignment, submission)
     if assignment.is_individual?
-      Grade.where(assignment_id: assignment.id, student_id: submission.student_id).student_visible.first
+      Grade.where(assignment_id: assignment.id, student_id: submission.student_id).student_visible
     else
-      Grade.for_group(assignment, submission.group).student_visible.first
+      Grade.for_group(assignment, submission.group).student_visible
     end
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -61,6 +61,11 @@ class SubmissionsController < ApplicationController
     submission = @assignment.submissions.find(params[:id])
     ensure_editable? submission, @assignment or return
 
+    grades = find_grades(@assignment, submission)
+    grades.each do |grade|
+      grade.update(submission_id: submission.id) unless grade.nil?
+    end
+
     submission_was_draft = submission.unsubmitted?
     respond_to do |format|
       if submission.update_attributes(submission_params.merge(submitted_at: DateTime.now)) && Services::DeletesSubmissionDraftContent.for(submission).success?

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -57,6 +57,7 @@ class Grade < ActiveRecord::Base
   scope :for_course, ->(course) { where(course_id: course.id) }
   scope :for_student, ->(student) { where(student_id: student.id) }
   scope :not_nil, -> { where.not(score: nil)}
+  scope :for_group, ->(assignment, group) { where(assignment_id: assignment.id, group_id: group.id) }
 
   scope :for_active_students, -> do
     joins("INNER JOIN course_memberships ON "\

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -30,7 +30,7 @@ class Submission < ActiveRecord::Base
 
   scope :by_active_individual_students, -> do
     individual
-      .joins(student: :course_memberships)
+      .includes(student: :course_memberships)
       .where(student: { course_memberships: { active: true }})
   end
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,7 +10,8 @@ Rails.application.configure do
     :address => "gcmailcatcher",
     :port => 25,
   }
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.active_support.deprecation = :notify
   config.assets.compile = ["1", "yes", "true", "on"].include?(ENV["GC_ASSETS_COMPILE"] || "0" )

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -62,6 +62,7 @@ describe SubmissionsController do
     end
 
     describe "POST create" do
+      let!(:grade) { create :grade, assignment: assignment, student_id: student.id, student_visible: true }
       it "assigns the assignment" do
         post :create, params: { assignment_id: assignment.id, submission: attributes_for(:submission) }
         expect(assigns(:assignment)).to eq assignment
@@ -94,6 +95,12 @@ describe SubmissionsController do
         params = attributes_for(:submission).merge!(student_id: student.id)
         expect_any_instance_of(Submission).to receive(:check_and_set_late_status!)
         post :create, params: { assignment_id: assignment.id, submission: params }
+      end
+
+      it "associates the submission with the grade" do
+        params = attributes_for(:submission).merge!(student_id: student.id)
+        post :create, params: { assignment_id: assignment.id, submission: params }
+        expect(Grade.first.submission_id).to eq (Submission.first.id)
       end
     end
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -100,7 +100,8 @@ describe SubmissionsController do
       it "associates the submission with the grade" do
         params = attributes_for(:submission).merge!(student_id: student.id)
         post :create, params: { assignment_id: assignment.id, submission: params }
-        expect(Grade.first.submission_id).to eq (Submission.first.id)
+        expect(Grade.where(student_id:student.id, assignment_id: assignment.id).first.submission_id).to \
+        eq(Submission.where(assignment_id: assignment.id).first.id)
       end
     end
 


### PR DESCRIPTION
### Status
**READY**

### Description
As a student, if I create a submission for Assignment A after a student-visible grade has already been created for Assignment A, the submission doesn't link to the grade. This creates several issues, including the submission not showing up in the Grading Status page. To resolve this, a method was created that links the submission to the grade even after it already exists.

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
There are several tests to reproduce the issue. However, the main one is:

As an instructor, create an assignment that accepts resubmissions. Create a student-visible grade for said assignment corresponding to Student A. As Student A, create a submission for the aforementioned assignment. As an instructor, go to the grading status page and observe that the resubmission for Student A for the assignment is in the queue.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignments, Submissions

======================
Closes #3899 
