### PR TITLE
Admin assignment control

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -224,7 +224,7 @@ class CoursesController < ApplicationController
       instructors_of_record_ids: [], course_memberships_attributes: [:id, :course_id, :user_id, :instructor_of_record]
     ]
     if current_user_is_admin?
-      params.require(:course).permit(*course_attrs << [:status, :has_paid, :allows_canvas, :allows_learning_objectives, :institution_id])
+      params.require(:course).permit(*course_attrs << [:status, :has_paid, :allows_canvas, :allows_learning_objectives, :institution_id, :disable_grade_emails])
     else
       params.require(:course).permit(*course_attrs)
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -235,6 +235,10 @@ class Course < ApplicationRecord
     return nonpredictors
   end
 
+  def admin_disabled_grade_email?
+    return self.disable_grade_emails
+  end
+
   private
 
   # If not using multipliers, reset the related columns

--- a/app/performers/grade_update_performer.rb
+++ b/app/performers/grade_update_performer.rb
@@ -43,7 +43,7 @@ class GradeUpdatePerformer < ResqueJob::Performer
 
   def notify_grade_released
     GradeAnnouncement.create @grade
-    if @grade.student.email_grade_notifications?(@grade.course)
+    if @grade.student.email_grade_notifications?(@grade.course) &&! @grade.course.admin_disabled_grade_email?
       NotificationMailer.grade_released(@grade.id).deliver_now
     end
   end

--- a/app/views/courses/_admin_only.haml
+++ b/app/views/courses/_admin_only.haml
@@ -2,12 +2,14 @@
   %section.form-section
     %h2.form-title Admin Only
     .form-item
-      = f.input :status, label: "Active?", hint: "Is this an active course?"
+      = f.input :status, label: "Active?", hint: " Is this an active course?"
     .form-item
-      = f.input :has_paid, label: "Has Paid?", hint: "If this course is not at Michigan, has it been paid for? This affects whether or not instructors can add users."
+      = f.input :has_paid, label: "Has Paid?", hint: " If this course is not at Michigan, has it been paid for? This affects whether or not instructors can add users."
     .form-item
-      = f.input :allows_canvas, label: "Allows Canvas?", hint: "Does this course allow integration with Canvas?"
+      = f.input :allows_canvas, label: "Allows Canvas?", hint: " Does this course allow integration with Canvas?"
     .form-item
-      = f.input :allows_learning_objectives, label: "Enable Learning Objectives?", hint: "Allow instructors to set up learning objectives for the course?"
+      = f.input :allows_learning_objectives, label: "Enable Learning Objectives?", hint: " Allow instructors to set up learning objectives for the course?"
+    .form-item
+      = f.input :disable_grade_emails, label: "Disable Grade Emails?", hint: " Emails are not sent to students upon the release of a grade"
     .form-item
       = f.association :institution, collection: Institution.all, prompt: "Select an institution"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # 4. set perform_deliveries to true
   config.action_mailer.default_url_options = { host: "localhost:5000" }
   config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
-  config.action_mailer.perform_deliveries = false
+  config.action_mailer.perform_deliveries = true
 
   # NOTE: to send emails via Gmail's SMTP server
   # 1. IMPORTANT! Set ENV["MAIL_INTERCEPTOR_RECIPIENT"]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # 4. set perform_deliveries to true
   config.action_mailer.default_url_options = { host: "localhost:5000" }
   config.action_mailer.smtp_settings = { address: '127.0.0.1', port: 1025 }
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
 
   # NOTE: to send emails via Gmail's SMTP server
   # 1. IMPORTANT! Set ENV["MAIL_INTERCEPTOR_RECIPIENT"]

--- a/db/migrate/20190104204001_add_disable_grade_emails_to_courses.rb
+++ b/db/migrate/20190104204001_add_disable_grade_emails_to_courses.rb
@@ -1,0 +1,5 @@
+class AddDisableGradeEmailsToCourses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses, :disable_grade_emails, :boolean, default: false 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_24_184812) do
+ActiveRecord::Schema.define(version: 2019_01_04_204001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -294,6 +294,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_184812) do
     t.boolean "email_grade_notifications", default: true
     t.boolean "email_challenge_grade_notifications", default: true
     t.boolean "active", default: true, null: false
+    t.boolean "email_learning_objective_achieved", default: true
     t.index ["course_id", "user_id"], name: "index_courses_users_on_course_id_and_user_id"
     t.index ["earned_grade_scheme_element_id"], name: "index_course_memberships_on_earned_grade_scheme_element_id"
     t.index ["user_id", "course_id"], name: "index_courses_users_on_user_id_and_course_id"
@@ -365,6 +366,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_184812) do
     t.boolean "objectives_award_points", default: false, null: false
     t.boolean "always_show_objectives", default: false, null: false
     t.boolean "allows_learning_objectives", default: false, null: false
+    t.boolean "disable_grade_emails", default: false
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
 
@@ -586,6 +588,7 @@ ActiveRecord::Schema.define(version: 2018_10_24_184812) do
     t.datetime "updated_at", null: false
     t.integer "learning_objective_id"
     t.integer "user_id"
+    t.boolean "achieved", default: false
     t.index ["learning_objective_id"], name: "index_lo_cumulative_outcomes_on_objective_id"
     t.index ["user_id"], name: "index_learning_objective_cumulative_outcomes_on_user_id"
   end


### PR DESCRIPTION
### Status
**READY**

### Description
This PR adds a feature to allow an admin to go into a courses settings and turn off emails so they are not sent upon the grading of an assignment

### Todos
- [x] QA / User testing


### Deploy Notes
Made a migration to add a variable to course settings

### Migrations
YES 

### Steps to Test or Reproduce
Logged in as an admin, go to the course settings then to the admin tab 
(ex: http://localhost:5000/courses/7/edit). Then check the input field marked "Disable grade emails" and save the changes.

Now when a grade is given to a student, the student should not receive an email saying the assignment was graded

### Impacted Areas in Application
* Course settings
* Admin Control
* Email notifications
