### PR TITLE
Self logged group assignments

### DIFF
--- a/app/assets/javascripts/angular/directives/assignments/edit_details.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/edit_details.coffee
@@ -8,6 +8,7 @@
     link: (scope, el, attr, ngModelCtrl)->
       scope.termFor = AssignmentService.termFor
       scope.learningObjectives = LearningObjectivesService.objectives
+      scope.isGroupGraded = () -> AssignmentService.isGroupGraded(@assignment)
 
       scope.hasLearningObjectives = () -> _.some(scope.learningObjectives())
 

--- a/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
@@ -20,7 +20,7 @@
           %input(ng-model="assignment.threshold_points" gc-number-input ng-change="updateAssignment()")
     .form-item
       %label
-        %input(type="checkbox" ng-model="assignment.student_logged" ng-click="updateAssignment()")
+        %input(type="checkbox" ng-model="assignment.student_logged" ng-disabled="isGroupGraded()" ng-click="updateAssignment()")
           Student Logged
           %span.has-tooltip
             %i.fa.fa-info-circle

--- a/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
@@ -19,7 +19,7 @@
           Points Threshold
           %input(ng-model="assignment.threshold_points" gc-number-input ng-change="updateAssignment()")
     .form-item
-      %label
+      %label(ng-class="{ 'disabled': isGroupGraded() }")
         %input(type="checkbox" ng-model="assignment.student_logged" ng-disabled="isGroupGraded()" ng-click="updateAssignment()")
           Student Logged
           %span.has-tooltip

--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -67,8 +67,7 @@ ul.conditional-options
   display: none
 
 .disabled
-  color: $color-grey-6
-  opacity: 0.7
+  opacity: 0.5
 
 .form-section
   margin-bottom: 1rem

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -61,6 +61,7 @@ class Assignment < ApplicationRecord
   validates_with SubmissionsAcceptedAfterDueValidator
   validates_with PointsUnderCapValidator
   validates_with MaxOverMinValidator
+  validates_with StudentLoggedValidator
 
   scope :group_assignments, -> { where grade_scope: "Group" }
 

--- a/app/validators/student_logged_validator.rb
+++ b/app/validators/student_logged_validator.rb
@@ -1,0 +1,6 @@
+class StudentLoggedValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add :base, "Assignment cannot be self-logged if group-graded" \
+      if record.student_logged? && record.has_groups?
+  end
+end

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -164,6 +164,13 @@ describe Assignment do
       expect(subject.errors[:base]).to include "Submission accept date must be after due date."
     end
 
+    it "is invalid if student-logged and group-graded" do
+      subject.student_logged = true
+      subject.grade_scope = "Group"
+      expect(subject).to_not be_valid
+      expect(subject.errors[:base]).to include "Assignment cannot be self-logged if group-graded"
+    end
+
     it "requires a numeric for max group size" do
       subject.max_group_size = "a"
       expect(subject).to_not be_valid


### PR DESCRIPTION
### Status
**READY**

### Description
Adds some UI changes to the assignment edit form to prevent the option for `student_logged` to be checked when the assignment is set as Group for the grading scope.

Since this also adds a validation on the model, a rake task must first be performed in order to clean up any existing data that is in error.

Must be merged after #4056 

======================
Closes #4055 
