### PR TITLE
Add missing field to API response

### DIFF
--- a/app/views/api/assignments/_assignment.json.jbuilder
+++ b/app/views/api/assignments/_assignment.json.jbuilder
@@ -31,6 +31,7 @@ json.attributes do
   json.updated_at                   assignment.updated_at
   json.visible_when_locked          assignment.visible_when_locked
   json.has_submitted_submissions    assignment.has_submitted_submissions?
+  json.hide_analytics               assignment.hide_analytics
 
   json.linked_objective_ids assignment.learning_objective_links.map(&:objective_id)
 


### PR DESCRIPTION
### Status
**READY**

### Description
The API for fetching an assignment wasn't returning the value for `hide_analytics`, which the checkbox value was being bound to.

======================
Closes #4191 
