### PR TITLE
added widget for learning objectives progress

### DIFF
--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -9,6 +9,9 @@
       .panel.todo.dashboard-module
         %dashboard-to-do-list
 
+      - if current_course.learning_objectives.present?
+        .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_learning_objectives"
+
       - if current_course.has_multipliers?
         .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_assignment_weights"
 

--- a/app/views/info/dashboard/_student_dashboard.html.haml
+++ b/app/views/info/dashboard/_student_dashboard.html.haml
@@ -9,7 +9,7 @@
       .panel.todo.dashboard-module
         %dashboard-to-do-list
 
-      - if current_course.learning_objectives.present?
+      - if current_course.uses_learning_objectives? && current_course.learning_objectives.present?
         .panel.dashboard-module= render partial: "info/dashboard/modules/dashboard_learning_objectives"
 
       - if current_course.has_multipliers?

--- a/app/views/info/dashboard/modules/_dashboard_learning_objectives.haml
+++ b/app/views/info/dashboard/modules/_dashboard_learning_objectives.haml
@@ -1,0 +1,12 @@
+.card-header
+  %h2
+    = term_for(:learning_objectives)
+.card-body
+  %table
+    - current_course.learning_objectives.each do |o|
+      %tr
+        %td
+          = link_to o.name, learning_objectives_objective_path(o)
+        %td
+          = render partial: "learning_objectives/components/progress_bar",
+        locals: { learning_objective: o, student: current_student }

--- a/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
+++ b/app/views/info/dashboard/modules/_dashboard_student_grading_scheme.haml
@@ -35,7 +35,6 @@ You have earned
   .progress.bar_magic.current.center.no-level
     %span.your-rank Your rank: Not on the board yet!
 
-
 - if presenter.previous_element.present?
   .progress.bar_magic.success.center
     .meter
@@ -45,7 +44,7 @@ You have earned
       %span=points presenter.previous_element.lowest_points
 
 - if current_course.has_badges?
-  %p= term_for :badges
+  %p.bold= term_for :badges
   %ul.badge-grid
     - current_student.unique_student_earned_badges(current_course).includes(:unlock_conditions).each do |badge|
       %li


### PR DESCRIPTION
### Status
**READY**

### Description
This PR adds a widget to the dashboard that summarizes a student's learning objectives progress

<img width="1280" alt="screen shot 2018-08-25 at 9 29 54 pm" src="https://user-images.githubusercontent.com/234276/44623998-6b228380-a8ae-11e8-9939-ab0e7e5a39a6.png">

### Migrations
NO

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Student dashboard

======================
Closes #3923 
