### PR TITLE
Removed 'Course Analytics' row from course data exports page

### DIFF
--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -47,10 +47,6 @@
           %td Level ID, Letter Grade, Level Name, Lowest Points, Highest Points
 
         %tr
-          %td= link_to glyph("file-excel-o") + "Course Analytics", course_analytics_exports_path, method: :post
-          %td Event data including pageviews, predictions, and logins
-
-        %tr
           %td= link_to glyph("file-excel-o") + "Multiplier Choices", export_course_multipliers_path(course_id: current_course, format: "csv")
           %td First Name, Last Name, Email, Fully Assigned, Unassigned Number, Weightable Assignment Types
 

--- a/app/views/downloads/index.html.haml
+++ b/app/views/downloads/index.html.haml
@@ -46,6 +46,10 @@
           %td= link_to glyph("file-excel-o") + "Grading Scheme", export_structure_grade_scheme_elements_path(id: current_course.id, format: "csv")
           %td Level ID, Letter Grade, Level Name, Lowest Points, Highest Points
 
+        -#%tr
+        -#  %td= link_to glyph("file-excel-o") + "Course Analytics", course_analytics_exports_path, method: :post
+        -#  %td Event data including pageviews, predictions, and logins
+
         %tr
           %td= link_to glyph("file-excel-o") + "Multiplier Choices", export_course_multipliers_path(course_id: current_course, format: "csv")
           %td First Name, Last Name, Email, Fully Assigned, Unassigned Number, Weightable Assignment Types


### PR DESCRIPTION
### Status
**READY**

### Description
Recently users have been experiencing problems when exporting course analytics, including having no results processed after a long time waiting for output consuming a lot of resources causing other problems within the application. 

This change removes the ability to export 'Course Analytics data' from the downloads page 

### Migrations
NO

### Impacted Areas in Application
Course analytics Export

