### PR TITLE
3563 uncomment onboarding access on every page

### DIFF
--- a/app/assets/javascripts/onboarding.js
+++ b/app/assets/javascripts/onboarding.js
@@ -115,7 +115,9 @@ if (m && p) {
     mClose.addEventListener('click', modalClose);
 
     // close modal by modal action btn click/hit
-    mAction.addEventListener('click', modalClose);
+    if (mAction) {
+      mAction.addEventListener('click', modalClose);
+    }
 
     // close modal by keydown, but only if modal is open
     document.addEventListener('keydown', modalClose);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,6 +208,10 @@ class User < ActiveRecord::Base
     name.downcase == another_user.name.downcase
   end
 
+  def onboarded?(course)
+    return course_memberships.where(course: course).first.has_seen_course_onboarding?
+  end
+
   Role.all.each do |role|
     define_method("is_#{role}?") do |course|
       self.role(course) == role

--- a/app/views/info/_student_onboarding.html.haml
+++ b/app/views/info/_student_onboarding.html.haml
@@ -1,14 +1,13 @@
-.modal-overlay#modal-window{'aria-hidden': 'true', role: 'dialog', 'aria-label': 'Student Onboarding', 'data-first-load': current_user.course_memberships.where(course: current_course).first.has_seen_course_onboarding? ? 'false' : 'true' }
+.modal-overlay#modal-window{'aria-hidden': 'true', role: 'dialog', 'aria-label': 'Student Onboarding', 'data-first-load': current_user.onboarded?(current_course) ? 'false' : 'true' }
   .modal-wrapper.modal-content#modal-holder{role: "document"}
     .modal-slider.onboarding-slides
       = render partial: "info/student_onboarding/student_onboarding_slide1"
       = render partial: "info/student_onboarding/student_onboarding_slide2"
       = render partial: "info/student_onboarding/student_onboarding_slide3"
       = render partial: "info/student_onboarding/student_onboarding_slide4"
-      = render partial: "info/student_onboarding/student_onboarding_slide5"
-      -# , locals: {presenter: presenter}
+      = render partial: "info/student_onboarding/student_onboarding_slide5", locals: { presenter: presenter }
 
-      -# - if presenter.has_course_specific_features?
-      -#   = render partial: "info/student_onboarding/student_onboarding_slide6", locals: { presenter: presenter }
+      - if presenter.has_course_specific_features?
+        = render partial: "info/student_onboarding/student_onboarding_slide6", locals: { presenter: presenter }
 
     %button.btn-close#modal-close{type: 'submit', 'aria-label': 'close'}= glyph(:times)

--- a/app/views/info/student_onboarding/_student_onboarding_slide5.haml
+++ b/app/views/info/student_onboarding/_student_onboarding_slide5.haml
@@ -5,6 +5,6 @@
     .modal-slide-text
       %h2 Plan your grade
       %p Plan out variable assignment pathways with #{term_for :grade_predictor} and use it to maximize your freedom of choice. Achieve the goals you want on your terms.
-      -# - if !presenter.has_course_specific_features?
-      -#   .modal-action-wrapper
-      -#     %button#modal-action{type: 'submit', 'aria-label': 'close'} Let's Go!
+      - if !presenter.has_course_specific_features?
+        .modal-action-wrapper
+          %button#modal-action{type: 'submit', 'aria-label': 'close'} Let's Go!

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -15,6 +15,7 @@
         = breadcrumbs
         %h1.pagetitle= title
         = yield(:context_menu)
-      //= render partial: "info/staff_onboarding"
+
+    = render partial: "info/staff_onboarding"
 
     = render partial: "layouts/content"

--- a/app/views/layouts/_student.haml
+++ b/app/views/layouts/_student.haml
@@ -5,7 +5,8 @@
     - if current_course.published || impersonating?
       .page-header
         %h1.pagetitle= title
-      -# = render partial: "info/student_onboarding", locals:  { presenter: Info::DashboardCourseRulesPresenter.new(course: current_course, current_user: current_student) }
+      - if ! impersonating?
+        = render partial: "info/student_onboarding", locals:  { presenter: Info::DashboardCourseRulesPresenter.new(course: current_course, current_user: current_student) }
       = render partial: "layouts/content"
     - else
       = render partial: "layouts/course_unpublished"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,10 +5,7 @@ describe User do
   let(:grade) { create(:grade, assignment: assignment, student:student) }
   let(:badge) { create(:badge, course: course, can_earn_multiple_times: true) }
   let(:single_badge) { create(:badge, course: course, can_earn_multiple_times: false) }
-
-  before do
-    create(:course_membership, user: student, course: course, role: "student", score: 100000, character_profile: "The six-fingered man.")
-  end
+  let!(:course_membership) { create(:course_membership, user: student, course: course, role: "student", score: 100000, character_profile: "The six-fingered man.") }
 
   describe "validations" do
     it "requires the password confirmation to match" do
@@ -110,6 +107,14 @@ describe User do
   describe "#time_zone" do
     it "defaults to Eastern Time" do
       expect(subject.time_zone).to eq("Eastern Time (US & Canada)")
+    end
+  end
+
+  describe "#onboarded?" do
+    it "responds with the onboarding state for student and course" do
+      expect(student.onboarded?(course)).to eq(false)
+      CourseMembership.where(user: student, course: course).first.update(has_seen_course_onboarding: true)
+      expect(student.onboarded?(course)).to eq(true)
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description

PR #3711 attempted to make the onboarding slideshow more performant by only loading it when the student had not yet seen it. The issue is, there is an access button to the slideshow which allows the student to view it again at any time.  The most performative and simplest way to make this work is to have the slideshow preloaded as Marie originally designed it.

In this PR, I have uncommented the slideshows so that they are available again to students and faculty, and they load when a student logs into a course for the first time.

I tried to run benchmarks on the same page with and without the slideshow, and noticed no meaningful differences with or without the slideshow.*

======================
Closes #3563 
Closes #3711

### Time Trials

*I reloaded the dashboard 8 times each with and without the slideshow.  The difference between each trial was actually greater than any difference with or without the slideshow. Loading the dashboard varied between 6.5 and 12 seconds, with both the fastest and slowest times recorded without the slideshow. All times were taken after an initial load to discount any differences due to caching. 

Load times for dashboard without slideshow 8 trials, ordered:
[6423, 9457, 9842, 10657, 11037, 11588, 11781, 12295] 
average: 10385ms 

Load times for dashboard with slideshow, ordered :
[6656, 7138, 9709, 9967, 10972, 11424, 11722, 11919] 
average: 9938ms 
