### PR TITLE
remove access for u-m faculty to add courses independently

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -24,7 +24,7 @@ class CoursesController < ApplicationController
 
   def index
     @courses = current_user.courses.includes(:earned_badges)
-    @can_create_courses = current_user_is_admin? || (!Rails.env.beta? && current_user_is_staff?)
+    @can_create_courses = current_user_is_admin?
   end
 
   def overview
@@ -250,7 +250,7 @@ class CoursesController < ApplicationController
   end
 
   def ensure_can_create_courses?
-    can_create_courses = current_user_is_admin? || (!Rails.env.beta? && current_user_is_staff?)
+    can_create_courses = current_user_is_admin?
     redirect_to action: :index and return unless can_create_courses
   end
 end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR removes Umich staff member's ability to add courses independently - we thought we'd already done this, but there was one button remaining that they could access! This was causing the crazy Canvas ID bug. 

### Migrations
NO

### Steps to Test or Reproduce
Prior to this, if the faculty members found their way to the courses index, there was a "New Course" button we didn't intend them to have. As a staff member who is NOT an admin, you should no longer be able to see that. 

