### PR TITLE
Improve

### DIFF
--- a/app/helpers/lms_helper.rb
+++ b/app/helpers/lms_helper.rb
@@ -3,8 +3,9 @@ module LMSHelper
     syllabus.user(user_id) || {}
   end
 
-  def lms_user_match?(email, course)
-    user = User.find_by_insensitive_email(email)
+  def lms_user_match?(email, username, course)
+    user = User.find_by_insensitive_email(email) unless email.blank?
+    user ||= User.find_by_insensitive_username(username) unless username.blank?
     user.present? && !user.role(course).nil?
   end
 end

--- a/app/views/api/grades/importers/show.json.jbuilder
+++ b/app/views/api/grades/importers/show.json.jbuilder
@@ -15,7 +15,7 @@ json.data @result[:grades] do |grade|
     json.feedback                             concat_submission_comments(grade["submission_comments"])
     json.gradecraft_score                     Grade.for_student_email_and_assignment_id(user["primary_email"],
                                                 @assignment.id) || Grade.new
-    json.user_exists                          lms_user_match?(user["primary_email"], current_course)
+    json.user_exists                          lms_user_match?(user["primary_email"], user["login_id"], current_course)
   end
 end
 

--- a/app/views/api/users/importers/index.json.jbuilder
+++ b/app/views/api/users/importers/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.data @result[:users] do |user|
   gradecraft_user = User.find_by_insensitive_email(user["email"])
-  user_exists = lms_user_match?(user["email"], current_course)
+  user_exists = lms_user_match?(user["email"], nil, current_course)
   gradecraft_role = lms_user_role(user["enrollments"])
 
   json.type                                   "imported_user"

--- a/spec/helpers/lms_helper_spec.rb
+++ b/spec/helpers/lms_helper_spec.rb
@@ -4,23 +4,31 @@ describe LMSHelper do
 
     context "the user does not exist" do
       it "returns false" do
-        expect(helper.lms_user_match?("blah@blah.com", course)).to eq false
+        expect(helper.lms_user_match?("blah@blah.com", "blah", course)).to eq false
       end
     end
 
     context "the user exists" do
       let(:email) { "jimmy@example.com" }
-      let!(:student) { create :user, email: email }
+      let!(:student) { create :user, email: email, username: "jimmy" }
 
-      it "returns false if the user does not belong to the course" do
-        expect(helper.lms_user_match?(email, course)).to eq false
+      context "when the user belongs to the course" do
+        let!(:course_membership) { create :course_membership, :student, user: student, course: course }
+
+        it "returns true if the user matches on username" do
+          create :course_membership, :student, user: student, course: course
+          expect(helper.lms_user_match?(nil, "jimmy", course)).to eq true
+        end
+
+        it "returns true if the user matches on email" do
+          create :course_membership, :student, user: student, course: course
+          expect(helper.lms_user_match?(email, nil, course)).to eq true
+        end
       end
 
-      context "the user belongs to the course" do
-        let!(:membership) { create :course_membership, :student, user: student, course: course }
-
-        it "returns true if the user exists and belongs to the course" do
-          expect(helper.lms_user_match?(email, course)).to eq true
+      context "when the user does not belong to the course" do
+        it "returns false" do
+          expect(helper.lms_user_match?(email, nil, course)).to eq false
         end
       end
     end


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes the issue where a user was seeing that a user did not exist in the course, if no email was returned by the Canvas submissions API. The change now will also try to match on the username.