### PR TITLE
Typo fixes

### DIFF
--- a/app/assets/stylesheets/components/_tables.sass
+++ b/app/assets/stylesheets/components/_tables.sass
@@ -31,7 +31,7 @@ table
   thead
     background-color: $blue-medium_2
     color: white
-    text-transform: capitalize
+    //text-transform: capitalize
     font-size: 0.9em
 
     th

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -14,7 +14,7 @@ module AnalyticsHelper
   end
 
   def analytics_switcher_option(path, label, term)
-    content_tag :option, 'data-path': path, selected: ('selected' if current_page?(path)) do "#{(term_for term).titleize} Analytics"
+    content_tag :option, 'data-path': path, selected: ('selected' if current_page?(path)) do "#{(term_for term)} Analytics"
     end
   end
 end

--- a/app/views/courses/_student_onboarding_setup.haml
+++ b/app/views/courses/_student_onboarding_setup.haml
@@ -11,5 +11,5 @@
   %h2.form-title Course Rules
   .form-item
     .textarea
-      .form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and avaialble accomodations for student disabilities.
+      .form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and available accomodations for student disabilities.
       = f.text_area :course_rules, class: "froala"

--- a/app/views/info/staff_onboarding/_staff_onboarding_slide4.haml
+++ b/app/views/info/staff_onboarding/_staff_onboarding_slide4.haml
@@ -4,4 +4,4 @@
   .modal-slide-bottom
     .modal-slide-text
       %h2 Extensive Customization
-      %p You have freedom to tailor and personalized features, course settings, and language based on your unique scenarios and needs
+      %p You have freedom to tailor and personalize features, course settings, and language based on your unique scenarios and needs

--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -57,7 +57,7 @@
             .form-hint What will you contribute to your #{term_for :team}?
 
         %h3.form-subtitle Email Settings
-        .form-hint You will always see your notifications in announcement center above. If there's a type of email you'd rather not get from GradeCraft, just uncheck the box below.
+        .form-hint You will always see your notifications in the announcement center above. If there's a type of email you'd rather not get from GradeCraft, just uncheck the box below.
         .form-item
           = p.input :email_announcements
           - if current_course.has_badges?


### PR DESCRIPTION
### Status
READY

### Description
Fixing the minor typo bugs that David found. Mostly to do with actual miss-typing within the templates, but also a couple SASS-related styling issues. 

### Todos
- Will want to verify on staging that these are fixed for everyone.
