### PR TITLE
Add recurring job to check stuck queues

### DIFF
--- a/app/background_jobs/check_throttled_queues_job.rb
+++ b/app/background_jobs/check_throttled_queues_job.rb
@@ -1,0 +1,39 @@
+class CheckThrottledQueuesJob < ResqueApplicationJob
+  THROTTLED_JOB_QUEUES = %w(pageview_event_logger login_event_logger predictor_event_logger).freeze
+
+  queue_as :check_throttled_queues
+
+  attr_reader :redis
+
+  def initialize
+    @redis = Resque.redis
+  end
+
+  def perform
+    THROTTLED_JOB_QUEUES.each do |q|
+      clear_queue(q) if next_job_at_or_exceeds_limit? q
+    end
+  end
+
+  def clear_queue(queue)
+    queue_key = "throttler:#{queue}_uuids"
+    uuids = @redis.smembers(queue_key)
+
+    while next_job_at_or_exceeds_limit? queue
+      uuid = uuids.first
+      @redis.srem(queue_key, uuid)
+      @redis.del("throttler:jobs:#{uuid}")
+      Rails.logger.debug "Deleted uuid #{uuid} from redis"
+    end
+  end
+
+  def next_job_at_or_exceeds_limit?(queue)
+    Resque.queue_at_or_over_rate_limit? queue
+  end
+end
+
+class QueueCheckThrottledQueuesJob
+  def self.perform
+    CheckThrottledQueuesJob.new.perform_now
+  end
+end

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -14,3 +14,14 @@ queue_created_courses_mailer_job:
   queue: created_courses_export
   description: "This job triggers an export of all courses created within the \
     last month and emails it to a list of recipients as a CSV attachment."
+
+queue_check_throttled_queues_job:
+  cron: "0 1 * * *"
+  persist: true
+  class: "QueueCheckThrottledQueuesJob"
+  queue: check_throttled_queues
+  description: "This job runs daily and checks if any of the throttled Resque \
+    queues are queue_at_or_over_rate_limit?. If yes, then the next job(s) will \
+    be removed as needed so that the queue does not continue to grow. See \
+    https://github.com/UM-USElab/gradecraft-development/blob/fbe5a46c1835a944c1e05afa25103c27cbae0535/doc/maintenance.md \
+    for additional details regarding this bug."


### PR DESCRIPTION
### Status
**READY**

### Description
Adds a new recurring job that occurs daily. It will check all three of the queues that are throttled via `resque-throttler` to see if they are at or over their rate limit. If so, the job at the top of the queue will be deleted so that the queue can process.

### Impacted Areas in Application
Eventloggers (pageview, login, and predictor)

======================
Closes #3904 in lieu of a heavier refactor, where we might remove one of the offending gems or switch to Sidekiq
