### PR TITLE
Update Google omniauth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM quay.io/gradecraft/secrets:production
 MAINTAINER Nagumalli Sundeep <nagumals@umich.edu>
 ENV DOCKER_FIX random
-RUN gem install -v 1.17.1 bundler
+RUN gem install -v 1.17.3 bundler
 RUN mkdir /gradecraft
 WORKDIR /gradecraft/
 ADD Gemfile /gradecraft/Gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     fast_blank (1.0.0)
     ffi (1.9.25)
@@ -255,7 +255,7 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hashdiff (0.3.7)
-    hashie (3.5.7)
+    hashie (3.6.0)
     hodel_3000_compliant_logger (0.1.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
@@ -350,14 +350,14 @@ GEM
       activerecord
       hodel_3000_compliant_logger
     oj (3.7.1)
-    omniauth (1.8.1)
-      hashie (>= 3.4.6, < 3.6.0)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
     omniauth-canvas (1.0.2)
       omniauth (~> 1.3)
       omniauth-oauth2 (~> 1.4)
-    omniauth-google-oauth2 (0.5.3)
-      jwt (>= 1.5)
+    omniauth-google-oauth2 (0.6.0)
+      jwt (>= 2.0)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.5)
     omniauth-kerberos (0.3.0)
@@ -368,9 +368,9 @@ GEM
       omniauth
     omniauth-multipassword (0.4.2)
       omniauth (~> 1.0)
-    omniauth-oauth2 (1.5.0)
+    omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
-      omniauth (~> 1.2)
+      omniauth (~> 1.9)
     os (1.0.0)
     pacecar (2.0.0)
       activerecord (>= 4.0.0)
@@ -750,4 +750,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
### Status
**READY**

### Description
- Updates `omniauth-google-oauth2` to latest version to prevent issues caused underlying Google+ API dependency
- Updates `bundler` to version 1.17.3

### Notes

Developers will want to `gem install bundler -v 1.17.3` after this is merged

======================
Closes #4197
