### PR TITLE
updated ruby version in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ gem 'sanitize'
 gem 'sassc-rails'
 
 # secure crypt hashing library stronger than bcrypt or PBDBF2
-gem 'scrypt', '3.0.5'
+gem 'scrypt', '3.0.6'
 
 gem 'select2-rails'
 gem 'simple_form'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '2.5.3'
 
 gem 'rails', '~> 5.2.0'
 gem 'resque'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -567,7 +567,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scrypt (3.0.5)
+    scrypt (3.0.6)
       ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
@@ -734,7 +734,7 @@ DEPENDENCIES
   sampler
   sanitize
   sassc-rails
-  scrypt (= 3.0.5)
+  scrypt (= 3.0.6)
   select2-rails
   simple_form
   simplecov
@@ -747,7 +747,7 @@ DEPENDENCIES
   wysiwyg-rails
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
### Status
**READY**

### Description
Dockerfile was updated recently to reflect this change, builds were failing in quay because the gemfile was trying to use ruby 2.5.1 instead of 2.5.3

Will need to update the production Dockerfile to have the ruby version be 2.5.3 in base image repo

Also updated scrypt 3.0.6 from 3.0.5 due to compile error

### Deploy Notes
Local ruby versions may need to be updated to 2.5.3 also.
easy to use rbenv to do this version updates

### Gem dependencies
Gemfile -- ruby version changed from 2.5.1 to 2.5.3

### Migrations
NO

### Impacted Areas in Application
Gemfile

