### PR TITLE
Remove deprecated Mongod argument

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@ web: bundle exec puma -p 5000
 redis: redis-server --port $REDIS_PORT
 resque_scheduler: bundle exec rake resque:scheduler
 resque_worker: bundle exec rake resque:work
-mongo: bundle exec mongod --dbpath=$MONGO_PATH --rest
+mongo: bundle exec mongod --dbpath=$MONGO_PATH


### PR DESCRIPTION
### Status
**READY**

### Description
While trying to set up Gradecraft locally, it was found that the `--rest` argument is deprecated in its current use in the Procfile.

This results in a failure if we ever want to upgrade Mongodb or we accidentally install the wrong version of Mongodb for the next local setup (currently the workaround is to ensure that we `brew install mongodb@3.4`)

This PR removes it, since it does not appear that we need this argument at all.
