### PR TITLE
Edit submission list

### DIFF
--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -22,9 +22,10 @@
         %h5.bold Uploaded files
         %ul.uploaded-files
           - presenter.submission.submission_files.each do |sf|
-            %li
-              = link_to sf.filename, sf.url, :target => "_blank"
-              = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id } )
+            - if sf.id != nil
+              %li
+                = link_to sf.filename, sf.url, :target => "_blank"
+                = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id } )
 
     - if presenter.assignment.accepts_links
       = f.input :link

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -881,7 +881,6 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.boolean "instructor_unlocked"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean "notified"
     t.index ["student_id"], name: "index_unlock_states_on_student_id"
     t.index ["unlockable_id", "unlockable_type"], name: "index_unlock_states_on_unlockable_id_and_unlockable_type"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -881,6 +881,7 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.boolean "instructor_unlocked"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "notified"
     t.index ["student_id"], name: "index_unlock_states_on_student_id"
     t.index ["unlockable_id", "unlockable_type"], name: "index_unlock_states_on_unlockable_id_and_unlockable_type"
   end


### PR DESCRIPTION
### Status
**READY**

### Description
Previously, when an instructor edited a student's assignment submission, an extra bullet would appear in the submission list with a file path. This update fixes that bug.

We found that when we went to go edit a submission, a second attachment was created, pointing to the first attachment. However, this had no submission id. Now, when displaying submissions, we check for the presence of a valid id.

### Steps to Test or Reproduce
https://github.com/UM-USElab/gradecraft-development/issues/3966

### Impacted Areas in Application
List general components of the application that this PR will affect:
* Editing assignment submissions

======================
Closes #3966 
