### PR TITLE
Dependent destroy submission exports

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -18,6 +18,8 @@ class Assignment < ApplicationRecord
   # has_many :level_badges, through: :criteria
   has_many :criterion_grades, dependent: :destroy
 
+  has_many :submissions_exports, dependent: :destroy
+
   multiple_files :assignment_files
   # Preventing malicious content from being submitted
   # clean_html :description


### PR DESCRIPTION
### Status
**READY**

### Description
Adds a dependent destroy association to the assignment model so that if the assignment is deleted, so are the exports.

======================
Closes #4063 
