### PR TITLE
Remove Hard Failure From Learning Objectives

### DIFF
--- a/app/controllers/api/learning_objectives/objectives_controller.rb
+++ b/app/controllers/api/learning_objectives/objectives_controller.rb
@@ -6,11 +6,14 @@ class API::LearningObjectives::ObjectivesController < ApplicationController
   # GET /api/learning_objectives/objectives
   def index
     if params[:assignment_id]
-      assignment = Assignment.find params[:assignment_id]
-      @objectives = assignment.learning_objectives.ordered_by_name
+      objectives = Assignment.find(params[:assignment_id]).learning_objectives
     else
-      @objectives = current_course.learning_objectives.ordered_by_name
+      objectives = current_course.learning_objectives
     end
+
+    @objectives = objectives
+      .includes(:category, :levels, :assignments, :learning_objective_links)
+      .ordered_by_name
   end
 
   # GET /api/learning_objectives/objectives/:id

--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -53,7 +53,7 @@ class LearningObjective < ApplicationRecord
     outcomes = cumulative_outcome
       .observed_outcomes
       .for_student_visible_grades
-    outcomes.shows_proficiency if proficient_only
+    outcomes = outcomes.shows_proficiency if proficient_only
     outcomes
   end
 
@@ -75,6 +75,6 @@ class LearningObjective < ApplicationRecord
 
   def in_progress_str(earned, total, include_details)
     return IN_PROGRESS_STATUS unless include_details
-    "#{IN IN_PROGRESS_STATUS} (#{earned}/#{total})"
+    "#{IN_PROGRESS_STATUS} (Earned #{earned} of #{total} tries)"
   end
 end

--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -1,4 +1,8 @@
 class LearningObjective < ApplicationRecord
+  NOT_STARTED_STATUS = "Not Started".freeze
+  IN_PROGRESS_STATUS = "In Progress".freeze
+  COMPLETED_STATUS = "Completed".freeze
+
   belongs_to :course
   belongs_to :category, class_name: "LearningObjectiveCategory", optional: true
 
@@ -22,7 +26,7 @@ class LearningObjective < ApplicationRecord
 
   def progress(student, include_details=false)
     cumulative_outcome = cumulative_outcomes.for_user(student.id).first
-    return "Not Started" if cumulative_outcome.nil?
+    return NOT_STARTED_STATUS if cumulative_outcome.nil?
 
     if course.objectives_award_points?
       point_progress_for cumulative_outcome, include_details
@@ -33,17 +37,16 @@ class LearningObjective < ApplicationRecord
 
   def point_progress_for(cumulative_outcome, include_details)
     earned = earned_assignment_points cumulative_outcome
-    return "Not Started" if earned.zero?
-    earned < points_to_completion ? in_progress_str(earned, points_to_completion, include_details) : "Completed"
+    return NOT_STARTED_STATUS if earned.zero?
+    earned < points_to_completion ? in_progress_str(earned, points_to_completion, include_details) : COMPLETED_STATUS
   end
 
   def grade_outcome_progress_for(cumulative_outcome, include_details)
     outcomes = observed_outcomes(cumulative_outcome)
-    return "Not Started" if outcomes.empty?
-    return "Failed" if outcomes.any? { |o| o.learning_objective_level.try(:failed?) }
+    return NOT_STARTED_STATUS if outcomes.empty?
 
     proficient_outcomes = observed_outcomes(cumulative_outcome, true)
-    proficient_outcomes.count < count_to_achieve ? in_progress_str(proficient_outcomes.count, count_to_achieve, include_details) : "Completed"
+    proficient_outcomes.count < count_to_achieve ? in_progress_str(proficient_outcomes.count, count_to_achieve, include_details) : COMPLETED_STATUS
   end
 
   def observed_outcomes(cumulative_outcome, proficient_only=false)
@@ -71,8 +74,7 @@ class LearningObjective < ApplicationRecord
   end
 
   def in_progress_str(earned, total, include_details)
-    str = "In Progress"
-    return str unless include_details
-    "#{str} (#{earned}/#{total})"
+    return IN_PROGRESS_STATUS unless include_details
+    "#{IN IN_PROGRESS_STATUS} (#{earned}/#{total})"
   end
 end

--- a/spec/models/learning_objective_spec.rb
+++ b/spec/models/learning_objective_spec.rb
@@ -49,12 +49,6 @@ describe LearningObjective do
           learning_objective_level: learning_objective_level
       end
 
-      it "returns 'Failed' if there are any failed observed outcomes" do
-        observed_outcome
-        learning_objective_level.update flagged_value: :not_proficient
-        expect(learning_objective.progress student).to eq "Failed"
-      end
-
       it "returns 'In Progress' if the count to achieve has not yet been met" do
         observed_outcome
         learning_objective.update count_to_achieve: 2


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Removes the "hard" failure state where a student could not recover after receiving a failing outcome.

### Impacted Areas in Application
Learning objectives

======================
Closes #4024 
