### PR TITLE
prevent menus from overlapping with tables

### DIFF
--- a/app/assets/stylesheets/layout/_context_menu.sass
+++ b/app/assets/stylesheets/layout/_context_menu.sass
@@ -3,7 +3,6 @@
 .context-menu
   float: right
   margin-top: 0.65rem
-  margin-bottom: 0.65rem
   display: inline-block
   position: relative
   z-index: 10

--- a/app/assets/stylesheets/layout/_context_menu.sass
+++ b/app/assets/stylesheets/layout/_context_menu.sass
@@ -3,6 +3,7 @@
 .context-menu
   float: right
   margin-top: 0.65rem
+  margin-bottom: 0.65rem
   display: inline-block
   position: relative
   z-index: 10

--- a/app/views/layouts/_staff.haml
+++ b/app/views/layouts/_staff.haml
@@ -15,6 +15,7 @@
         = breadcrumbs
         %h1.pagetitle= title
         = yield(:context_menu)
+        .clear
 
     = render partial: "info/staff_onboarding"
 


### PR DESCRIPTION
### Status
**READY**

### Description
A tiny UX improvement that adds a margin to prevent context menus from overlapping with the tables beneath
