### PR TITLE
Re-enable email field if creating new user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -135,7 +135,7 @@ class UsersController < ApplicationController
       up.delete(:password)
       up.delete(:password_confirmation)
     end
-    @user.assign_attributes user_proctor.can_update_email?(current_user, current_course) ? up : up.except(:email)
+    @user.assign_attributes user_proctor.can_set_email?(current_user, current_course) ? up : up.except(:email)
     cancel_course_memberships @user
     if @user.save
       @user.activate! if up[:password].present? && !@user.activated?

--- a/app/proctors/user_proctor.rb
+++ b/app/proctors/user_proctor.rb
@@ -12,7 +12,8 @@ class UserProctor
     Rails.env.beta? && course.institution.try(:institution_type) == "K-12"
   end
 
-  def can_update_email?(proxy, course)
+  def can_set_email?(proxy, course)
+    return true if !user.persisted?
     return true if proxy.is_admin? course
     !Rails.env.production?
   end

--- a/app/views/users/_gradecraft_user_form.html.haml
+++ b/app/views/users/_gradecraft_user_form.html.haml
@@ -9,7 +9,7 @@
       = f.text_field :last_name, "aria-required": "true"
     .form-item
       = f.label :email
-      = f.text_field :email, "aria-required": "true", disabled: UserProctor.new(@user).can_update_email?(current_user, current_course) ? nil : ""
+      = f.text_field :email, "aria-required": "true", disabled: UserProctor.new(@user).can_set_email?(current_user, current_course) ? nil : ""
     - if UserProctor.new(@user).can_update_password? current_user, current_course
       .form-item
         = f.label :password

--- a/app/views/users/_internal_user_form.html.haml
+++ b/app/views/users/_internal_user_form.html.haml
@@ -9,7 +9,7 @@
       = f.text_field :last_name, "aria-required": "true"
     .form-item
       = f.label :email
-      = f.text_field :email, "aria-required": "true", disabled: UserProctor.new(@user).can_update_email?(current_user, current_course) ? nil : ""
+      = f.text_field :email, "aria-required": "true", disabled: UserProctor.new(@user).can_set_email?(current_user, current_course) ? nil : ""
     = f.hidden_field :internal, value: true
     - if @user.new_record?
       .form-item

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -63,7 +63,7 @@ describe UsersController do
       end
 
       it "activates the user if the user is not activated and the password changed" do
-        allow(UserProctor).to receive(:new).and_return instance_double("UserProctor", can_update_password?: true, can_update_email?: true)
+        allow(UserProctor).to receive(:new).and_return instance_double("UserProctor", can_update_password?: true, can_set_email?: true)
         user = create :user, activated: false
         params = { password: "password", password_confirmation: "password" }
         put :update, params: { id: user.id, user: params }
@@ -132,7 +132,7 @@ describe UsersController do
 
       it "deletes the password params if the user is not permitted to change it" do
         user_params = { password: "password", password_confirmation: "password" }
-        allow(UserProctor).to receive(:new).with(user).and_return instance_double("UserProctor", can_update_password?: false, can_update_email?: true)
+        allow(UserProctor).to receive(:new).with(user).and_return instance_double("UserProctor", can_update_password?: false, can_set_email?: true)
         expect{ put :update, params: { id: user.id, user: user_params } }.to_not change { user.reload.crypted_password }
       end
     end

--- a/spec/proctors/user_proctor_spec.rb
+++ b/spec/proctors/user_proctor_spec.rb
@@ -38,19 +38,19 @@ describe UserProctor do
     end
   end
 
-  describe "#can_update_email?" do
+  describe "#can_set_email?" do
     let(:proxy) { build :user }
 
     before(:each) { stub_env "production" }
 
     it "returns true if the user is an admin for the course" do
       create :course_membership, :admin, course: course, user: proxy
-      expect(subject.can_update_email? proxy, course).to eq true
+      expect(subject.can_set_email? proxy, course).to eq true
     end
 
     it "returns true if the environment is not production" do
       stub_env "beta"
-      expect(subject.can_update_email? proxy, course).to eq true
+      expect(subject.can_set_email? proxy, course).to eq true
     end
   end
 end


### PR DESCRIPTION
### Status
**READY**

### Description
The email field when creating a **new** user on Umich is still disabled.
