### PR TITLE
Added assignment column to students grade table

### DIFF
--- a/app/views/students/_grade_index.haml
+++ b/app/views/students/_grade_index.haml
@@ -1,6 +1,7 @@
 %table.dynatable
   %thead
     %tr
+      %th Assignment Type
       %th Assignment
       %th Feedback
       %th Final Score
@@ -12,6 +13,7 @@
   %tbody
     - presenter.grades_for_course.each do |grade|
       %tr
+        %td= link_to grade.assignment_type.name, edit_assignment_type_path(grade.assignment_type.id)
         %td= link_to grade.assignment.name, grade.assignment
         %td= raw grade.feedback
         %td


### PR DESCRIPTION
### Status
**READY**

### Description
Added table header for assignment type and assignment type column to the students grade table 

### Steps to Test or Reproduce
Go to students/:id the table at the bottom of the page will now have an assignment type sortable column. On click you are taken to edit the assignment 

Closes #3840
