### PR TITLE
Disable doc size check for now

### DIFF
--- a/app/event_loggers/pageview_event_logger.rb
+++ b/app/event_loggers/pageview_event_logger.rb
@@ -27,10 +27,10 @@ class PageviewEventLogger < ApplicationEventLogger
   end
 
   def enqueue_in_and_check_with_fallback(time_until_start)
-    raise EventLogger::Exceptions::DocumentSizeExceededError.new(
-      "Failed to enqueue pageview event logger job due to exceeded document size; attributes",
-      event_attrs
-    ) if documents_exceeded_maximum_size?
+    # raise EventLogger::Exceptions::DocumentSizeExceededError.new(
+    #   "Failed to enqueue pageview event logger job due to exceeded document size; attributes",
+    #   event_attrs
+    # ) if documents_exceeded_maximum_size?
 
     enqueue_in_with_fallback(time_until_start)
   end

--- a/spec/event_loggers/pageview_event_logger_spec.rb
+++ b/spec/event_loggers/pageview_event_logger_spec.rb
@@ -91,19 +91,19 @@ RSpec.describe PageviewEventLogger, type: :event_logger do
     describe "#enqueue_in_and_check_with_fallback" do
       let(:enqueue_time) { Faker::Time.forward 1 }
 
-      context "when the underlying document has exceeded the maximum allowable size" do
-        before(:each) { allow(subject).to receive(:documents_exceeded_maximum_size?).and_return true }
+      # context "when the underlying document has exceeded the maximum allowable size" do
+      #   before(:each) { allow(subject).to receive(:documents_exceeded_maximum_size?).and_return true }
 
-        it "raises an exception" do
-          expect{ subject.enqueue_in_and_check_with_fallback(enqueue_time) }.to \
-            raise_error EventLogger::Exceptions::DocumentSizeExceededError
-        end
+      #   it "raises an exception" do
+      #     expect{ subject.enqueue_in_and_check_with_fallback(enqueue_time) }.to \
+      #       raise_error EventLogger::Exceptions::DocumentSizeExceededError
+      #   end
 
-        it "does not enqueue the job" do
-          expect(subject).to_not receive(:enqueue_in_with_fallback)
-          subject.enqueue_in_and_check_with_fallback(enqueue_time) rescue nil
-        end
-      end
+      #   it "does not enqueue the job" do
+      #     expect(subject).to_not receive(:enqueue_in_with_fallback)
+      #     subject.enqueue_in_and_check_with_fallback(enqueue_time) rescue nil
+      #   end
+      # end
 
       context "with the underlying document has not exceeded the maximum allowable size" do
         before(:each) { allow(subject).to receive(:documents_exceeded_maximum_size?).and_return false }


### PR DESCRIPTION
### Status
**READY**

### Description
I'm not seeing any evidence of document sizes exceeding the max size yet in production, and this check effectively doubles the number of MongoDB read operations right now. I'm temporarily disabling this logic for now so that we can think about this later, either in the form of the work described in #4167 or by moving off MongoDB entirely.
