### PR TITLE
Nil-coalesce graded_at

### DIFF
--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -107,9 +107,12 @@ class Assignments::GradesController < ApplicationController
         @grade.raw_points = @assignment.full_points
       end
 
-      @grade.instructor_modified = true
-      @grade.complete = true
-      @grade.student_visible = true
+      @grade.assign_attributes(
+        instructor_modified: true,
+        student_visible: true,
+        complete: true,
+        graded_at: DateTime.now
+      )
 
       if @grade.save
         grade_updater_job = GradeUpdaterJob.new(grade_id: @grade.id)

--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -10,7 +10,7 @@
 
     - if presenter.submission.will_be_resubmitted?
       %section.grade-form-section
-        .italic.not_bold= "Graded: #{l presenter.submission.graded_at.in_time_zone(current_user.time_zone)}"
+        .italic.not_bold= "Graded: #{l presenter.submission.graded_at&.in_time_zone(current_user.time_zone)}"
         %span.label.alert Resubmission!
 
     %section.grade-form-section

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -204,6 +204,16 @@ describe Assignments::GradesController do
           expect(grade.raw_points).to eq assignment.full_points
         end
 
+        it "updates the attributes on the grade" do
+          post :self_log, params: { assignment_id: assignment.id }
+          grade = student.grade_for_assignment(assignment)
+          grade.reload
+          expect(grade.instructor_modified).to eq true
+          expect(grade.student_visible).to eq true
+          expect(grade.complete).to eq true
+          expect(grade.graded_at).to be_within(1.second).of(DateTime.now)
+        end
+
         it "reports errors on failure to save" do
           allow_any_instance_of(Grade).to receive(:save).and_return false
           post :self_log, params: { assignment_id: assignment.id }


### PR DESCRIPTION
### Status
**READY**

### Description
This fixes an issue on the autosave template for a student when they are submitting for an assignment where the `graded_at` column for a grade is `nil` and we are trying to convert it to the current user's specified time zone.

======================
Closes #4145 
