### PR TITLE
Add Unlock Button to mass edit page for earned badges

### DIFF
--- a/app/views/earned_badges/mass_edit.html.haml
+++ b/app/views/earned_badges/mass_edit.html.haml
@@ -24,7 +24,7 @@
                 %img{:src => earned_badge.badge.try(:icon), :alt => earned_badge.badge.try(:name), :width => "25", :height => "25"}
             %td
               - if ! @badge.is_unlocked_for_student?(earned_badge.student)
-                = link_to glyph(:lock) + "Unlock", manually_unlock_unlock_state_path(id: @badge.id, student_id: earned_badge.student.id, badge_id: @badge.id), :method => :post, class: "button"
+                = link_to glyph(:unlock) + "Unlock", manually_unlock_unlock_state_path(id: @badge.id, student_id: earned_badge.student.id, badge_id: @badge.id), :method => :post, class: "button"
             %td
               - if @badge.can_earn_multiple_times? || ! earned_badge.student.earned_badges.where(badge_id: @badge).present?
                 %input(type="checkbox" id="student-id-#{earned_badge[:student_id]}" name="student_ids[]" value="#{earned_badge[:student_id]}")

--- a/app/views/earned_badges/mass_edit.html.haml
+++ b/app/views/earned_badges/mass_edit.html.haml
@@ -10,6 +10,7 @@
           %tr
             %th{:width => "50%"} Name
             %th{:width => "15%"} Earned
+            %th{:width => "25%"}
             %th.has_button{"data-dynatable-no-sort" => "true", :width => "140px" }
               %button.button.select-all{role: "button", type: "button"}
                 = "Check"
@@ -21,6 +22,9 @@
             %td
               - earned_badge.student.earned_badges.where(badge_id: @badge).each do |earned_badge|
                 %img{:src => earned_badge.badge.try(:icon), :alt => earned_badge.badge.try(:name), :width => "25", :height => "25"}
+            %td
+              - if ! @badge.is_unlocked_for_student?(earned_badge.student)
+                = link_to glyph(:lock) + "Unlock", manually_unlock_unlock_state_path(id: @badge.id, student_id: earned_badge.student.id, badge_id: @badge.id), :method => :post, class: "button"
             %td
               - if @badge.can_earn_multiple_times? || ! earned_badge.student.earned_badges.where(badge_id: @badge).present?
                 %input(type="checkbox" id="student-id-#{earned_badge[:student_id]}" name="student_ids[]" value="#{earned_badge[:student_id]}")


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
See Title

### Related PRs
N/A


### Todos
N/A


### Deploy Notes
N/A

### Gem dependencies
N/A

### Migrations
NO

### Steps to Test or Reproduce
As an instructor, go to badges mass edit page (using Quick Award). Observe that the Unlock Buttons correspond with what is seen on the Badges Show page

### Impacted Areas in Application
* Badges

======================
Closes #[ISSUE NUMBER]
