### PR TITLE
Revised double-Downloads headings

### DIFF
--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -93,7 +93,7 @@
 
 - if presenter.assignment_has_viewable_description?(current_user)
   - if presenter.assignment.assignment_files.present?
-    %h3.uppercase Resources
+    %h3.uppercase Attachments:
     %ul
       - presenter.assignment.assignment_files.each do |af|
         %li= link_to af.filename, af.url

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -93,7 +93,7 @@
 
 - if presenter.assignment_has_viewable_description?(current_user)
   - if presenter.assignment.assignment_files.present?
-    %h3.uppercase Downloads
+    %h3.uppercase Resources
     %ul
       - presenter.assignment.assignment_files.each do |af|
         %li= link_to af.filename, af.url


### PR DESCRIPTION
### Status
**READY**

### Description
Tiny UX change, switching a double-Downloads heading to be "Downloads" (for exported grade files) and then "Resources" (for attached documents)

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

1. Load a single assignment page that has both 1) grades, and 2) an attached file 
2) Click the Description & Downloads tab

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment Show page

======================
Closes #3969 
