### PR TITLE
added a check so that locked assignments do now show in lo table

### DIFF
--- a/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
+++ b/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
@@ -98,7 +98,8 @@
                              "data-sortable-fn"=>"loShowCtrl.sortByAssessment"}
 
       %tbody
-        %tr{"ng-repeat"=>"assignment in loShowCtrl.linkedAssignments | orderBy : loShowCtrl.sortable.predicate : loShowCtrl.sortable.reverse"}
+        %tr{"ng-if"=>"assignment.is_locked != true",
+            "ng-repeat"=>"assignment in loShowCtrl.linkedAssignments | orderBy : loShowCtrl.sortable.predicate : loShowCtrl.sortable.reverse"}
           %td
             %a{"ng-href"=>"/assignments/{{assignment.id}}"} {{assignment.name}}
             %assignment-descriptor-icons{"data-assignment"=>"assignment"}
@@ -115,7 +116,7 @@
           %td
             %lo-proficiency-indicator{"ng-if"=>"loShowCtrl.earnedOutcome(assignment.id) != null",
                                       "data-observed-outcome"=>"loShowCtrl.earnedOutcome(assignment.id)"}
-  
+
   %section{"ng-if"=>"loShowCtrl.linkedAssignments.length == 0"}
     %span
       There is no linked {{loShowCtrl.termFor('assignment')}} for this {{loShowCtrl.termFor('learning_objective')}}.


### PR DESCRIPTION
### Status
**READY**

### Description
When an assignment was locked, and not visible to the student, it would show up hidden in the assignments page, but would show up if it was linked to a learning objective. 

Now a locked assignment will not show up in a learning objective in the students view

### Todos
- [x] User Testing

### Migrations
NO

### Impacted Areas in Application
Students view of Learning objectives

======================
Closes #4119 
