### PR TITLE
Add additional scope for ordering

### DIFF
--- a/app/controllers/api/grade_scheme_elements_controller.rb
+++ b/app/controllers/api/grade_scheme_elements_controller.rb
@@ -7,9 +7,7 @@ class API::GradeSchemeElementsController < ApplicationController
   # GET /api/grade_scheme_elements
   def index
     assign_for_index
-    if current_user_is_student?
-      @student = current_student
-    end
+    @student = current_student if current_user_is_student?
   end
 
   # POST /api/grade_scheme_elements
@@ -55,13 +53,10 @@ class API::GradeSchemeElementsController < ApplicationController
   def assign_for_index
     @grade_scheme_elements = current_course
       .grade_scheme_elements
-      .order_by_points_desc.select(
-        :id,
-        :lowest_points,
-        :letter,
-        :level)
+      .ordered
+      .select(:id, :lowest_points, :letter, :level)
 
-    if @grade_scheme_elements.present?
+    if @grade_scheme_elements.any?
       @total_points = (@grade_scheme_elements.first.lowest_points).to_i
     else
       @total_points = current_course.total_points

--- a/app/models/grade_scheme_element.rb
+++ b/app/models/grade_scheme_element.rb
@@ -11,6 +11,7 @@ class GradeSchemeElement < ApplicationRecord
 
   scope :with_lowest_points, -> { where.not(lowest_points: nil) }
   scope :for_course, -> (course_id) { where(course_id: course_id) }
+  scope :ordered, -> { order({ lowest_points: :desc }, :letter) }
   scope :order_by_points_asc, -> { order lowest_points: :asc }
   scope :order_by_points_desc, -> { order lowest_points: :desc }
 


### PR DESCRIPTION
### Status
**READY**

### Description
Adds an additional scope that orders first by `lowest_points` descending and then by letter, which should give us the intended ordering.

### Impacted Areas in Application
Grade scheme elements ordering, after configuring them via the setup form

======================
Closes #4062 
