### PR TITLE
Tweak eager-loading on students index page

### DIFF
--- a/app/controllers/api/courses/students_controller.rb
+++ b/app/controllers/api/courses/students_controller.rb
@@ -13,13 +13,13 @@ class API::Courses::StudentsController < ApplicationController
 
     @students = @students.where(id: params[:student_ids]) if params[:student_ids].present?
     @teams = @course.teams if @course.has_teams?
-    @earned_badges = @course.earned_badges.where student_id: @students.pluck(:id)
+    @earned_badges = @course.earned_badges.includes(:badge).where student_id: @students.pluck(:id)
     @flagged_users = FlaggedUser.for_course(@course).for_flagger current_user
   end
 
   private
 
   def find_course
-    @course = Course.includes(:teams, :earned_badges).find params[:course_id]
+    @course = Course.find params[:course_id]
   end
 end

--- a/app/controllers/api/courses/teams_controller.rb
+++ b/app/controllers/api/courses/teams_controller.rb
@@ -3,7 +3,7 @@ class API::Courses::TeamsController < ApplicationController
 
   # GET api/courses/:course_id/teams
   def index
-    course = Course.includes(:teams).find params[:course_id]
+    course = Course.find params[:course_id]
     teams = course.teams.select(:id, :name).order(:name) if course.has_teams?
     render json: MultiJson.dump(teams: teams, term_for_team: term_for(:team)), status: :ok
   end

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -74,6 +74,7 @@ class CourseMembership < ActiveRecord::Base
 
   def earned_grade_scheme_element(grade_scheme_elements=nil)
     elements = grade_scheme_elements || course.grade_scheme_elements.with_lowest_points.order_by_points_asc
+    elements = elements.includes(:unlock_conditions) if elements.any?
     element_earned = nil
 
     elements.sort_by{ |element| element.lowest_points }.each_with_index do |gse, index|


### PR DESCRIPTION
### Status
**READY**

### Description
Occasionally seeing some server degradation when people are hitting the student index page hard for large datasets (e.g. TG). This mainly needs to be addressed through a review of available infrastructure resources, but in the meantime we at least can optimize the queries a bit on the API.

### Impacted Areas in Application
Student index page

======================
Closes #[ISSUE NUMBER]