### PR TITLE
Fall back on using email and login_id from Canvas

### DIFF
--- a/app/assets/javascripts/angular/templates/grades/import/form.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/import/form.html.haml
@@ -51,7 +51,7 @@
                                        "ng-click"=>"vm.deselectAllGrades()"}= "Uncheck"
       %tbody
         %tr{"ng-if"=>"grades.length > 0", "ng-repeat"=>"grade in grades"}
-          %td {{grade.primary_email}}
+          %td {{grade.primary_email || grade.email || grade.user_id}}
           %td {{grade.score}}
           %td {{grade.feedback}}
           %td {{grade.gradecraft_score.raw_points}}

--- a/app/importers/grade_importers/canvas_grade_importer.rb
+++ b/app/importers/grade_importers/canvas_grade_importer.rb
@@ -49,7 +49,8 @@ class CanvasGradeImporter
     canvas_user = syllabus.user(user_id)
     return nil if canvas_user.nil?
 
-    User.find_by_insensitive_email(canvas_user["primary_email"])
+    user = User.find_by_insensitive_email(canvas_user["primary_email"] || canvas_user["email"])
+    user ||= User.find_by_insensitive_username(canvas_user["login_id"])
   end
 
   def link_imported(provider_resource_id, grade)

--- a/app/importers/user_importers/canvas_user_importer.rb
+++ b/app/importers/user_importers/canvas_user_importer.rb
@@ -39,6 +39,7 @@ class CanvasUserImporter
 
   def find_or_create_user(row, course)
     user = User.find_by_insensitive_email row.email if row.email
+    user ||= User.find_by_insensitive_username row.user_id if row.user_id
     user ||= Services::CreatesNewUser
       .call(row.to_h.merge(internal: false), send_welcome)[:user]
     role_changed = false
@@ -80,6 +81,10 @@ class CanvasUserImporter
 
     def email
       data["primary_email"] || data["email"]
+    end
+
+    def user_id
+      data["login_id"]
     end
 
     def role

--- a/app/views/api/grades/importers/show.json.jbuilder
+++ b/app/views/api/grades/importers/show.json.jbuilder
@@ -6,6 +6,9 @@ json.data @result[:grades] do |grade|
 
   json.attributes do
     json.id                                   grade["id"].to_s
+
+    json.user_id                              user["login_id"]
+    json.email                                user["email"]
     json.primary_email                        user["primary_email"]
 
     json.score                                grade["score"]


### PR DESCRIPTION
### Status
**READY**

### Description

This PR makes it so that we also will try to look up an existing user based on their `login_id` provided by the User API.

We still need to figure out why no email data is returned from Canvas because if that user has never logged into Gradecraft before, the import will be unable to create new accounts for them since it is a required column in our model.

A possibility might be that we make some sort of assumption that if we connect to Umich instructure we should expect that the email will follow the format `[login_id]@umich.edu`, but this may not be ideal.

Closes #4102