### PR TITLE
Submission button change

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -36,7 +36,7 @@ module SubmissionsHelper
 
     if submission.nil?
       return unless allows_new_submissions? assignment, student
-      link = link_to glyph(:upload) + "Submit", submit_assignment_submission_path(assignment, student), class: "button"
+      link = link_to glyph(:upload) + "Start Submission", submit_assignment_submission_path(assignment, student), class: "button"
     else
       sp = SubmissionProctor.new(submission)
       return unless sp.viewable? current_user

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -80,8 +80,8 @@ describe SubmissionsHelper do
           expect(helper.submission_link_to(assignment, student)).to be_nil
         end
 
-        it "returns a link to create a submission" do
-          expect(helper.submission_link_to(assignment, student)).to include "Submit"
+        it "returns a link to create a submission", :focus => true  do 
+          expect(helper.submission_link_to(assignment, student)).to include "Start Submission"
           expect(helper.submission_link_to(assignment, student)).to include \
             submit_assignment_submission_path(assignment, student)
         end


### PR DESCRIPTION
### Status
**READY**

### Description
Quick change to the label of the submission button that takes you to where a student can actually submit.

### Migrations
NO

### Steps to Test or Reproduce
As a student, go to an assignment that takes a submission. Now the button is labeled "Start Submission" instead of just "Submit.

======================
Closes #4192 
