### PR TITLE
Restrict Email Updates

### DIFF
--- a/app/assets/stylesheets/layout/_forms.sass
+++ b/app/assets/stylesheets/layout/_forms.sass
@@ -18,7 +18,9 @@ textarea,
   border: 1px solid rgba(42, 43, 43, 0.2)
   transition: border-color 0.2s
   &:focus
-    border: 1px solid rgba(42, 43, 43, 0.8)
+    border: 1px solid rgba(42, 43, 43, 0.8) 
+  &:disabled
+    color: $grey_1
   @media (max-width: $media-small-max)
     width: 100%
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -134,7 +134,7 @@ class UsersController < ApplicationController
       up.delete(:password)
       up.delete(:password_confirmation)
     end
-    @user.assign_attributes up
+    @user.assign_attributes current_user_is_admin? ? up : up.except(:email)
     cancel_course_memberships @user
     if @user.save
       @user.activate! if up[:password].present? && !@user.activated?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -261,6 +261,7 @@ class UsersController < ApplicationController
   end
 
   def import
+    redirect_to users_importers_path unless current_user_is_admin? || accessible_to_app_env?
   end
 
   # import users for class

--- a/app/views/users/_gradecraft_user_form.html.haml
+++ b/app/views/users/_gradecraft_user_form.html.haml
@@ -9,7 +9,7 @@
       = f.text_field :last_name, "aria-required": "true"
     .form-item
       = f.label :email
-      = f.text_field :email, "aria-required": "true"
+      = f.text_field :email, "aria-required": "true", disabled: current_user_is_admin? ? nil : ""
     - if UserProctor.new(@user).can_update_password? current_user, current_course
       .form-item
         = f.label :password

--- a/app/views/users/_internal_user_form.html.haml
+++ b/app/views/users/_internal_user_form.html.haml
@@ -9,7 +9,7 @@
       = f.text_field :last_name, "aria-required": "true"
     .form-item
       = f.label :email
-      = f.text_field :email, "aria-required": "true"
+      = f.text_field :email, "aria-required": "true", disabled: current_user_is_admin? ? nil : ""
     = f.hidden_field :internal, value: true
     - if @user.new_record?
       .form-item

--- a/app/views/users/importers/index.html.haml
+++ b/app/views/users/importers/index.html.haml
@@ -2,16 +2,17 @@
   = render partial: "layouts/alerts"
 
   %section
-    .card{style: "height: 400px;"}
-      .card-cap
-        = image_tag "csv-logo.png", height: "46px"
-      .card-block
-        %h4.card-title CSV
-        .card-text
-        %p.card-text
-          Upload a .csv file with user information to import users.
+    - if current_user_is_admin? || accessible_to_app_env?
+      .card{style: "height: 400px;"}
+        .card-cap
+          = image_tag "csv-logo.png", height: "46px"
+        .card-block
+          %h4.card-title CSV
+          .card-text
+          %p.card-text
+            Upload a .csv file with user information to import users.
 
-        = link_to "Import Users from CSV", import_users_path, class: "card-link button"
+          = link_to "Import Users from CSV", import_users_path, class: "card-link button"
 
     - if current_course.allows_canvas?
       .card{style: "height: 400px;"}

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -201,7 +201,8 @@ describe UsersController do
     end
 
     describe "GET import" do
-      it "renders the import page" do
+      it "renders the import page if allowed" do
+        stub_env "beta"
         get :import
         expect(response).to render_template(:import)
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -54,35 +54,6 @@ describe UsersController do
       end
     end
 
-    describe "POST create" do
-      let(:user) { User.unscoped.last }
-
-      context "calling create" do
-        before(:each) do
-          post :create, params: { user: { first_name: "Jimmy",
-                                          last_name: "Page",
-                                          username: "jimmy",
-                                          email: "jimmy@example.com" }}
-        end
-
-        it "creates a new user" do
-          expect(user.email).to eq "jimmy@example.com"
-          expect(user.username).to eq "jimmy"
-          expect(user.first_name).to eq "Jimmy"
-          expect(user.last_name).to eq "Page"
-        end
-
-        it "generates a random password for a user" do
-          expect(user.crypted_password).to_not be_blank
-        end
-
-        it "requires the new user to be activated" do
-          expect(user.activation_token).to_not be_blank
-          expect(user.activation_state).to eq "pending"
-        end
-      end
-    end
-
     describe "PUT update" do
       it "updates an existing user" do
         user
@@ -98,10 +69,16 @@ describe UsersController do
         put :update, params: { id: user.id, user: params }
         expect(user.reload.activated?).to be_truthy
       end
+
+      it "does not allow the email to be updated" do
+        user
+        params = { email: "blah@blahblah.com" }
+        put :update, params: { id: user.id, user: params }
+        expect(user.reload.email).to_not eq "blah@blahblah.com"
+      end
     end
 
     context "calling create" do
-
       it "creates a new staff member" do
         post :create, params: { user: { first_name: "Bob",
                   last_name: "Ross",


### PR DESCRIPTION
### Status
**READY**

### Description
- Restricts the CSV user import to be available only for admins and non-Umich users.
- Disables the email input on the user update page if not an admin