### PR TITLE
Add interim save button

### DIFF
--- a/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
+++ b/app/assets/javascripts/angular/directives/grade_scheme_elements/mass_edit.coffee
@@ -12,6 +12,12 @@
     vm.addElement = () ->
       GradeSchemeElementsService.addElement()
 
+    vm.save = () ->
+      GradeSchemeElementsService.validateElements()
+      vm.updateFormValidity()
+      return if vm.gradeSchemeElementsForm.$invalid
+      GradeSchemeElementsService.postGradeSchemeElements(null, true, true)
+
     vm.deleteGradeSchemeElements = () ->
       if confirm "Are you sure you want to delete all grade scheme elements?"
         GradeSchemeElementsService.deleteGradeSchemeElements('/grade_scheme_elements/')

--- a/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
+++ b/app/assets/javascripts/angular/templates/grade_scheme_elements/main.html.haml
@@ -9,7 +9,10 @@
                        'ng-click'=>'vm.addElement()',
                        'ng-if'=>'vm.gradeSchemeElements.length == 0'} Add Your Highest Grade
 
-  .main-buttons
-    %button.action{'type'=>'button',
-                  'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0',
-                  'ng-click'=>'vm.deleteGradeSchemeElements()'} Delete All Elements
+  .main-buttons{'ng-if'=>'vm.gradeSchemeElements && vm.gradeSchemeElements.length > 0'}
+    %button.action{'ng-click'=>"vm.save()"}
+      %i.fa.fa-save
+      Save
+    %button.secondary{'ng-click'=>'vm.deleteGradeSchemeElements()'}
+      %i.fa.fa-trash
+      Delete All Elements


### PR DESCRIPTION
### Status
**READY**

### Description
As an intermediate solution, adds a button to manually trigger a save when editing grade scheme elements. Follow up in response to some observed issues relating to the autosaving of work.
