### PR TITLE
Clean up routes, fix grade release

### DIFF
--- a/app/assets/javascripts/angular/directives/assignments/show/group/table.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/show/group/table.coffee
@@ -8,7 +8,7 @@
 
       vm.releaseGrades = () ->
         return unless vm.hasSelectedGrades()
-        GradeReleaseService.postReleaseForAssignment(@assignmentId).then(
+        GradeReleaseService.postRelease(
           () ->
             alert("#{GradeReleaseService.gradeIds.length} grade(s) successfully released")
             GradeReleaseService.clearGradeIds()

--- a/app/assets/javascripts/angular/directives/assignments/show/individual/table.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/show/individual/table.coffee
@@ -5,12 +5,12 @@
       vm.loading = true
       vm.searchCriteria = SortableService.filterCriteria
       vm.hasSelectedGrades = GradeReleaseService.hasSelectedGrades
-      
+
       vm.hasUnreleasedGrades = () -> _.some(StudentService.students, (student) -> student.grade_id? and student.grade_not_released is true)
 
       vm.releaseGrades = () ->
         return unless vm.hasSelectedGrades()
-        GradeReleaseService.postReleaseForAssignment(@assignmentId).then(
+        GradeReleaseService.postRelease(
           () ->
             alert("#{GradeReleaseService.gradeIds.length} grade(s) successfully released")
             # Refresh the list of students with new release statuses

--- a/app/assets/javascripts/angular/directives/grading_status/grades.coffee
+++ b/app/assets/javascripts/angular/directives/grading_status/grades.coffee
@@ -25,7 +25,8 @@
 
       vm.releaseGrades = () ->
         return unless GradeReleaseService.hasSelectedGrades()
-        GradeReleaseService.postRelease().then(
+
+        GradeReleaseService.postRelease(
           () ->
             alert("#{GradeReleaseService.gradeIds.length} grade(s) successfully released")
             GradeReleaseService.clearGradeIds()

--- a/app/assets/javascripts/angular/services/GradeReleaseService.coffee
+++ b/app/assets/javascripts/angular/services/GradeReleaseService.coffee
@@ -3,20 +3,13 @@
   gradeIds = []
 
   # If grade ids are for assorted assignment ids in the course
-  postRelease = () ->
+  postRelease = (successCallback, failureCallback) ->
     $http.put("/api/assignments/grades/release", grade_ids: gradeIds).then(
       (response) ->
+        successCallback() if successCallback?
         GradeCraftAPI.logResponse(response)
       , (error) ->
-        GradeCraftAPI.logResponse(error)
-    )
-
-  # If the grade ids all belong to a specific assignment in the course
-  postReleaseForAssignment = (assignmentId) ->
-    $http.put("/api/assignments/#{assignmentId}/grades/release", grade_ids: gradeIds).then(
-      (response) ->
-        GradeCraftAPI.logResponse(response)
-      , (error) ->
+        failureCallback() if failureCallback?
         GradeCraftAPI.logResponse(error)
     )
 
@@ -33,7 +26,6 @@
   {
     gradeIds: gradeIds
     postRelease: postRelease
-    postReleaseForAssignment: postReleaseForAssignment
     addGradeIds: addGradeIds
     clearGradeIds: clearGradeIds
     hasSelectedGrades: hasSelectedGrades

--- a/app/controllers/api/assignments/grades_controller.rb
+++ b/app/controllers/api/assignments/grades_controller.rb
@@ -14,21 +14,10 @@ class API::Assignments::GradesController < ApplicationController
     @grades = Gradebook.new(@assignment, students).grades
   end
 
-  # /api/assignments/grades/release
+  # GET /api/assignments/grades/release
+  # Params: grade_ids[]
   def release
     grades = current_course.grades.where(id: params[:grade_ids])
-    return head :not_found if grades.empty?
-
-    release_grades(grades)
-    head :ok
-  end
-
-  # /api/assignments/:assignment_id/grades/release
-  # Optional: params[:grade_ids]
-  def release_for_assignment
-    assignment = current_course.assignments.find params[:assignment_id]
-    grades = assignment.grades
-    grades = grades.where(id: params[:grade_ids]) if params[:grade_ids].present?
     return head :not_found if grades.empty?
 
     release_grades(grades)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -403,10 +403,7 @@ Rails.application.routes.draw do
         get :outcomes, to: "outcomes#outcomes_for_assignment"
       end
       resources :grades, only: [], module: :assignments do
-        collection do
-          get :show
-          put :release_for_assignment
-        end
+        get :show, on: :collection
       end
       resource :groups, only: [], module: :assignments do
         resources :grades, only: :index, module: :groups do


### PR DESCRIPTION
### Status
**READY**

### Description
This PR consolidates two very similar API endpoints into one and fixes a bug where there was a routing error when releasing grades in bulk while viewing a specific assignment.

Also when an error was returned in the API response, the exception was not being propagated properly to the caller in the Angular directive. The service method was tweaked a bit so that it optionally takes a success and an error callback.

### Gem dependencies
N/A

### Migrations
NO

### Impacted Areas in Application
- Grade release from grading status page
- Grade release from individual assignment show page
- Grade release from group assignment show page

======================
Closes #4034 
