### PR TITLE
Activate Imported Users That Have Their Passwords Specified

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -275,9 +275,10 @@ class UsersController < ApplicationController
     end
 
     @result = CSVStudentImporter.new(params[:file].tempfile,
+                                     current_course,
                                      params[:internal_students] == "1",
                                      params[:send_welcome] == "1")
-      .import(current_course)
+      .import
     render :import_results
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -267,7 +267,7 @@ class UsersController < ApplicationController
   def upload
     if params[:file].blank?
       flash[:notice] = "File missing"
-      redirect_to users_path and return
+      redirect_to action: :import and return
     end
 
     if (File.extname params[:file].original_filename) != ".csv"

--- a/app/services/creates_new_user.rb
+++ b/app/services/creates_new_user.rb
@@ -19,9 +19,7 @@ module Services
     def self.actions
       [
         Actions::BuildsUser,
-        reduce_if(-> (context) { context.user.password.blank? }, [
-          Actions::GeneratesPassword
-        ]),
+        reduce_if(-> (context) { context.user.password.blank? }, [Actions::GeneratesPassword]),
         Actions::GeneratesUsernames,
         Actions::SavesUser,
         Actions::ActivatesUser,

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -15,7 +15,7 @@
   = form_tag({action: :upload}, :multipart => true) do
     %div
       = check_box_tag "internal_students", "1", false, { data: { behavior: "toggle-disable", "toggle-disable-target": ".send-welcome *" }}
-      = label_tag "internal_students", "Use UM Authentication for the new user accounts"
+      = label_tag "internal_students", "Activate imported users"
     .send-welcome
       = check_box_tag "send_welcome", "1", false, { disabled: true }
       = label_tag "send_welcome", "Send welcome email to new user accounts", { class: "disabled" }

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -15,7 +15,7 @@
   = form_tag({ action: :upload }, multipart: true) do
     %div
       = check_box_tag "internal_students", "1", false, { data: { behavior: "toggle-disable", "toggle-disable-target": ".send-welcome *" }}
-      = label_tag "internal_students", "Activate imported users"
+      = label_tag "internal_students", "Use UM Authentication for the new user accounts"
     .send-welcome
       = check_box_tag "send_welcome", "1", false, { disabled: true }
       = label_tag "send_welcome", "Send welcome email to new user accounts", { class: "disabled" }

--- a/app/views/users/import.html.haml
+++ b/app/views/users/import.html.haml
@@ -12,7 +12,7 @@
 
     You can download a sample file #{link_to "here", users_importer_download_path(:csv, format: "csv"), class: "bold"}
 
-  = form_tag({action: :upload}, :multipart => true) do
+  = form_tag({ action: :upload }, multipart: true) do
     %div
       = check_box_tag "internal_students", "1", false, { data: { behavior: "toggle-disable", "toggle-disable-target": ".send-welcome *" }}
       = label_tag "internal_students", "Activate imported users"

--- a/spec/importers/user_importers/csv_student_importer_spec.rb
+++ b/spec/importers/user_importers/csv_student_importer_spec.rb
@@ -1,25 +1,25 @@
 describe CSVStudentImporter do
+  let(:course) { create :course }
   before(:all) { User.destroy_all }
 
   describe "#import" do
     it "returns empty results when there is no file" do
-      result = described_class.new(nil).import
+      result = described_class.new(nil, course).import
       expect(result.successful).to be_empty
       expect(result.unsuccessful).to be_empty
     end
 
     context "with a file" do
-      let(:course) { create :course }
       let(:team) { Team.unscoped.last }
       let(:user) { User.unscoped.last }
       before { create :team, course: course, name: "Zeppelin" }
 
       context "with GradeCraft students" do
         let(:file) { fixture_file "users.csv", "text/csv" }
-        subject { described_class.new(file.tempfile) }
+        subject { described_class.new(file.tempfile, course) }
 
         it "creates the student accounts" do
-          subject.import course
+          subject.import
           expect(user.email).to eq "csv_jimmy@example.com"
           expect(user.crypted_password).to_not be_blank
           expect(user.course_memberships.first.course).to eq course
@@ -27,7 +27,7 @@ describe CSVStudentImporter do
         end
 
         it "strips whitespace and creates a valid user" do
-          subject.import course
+          subject.import
           user_2 = User.unscoped.first
           expect(user_2.first_name).to eq "leading"
           expect(user_2.last_name).to eq "trailing"
@@ -37,54 +37,54 @@ describe CSVStudentImporter do
         it "does not create the student membership if it already exists" do
           create :user, first_name: "Jimmy", last_name: "Page", email: "csv_jimmy@example.com",
             username: "csv_jimmy", password: "blah", courses: [course], role: :student
-          expect { subject.import course }.to change { CourseMembership.count }.by(2)
+          expect { subject.import }.to change { CourseMembership.count }.by(2)
         end
 
         it "adds the students to the team if the team exists" do
-          subject.import course
+          subject.import
           expect(team.name).to eq "Zeppelin"
           expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "handles empty fields with whitespace" do
-          subject.import course
+          subject.import
           expect(User.unscoped.first.team).to be_nil
         end
 
         it "just adds the student to the team if the student already exists" do
           User.create first_name: "Jimmy", last_name: "Page",
               email: "csv_jimmy@example.com", username: "jimmy", password: "blah"
-          subject.import course
+          subject.import
           expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "appends unsuccessful if a course membership already exists for user and there is no change to team" do
-          subject.import course
-          result = subject.import course
+          subject.import
+          result = subject.import
           expect(result.unsuccessful).to include({data: "Jimmy,Page,csv_jimmy,csv_jimmy@example.com,Zeppelin\n",
             errors: "Unable to import this user, they have already been added to the course"})
         end
 
         it "creates the team and adds the student if the team does not exist" do
           Team.unscoped.last.destroy
-          subject.import course
+          subject.import
           expect(team.name).to eq "Zeppelin"
           expect(team.students.first.email).to eq "csv_jimmy@example.com"
         end
 
         it "does not add the student to the team if a team is not specified" do
-          subject.import course
+          subject.import
           user = User.unscoped.first
           expect(team.students).to_not include user
         end
 
         it "sends the activation email to each student" do
-          expect { subject.import course }.to \
+          expect { subject.import }.to \
             change { ActionMailer::Base.deliveries.count }.by 3
         end
 
         it "contains a successful user if the user and team are valid" do
-          result = subject.import course
+          result = subject.import
           expect(result.successful.count).to eq 3
           expect(result.successful.last).to eq user
         end
@@ -92,7 +92,7 @@ describe CSVStudentImporter do
         it "contains unsuccessful rows if the user cannot be created or updated" do
           allow(Services::CreatesOrUpdatesUser).to receive(:call).and_return \
             double(:result, success?: false, message: "")
-          result = subject.import course
+          result = subject.import
           expect(result.unsuccessful.count).to eq 3
           expect(result.unsuccessful.pluck(:errors)).to include "Unable to create or update user"
         end
@@ -100,7 +100,7 @@ describe CSVStudentImporter do
         it "contains an unsuccessful row if the team is not valid" do
           allow_any_instance_of(Team).to receive(:valid?).and_return false
           allow_any_instance_of(Team).to receive(:errors).and_return double(full_messages: ["The team is not cool"])
-          result = subject.import course
+          result = subject.import
           expect(result.successful.count).to eq 2
           expect(result.unsuccessful.count).to eq 1
           expect(result.unsuccessful.first[:errors]).to eq "The team is not cool"
@@ -109,10 +109,10 @@ describe CSVStudentImporter do
 
       context "with UM students" do
         let(:file) { fixture_file "internal_users.csv", "text/csv" }
-        subject { described_class.new(file.tempfile, true) }
+        subject { described_class.new(file.tempfile, course, true) }
 
         it "creates the student accounts with emails specified" do
-          subject.import course
+          subject.import
           expect(user.email).to eq "richard@umich.edu"
           expect(user.username).to eq "richard"
           expect(user.kerberos_uid).to eq "richard"
@@ -121,7 +121,7 @@ describe CSVStudentImporter do
         end
 
         it "creates the student accounts with unique names specified" do
-          subject.import course
+          subject.import
           user =  User.unscoped.first
           expect(user.email).to eq "peter@umich.edu"
           expect(user.username).to eq "peter"
@@ -131,23 +131,23 @@ describe CSVStudentImporter do
         end
 
         it "does not store a password for the student" do
-          subject.import course
+          subject.import
           expect(user.crypted_password).to be_blank
         end
 
         it "activates the users" do
-          subject.import course
+          subject.import
           expect(User.all.all?(&:activated?)).to eq true
         end
 
         it "does not send the activation email to each student" do
-          expect { subject.import course }.to_not \
+          expect { subject.import }.to_not \
             change { ActionMailer::Base.deliveries.count }
         end
 
         it "can send a welcome email to each student" do
-          subject = described_class.new(file.tempfile, true, true)
-          expect { subject.import course }.to \
+          subject = described_class.new(file.tempfile, course, true, true)
+          expect { subject.import }.to \
             change { ActionMailer::Base.deliveries.count }.by 2
         end
       end

--- a/spec/services/creates_new_user_spec.rb
+++ b/spec/services/creates_new_user_spec.rb
@@ -18,6 +18,12 @@ describe Services::CreatesNewUser do
       described_class.call params
     end
 
+    it "does not generate a password if a password was provided" do
+      params.merge! password: "password1"
+      expect(Services::Actions::GeneratesPassword).not_to receive(:execute)
+      described_class.call params
+    end
+
     it "updates user usernames and emails" do
       expect(Services::Actions::GeneratesUsernames).to receive(:execute).and_call_original
       described_class.call params


### PR DESCRIPTION
### Status
**READY**

### Description
If a password is provided for any given row in the CSV, do not override it with a generated password and automatically activate their account.

85% of the functionality to do this is already built in.

### Impacted Areas in Application
CSV user import

======================
Closes #[ISSUE NUMBER]
