### PR TITLE
3972 Add Team Section to Assignment Submission Export

### DIFF
--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -4,7 +4,7 @@ class SubmissionExporter
       csv << baseline_headers
       course.submissions.submitted.each do |submission|
         csv << [ submission.id, submission.assignment.assignment_type.name, submission.assignment_id, submission.assignment.name,
-          submission.student.try(:email), submission.student_id, submission.group.try(:name), submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
+          submission.student.try(:email), submission.student_id, submission.group.try(:name), find_team_name(submission), submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
       end
     end
   end
@@ -12,11 +12,17 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
+    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Team Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
   end
 
   def find_graded_by_name(graded_by_id)
     return nil unless !graded_by_id.nil?
     User.find(graded_by_id).name
   end
+
+  def find_team_name(submission)
+    return nil unless submission.student.present?
+    submission.student.team_for_course(submission.course).name
+  end
+
 end

--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -1,7 +1,7 @@
 class SubmissionExporter
   def export(course)
     CSV.generate do |csv|
-      csv << baseline_headers
+      csv << baseline_headers(course)
       course.submissions.submitted.each do |submission|
         csv << [ submission.id, submission.assignment.assignment_type.name, submission.assignment_id, submission.assignment.name,
           submission.student.try(:email), submission.student_id, submission.group.try(:name), find_team_name(submission), submission.text_comment, submission.created_at, submission.updated_at, submission.grade.try(:score), find_graded_by_name(submission.grade.try(:graded_by_id)), submission.grade.try(:feedback), submission.grade.try(:graded_at) ]
@@ -11,12 +11,14 @@ class SubmissionExporter
 
   private
 
-  def baseline_headers
+  def baseline_headers(course)
     [
-      "Submission ID", "Assignment Type", "Assignment ID", "Assignment Name",
-      "Student Email", "Student ID", "Group Name", "Team Name",
-      "Student Comment", "Created At", "Updated At", "Score", "Graded By",
-      "Grader Feedback", "Grade Last Updated"
+      "Submission ID", "#{course.assignment_term} Type",
+      "#{course.assignment_term} ID", "#{course.assignment_term} Name",
+      "#{course.student_term} Email", "#{course.student_term} ID",
+      "#{course.group_term} Name", "#{course.team_term} Name",
+      "#{course.student_term} Comment", "Created At", "Updated At", "Score",
+      "Graded By", "Grader Feedback", "Grade Last Updated"
     ]
   end
 

--- a/app/exporters/submission_exporter.rb
+++ b/app/exporters/submission_exporter.rb
@@ -12,7 +12,12 @@ class SubmissionExporter
   private
 
   def baseline_headers
-    ["Submission ID", "Assignment Type", "Assignment ID", "Assignment Name", "Student Email", "Student ID", "Group Name", "Team Name", "Student Comment", "Created At", "Updated At", "Score", "Graded By", "Grader Feedback", "Grade Last Updated"]
+    [
+      "Submission ID", "Assignment Type", "Assignment ID", "Assignment Name",
+      "Student Email", "Student ID", "Group Name", "Team Name",
+      "Student Comment", "Created At", "Updated At", "Score", "Graded By",
+      "Grader Feedback", "Grade Last Updated"
+    ]
   end
 
   def find_graded_by_name(graded_by_id)
@@ -22,7 +27,6 @@ class SubmissionExporter
 
   def find_team_name(submission)
     return nil unless submission.student.present?
-    submission.student.team_for_course(submission.course).name
+    submission.student.team_for_course(submission.course).try(:name)
   end
-
 end

--- a/app/performers/submission_export_performer.rb
+++ b/app/performers/submission_export_performer.rb
@@ -10,7 +10,7 @@ class SubmissionExportPerformer < ResqueJob::Performer
     if @course.present? && @user.present?
       require_success(fetch_csv_messages, max_result_size: 250) do
        fetch_csv_data(@course)
-     end
+      end
 
       require_success(notification_messages, max_result_size: 200) do
         notify_submission_export # the result of this block determines the outcome
@@ -26,7 +26,7 @@ class SubmissionExportPerformer < ResqueJob::Performer
 
   # TODO: speed this up by condensing the CSV generator into a single query
   def fetch_course # TODO: add specs for includes
-    Course.find @attrs[:course_id]
+    Course.includes(:assignments, :assignment_types, submissions: :grade).find @attrs[:course_id]
   end
 
   def fetch_csv_data(course)

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -29,7 +29,7 @@
           %td Assignment ID, Name, Assignment Type, Point Total, Description, Open At, Due At, Accept Until, Submissions Count, Grades Count, Created At, Learning Objectives
         %tr
           %td= link_to glyph("file-excel-o") + "#{term_for :assignment} Submissions", submissions_path(id: current_course.id, format: "csv")
-          %td Submission ID, Assignment Type, Assignment ID, Assignment Name, Student Email, Student ID, Team Name, Group Name, Student Comment, Created At, Updated At, Score, Graded By, Grader Feedback, Grade Last Updated
+          %td= "Submission ID, #{term_for(:assignment_type)}, #{term_for(:assignment)} ID, #{term_for(:assignment)} Name, #{term_for(:student)} Email, #{term_for(:student)} ID, #{term_for(:team)} Name, #{term_for(:group)} Name, #{term_for(:student)} Comment, Created At, Updated At, Score, Graded By, Grader Feedback, Grade Last Updated"
         - if current_course.has_badges?
           %tr
             %td

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -29,7 +29,7 @@
           %td Assignment ID, Name, Assignment Type, Point Total, Description, Open At, Due At, Accept Until, Submissions Count, Grades Count, Created At, Learning Objectives
         %tr
           %td= link_to glyph("file-excel-o") + "#{term_for :assignment} Submissions", submissions_path(id: current_course.id, format: "csv")
-          %td Submission ID, Assignment Type, Assignment ID, Assignment Name, Student Email, Student ID, Group Name, Student Comment, Created At, Updated At, Score, Graded By, Grader Feedback, Grade Last Updated
+          %td Submission ID, Assignment Type, Assignment ID, Assignment Name, Student Email, Student ID, Team Name, Group Name, Student Comment, Created At, Updated At, Score, Graded By, Grader Feedback, Grade Last Updated
         - if current_course.has_badges?
           %tr
             %td

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,11 +3,16 @@ Rails.application.configure do
   config.action_dispatch.best_standards_support = :builtin
   config.asset_host = ENV["GC_ASSET_HOST"] || "//"
 
-  config.action_mailer.default_url_options = { :host => "localhost:5000" }
-  config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.perform_deliveries = false
-
+  # NOTE: to test emails locally
+  # 1. gem install mailcatcher
+  # 2. run 'mailcatcher' in terminal
+  # 3. visit http://127.0.0.1:1080/
+  config.action_mailer.default_url_options = { host: "localhost:5000" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
   config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = true
+
   config.action_view.raise_on_missing_translations = true
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Added section/team name to Assignment Submissions export

### Related PRs
N/A

### Todos
- [ ] Add Tests

### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, navigate to the course exports page and download the Assignment Submissions csv. Note that their is now a column called 'Team Name' with the section/team name for each corresponding student.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Exports

======================
Closes #3972
