### PR TITLE
Fixed learning objective table to only display if there are linked assignments

### DIFF
--- a/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
+++ b/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
@@ -35,7 +35,7 @@
           %span{"ng-if"=>"!loShowCtrl.cumulativeOutcome(student.id)"} Not Yet Started
 
   -# Table for all students in the course
-  %section{"ng-if"=>"!loShowCtrl.studentId"}
+  %section{"ng-if"=>"!loShowCtrl.studentId && loShowCtrl.linkedAssignments.length > 0"}
     %h3.subtitle Student Progress
 
     %table
@@ -75,7 +75,7 @@
 
 
   -# Progress for an individual student
-  %section{"ng-if"=>"loShowCtrl.studentId"}
+  %section{"ng-if"=>"loShowCtrl.studentId && loShowCtrl.linkedAssignments.length > 0"}
     %h2.subtitle {{loShowCtrl.termFor('assignments')}} That Meet This {{loShowCtrl.termFor('learning_objective')}}
 
     %table
@@ -115,3 +115,7 @@
           %td
             %lo-proficiency-indicator{"ng-if"=>"loShowCtrl.earnedOutcome(assignment.id) != null",
                                       "data-observed-outcome"=>"loShowCtrl.earnedOutcome(assignment.id)"}
+  
+  %section{"ng-if"=>"loShowCtrl.linkedAssignments.length == 0"}
+    %span
+      There is no linked {{loShowCtrl.termFor('assignment')}} for this {{loShowCtrl.termFor('learning_objective')}}.


### PR DESCRIPTION
### Status
**READY**

### Description
When a student/professor visits a learning objective, they should only see the linked assignments table if there are assignments that are actually linked. Otherwise, an line is displayed to inform them that there are no linked assignments for the specific learning objective.

### Todos
- [x] Confirm that the informative statement is appropriate, otherwise update accordingly.

### Migrations
No

### Steps to Test or Reproduce
As a student or as a professor:
1. Visit any learning objective
2. Confirm that if there are no linked assignments, a table is not displayed. Otherwise, a table should be displayed with the relative assignments.

### Impacted Areas in Application
Learning objectives

======================
Closes #4069 
