### PR TITLE
3967 Google Batch Bug

### DIFF
--- a/app/presenters/info/dashboard_course_events_presenter.rb
+++ b/app/presenters/info/dashboard_course_events_presenter.rb
@@ -19,4 +19,8 @@ class Info::DashboardCourseEventsPresenter < Showtime::Presenter
   def assignments_due_on(event)
     assignments.where('DATE(due_at) = ?', event.due_at.to_date)
   end
+
+  def show_add_assignments_to_google_button?(user)
+    course.institution.try(:has_google_access?) && course.assignments.any? { |a| AssignmentProctor.new(a).viewable?(user) }
+  end
 end

--- a/app/proctors/assignment_proctor.rb
+++ b/app/proctors/assignment_proctor.rb
@@ -1,0 +1,13 @@
+class AssignmentProctor
+  attr_reader :assignment
+
+  def initialize(assignment)
+    @assignment = assignment
+  end
+
+  def viewable?(user, course)
+    return true if @assignment.visible?
+    return true if user.is_staff?(course) || user.is_admin?(course)
+    return false
+  end
+end

--- a/app/proctors/assignment_proctor.rb
+++ b/app/proctors/assignment_proctor.rb
@@ -5,9 +5,9 @@ class AssignmentProctor
     @assignment = assignment
   end
 
-  def viewable?(user, course)
-    return true if @assignment.visible?
-    return true if user.is_staff?(course) || user.is_admin?(course)
-    return false
+  def viewable?(user)
+    return true if user.is_staff?(@assignment.course)
+    @assignment.visible_for_student?(user)
   end
+
 end

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -30,5 +30,5 @@
                   %li #{ link_to assignment.name, assignment } due at #{ l assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    - if presenter.course.institution.try(:has_google_access) && presenter.course.assignments.any? { |a| AssignmentProctor.new(a).viewable?(current_user, presenter.course) }
+    - if presenter.course.institution.try(:has_google_access) && presenter.course.assignments.any? { |a| AssignmentProctor.new(a).viewable?(current_user) }
       = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -30,5 +30,5 @@
                   %li #{ link_to assignment.name, assignment } due at #{ l assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    - if presenter.course.institution.try(:has_google_access)
+    - if presenter.course.institution.try(:has_google_access) && presenter.course.assignments.any? { |a| AssignmentProctor.new(a).viewable?(current_user, presenter.course) }
       = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/app/views/info/dashboard/modules/_dashboard_course_events.haml
+++ b/app/views/info/dashboard/modules/_dashboard_course_events.haml
@@ -30,5 +30,5 @@
                   %li #{ link_to assignment.name, assignment } due at #{ l assignment.due_at.in_time_zone(current_user.time_zone) }
 
   .calendar-access
-    - if presenter.course.institution.try(:has_google_access) && presenter.course.assignments.any? { |a| AssignmentProctor.new(a).viewable?(current_user) }
+    - if presenter.show_add_assignments_to_google_button?(current_user)
       = link_to decorative_glyph(:calendar) + "Add All Assignments to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post, data: { disable_with: "Adding Your Assignments..." }

--- a/spec/proctors/assignment_proctor_spec.rb
+++ b/spec/proctors/assignment_proctor_spec.rb
@@ -4,12 +4,6 @@ describe AssignmentProctor do
   let(:course) { build_stubbed :course }
   let(:subject) { described_class.new assignment }
 
-  describe "#initialize" do
-    it "sets the given assignment to @assignment" do
-      expect(subject.instance_variable_get :@assignment).to eq assignment
-    end
-  end
-
   describe "#viewable?" do
     context "as an instructor" do
       let(:user) { build_stubbed :user, courses: [course], role: :admin }

--- a/spec/proctors/assignment_proctor_spec.rb
+++ b/spec/proctors/assignment_proctor_spec.rb
@@ -1,0 +1,28 @@
+describe AssignmentProctor, focus: true do
+  let(:assignment) { build_stubbed :assignment, course: course, visible: false }
+  let(:user) { build_stubbed :user }
+  let(:course) { build_stubbed :course }
+  let(:subject) { described_class.new assignment }
+
+  describe "#initialize" do
+    it "sets the given assignment to @assignment" do
+      expect(subject.instance_variable_get :@assignment).to eq assignment
+    end
+  end
+
+  describe "#viewable?" do
+    context "as an instructor" do
+      let(:user) { build_stubbed :user, courses: [course], role: :admin }
+      it "returns true" do
+        expect(subject.viewable?(user, course)).to eq true
+      end
+    end
+
+    context "as a student" do
+      let(:user) { build_stubbed :user, courses: [course], role: :student }
+      it "returns false" do
+        expect(subject.viewable?(user, course)).to eq false
+      end
+    end
+  end
+end

--- a/spec/proctors/assignment_proctor_spec.rb
+++ b/spec/proctors/assignment_proctor_spec.rb
@@ -1,4 +1,4 @@
-describe AssignmentProctor, focus: true do
+describe AssignmentProctor do
   let(:assignment) { build_stubbed :assignment, course: course, visible: false }
   let(:user) { build_stubbed :user }
   let(:course) { build_stubbed :course }

--- a/spec/proctors/assignment_proctor_spec.rb
+++ b/spec/proctors/assignment_proctor_spec.rb
@@ -8,14 +8,14 @@ describe AssignmentProctor do
     context "as an instructor" do
       let(:user) { build_stubbed :user, courses: [course], role: :admin }
       it "returns true" do
-        expect(subject.viewable?(user, course)).to eq true
+        expect(subject.viewable?(user)).to eq true
       end
     end
 
     context "as a student" do
       let(:user) { build_stubbed :user, courses: [course], role: :student }
       it "returns false" do
-        expect(subject.viewable?(user, course)).to eq false
+        expect(subject.viewable?(user)).to eq false
       end
     end
   end


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Current Behavior: In a course, it is possible for the "Add All Assignments" link button to appear while there are no assignments in the course. When a user clicks the button, there is a reported google error reporting that an empty batch cannot be processed.

Expected Behavior: The "Add All Assignments" link button should only appear if there are actually visible assignments in the course.

### Related PRs
N/A

### Todos
- [x] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
NOTE: Before beginning, verify that the course you are testing in is an institutional course AND that the institution has opted to use Google Access.

As an instructor, in a course with no assignments, create 1 invisible assignment. On the instructor's Dashboard, the instructor should see the "Add All Assignments" link button. As a student, I should not see the "Add All Assignments" link button. As an instructor, edit the 1 assignment so that it is now visible. As a student I should now see the "Add All Assignments" link button.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Dashboards, Assignments

======================
Closes #3967 
