### PR TITLE
Leaner course api

### DIFF
--- a/app/assets/javascripts/courses.js
+++ b/app/assets/javascripts/courses.js
@@ -8,20 +8,20 @@
         dataType: "json",
         success: function(response) {
           target.omniselect({
-            source: response.data,
+            source: response,
             resultsClass: 'typeahead dropdown-menu course-result',
             activeClass: 'active',
             itemLabel: function(course) {
-              return course.attributes.formatted_name;
+              return course.formatted_name;
             },
             itemId: function(course) {
-              return course.attributes.id;
+              return course.id;
             },
             renderItem: function(label) {
               return '<li><a href="#">' + label + '</a></li>';
             },
             filter: function(course, query) {
-              return course.attributes.search_string.match(new RegExp(query, 'i'));
+              return course.search_string.match(new RegExp(query, 'i'));
             }
           }).on('omniselect:select', function(event, id) {
             window.location = "/courses/" + id + "/change"

--- a/app/controllers/api/courses_controller.rb
+++ b/app/controllers/api/courses_controller.rb
@@ -9,7 +9,7 @@ class API::CoursesController < ApplicationController
     course_attrs = current_user.courses.map do |c|
       {
         id: c.id,
-        name: c.formatted_long_name,
+        formatted_name: c.formatted_long_name,
         search_string: c.searchable_name
       }
     end

--- a/app/views/layouts/navigation/_course_search.haml
+++ b/app/views/layouts/navigation/_course_search.haml
@@ -1,3 +1,3 @@
 .has-form{role: "search"}
-  %input.courses-search-query.search-input{ data: { autocompleteUrl: api_courses_path }, type: "text", placeholder: "Switch Course", "aria-label": "Search your courses" }
+  %input.courses-search-query.search-input{ data: { autocompleteUrl: search_api_courses_path }, type: "text", placeholder: "Switch Course", "aria-label": "Search your courses" }
   %button.search-submit-button.alert{type: "submit", "aria-label": "Search"} Go

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -457,6 +457,7 @@ Rails.application.routes.draw do
       resource :copy_log, only: [:show]
       resources :students, only: :index, module: :courses
       collection do
+        get :search
         get "analytics"
         get "one_week_analytics", to: "courses#one_week_analytics"
         resources :importers, only: [], module: :courses, param: :provider_id do

--- a/spec/controllers/api/courses_controller_spec.rb
+++ b/spec/controllers/api/courses_controller_spec.rb
@@ -8,6 +8,16 @@ describe API::CoursesController do
 
     before(:each) { login_user admin }
 
+    describe "GET search" do
+      it "returns a hash of search attributes for the user's courses" do
+        get :search, format: :json
+        body = JSON.parse(response.body)
+        expect(body).to include "id" => course.id,
+          "name" => course.formatted_long_name,
+          "search_string" => course.searchable_name
+      end
+    end
+
     describe "GET index" do
       let!(:another_course) { create :course }
 

--- a/spec/controllers/api/courses_controller_spec.rb
+++ b/spec/controllers/api/courses_controller_spec.rb
@@ -13,7 +13,7 @@ describe API::CoursesController do
         get :search, format: :json
         body = JSON.parse(response.body)
         expect(body).to include "id" => course.id,
-          "name" => course.formatted_long_name,
+          "formatted_name" => course.formatted_long_name,
           "search_string" => course.searchable_name
       end
     end


### PR DESCRIPTION
### Status
**READY**

### Description
After making some changes to accommodate the AJAX-loading manage courses page, the shared API at `/api/courses` now returns a potentially large response if the current user is an admin.

This PR adds a separate endpoint specifically for use with the typeahead course selector input.

======================
Closes #4004
