### PR TITLE
Changed Analytics link in staff nav to go to assignments analytics instead of student analytics

### DIFF
--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -15,7 +15,7 @@
 
 %li
   = link_to_unless_current decorative_glyph("file-archive-o") + "Course Data Exports", downloads_path
-%li= link_to_unless_current decorative_glyph("bar-chart") + "Analytics", analytics_students_path
+%li= link_to_unless_current decorative_glyph("bar-chart") + "Analytics", per_assign_path
 %li= link_to_unless_current decorative_glyph(:bullhorn) + "Announcements", announcements_path
 %li= link_to_unless_current decorative_glyph(:calendar) + "Calendar Events", events_path
 


### PR DESCRIPTION
### Status
**READY**

### Description
We had discussed this a little while ago and I just got to implementing it. 

Changed the link in the analytics navigation bar to go directly to the Assignment analytics page instead of the student analytics page first.

In the hopes to make this page move visited by the instructors. 

### Todos
- [x] Check to make sure this is what we want

### Migrations
NO

### Steps to Test or Reproduce
Login as instructor and go to the dashboard. Now click on 'Analytics' on the side nav-bar underneath 'course data export'. This will take you to the assignments analytics page, instead of directing you to the student analytics page. 

Student analytics page is still reachable using the dropdown selection on this page.

### Impacted Areas in Application
Staff navigation bar