### PR TITLE
Fix bugs

### DIFF
--- a/app/assets/javascripts/angular/directives/rubrics/criterion.coffee
+++ b/app/assets/javascripts/angular/directives/rubrics/criterion.coffee
@@ -2,21 +2,19 @@
 
 @gradecraft.directive 'rubricCriterion', ['RubricService', (RubricService) ->
 
-  return {
+  {
     templateUrl: 'rubrics/criterion.html'
-    scope: {
-      criterion: "=",
+    scope:
+      criterion: "="
       reordering: "="
-    }
-    link: (scope, el, attr)->
-
-      scope.queueUpdateCriterion = ()->
+    link: (scope, el, attr) ->
+      scope.queueUpdateCriterion = () ->
         if scope.criterionIsSaved()
           RubricService.queueUpdateCriterion(@criterion)
         else if scope.requirementsMet()
           RubricService.saveNewCriterion(@criterion)
 
-      scope.deleteCriterion = ()->
+      scope.deleteCriterion = () ->
         if scope.criterionIsSaved()
           RubricService.deleteCriterion(@criterion)
         else
@@ -24,10 +22,9 @@
 
       #--------------------- NEW LEVELS ---------------------------------------#
 
-      scope.criterionIsSaved = ()->
-        !@criterion.newCriterion
+      scope.criterionIsSaved = () -> !@criterion.newCriterion
 
-      scope.requirements = ()->
+      scope.requirements = () ->
         reqs = []
         if !@criterion.name || @criterion.name.length < 1
           reqs.push "The criterion must have a name"
@@ -35,9 +32,6 @@
           reqs.push "The criterion must have max points assigned"
         return reqs
 
-      scope.requirementsMet = ()->
-        scope.requirements().length == 0
-
+      scope.requirementsMet = () -> scope.requirements().length == 0
   }
 ]
-

--- a/app/assets/javascripts/angular/services/TeamService.coffee
+++ b/app/assets/javascripts/angular/services/TeamService.coffee
@@ -16,7 +16,7 @@
   selectedTeamId = (teamId) ->
     if angular.isDefined(teamId)
       _selectedTeamId = teamId
-      _callback() if callback?
+      callback()
     else
       _selectedTeamId
 

--- a/app/assets/javascripts/angular/templates/rubrics/criterion.html.haml
+++ b/app/assets/javascripts/angular/templates/rubrics/criterion.html.haml
@@ -2,7 +2,7 @@
   %i.fa.fa-fw.fa-arrows-v.criterion-drag-handle(ng-if="reordering")
   %label
     %span.sr-only Criterion Name
-    %input(type="text" ng-model="criterion.name" name="name" placeholder="Criterion Name" value="{{criterion.name}}"  required ng-blur="queueUpdateCriterion()")
+    %input(type="text" ng-model="criterion.name" name="name" placeholder="Criterion Name" value="{{criterion.name}}" required ng-blur="queueUpdateCriterion()")
   %label
     %span.sr-only Criterion Max Points
     %input.points(type="number" ng-model="criterion.max_points" name="maxPoints" placeholder="Max Points" required integer min=0 ng-blur="queueUpdateCriterion()")
@@ -16,7 +16,6 @@
 %ul.criterion-requirements(ng-if="!requirementsMet() && !criterionIsSaved()")
   %li.requirements(ng-repeat="requirement in requirements()")
     {{ requirement }}
-
 
 .level-container(ng-if="!reordering && criterionIsSaved()")
   %rubric-criterion-levels.level-wrapper(criterion="criterion")

--- a/app/controllers/grade_scheme_elements_controller.rb
+++ b/app/controllers/grade_scheme_elements_controller.rb
@@ -1,7 +1,7 @@
 # The Grade Scheme Elements define the point thresholds earned at which students
 # earn course wide levels and grades
 class GradeSchemeElementsController < ApplicationController
-  before_action :ensure_staff?
+  before_action :ensure_staff?, except: :index
   before_action :use_current_course, only: :mass_edit
 
   def index

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -15,9 +15,8 @@ class Criterion < ApplicationRecord
   after_create :generate_default_levels, if: :add_default_levels?
   # after_save :update_full_credit, if: :add_default_levels?
 
+  validates_presence_of :name, :order
   validates :max_points, presence: true, length: { maximum: 9 }
-  validates :name, presence: true, length: { maximum: 30 }
-  validates :order, presence: true
 
   scope :ordered, -> { order(:order) }
 

--- a/app/models/criterion.rb
+++ b/app/models/criterion.rb
@@ -15,8 +15,8 @@ class Criterion < ApplicationRecord
   after_create :generate_default_levels, if: :add_default_levels?
   # after_save :update_full_credit, if: :add_default_levels?
 
-  validates_presence_of :name, :order
-  validates :max_points, presence: true, length: { maximum: 9 }
+  validates_presence_of :name, :order, :max_points
+  validates :max_points, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :ordered, -> { order(:order) }
 

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -30,18 +30,20 @@ class UnlockCondition < ApplicationRecord
   end
 
   # Human readable sentence to describe what students need to do to unlock this
-  def requirements_description_sentence
+  def requirements_description_sentence(condition_date_timezone=nil)
     if condition_type == "Course"
-      "#{ condition_state_do } #{ condition_value } points in this course"
+      description = "#{ condition_state_do } #{ condition_value } points in this course"
     elsif condition_type == "AssignmentType"
       if condition_state == "Minimum Points Earned"
-        "#{ condition_state_do } #{ condition_value } points in the #{ condition.name } #{unlockable.course.assignment_term} Type"
+        description = "#{ condition_state_do } #{ condition_value } points in the #{ condition.name } #{unlockable.course.assignment_term} Type"
       elsif condition_state == "Assignments Completed"
-        "#{ condition_state_do } in the #{ condition.name } #{unlockable.course.assignment_term} Type"
+        description = "#{ condition_state_do } in the #{ condition.name } #{unlockable.course.assignment_term} Type"
       end
     else
-      "#{ condition_state_do } the #{ condition.name } #{ condition_type }"
+      description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }"
     end
+    description += " by #{ formatted_condition_date(condition_date_timezone) }" if condition_date.present?
+    description
   end
 
   def requirements_completed_sentence
@@ -132,6 +134,10 @@ class UnlockCondition < ApplicationRecord
     elsif condition_state == "Assignments Completed"
       "Completed #{condition_value} #{unlockable.course.assignment_term.pluralize.downcase} in"
     end
+  end
+
+  def formatted_condition_date(timezone)
+    timezone.nil? ? condition_date : condition_date.in_time_zone(timezone)
   end
 
   def check_assignment_type_condition(student)

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -42,18 +42,25 @@ class UnlockCondition < ApplicationRecord
     else
       description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }"
     end
-    description += " by #{ formatted_condition_date(condition_date_timezone) }" if condition_date.present?
+    description += condition_date_sentence(condition_date_timezone) if condition_date.present?
     description
   end
 
-  def requirements_completed_sentence
-    return "#{ condition_state_past } the #{ condition.name } #{ condition_type }" unless condition_type == "Course"
-    return "Earned #{ condition_value } points in this course"
+  def requirements_completed_sentence(condition_date_timezone=nil)
+    if condition_type != "Course"
+      description = "#{ condition_state_past } the #{ condition.name } #{ condition_type }"
+    else
+      description = "Earned #{ condition_value } points in this course"
+    end
+    description += condition_date_sentence(condition_date_timezone) if condition_date.present?
+    description
   end
 
   # Human readable sentence to describe what doing work on this thing unlocks
-  def key_description_sentence
-    "#{ condition_state_doing } unlocks the #{ unlockable.name } #{ unlockable_type }"
+  def key_description_sentence(condition_date_timezone=nil)
+    description = "#{ condition_state_doing }"
+    description += condition_date_sentence(condition_date_timezone) if condition_date.present?
+    description += " unlocks the #{ unlockable.name } #{ unlockable_type }"
   end
 
   # Counting how many students in a group have done the work to unlock an
@@ -136,8 +143,8 @@ class UnlockCondition < ApplicationRecord
     end
   end
 
-  def formatted_condition_date(timezone)
-    timezone.nil? ? condition_date : condition_date.in_time_zone(timezone)
+  def condition_date_sentence(time_zone=nil)
+    " by #{ time_zone.nil? ? condition_date : condition_date.in_time_zone(time_zone) }"
   end
 
   def check_assignment_type_condition(student)

--- a/app/views/api/assignments/_assignment_unlocks.json.jbuilder
+++ b/app/views/api/assignments/_assignment_unlocks.json.jbuilder
@@ -1,11 +1,11 @@
 if assignment.unlock_conditions.present?
   unlock_conditions = assignment.unlock_conditions.map do |condition|
-    condition.requirements_description_sentence
+    condition.requirements_description_sentence(current_user.time_zone)
   end
   json.unlock_conditions unlock_conditions
 
   unlocked_conditions = assignment.unlock_conditions.map do |condition|
-    condition.requirements_completed_sentence
+    condition.requirements_completed_sentence(current_user.time_zone)
   end
   json.unlocked_conditions unlocked_conditions
 
@@ -15,7 +15,7 @@ end
 
 if assignment.unlock_keys.present?
   unlock_keys = assignment.unlock_keys.map do |key|
-    key.key_description_sentence
+    key.key_description_sentence(current_user.time_zone)
   end
   json.unlock_keys unlock_keys
 end

--- a/app/views/api/learning_objectives/objectives/index.json.jbuilder
+++ b/app/views/api/learning_objectives/objectives/index.json.jbuilder
@@ -20,7 +20,7 @@ end
 
 json.included do
   @objectives.each do |o|
-    json.array! o.levels do |level|
+    json.array! o.levels.ordered do |level|
       json.type "levels"
       json.id level.id.to_s
 

--- a/app/views/api/learning_objectives/objectives/show.json.jbuilder
+++ b/app/views/api/learning_objectives/objectives/show.json.jbuilder
@@ -8,7 +8,7 @@ json.data do
 end
 
 json.included do
-  json.array! @objective.levels do |level|
+  json.array! @objective.levels.ordered do |level|
     json.type "levels"
     json.id level.id.to_s
 
@@ -20,7 +20,7 @@ json.included do
 
   json.array! @objective.assignments do |assignment|
     next if current_user_is_student? && !assignment.visible_for_student?(current_user)
-    
+
     json.type "assignments"
     json.id assignment.id.to_s
 

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -55,7 +55,7 @@
       %ul
         - presenter.assignment.unlock_conditions.each do |condition|
           %li
-            = condition.requirements_completed_sentence
+            = condition.requirements_completed_sentence(current_user.time_zone)
             - if presenter.assignment.has_groups? && @group.present?
               = "(#{condition.count_unlocked_in_group(@group)}/#{@group.students.count} #{term_for :group} members have completed this requirement)"
       - if presenter.assignment.has_groups? && @group.present?
@@ -71,25 +71,25 @@
       %p.italic You have not unlocked this #{term_for :assignment}. To achieve this you must:
       %ul
         - presenter.assignment.unlock_conditions.each do |uc|
-          %li= link_to uc.requirements_description_sentence, uc.condition
+          %li= link_to uc.requirements_description_sentence(current_user.time_zone), uc.condition
 - elsif presenter.assignment.is_unlockable?
   %h3.uppercase #{glyph(:lock)} This #{term_for :assignment} is Locked
   %p.italic To unlock it, #{ term_for :students } must:
   %ul
     - presenter.assignment.unlock_conditions.each do |condition|
       - if !condition.unlockable_type == GradeSchemeElement
-        %li= link_to condition.requirements_description_sentence, condition.unlockable
+        %li= link_to condition.requirements_description_sentence(current_user.time_zone), condition.unlockable
       - else
-        %li= condition.requirements_description_sentence
+        %li= condition.requirements_description_sentence(current_user.time_zone)
 
 - if presenter.assignment.is_a_condition?
   %h3.uppercase #{glyph(:key)} This #{term_for :assignment} is a Key:
   %ul
     - presenter.assignment.unlock_keys.each do |key|
       - if !key.unlockable_type == GradeSchemeElement
-        %li= link_to key.key_description_sentence, key.unlockable
+        %li= link_to key.key_description_sentence(current_user.time_zone), key.unlockable
       - else
-        %li= key.key_description_sentence
+        %li= key.key_description_sentence(current_user.time_zone)
 
 - if presenter.assignment_has_viewable_description?(current_user)
   - if presenter.assignment.assignment_files.present?

--- a/app/views/assignments/_index_icons.haml
+++ b/app/views/assignments/_index_icons.haml
@@ -4,14 +4,13 @@
     .small.italic In order to unlock it you must:
     %ol
       - assignment.unlock_conditions.each do |condition|
-        %li= condition.requirements_description_sentence
+        %li= condition.requirements_description_sentence(current_user.time_zone)
 - if assignment.is_a_condition?
   = tooltip("key-assignment-tip_#{assignment.id}", :key) do
     %p This #{term_for :assignment} is a Key
     %ol
       - assignment.unlock_keys.each do |key|
-        %li= key.key_description_sentence
+        %li= key.key_description_sentence(current_user.time_zone)
 - if assignment.has_groups?
   = tooltip("group-assignment-tip_#{assignment.id}", :group) do
     This #{term_for :assignment} is completed by #{term_for :students} in #{term_for :groups}
-

--- a/app/views/assignments/index_student/components/_assignment_icons.haml
+++ b/app/views/assignments/index_student/components/_assignment_icons.haml
@@ -10,7 +10,7 @@
         .small.italic In order to unlock it you must:
         %ol
           - assignment.unlock_conditions.each do |condition|
-            %li= condition.requirements_description_sentence
+            %li= condition.requirements_description_sentence(current_user.time_zone)
 
     - else
       = tooltip("unlocked-assignment-tip_#{assignment.id}", :unlock) do
@@ -18,14 +18,14 @@
         .small.italic To achieve this you:
         %ol
           - assignment.unlock_conditions.each do |condition|
-            %li= condition.requirements_completed_sentence
+            %li= condition.requirements_completed_sentence(current_user.time_zone)
 
   - if assignment.is_a_condition?
     = tooltip("key-assignment-tip_#{assignment.id}", :key) do
       %p This #{term_for :assignment} is a Key
       %ol
         - assignment.unlock_keys.each do |key|
-          %li= key.key_description_sentence
+          %li= key.key_description_sentence(current_user.time_zone)
 
   - if presenter.submission_for(assignment).present?
     - if presenter.submission_for(assignment).unsubmitted?

--- a/app/views/badges/components/_hover_icons.haml
+++ b/app/views/badges/components/_hover_icons.haml
@@ -3,10 +3,10 @@
     %p Unlock Requirements
     %ul
       - badge.unlock_conditions.each do |condition|
-        %li= condition.requirements_description_sentence
+        %li= condition.requirements_description_sentence(current_user.time_zone)
 - if badge.is_a_condition?
   = tooltip("unlock-key-tip_#{badge.id}", :key) do
     %p Unlock Key
     %ul
       - badge.unlock_keys.each do |key|
-        %li= key.key_description_sentence
+        %li= key.key_description_sentence(current_user.time_zone)

--- a/app/views/grade_scheme_elements/_index_observer.html.haml
+++ b/app/views/grade_scheme_elements/_index_observer.html.haml
@@ -19,6 +19,6 @@
           %td
             - if element.unlock_conditions.present?
               - element.unlock_conditions.each do |uc|
-                .condition= glyph(:lock) + uc.requirements_description_sentence
+                .condition= glyph(:lock) + uc.requirements_description_sentence(current_user.time_zone)
 
   = render partial: "courses/grading_philosophy", locals: { course: current_course }

--- a/app/views/grade_scheme_elements/_unlock_icons.haml
+++ b/app/views/grade_scheme_elements/_unlock_icons.haml
@@ -2,4 +2,4 @@
   %h3.bold This Level is Locked
   .small.italic In order to unlock it you must:
   - gse.unlock_conditions.each do |condition|
-    .condition= condition.requirements_description_sentence
+    .condition= condition.requirements_description_sentence(current_user.time_zone)

--- a/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
+++ b/app/views/grade_scheme_elements/components/_grade_scheme_elements_table.haml
@@ -17,7 +17,7 @@
         %td
           - if element.unlock_conditions.present?
             - element.unlock_conditions.each do |uc|
-              .condition= glyph(:lock) + uc.requirements_description_sentence
+              .condition= glyph(:lock) + uc.requirements_description_sentence(current_user.time_zone)
         %td
           - if current_user_is_admin? || current_course.active?
             .button-container.dropdown

--- a/spec/controllers/grade_scheme_elements_controller_spec.rb
+++ b/spec/controllers/grade_scheme_elements_controller_spec.rb
@@ -48,7 +48,6 @@ describe GradeSchemeElementsController do
 
     it "redirects protected routes to root" do
       [
-        -> { get :index },
         -> { get :mass_edit },
         -> { get :edit, params: { id: 1 } },
         -> { put :update, params: { id: 1 } },

--- a/spec/models/criterion_spec.rb
+++ b/spec/models/criterion_spec.rb
@@ -64,7 +64,6 @@ describe Criterion do
   end
 
   describe "#comments_for" do
-
     it "returns comments for student" do
       subject.save
       grade = create :criterion_grade, criterion: subject, comments: "xo"

--- a/spec/models/criterion_spec.rb
+++ b/spec/models/criterion_spec.rb
@@ -15,6 +15,11 @@ describe Criterion do
       subject.order = nil
       expect(subject).to be_invalid
     end
+
+    it "is invalid if the max points value is less than 0" do
+      subject.max_points = -1
+      expect(subject).to be_invalid
+    end
   end
 
   describe "#update_meets_expectations!" do

--- a/spec/models/unlock_condition_spec.rb
+++ b/spec/models/unlock_condition_spec.rb
@@ -587,6 +587,16 @@ describe UnlockCondition do
       expect(unlock_condition.requirements_description_sentence).to \
         eq("Earn a grade for the #{assignment.name} Assignment")
     end
+
+    it "includes a formatted description for the condition by date if provided" do
+      time_zone = "Eastern Time (US & Canada)"
+      unlock_condition = UnlockCondition.new(
+        condition_id: assignment.id, condition_type: "Assignment",
+        condition_state: "Submitted", condition_date: Faker::Date.between(2.days.ago, Date.today)
+      )
+      expect(unlock_condition.requirements_description_sentence(time_zone)).to \
+        eq("Submit the #{assignment.name} Assignment by #{unlock_condition.condition_date.in_time_zone(time_zone)}")
+    end
   end
 
   describe "#key_description_sentence" do


### PR DESCRIPTION
### Status
**READY**

### Description
- Fixes an observed issue in Rollbar related to the shared team selector component
- Fixes an issue where a character limit of 30 on the criterion name was preventing users from saving (and no error was provided)
- Fixes an issue where `condition_date` was not included in any way on an unlock condition description
- Fix issue where a student was not able to visit the link to see all grade scheme elements

### Impacted Areas in Application
- Teams selector
- Rubric criterion
- Unlock conditions 
- Grade scheme elements

