### PR TITLE
remove fixed height from rubric

### DIFF
--- a/app/assets/stylesheets/pages/_rubrics.sass
+++ b/app/assets/stylesheets/pages/_rubrics.sass
@@ -71,7 +71,6 @@ $not-saved-color: $color-yellow-1
     font-size: 0.8rem
     cursor: pointer
     position: relative
-    height: 395px
     &:hover
       background-color: lighten($color-grey-6, 5%)
     &.selected


### PR DESCRIPTION
### Status
**READY**

### Description

Evan had remarked that rubrics are always really big when doing demonstrations, even if there is very little description in the box.

@jonathoy please just confirm that it is OK to remove this line, and that it doesn't mess anything up with learning objectives which is when it was added.