### PR TITLE
Revise paginated loading for Canvas API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -370,11 +370,6 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: true
 
-Style/MethodCallWithoutArgsParentheses:
-  Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
-  Enabled: true
-
 Style/MethodDefParentheses:
   Description: >-
                  Checks if the method definitions have or don't have

--- a/app/assets/javascripts/angular/directives/grades/import/form.coffee
+++ b/app/assets/javascripts/angular/directives/grades/import/form.coffee
@@ -9,22 +9,15 @@
     vm.assignmentLink = "/assignments/#{@currentAssignmentId}/grades/importers/#{@provider}/assignments"
     vm.formAction = "/assignments/#{@currentAssignmentId}/grades/importers/#{@provider}/courses/#{@courseId}/grades/import"
 
-    vm.selectAllGrades = () ->
-      GradeImporterService.selectAllGrades()
-
-    vm.deselectAllGrades = () ->
-      GradeImporterService.deselectAllGrades()
+    vm.hasError = () -> GradeImporterService.checkHasError()
+    vm.selectAllGrades = () -> GradeImporterService.selectAllGrades()
+    vm.deselectAllGrades = () -> GradeImporterService.deselectAllGrades()
 
     vm.hasSelectedGrades = () ->
-      _.any(GradeImporterService.grades, (grade) ->
-        grade.selected_for_import is true
-      )
+      _.any(GradeImporterService.grades, (grade) -> grade.selected_for_import is true)
 
     vm.termForUserExists = (value) ->
       if value is true then "Yes" else "No"
-
-    vm.hasError = () ->
-      GradeImporterService.checkHasError()
 
     GradeImporterService.getGrades(@currentAssignmentId, @courseId, @provider, @assignmentIds).finally(() ->
       vm.loading = false

--- a/app/assets/javascripts/angular/directives/user/import/form.coffee
+++ b/app/assets/javascripts/angular/directives/user/import/form.coffee
@@ -2,9 +2,10 @@
 @gradecraft.directive 'userImportForm', ['CanvasImporterService', (CanvasImporterService) ->
   UserImportFormCtrl = ['$scope', ($scope) ->
     vm = this
-
     vm.hasError = false
+    vm.loading = undefined
     vm.formSubmitted = false
+
     vm.users = CanvasImporterService.users
     vm.currentCourseId = CanvasImporterService.currentCourseId
 
@@ -12,8 +13,10 @@
       "/users/importers/#{@provider}/course/#{vm.currentCourseId()}/users/import"
 
     vm.getUsers = () ->
+      vm.loading = true
       CanvasImporterService.getUsers(vm.provider, vm.currentCourseId(), true).then((success) ->
         vm.hasError = false
+        vm.loading = false
       , (error) ->
         vm.hasError = true
       )

--- a/app/assets/javascripts/angular/directives/user/import/form.coffee
+++ b/app/assets/javascripts/angular/directives/user/import/form.coffee
@@ -12,7 +12,7 @@
       "/users/importers/#{@provider}/course/#{vm.currentCourseId()}/users/import"
 
     vm.getUsers = () ->
-      CanvasImporterService.getUsers(vm.provider, vm.currentCourseId()).then((success) ->
+      CanvasImporterService.getUsers(vm.provider, vm.currentCourseId(), true).then((success) ->
         vm.hasError = false
       , (error) ->
         vm.hasError = true

--- a/app/assets/javascripts/angular/services/CanvasImporterService.coffee
+++ b/app/assets/javascripts/angular/services/CanvasImporterService.coffee
@@ -28,10 +28,11 @@
       GradeCraftAPI.logResponse(error)
     )
 
-  getUsers = (provider, courseId) ->
-    _clearUsers()
-    $http.get("/api/users/importers/#{provider}/course/#{_currentCourseId}/users").then((response) ->
+  getUsers = (provider, courseId, clearUsers, options={}) ->
+    _clearUsers() if clearUsers is true
+    $http.get("/api/users/importers/#{provider}/course/#{_currentCourseId}/users", params: options).then((response) ->
       GradeCraftAPI.loadMany(users, response.data)
+      getUsers(provider, courseId, false, _nextPageParams(response)) if _nextPageParams(response)?
       GradeCraftAPI.logResponse(response)
     , (error) ->
       window.location.replace("/auth/#{provider}") if error.status == 401
@@ -65,6 +66,8 @@
 
   _clearUsers = () ->
     users.length = 0
+
+  _nextPageParams = (response) -> response.data.meta.page_params
 
   {
     users: users

--- a/app/assets/javascripts/angular/services/GradeImporterService.coffee
+++ b/app/assets/javascripts/angular/services/GradeImporterService.coffee
@@ -4,19 +4,19 @@
   hasError = false
 
   # Fetch grades by batch with a page number
-  getGrades = (assignmentId, courseId, provider, assignmentIds, page = 1) ->
-    $http.get("/api/assignments/#{assignmentId}/grades/importers/#{provider}/course/#{courseId}",
-      params: _gradeParams(page, assignmentIds)).then(
-        (response) ->
-          GradeCraftAPI.addItems(grades, "imported_grade", response.data)
-          GradeCraftAPI.setTermFor("assignment", response.data.meta.term_for_assignment)
-          GradeCraftAPI.setTermFor("provider_assignment_name", response.data.meta.term_for_provider_assignment)
-          GradeCraftAPI.logResponse(response.data)
-          getGrades(assignmentId, courseId, provider, assignmentIds, page + 1) if _hasNextPage(response)
-        , (response) ->
-          hasError = true
-          window.location.replace("/auth/#{provider}") if response.status == 401
-          GradeCraftAPI.logResponse(response.data)
+  getGrades = (assignmentId, courseId, provider, assignmentIds, options={}) ->
+    options.assignment_ids = assignmentIds
+    $http.get("/api/assignments/#{assignmentId}/grades/importers/#{provider}/course/#{courseId}", params: options).then(
+      (response) ->
+        GradeCraftAPI.addItems(grades, "imported_grade", response.data)
+        GradeCraftAPI.setTermFor("assignment", response.data.meta.term_for_assignment)
+        GradeCraftAPI.setTermFor("provider_assignment_name", response.data.meta.term_for_provider_assignment)
+        GradeCraftAPI.logResponse(response.data)
+        getGrades(assignmentId, courseId, provider, assignmentIds, _nextPageParams(response)) if _nextPageParams(response)?
+      , (response) ->
+        hasError = true
+        window.location.replace("/auth/#{provider}") if response.status == 401
+        GradeCraftAPI.logResponse(response.data)
     )
 
   termFor = (article) ->
@@ -31,20 +31,13 @@
   checkHasError = () ->
     hasError
 
-  _hasNextPage = (response) ->
-    response.data.meta.has_next_page
+  _nextPageParams = (response) -> response.data.meta.page_params
 
   _setGradesSelected = (selected) ->
     _.each(grades, (grade) ->
       grade.selected_for_import = selected
       true  # if selected is false, this loop is broken without this line
     )
-
-  _gradeParams = (page, assignmentIds) ->
-    {
-      page: page
-      assignment_ids: assignmentIds
-    }
 
   {
     grades: grades

--- a/app/assets/javascripts/angular/templates/grades/import/form.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/import/form.html.haml
@@ -1,92 +1,85 @@
 %error-message{"visible"=>"vm.hasError()", "message"=>"An unexpected error occurred while loading grades."}
 
-%loading{"ng-if"=>"vm.loading"}
-  %h2
-    %i.fa.fa-spinner.fa-spin.fa-fw
-    Loading {{vm.provider}} grades..
-  %br
+%h2.loading{"ng-if"=>"vm.loading"}
+  %i.fa.fa-spinner.fa-spin.fa-fw
+  Loading grades...
 
-%loaded{"ng-if"=>"!vm.loading"}
-  %without_grades{"ng-if"=>"!grades || grades.length < 1"}
-    %div
-      There are no grades to import for this
-      %span.lowercase {{termFor("assignment")}}.
-    %div
-      You can
-      %a{"ng-href"=>"{{vm.assignmentLink}}"} modify your assignment selection
-      to find grades to import.
+%without_grades{"ng-if"=>"!vm.loading && grades.length < 1"}
+  %div
+    There are no grades to import for this
+    %span.lowercase {{termFor("assignment")}}.
+  %div
+    You can
+    %a{"ng-href"=>"{{vm.assignmentLink}}"} modify your assignment selection
+    to find grades to import.
 
-  %with_grades{"ng-if"=>"grades && grades.length > 0"}
-    %form{"action"=>"{{vm.formAction}}", "method"=>"post", "accept-charset"=>"UTF-8", "ng-submit"=>"vm.formSubmitted = true"}
-      -# Hidden inputs that Rails would normally generate for a form
-      %input{"type"=>"hidden", "name"=>"authenticity_token", "value"=>"{{vm.authenticityToken}}"}
-      %input{"type"=>"hidden", "name"=>"utf8", "value"=>"✓"}
+%with_grades{"ng-if"=>"grades && grades.length > 0"}
+  %form{"action"=>"{{vm.formAction}}", "method"=>"post", "accept-charset"=>"UTF-8", "ng-submit"=>"vm.formSubmitted = true"}
+    -# Hidden inputs that Rails would normally generate for a form
+    %input{"type"=>"hidden", "name"=>"authenticity_token", "value"=>"{{vm.authenticityToken}}"}
+    %input{"type"=>"hidden", "name"=>"utf8", "value"=>"✓"}
 
-      %input{"type"=>"hidden", "name"=>"assignment_ids[]", "value"=>"{{vm.assignmentIds}}"}
+    %input{"type"=>"hidden", "name"=>"assignment_ids[]", "value"=>"{{vm.assignmentIds}}"}
 
-      .table-header-information
-        %div
-          %strong
-            Selected
-            %span.capitalize {{vm.provider}}
-            {{termFor("assignment")}}: {{termFor("provider_assignment_name")}}
-        %div
-          %em Wrong {{termFor("assignment")}}?
-          %a{"ng-href"=>"{{vm.assignmentLink}}"}
-            Switch {{vm.provider}}
-            %span.lowercase {{termFor("assignment")}}
+    .table-header-information
+      %div
+        %strong
+          Selected
+          %span.capitalize {{vm.provider}}
+          {{termFor("assignment")}}: {{termFor("provider_assignment_name")}}
+      %div
+        %em Wrong {{termFor("assignment")}}?
+        %a{"ng-href"=>"{{vm.assignmentLink}}"}
+          Switch {{vm.provider}}
+          %span.lowercase {{termFor("assignment")}}
 
-      %table.no-table-header
-        %thead
-          %tr
-            %th{"scope"=>"col"} Student Name
-            %th{"scope"=>"col"} {{vm.provider}} Score
-            %th{"scope"=>"col"} {{vm.provider}} Feedback
-            %th{"scope"=>"col"} GradeCraft Score
-            %th{"scope"=>"col"} GradeCraft Feedback
-            %th{"scope"=>"col"} User Found?
-            %th
-              %button.button.select-all{"role"=>"button",
-                                        "type"=>"button",
-                                        "ng-click"=>"vm.selectAllGrades()"}= "Check"
-              %button.button.select-none{"role"=>"button",
-                                         "type"=>"button",
-                                         "ng-click"=>"vm.deselectAllGrades()"}= "Uncheck"
-        %tbody
-          %tr{"ng-if"=>"grades.length > 0", "ng-repeat"=>"grade in grades"}
-            %td {{grade.primary_email}}
-            %td {{grade.score}}
-            %td {{grade.feedback}}
-            %td {{grade.gradecraft_score.raw_points}}
-            %td {{grade.gradecraft_score.feedback}}
-            %td
-              %div{"ng-if"=>"grade.user_exists"}
-                {{vm.termForUserExists(grade.user_exists)}}
-              %div{"ng-if"=>"!grade.user_exists"}
-                {{vm.termForUserExists(grade.user_exists)}}
-                %span.has-tooltip
-                  %i.fa.fa-info-circle
-                  .display-on-hover.hover-style
-                    Import grade to create a GradeCraft account for this user
-            %td.center
-              %input{"type"=>"checkbox",
-                     "name"=>"grade_ids[]",
-                     "value"=>"{{grade.id}}",
-                     "ng-model"=>"grade.selected_for_import"}
-                %span.has-tooltip{"ng-style"=>"{'visibility': grade.gradecraft_score.raw_points == null ? 'hidden' : 'visible'}"}
-                  %i.fa.fa-info-circle
-                  .display-on-hover.hover-style
-                    Importing this grade would override the existing grade in GradeCraft with the grade from
-                    %span.capitalize {{vm.provider}}
-          %tr{"ng-if"=>"vm.loading"}
-            %td.center{"colspan"=>"7"}
-              %i.fa.fa-spinner.fa-spin.fa-fw
-              Loading...
+    %table.no-table-header
+      %thead
+        %tr
+          %th{"scope"=>"col"} Student Name
+          %th{"scope"=>"col"} {{vm.provider}} Score
+          %th{"scope"=>"col"} {{vm.provider}} Feedback
+          %th{"scope"=>"col"} GradeCraft Score
+          %th{"scope"=>"col"} GradeCraft Feedback
+          %th{"scope"=>"col"} User Found?
+          %th
+            %button.button.select-all{"role"=>"button",
+                                      "type"=>"button",
+                                      "ng-click"=>"vm.selectAllGrades()"}= "Check"
+            %button.button.select-none{"role"=>"button",
+                                       "type"=>"button",
+                                       "ng-click"=>"vm.deselectAllGrades()"}= "Uncheck"
+      %tbody
+        %tr{"ng-if"=>"grades.length > 0", "ng-repeat"=>"grade in grades"}
+          %td {{grade.primary_email}}
+          %td {{grade.score}}
+          %td {{grade.feedback}}
+          %td {{grade.gradecraft_score.raw_points}}
+          %td {{grade.gradecraft_score.feedback}}
+          %td
+            %div{"ng-if"=>"grade.user_exists"}
+              {{vm.termForUserExists(grade.user_exists)}}
+            %div{"ng-if"=>"!grade.user_exists"}
+              {{vm.termForUserExists(grade.user_exists)}}
+              %span.has-tooltip
+                %i.fa.fa-info-circle
+                .display-on-hover.hover-style
+                  Import grade to create a GradeCraft account for this user
+          %td.center
+            %input{"type"=>"checkbox",
+                   "name"=>"grade_ids[]",
+                   "value"=>"{{grade.id}}",
+                   "ng-model"=>"grade.selected_for_import"}
+              %span.has-tooltip{"ng-style"=>"{'visibility': grade.gradecraft_score.raw_points == null ? 'hidden' : 'visible'}"}
+                %i.fa.fa-info-circle
+                .display-on-hover.hover-style
+                  Importing this grade would override the existing grade in GradeCraft with the grade from
+                  %span.capitalize {{vm.provider}}
 
-      .submit-buttons
-        .right
-          %input{"type"=>"submit",
-                 "class"=>"button",
-                 "ng-disabled"=>"!vm.hasSelectedGrades() || vm.formSubmitted",
-                 "ng-class"=>"{'disabled': !vm.hasSelectedGrades() || vm.formSubmitted}",
-                 "value"=>"Import Selected Grades Into {{vm.assignmentName}}"}
+    .submit-buttons
+      .right
+        %input{"type"=>"submit",
+               "class"=>"button",
+               "ng-disabled"=>"vm.loading || !vm.hasSelectedGrades() || vm.formSubmitted",
+               "ng-class"=>"{'disabled': vm.loading || !vm.hasSelectedGrades() || vm.formSubmitted}",
+               "value"=>"Import Selected Grades Into {{vm.assignmentName}}"}

--- a/app/assets/javascripts/angular/templates/user/import/form.html.haml
+++ b/app/assets/javascripts/angular/templates/user/import/form.html.haml
@@ -2,12 +2,12 @@
 
 %canvas-course-selector{"provider"=>"{{vm.provider}}"}
 
-%without-users{"ng-if"=>"!vm.loading && vm.users.length < 1"}
-  %p There are no users to import for this course
-
-.loading-message{"ng-if"=>"vm.loading"}
+%h2.loading{"ng-if"=>"vm.loading"}
   %i.fa.fa-spinner.fa-spin.fa-fw
   Loading users...
+
+%without-users{"ng-if"=>"!vm.loading && vm.users.length < 1"}
+  %p There are no users to import for this course
 
 %with_users{"ng-if"=>"vm.users.length > 0"}
 

--- a/app/assets/javascripts/angular/templates/user/import/form.html.haml
+++ b/app/assets/javascripts/angular/templates/user/import/form.html.haml
@@ -2,8 +2,12 @@
 
 %canvas-course-selector{"provider"=>"{{vm.provider}}"}
 
-%without-users{"ng-if"=>"vm.users.length < 1"}
+%without-users{"ng-if"=>"!vm.loading && vm.users.length < 1"}
   %p There are no users to import for this course
+
+.loading-message{"ng-if"=>"vm.loading"}
+  %i.fa.fa-spinner.fa-spin.fa-fw
+  Loading users...
 
 %with_users{"ng-if"=>"vm.users.length > 0"}
 

--- a/app/controllers/api/grades/importers_controller.rb
+++ b/app/controllers/api/grades/importers_controller.rb
@@ -13,7 +13,7 @@ class API::Grades::ImportersController < ApplicationController
   def show
     @assignment = Assignment.find params[:assignment_id]
     @provider_name = params[:importer_provider_id]
-    @grades = syllabus.grades(params[:id], [params[:assignment_ids]].flatten, nil, false, importer_params.to_h) do
+    @result = syllabus.grades(params[:id], [params[:assignment_ids]].flatten, nil, false, importer_params.to_h) do
       render json: { message: "There was an issue trying to retrieve the grades from #{@provider_name.capitalize}.",
         success: false }, status: 500 and return
     end
@@ -27,7 +27,7 @@ class API::Grades::ImportersController < ApplicationController
   private
 
   def importer_params
-    params.permit(:page, :per_page)
+    params.permit :page
   end
 
   def syllabus

--- a/app/controllers/api/users/importers_controller.rb
+++ b/app/controllers/api/users/importers_controller.rb
@@ -14,7 +14,7 @@ class API::Users::ImportersController < ApplicationController
   # GET /api/users/importers/:importer_provider_id/course/:id/users
   def index
     @provider_name = params[:importer_provider_id]
-    @users = syllabus.users(params[:id], true, importer_params.to_h) do
+    @result = syllabus.users(params[:id], true, importer_params.to_h) do
       render json: { message: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}.",
         success: false }, status: 500 and return
     end
@@ -25,7 +25,7 @@ class API::Users::ImportersController < ApplicationController
 
   # Permissible params to include in the request
   def importer_params
-    params.permit(:enrollment_type, :user_ids)
+    params.permit :page
   end
 
   def syllabus

--- a/app/controllers/api/users/importers_controller.rb
+++ b/app/controllers/api/users/importers_controller.rb
@@ -14,7 +14,7 @@ class API::Users::ImportersController < ApplicationController
   # GET /api/users/importers/:importer_provider_id/course/:id/users
   def index
     @provider_name = params[:importer_provider_id]
-    @result = syllabus.users(params[:id], true, importer_params.to_h) do
+    @result = syllabus.users(params[:id], false, importer_params.to_h) do
       render json: { message: "There was an issue trying to retrieve the course from #{@provider_name.capitalize}.",
         success: false }, status: 500 and return
     end

--- a/app/services/imports_lms_grades/retrieves_lms_grades.rb
+++ b/app/services/imports_lms_grades/retrieves_lms_grades.rb
@@ -19,9 +19,9 @@ module Services
         context.grades = syllabus.grades(course_id, assignment_ids, grade_ids) do
           context.fail!("An error occurred while attempting to retrieve #{provider} grades", error_code: 500)
           next context
-        end[:data]
+        end[:grades]
 
-        next context if context.failure?
+        next context if context.failure? || context.grades.nil?
         context.user_ids = context.grades.map { |h| h["user_id"] }.compact.uniq
       end
     end

--- a/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
+++ b/app/services/imports_lms_users/retrieves_lms_users_with_roles.rb
@@ -18,9 +18,9 @@ module Services
         context.users = syllabus.users(course_id, true, user_ids: user_ids) do
           context.fail!("An error occurred while attempting to retrieve #{provider} users", error_code: 500)
           next context
-        end[:data]
+        end[:users]
 
-        next context if context.failure?
+        next context if context.failure? || context.users.nil?
       end
     end
   end

--- a/app/views/api/grades/importers/show.json.jbuilder
+++ b/app/views/api/grades/importers/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.data @grades[:data] do |grade|
+json.data @result[:grades] do |grade|
   user = lms_user(@syllabus, grade["user_id"])
 
   json.type                                   "imported_grade"
@@ -7,6 +7,7 @@ json.data @grades[:data] do |grade|
   json.attributes do
     json.id                                   grade["id"].to_s
     json.primary_email                        user["primary_email"]
+
     json.score                                grade["score"]
     json.feedback                             concat_submission_comments(grade["submission_comments"])
     json.gradecraft_score                     Grade.for_student_email_and_assignment_id(user["primary_email"],
@@ -18,5 +19,5 @@ end
 json.meta do
   json.term_for_provider_assignment           @provider_assignment["name"]
   json.term_for_assignment                    term_for :assignment
-  json.has_next_page                          @grades[:has_next_page]
+  json.page_params                            @result[:page_params]
 end

--- a/app/views/api/users/importers/index.json.jbuilder
+++ b/app/views/api/users/importers/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.data @users[:data] do |user|
+json.data @result[:users] do |user|
   gradecraft_user = User.find_by_insensitive_email(user["email"])
   user_exists = lms_user_match?(user["email"], current_course)
   gradecraft_role = lms_user_role(user["enrollments"])
@@ -21,5 +21,5 @@ json.data @users[:data] do |user|
 end
 
 json.meta do
-  json.has_next_page @users[:has_next_page]
+  json.page_params                            @result[:page_params]
 end

--- a/app/views/api/users/importers/index.json.jbuilder
+++ b/app/views/api/users/importers/index.json.jbuilder
@@ -21,5 +21,5 @@ json.data @result[:users] do |user|
 end
 
 json.meta do
-  json.page_params                            @result[:page_params]
+  json.page_params @result[:page_params]
 end

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -7,6 +7,7 @@ require "canvas"
 # ActiveLMS::Syllabus.
 module ActiveLMS
   GRADE_API_PARAMS = ["assignment_ids[]", "enrollment_state", "workflow_state", "student_ids", "include[]", "per_page"].freeze
+  USERS_API_PARAMS = ["include"].freeze
 
   class CanvasSyllabus
     # Internal: Initializes a CanvasSyllabus
@@ -555,13 +556,12 @@ module ActiveLMS
     def users(course_id, fetch_next=true, options={}, &exception_handler)
       handle_exceptions(exception_handler) do
         users = []
-        params = {
-          include: ["enrollments", "email"]
-        }.merge(options)
-        result = client.get_data("/courses/#{course_id}/users", params, fetch_next) do |data|
+        params = { include: ["enrollments", "email"] }.merge(options)
+        result = client.get_data("/courses/#{course_id}/users", params) do |data, next_url|
           users += data
+          return { users: users, page_params: parse_params(next_url, *USERS_API_PARAMS) } if !fetch_next
         end
-        { data: users, has_next_page: result[:has_next_page] }
+        { users: users }
       end
     end
 

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -376,7 +376,7 @@ module ActiveLMS
                    workflow_state: "graded",
                    student_ids: "all",
                    include: ["assignment", "course", "user", "submission_comments"],
-                   per_page: options.delete(:per_page) || 1 }.merge(options)
+                   per_page: options.delete(:per_page) || 25 }.merge(options)
         client.get_data("/courses/#{course_id}/students/submissions", params) do |data, next_url|
           data.select! { |grade| !grade["score"].blank? || !grade["submission_comments"].blank? }
           if grade_ids.nil?

--- a/lib/active_lms/syllabus/canvas_syllabus.rb
+++ b/lib/active_lms/syllabus/canvas_syllabus.rb
@@ -556,7 +556,7 @@ module ActiveLMS
     def users(course_id, fetch_next=true, options={}, &exception_handler)
       handle_exceptions(exception_handler) do
         users = []
-        params = { include: ["enrollments", "email"] }.merge(options)
+        params = { include: ["enrollments", "email"], per_page: 25 }.merge(options)
         result = client.get_data("/courses/#{course_id}/users", params) do |data, next_url|
           users += data
           return { users: users, page_params: parse_params(next_url, *USERS_API_PARAMS) } if !fetch_next

--- a/lib/canvas/api.rb
+++ b/lib/canvas/api.rb
@@ -15,8 +15,7 @@ module Canvas
 
     # Fetch data from Canvas
     # Optionally decide whether to automatically traverse additional pages
-    def get_data(path="/", params={}, fetch_next=true)
-      result = {}
+    def get_data(path="/", params={})
       params.merge! access_token: access_token
       next_url = "#{base_uri}#{path}"
       next_url += "?#{params.to_query}" unless params.empty?
@@ -25,12 +24,10 @@ module Canvas
         # attached to the next url in the header
         response = self.class.get(next_url, query: { access_token: access_token })
         raise ResponseError.new(response) unless response.success?
-        yield response.parsed_response if block_given?
         next_url = get_next_url(response)
-        result[:has_next_page] = next_url.present?
-        break if !fetch_next || next_url.nil?
+        yield response.parsed_response, next_url if block_given?
+        break if next_url.nil?
       end
-      result
     end
 
     def set_data(path="/", method=:post, params={})

--- a/spec/controllers/api/grades/importers_controller_spec.rb
+++ b/spec/controllers/api/grades/importers_controller_spec.rb
@@ -11,7 +11,7 @@ describe API::Grades::ImportersController, type: [:disable_external_api, :contro
   context "as a professor" do
     let(:user) { build :user, courses: [course], role: :professor }
     let(:access_token) { "topsecret" }
-    let(:syllabus) { double :syllabus, grades: grades, assignment: provider_assignment }
+    let(:syllabus) { instance_double "Syllabus", grades: { grades: grades }, assignment: provider_assignment }
     let(:grades) { [{ id: 1, score: 100 }, { id: 2, score: 120 }] }
     let(:provider_assignment) { { name: "Pass/Fail" } }
     let!(:user_authorization) do
@@ -36,7 +36,8 @@ describe API::Grades::ImportersController, type: [:disable_external_api, :contro
           format: :json
         expect(assigns :assignment).to eq assignment
         expect(assigns :provider_name).to eq "canvas"
-        expect(assigns :grades).to eq grades
+        expect(assigns :result).to include :grades
+        expect(assigns(:result)[:grades]).to match_array grades
       end
 
       it "renders the template" do

--- a/spec/controllers/api/users/importers_controller_spec.rb
+++ b/spec/controllers/api/users/importers_controller_spec.rb
@@ -11,13 +11,8 @@ describe API::Users::ImportersController, type: [:disable_external_api, :control
 
   context "as a professor" do
     let(:user) { build :user, courses: [course], role: :professor }
-    let(:syllabus) { double :syllabus, users: users }
-    let(:users) do
-      {
-        data: [{ name: "Robert W" }, { name: "Joe Q" }],
-        has_next_page: true
-      }
-    end
+    let(:syllabus) { instance_double "Syllabus", users: { users: users } }
+    let(:users) { [{ name: "Robert W" }, { name: "Joe Q" }] }
     let!(:user_authorization) do
       create :user_authorization, :canvas, user: user, access_token: access_token,
         expires_at: 2.days.from_now
@@ -30,11 +25,12 @@ describe API::Users::ImportersController, type: [:disable_external_api, :control
 
     describe "#index" do
       context "when successful" do
-        it "returns the users" do
+        it "assigns the users and provider" do
           get :index, params: { id: course.id, importer_provider_id: provider },
             format: :json
           expect(assigns :provider_name).to eq "canvas"
-          expect(assigns :users).to eq users
+          expect(assigns :result).to include :users
+          expect(assigns(:result)[:users]).to match_array users
         end
 
         it "renders the template" do

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -1,6 +1,6 @@
 require "api_spec_helper"
 
-describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
+describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
   let(:access_token) { "BLAH" }
 
   before do

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -1,6 +1,6 @@
 require "api_spec_helper"
 
-describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
+describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
   let(:access_token) { "BLAH" }
 
   before do
@@ -219,10 +219,9 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
       it "returns a hash containing only grades with scores or feedback" do
         result = subject.grades(123, assignment_ids)
 
-        expect(result[:data].count).to eq 2
-        expect(result[:data]).to include({ "id" => 456, "score" => 87 },
+        expect(result[:grades].count).to eq 2
+        expect(result[:grades]).to include({ "id" => 456, "score" => 87 },
           { "id" => 777, "score" => nil, "submission_comments" => "good jorb!" })
-        expect(result[:has_next_page]).to eq false
       end
 
       it "merges options if provided" do
@@ -237,26 +236,26 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
                          "access_token" => access_token })
           .to_return(status: 200, body: [{ id: 456, score: 87 }].to_json, headers: {})
         result = subject.grades(123, assignment_ids, nil, nil, { per_page: 5, test: true })
-        expect(result[:data].count).to eq 1
+        expect(result[:grades].count).to eq 1
       end
 
       context "for specific ids" do
         it "filters out a single id" do
           result = subject.grades(123, assignment_ids, "456")
 
-          expect(result[:data].first["id"]).to eq 456
+          expect(result[:grades].first["id"]).to eq 456
         end
 
         it "does not duplicate the grades for double grade ids" do
           result = subject.grades(123, assignment_ids, [456, 456])
 
-          expect(result[:data].count).to eq 1
+          expect(result[:grades].count).to eq 1
         end
 
         it "filters out the grade ids" do
           result = subject.grades(123, assignment_ids, [123])
 
-          expect(result[:data]).to be_empty
+          expect(result[:grades]).to be_empty
         end
       end
     end
@@ -352,12 +351,11 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
                          "include" => ["enrollments", "email"] })
           .to_return(status: 200, body: body.to_json, headers: {})
 
-        users = subject.users(123)
+        result = subject.users(123)
 
-        expect(users[:data].length).to eq 2
-        expect(users[:has_next_page]).to be_falsey
-        expect(users[:data].first).to eq({ "name" => "Jimmy Page", "id" => 1 })
-        expect(users[:data].second).to eq({ "name" => "Robert Plant", "id" => 2 })
+        expect(result[:users].length).to eq 2
+        expect(result[:users].first).to eq({ "name" => "Jimmy Page", "id" => 1 })
+        expect(result[:users].second).to eq({ "name" => "Robert Plant", "id" => 2 })
       end
 
       it "merges options if provided" do
@@ -368,9 +366,9 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api, focus: true do
                          "include" => ["enrollments", "email"] })
           .to_return(status: 200, body: body.to_json, headers: {})
 
-        users = subject.users(123, false, { "enrollment_type": ["student", "teacher"] })
+        result = subject.users(123, false, { "enrollment_type": ["student", "teacher"] })
 
-        expect(users[:data].length).to eq 1
+        expect(result[:users].length).to eq 1
       end
     end
 

--- a/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
+++ b/spec/lib/active_lms/syllabus/canvas_syllabus_spec.rb
@@ -348,7 +348,8 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
         body = [{ name: "Jimmy Page", id: 1 }, { name: "Robert Plant", id: 2 }]
         stub_request(:get, "https://canvas.instructure.com/api/v1/courses/123/users")
           .with(query: { "access_token" => access_token,
-                         "include" => ["enrollments", "email"] })
+                         "include" => ["enrollments", "email"],
+                         "per_page" => 25 })
           .to_return(status: 200, body: body.to_json, headers: {})
 
         result = subject.users(123)
@@ -363,7 +364,8 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
         stub_request(:get, "https://canvas.instructure.com/api/v1/courses/123/users")
           .with(query: { "access_token" => access_token,
                          "enrollment_type" => ["student", "teacher"],
-                         "include" => ["enrollments", "email"] })
+                         "include" => ["enrollments", "email"],
+                         "per_page" => 25 })
           .to_return(status: 200, body: body.to_json, headers: {})
 
         result = subject.users(123, false, { "enrollment_type": ["student", "teacher"] })
@@ -376,7 +378,8 @@ describe ActiveLMS::CanvasSyllabus, type: :disable_external_api do
       let(:stub) {
         stub_request(:get, "https://canvas.instructure.com/api/v1/courses/123/users")
           .with(query: { "access_token" => access_token,
-                         "include" => ["enrollments", "email"] })
+                         "include" => ["enrollments", "email"],
+                         "per_page" => 25 })
       }
       let!(:json_error) { stub.to_raise(JSON::ParserError) }
 

--- a/spec/lib/canvas/api_spec.rb
+++ b/spec/lib/canvas/api_spec.rb
@@ -87,45 +87,6 @@ describe Canvas::API, type: :disable_external_api do
       expect(first_request).to have_been_made
       expect(second_request).to have_been_made
     end
-
-    it "fetches only the first page if specified" do
-      links = <<-LINKS
-      <https://canvas.instructure.com/api/v1/courses?page=1&per_page=10>; rel="current",<https://canvas.instructure.com/api/v1/courses?page=2&per_page=10>; rel="next"
-      LINKS
-      headers = { "Link" => links }
-
-      body = { name: "This is a course on page 1" }
-      first_request = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
-        .with(query: { "access_token" => access_token })
-        .to_return(status: 200, body: body.to_json, headers: headers)
-
-      body2 = { name: "This is a course on page 2" }
-      second_request = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
-        .with(query: { "page" => "2", "per_page" => "10", "access_token" => access_token })
-        .to_return(status: 200, body: body2.to_json, headers: {})
-
-      grades = []
-      subject.get_data("/courses", {}, false) { |course| grades << course }
-
-      expect(grades.count).to eq 1
-      expect(first_request).to have_been_made
-      expect(second_request).to_not have_been_made
-    end
-
-    it "returns a hash with the result" do
-      links = <<-LINKS
-      <https://canvas.instructure.com/api/v1/courses?enrollment_type=student&page=1&per_page=10>; rel="current",<https://canvas.instructure.com/api/v1/courses?enrollment_type=student&page=2&per_page=10>; rel="next"
-      LINKS
-      headers = { "Link" => links }
-
-      body = { name: "This is a course on page 1" }
-      request = stub_request(:get, "https://canvas.instructure.com/api/v1/courses")
-        .with(query: { "access_token" => access_token })
-        .to_return(status: 200, body: body.to_json, headers: headers)
-      result = subject.get_data("/courses", {}, false) { |course| [] << course }
-
-      expect(result[:has_next_page]).to eq true
-    end
   end
 
   describe "#set_data" do

--- a/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades/retrieves_lms_grades_spec.rb
@@ -40,7 +40,7 @@ describe Services::Actions::RetrievesLMSGrades do
       receive(:new).with(provider, access_token).and_call_original
     expect_any_instance_of(ActiveLMS::Syllabus).to \
       receive(:grades).with(course_id, assignment_ids, grade_ids)
-        .and_return({ data: [{ grade: "A+" }, { grade: "D-" }] })
+        .and_return({ grades: [{ grade: "A+" }, { grade: "D-" }] })
 
     described_class.execute provider: provider, access_token: access_token,
       course_id: course_id, assignment_ids: assignment_ids, grade_ids: grade_ids
@@ -48,7 +48,7 @@ describe Services::Actions::RetrievesLMSGrades do
 
   it "promises the user ids from the grades" do
     allow_any_instance_of(ActiveLMS::Syllabus).to \
-      receive(:grades).and_return({ data: [{ "user_id" => "123" }] })
+      receive(:grades).and_return({ grades: [{ "user_id" => "123" }] })
 
     result = described_class.execute provider: provider, access_token: access_token,
       course_id: course_id, assignment_ids: assignment_ids, grade_ids: grade_ids

--- a/spec/services/imports_lms_grades_spec.rb
+++ b/spec/services/imports_lms_grades_spec.rb
@@ -10,7 +10,7 @@ describe Services::ImportsLMSGrades do
 
     before do
       # do not call the API
-      allow_any_instance_of(ActiveLMS::Syllabus).to receive(:grades).and_return({ data: [] })
+      allow_any_instance_of(ActiveLMS::Syllabus).to receive(:grades).and_return({ grades: [] })
     end
 
     it "retrieves the grade details from the lms provider" do


### PR DESCRIPTION
### Status
**READY**

### Description
Feeling like this is a change with the Canvas API but not 100% sure....

Previously our expectation was that if we paginate via the API and there were more pages to be fetched, the provided link in the header would contain something to the effect of `page=1&per_page=10`.

In this scenario, we would previously fetch additional pages by incrementing the page number for the next call. However, now the page number returned by Canvas in the links header now resembles `page=bookmark:WzD4DQ&per_page=1`.

This PR changes how the params are passed around from the server-side, to the client, and back to server between AJAX calls so that it no longer operates simply off of the assumption that the page is an int.

### Impacted Areas in Application
Canvas grade import
Canvas user import

======================
Closes #4003
