### PR TITLE
Add cron job that trims the Session table daily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN cp /intermidiate/puma.rb /gradecraft/config/puma.rb
 RUN cp /intermidiate/Procfile /gradecraft/Procfile
 RUN printf  "if [ \$WEBRESQUE = 'WEB' ]\nthen \n RAILS_ENV=production bundle exec rake resque:scheduler &\n/mounts3.sh\nservice nginx start\npuma\nelse \n RAILS_ENV=production bundle exec rake resque:scheduler & \nbundle exec rake resque:work >> resque.log\nfi" > /gradecraft/start.sh
 RUN chmod +x /gradecraft/start.sh
+RUN crontab /etc/cron.d/trim-cron
+CMD cron && tail -f /var/log/cron.log
 RUN RAILS_ENV=production bundle exec rake assets:precompile
 RUN RAILS_ENV=production bundle exec rake db:migrate
 ENTRYPOINT /gradecraft/start.sh


### PR DESCRIPTION
### Status
**READY**

### Description
Currently we are utilizing the ActiveRecord Sessionstore gem for storing sessions in the database. Per the gem documentation, the table should be trimmed periodically via `bundle exec rails db:sessions:trim` in order to prevent the table from growing without limit.

This PR adds the Docker commands necessary to invoke the cron job. The precondition is that `cron` has been installed and the cron job has already been added in the `base_image`

======================
Intermediate solution for #2115
