### PR TITLE
3885 learning objectives export

### DIFF
--- a/app/background_jobs/learning_objectives_outcomes_exporter_job.rb
+++ b/app/background_jobs/learning_objectives_outcomes_exporter_job.rb
@@ -1,0 +1,4 @@
+class LearningObjectivesOutcomesExporterJob < ResqueJob::Base
+  @queue = :learning_objectives_outcomes_exporter
+  @performer_class = LearningObjectivesOutcomesExportPerformer
+end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -72,6 +72,19 @@ class InfoController < ApplicationController
   def gradebook
   end
 
+  def learning_objectives_outcomes_file
+    course = current_user.courses.find_by(id: params[:id])
+    LearningObjectivesOutcomesExporterJob
+      .new(
+        user_id: current_user.id,
+        course_id: course.id,
+        filename: "#{ course.name } Learning Objectives Outcomes - #{ Date.today }.csv"
+      ).enqueue
+
+    flash[:notice]="Your request to export the learning objectives outcomes for \"#{ course.name }\" is currently being processed. We will email you the data shortly."
+    redirect_back_or_default
+  end
+
   def gradebook_file
     course = current_user.courses.find_by(id: params[:id])
     GradebookExporterJob

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -80,7 +80,7 @@ class InfoController < ApplicationController
         course_id: course.id,
         filename: "#{ course.name } Learning Objectives Outcomes - #{ Date.today }.csv"
       ).enqueue
-
+      
     flash[:notice]="Your request to export the learning objectives outcomes for \"#{ course.name }\" is currently being processed. We will email you the data shortly."
     redirect_back_or_default
   end

--- a/app/exporters/learning_objectives_outcomes_exporter.rb
+++ b/app/exporters/learning_objectives_outcomes_exporter.rb
@@ -1,0 +1,46 @@
+class LearningObjectivesOutcomesExporter
+
+  # gradebook spreadsheet export for course
+  def learning_objectives_outcomes(course)
+    CSV.generate do |csv|
+      csv << learning_objective_outcomes_columns(course)
+      course.students.order_by_name.each do |student|
+        csv << student_data_for(student, course)
+      end
+    end
+  end
+
+  private
+
+  def base_student_columns
+    ["First Name", "Last Name", "Email", "Username", "Team"]
+  end
+
+  def learning_objective_name_columns(course)
+    course.learning_objectives.collect(&:name)
+  end
+
+  def learning_objective_outcomes_columns(course)
+    base_student_columns + learning_objective_name_columns(course)
+  end
+
+  def base_student_methods
+    [:first_name, :last_name, :email, :username]
+  end
+
+  def student_data_for(student, course)
+    # add the base column names
+    student_data = base_student_methods.inject([]) do |memo, method|
+      memo << student.send(method)
+    end
+
+    student_data << student.team_for_course(course).try(:name)
+
+    # add the grades for the necessary assignments
+    course.learning_objectives.inject(student_data) do |memo, learning_objective|
+      outcome = learning_objective.numeric_progress(student)
+      memo << outcome
+      memo
+    end
+  end
+end

--- a/app/exporters/learning_objectives_outcomes_exporter.rb
+++ b/app/exporters/learning_objectives_outcomes_exporter.rb
@@ -1,11 +1,16 @@
 class LearningObjectivesOutcomesExporter
+  attr_accessor :course
+
+  def initialize(course)
+    @course = course
+  end
 
   # gradebook spreadsheet export for course
-  def learning_objectives_outcomes(course)
+  def learning_objective_outcomes
     CSV.generate do |csv|
-      csv << learning_objective_outcomes_columns(course)
-      course.students.order_by_name.each do |student|
-        csv << student_data_for(student, course)
+      csv << learning_objective_outcomes_columns
+      @course.students.order_by_name.each do |student|
+        csv << student_data_for(student)
       end
     end
   end
@@ -13,31 +18,31 @@ class LearningObjectivesOutcomesExporter
   private
 
   def base_student_columns
-    ["First Name", "Last Name", "Email", "Username", "Team"]
+    ["First Name", "Last Name", "Email", "Username", "Team"].freeze
   end
 
-  def learning_objective_name_columns(course)
-    course.learning_objectives.collect(&:name)
+  def learning_objective_name_columns
+    @course.learning_objectives.collect(&:name)
   end
 
-  def learning_objective_outcomes_columns(course)
-    base_student_columns + learning_objective_name_columns(course)
+  def learning_objective_outcomes_columns
+    base_student_columns + learning_objective_name_columns
   end
 
   def base_student_methods
     [:first_name, :last_name, :email, :username]
   end
 
-  def student_data_for(student, course)
+  def student_data_for(student)
     # add the base column names
     student_data = base_student_methods.inject([]) do |memo, method|
       memo << student.send(method)
     end
 
-    student_data << student.team_for_course(course).try(:name)
+    student_data << student.team_for_course(@course).try(:name)
 
     # add the grades for the necessary assignments
-    course.learning_objectives.inject(student_data) do |memo, learning_objective|
+    @course.learning_objectives.inject(student_data) do |memo, learning_objective|
       outcome = learning_objective.numeric_progress(student)
       memo << outcome
       memo

--- a/app/exporters/learning_objectives_outcomes_exporter.rb
+++ b/app/exporters/learning_objectives_outcomes_exporter.rb
@@ -22,7 +22,7 @@ class LearningObjectivesOutcomesExporter
   end
 
   def learning_objective_name_columns
-    @course.learning_objectives.collect(&:name)
+    @course.learning_objectives.pluck(:name)
   end
 
   def learning_objective_outcomes_columns
@@ -30,7 +30,7 @@ class LearningObjectivesOutcomesExporter
   end
 
   def base_student_methods
-    [:first_name, :last_name, :email, :username]
+    [:first_name, :last_name, :email, :username].freeze
   end
 
   def student_data_for(student)

--- a/app/mailers/exports_mailer.rb
+++ b/app/mailers/exports_mailer.rb
@@ -53,6 +53,12 @@ class ExportsMailer < ApplicationMailer
     send_export_email "Gradebook export for #{ course.name } is attached"
   end
 
+  def learning_objectives_outcomes_exporter(course, user, filename, csv_data)
+    set_export_ivars(course, user)
+    attachments["#{ course.name } Learning Objectives Outcomes - #{ Date.today }.csv"] = csv_attachment(csv_data)
+    send_export_email "Learning Objectives Outcomes export for #{ course.name } is attached"
+  end
+
   def created_courses_export(csv)
     @dates = { today: Date.today.strftime("%B %d, %Y"), last_month: 1.month.ago.strftime("%B %d, %Y") }
     attachments["export.csv"] = csv_attachment(csv)

--- a/app/performers/learning_objectives_outcomes_export_performer.rb
+++ b/app/performers/learning_objectives_outcomes_export_performer.rb
@@ -25,7 +25,7 @@ class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
   end
 
   def fetch_course
-    Course.find @attrs[:course_id]
+    Course.includes(:learning_objectives).find @attrs[:course_id]
   end
 
   def fetch_csv_data(course)

--- a/app/performers/learning_objectives_outcomes_export_performer.rb
+++ b/app/performers/learning_objectives_outcomes_export_performer.rb
@@ -9,11 +9,11 @@ class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
   def do_the_work
     if @course.present? && @user.present?
       require_success(fetch_csv_messages, max_result_size: 250) do
-       fetch_csv_data(@course)
+        fetch_csv_data(@course)
       end
 
       require_success(notification_messages, max_result_size: 200) do
-        notify_learning_objective_outcomes_exporter # the result of this block determines the outcome
+        notify_learning_objectives_outcomes_export
       end
     end
   end
@@ -24,8 +24,7 @@ class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
     User.find @attrs[:user_id]
   end
 
-  # TODO: speed this up by condensing the CSV generator into a single query
-  def fetch_course # TODO: add specs for includes
+  def fetch_course
     Course.find @attrs[:course_id]
   end
 

--- a/app/performers/learning_objectives_outcomes_export_performer.rb
+++ b/app/performers/learning_objectives_outcomes_export_performer.rb
@@ -10,7 +10,7 @@ class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
     if @course.present? && @user.present?
       require_success(fetch_csv_messages, max_result_size: 250) do
        fetch_csv_data(@course)
-     end
+      end
 
       require_success(notification_messages, max_result_size: 200) do
         notify_learning_objective_outcomes_exporter # the result of this block determines the outcome
@@ -30,7 +30,7 @@ class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
   end
 
   def fetch_csv_data(course)
-    @csv_data = LearningObjectivesOutcomesExporter.new.learning_objective_outcome(course)
+    @csv_data = LearningObjectivesOutcomesExporter.new(course).learning_objective_outcomes
   end
 
   def notify_learning_objectives_outcomes_export

--- a/app/performers/learning_objectives_outcomes_export_performer.rb
+++ b/app/performers/learning_objectives_outcomes_export_performer.rb
@@ -1,0 +1,55 @@
+class LearningObjectivesOutcomesExportPerformer < ResqueJob::Performer
+  def setup
+    @user = fetch_user
+    @course = fetch_course
+    @filename = @attrs[:filename]
+  end
+
+  # perform() attributes assigned to @attrs in the ResqueJob::Base class
+  def do_the_work
+    if @course.present? && @user.present?
+      require_success(fetch_csv_messages, max_result_size: 250) do
+       fetch_csv_data(@course)
+     end
+
+      require_success(notification_messages, max_result_size: 200) do
+        notify_learning_objective_outcomes_exporter # the result of this block determines the outcome
+      end
+    end
+  end
+
+  protected
+
+  def fetch_user
+    User.find @attrs[:user_id]
+  end
+
+  # TODO: speed this up by condensing the CSV generator into a single query
+  def fetch_course # TODO: add specs for includes
+    Course.find @attrs[:course_id]
+  end
+
+  def fetch_csv_data(course)
+    @csv_data = LearningObjectivesOutcomesExporter.new.learning_objective_outcome(course)
+  end
+
+  def notify_learning_objectives_outcomes_export
+    ExportsMailer
+      .learning_objectives_outcomes_exporter(@course, @user, @filename, @csv_data)
+      .deliver_now
+  end
+
+  def fetch_csv_messages
+    {
+      success: "Successfully fetched CSV learning objectives outcomes data for course ##{@course.id}.",
+      failure: "Failed to fetch CSV learning objectives outcomes data for course ##{@course.id}."
+    }
+  end
+
+  def notification_messages
+    {
+      success: "Learning objectives outcomes exporter notification mailer was successfully delivered.",
+      failure: "Learning objectives outcomes exporter notification mailer was not delivered."
+    }
+  end
+end

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -23,7 +23,7 @@
         - if current_course.learning_objectives.present?
           %tr
             %td= link_to glyph("file-excel-o") + "Learning Objectives Outcomes", learning_objectives_outcomes_file_path(id: current_course.id, format: "csv")
-            %td First Name, Last Name, Email, Username, #{ term_for :team }, current outcomes for all #{ term_for :learning_objectives }
+            %td First Name, Last Name, Email, Username, #{ term_for :team }, Current Outcomes for All #{ term_for :learning_objectives }
         %tr
           %td
             = link_to glyph("file-excel-o") + "#{(term_for :assignment_type).titleize } Summaries", export_all_scores_assignment_types_path(id: current_course.id, format: "csv")

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -20,6 +20,10 @@
           %tr
             %td= link_to glyph("file-excel-o") + "#{ (term_for :weight).titleize } Gradebook",  multiplied_gradebook_path(id: current_course.id, format: "csv")
             %td First Name, Last Name, Email, Username, #{ term_for :team }, Raw and #{ (term_for :weight).titleize }-weighted grades for all #{ term_for :assignments }
+        - if current_course.learning_objectives.present?
+          %tr
+            %td= link_to glyph("file-excel-o") + "Learning Objectives Outcomes", learning_objectives_outcomes_file_path(id: current_course.id, format: "csv")
+            %td First Name, Last Name, Email, Username, #{ term_for :team }, current outcomes for all #{ term_for :learning_objectives }
         %tr
           %td
             = link_to glyph("file-excel-o") + "#{(term_for :assignment_type).titleize } Summaries", export_all_scores_assignment_types_path(id: current_course.id, format: "csv")

--- a/app/views/exports_mailer/learning_objectives_outcomes_exporter.html.haml
+++ b/app/views/exports_mailer/learning_objectives_outcomes_exporter.html.haml
@@ -1,0 +1,5 @@
+%h2{ :align => "center" }
+  %strong Dear #{ @user.first_name },
+
+%p{ :align => "center" }
+  The learning objectives outcomes export you have requested for #{ @course.name } is attached.

--- a/app/views/exports_mailer/learning_objectives_outcomes_exporter.text.haml
+++ b/app/views/exports_mailer/learning_objectives_outcomes_exporter.text.haml
@@ -1,0 +1,7 @@
+Dear #{ @user.first_name },
+
+The #{ @export_type } you have requested for #{ @course.name } is attached.
+
+Thanks,
+
+GradeCraft

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
     get :export_earned_badges
     get :final_grades
     get :gradebook
+    get :learning_objectives_outcomes_file
     get :submissions
     get :grading_status
     get :gradebook_file

--- a/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
+++ b/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
@@ -1,10 +1,9 @@
-describe LearningObjectivesOutcomesExporter, focus: true do
+describe LearningObjectivesOutcomesExporter do
   let(:course) { create :course }
   subject { LearningObjectivesOutcomesExporter.new }
 
   describe "#export" do
-    let(:learning_objectives) { create_list :learning_objective, 3, course: course }
-    let(:proficient_learning_objective_level) { create :learning_objective_level, objective: learning_objectives.first }
+    let(:learning_objectives) { create_list :learning_objective, 3, course: course, count_to_achieve: 3 }
 
     it "generates an empty CSV if there are no students or learning objectives" do
       csv = subject.learning_objectives_outcomes course
@@ -21,18 +20,20 @@ describe LearningObjectivesOutcomesExporter, focus: true do
       student = create :user, courses: [course], role: :student, last_name: "Aad"
       another_student = create :user, courses: [course], role: :student, last_name: "Zep"
 
-      @proficient_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: student
-      @proficient_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: proficient_learning_objective_level.id, learning_objective_cumulative_outcomes_id: @proficient_cumulative_outcome.id
-      create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.second, user: student
-      create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.third, user: student
+      proficient_learning_objective_level =  create :learning_objective_level, objective: learning_objectives.first, flagged_value: "proficient"
+      failed_learning_objective_level = create :learning_objective_level, objective: learning_objectives.first, flagged_value: "not_proficient"
+      proficient_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: student
+      proficient_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: proficient_learning_objective_level.id, learning_objective_cumulative_outcomes_id: proficient_cumulative_outcome.id
+      failed_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: another_student
+      failed_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: failed_learning_objective_level.id, learning_objective_cumulative_outcomes_id: failed_cumulative_outcome.id
 
       csv = CSV.new(subject.learning_objectives_outcomes(course)).read
 
       expect(csv.length).to eq 3
       expect(csv[1]).to eq [student.first_name, student.last_name, student.email,
-        student.username, student.team_for_course(course), "1", "0", "0"]
+        student.username, student.team_for_course(course), "#{learning_objectives.first.numeric_progress(student)}", "0", "0"]
       expect(csv[2]).to eq [another_student.first_name, another_student.last_name,
-        another_student.email, another_student.username, another_student.team_for_course(course), "0", "0", "0"]
+        another_student.email, another_student.username, another_student.team_for_course(course), "#{learning_objectives.first.numeric_progress(another_student)}", "0", "0"]
     end
   end
 end

--- a/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
+++ b/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
@@ -6,13 +6,13 @@ describe LearningObjectivesOutcomesExporter do
     let(:learning_objectives) { create_list :learning_objective, 3, course: course, count_to_achieve: 3 }
 
     it "generates an empty CSV if there are no students or learning objectives" do
-      csv = subject.learning_objectives_outcomes
+      csv = subject.learning_objective_outcomes
       expect(csv).to eq "First Name,Last Name,Email,Username,Team\n"
     end
 
     it "generates an empty CSV if there are no students" do
       learning_objectives
-      csv = subject.learning_objectives_outcomes
+      csv = subject.learning_objective_outcomes
       expect(csv).to eq "First Name,Last Name,Email,Username,Team,#{learning_objectives.first.name},#{learning_objectives.second.name},#{learning_objectives.third.name}\n"
     end
 
@@ -27,7 +27,7 @@ describe LearningObjectivesOutcomesExporter do
       failed_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: another_student
       failed_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: failed_learning_objective_level.id, learning_objective_cumulative_outcomes_id: failed_cumulative_outcome.id
 
-      csv = CSV.new(subject.learning_objectives_outcomes).read
+      csv = CSV.new(subject.learning_objective_outcomes).read
 
       expect(csv.length).to eq 3
       expect(csv[1]).to eq [student.first_name, student.last_name, student.email,

--- a/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
+++ b/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
@@ -1,18 +1,18 @@
 describe LearningObjectivesOutcomesExporter do
   let(:course) { create :course }
-  subject { LearningObjectivesOutcomesExporter.new }
+  subject { LearningObjectivesOutcomesExporter.new course }
 
   describe "#export" do
     let(:learning_objectives) { create_list :learning_objective, 3, course: course, count_to_achieve: 3 }
 
     it "generates an empty CSV if there are no students or learning objectives" do
-      csv = subject.learning_objectives_outcomes course
+      csv = subject.learning_objectives_outcomes
       expect(csv).to eq "First Name,Last Name,Email,Username,Team\n"
     end
 
     it "generates an empty CSV if there are no students" do
       learning_objectives
-      csv = subject.learning_objectives_outcomes course
+      csv = subject.learning_objectives_outcomes
       expect(csv).to eq "First Name,Last Name,Email,Username,Team,#{learning_objectives.first.name},#{learning_objectives.second.name},#{learning_objectives.third.name}\n"
     end
 
@@ -27,7 +27,7 @@ describe LearningObjectivesOutcomesExporter do
       failed_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: another_student
       failed_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: failed_learning_objective_level.id, learning_objective_cumulative_outcomes_id: failed_cumulative_outcome.id
 
-      csv = CSV.new(subject.learning_objectives_outcomes(course)).read
+      csv = CSV.new(subject.learning_objectives_outcomes).read
 
       expect(csv.length).to eq 3
       expect(csv[1]).to eq [student.first_name, student.last_name, student.email,

--- a/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
+++ b/spec/exporters/learning_objectives_outcomes_exporter_spec.rb
@@ -1,0 +1,38 @@
+describe LearningObjectivesOutcomesExporter, focus: true do
+  let(:course) { create :course }
+  subject { LearningObjectivesOutcomesExporter.new }
+
+  describe "#export" do
+    let(:learning_objectives) { create_list :learning_objective, 3, course: course }
+    let(:proficient_learning_objective_level) { create :learning_objective_level, objective: learning_objectives.first }
+
+    it "generates an empty CSV if there are no students or learning objectives" do
+      csv = subject.learning_objectives_outcomes course
+      expect(csv).to eq "First Name,Last Name,Email,Username,Team\n"
+    end
+
+    it "generates an empty CSV if there are no students" do
+      learning_objectives
+      csv = subject.learning_objectives_outcomes course
+      expect(csv).to eq "First Name,Last Name,Email,Username,Team,#{learning_objectives.first.name},#{learning_objectives.second.name},#{learning_objectives.third.name}\n"
+    end
+
+    it "generates an gradebook CSV if there are students and assignments present" do
+      student = create :user, courses: [course], role: :student, last_name: "Aad"
+      another_student = create :user, courses: [course], role: :student, last_name: "Zep"
+
+      @proficient_cumulative_outcome = create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.first, user: student
+      @proficient_observed_outcome = create :learning_objective_observed_outcome, objective_level_id: proficient_learning_objective_level.id, learning_objective_cumulative_outcomes_id: @proficient_cumulative_outcome.id
+      create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.second, user: student
+      create :learning_objective_cumulative_outcome, learning_objective: learning_objectives.third, user: student
+
+      csv = CSV.new(subject.learning_objectives_outcomes(course)).read
+
+      expect(csv.length).to eq 3
+      expect(csv[1]).to eq [student.first_name, student.last_name, student.email,
+        student.username, student.team_for_course(course), "1", "0", "0"]
+      expect(csv[2]).to eq [another_student.first_name, another_student.last_name,
+        another_student.email, another_student.username, another_student.team_for_course(course), "0", "0", "0"]
+    end
+  end
+end

--- a/test/mailers/previews/exports_mailer_preview.rb
+++ b/test/mailers/previews/exports_mailer_preview.rb
@@ -63,6 +63,16 @@ class ExportsMailerPreview < ActionMailer::Preview
     ExportsMailer.gradebook_export course, user, "gradebook_export", csv_data
   end
 
+  def learning_objectives_outcomes_exporter
+    course = Course.find(7)
+    ExportsMailer.learning_objectives_outcomes_exporter(
+      course,
+      user = User.find(3),
+      csv_data = course.learning_objectives.to_a.to_csv
+    )
+    ExportsMailer.learning_objectives_outcomes_exporter course, user, "learning_objectives_outcomes_exporter", csv_data
+  end
+
   def created_courses_export
     csv_data = CreatedCoursesExporter::BASELINE_HEADERS
     ExportsMailer.created_courses_export csv_data


### PR DESCRIPTION
### Status
**READY**

### Description
This PR adds the ability for instructors to export learning objective outcomes for all students - essentially, a learning objective "gradebook." I confirmed with Evan that the first/best value to put in here is the number of proficient demonstrations a student has completed. 

### Todos
- [x] Add Tests

### Deploy Notes
n/a

### Gem dependencies
n/a

### Migrations
NO

### Steps to Test or Reproduce
Log in as an instructor in a course where there are learning objectives. Navigate to the Course Exports page, and click the "Learning Objectives Outcomes" download. You will need to post this to staging to confirm the email receipt (or else load up the demo version in http://localhost:5000/rails/mailers to see the demo)

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Instructor course exports

======================
Closes #3885 
