### PR TITLE
Self graded assignments

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/edit.coffee
+++ b/app/assets/javascripts/angular/directives/grades/edit.coffee
@@ -28,7 +28,7 @@
         assignment = AssignmentService.assignment()
         return "" if !assignment
 
-        if assignment.is_rubric_graded == true
+        if assignment.is_rubric_graded == true && !assignment.student_logged
           return "RUBRIC"
         if assignment.pass_fail == true
           return "PASS_FAIL"

--- a/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
@@ -23,8 +23,8 @@
               You can set a minimum score that must be earned to accrue any points. Earning less than the threshold will automatically result in 0 points
           %input(ng-model="assignment.threshold_points" gc-number-input ng-change="updateAssignment()")
     .form-item
-      %label(ng-class="{ 'disabled': isGroupGraded() }")
-        %input(type="checkbox" ng-model="assignment.student_logged" ng-disabled="isGroupGraded()" ng-click="updateAssignment()")
+      %label(ng-class="{ 'disabled': isGroupGraded() || assignment.resubmissions_allowed }")
+        %input(type="checkbox" ng-model="assignment.student_logged" ng-disabled="isGroupGraded() || assignment.resubmissions_allowed" ng-click="updateAssignment()")
           Student Logged
           %span.has-tooltip
             %i.fa.fa-info-circle
@@ -54,8 +54,8 @@
             %input(type="checkbox" ng-model="assignment.accepts_text" ng-click="updateAssignment()")  Accepts Text
 
     .form-item(ng-if="assignment.accepts_submissions")
-      %label
-        %input(type="checkbox" ng-model="assignment.resubmissions_allowed" ng-click="updateAssignment()")
+      %label(ng-class="{ 'disabled': assignment.student_logged }")
+        %input(type="checkbox" ng-model="assignment.resubmissions_allowed" ng-disabled="assignment.student_logged" ng-click="updateAssignment()")
           Resubmissions Allowed
           %span.has-tooltip
             %i.fa.fa-info-circle

--- a/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_details.html.haml
@@ -30,6 +30,9 @@
             %i.fa.fa-info-circle
             .display-on-hover.hover-style
               Do {{ termFor("students")}} self-report their grade for this {{ termFor("assignment")}}?  If you add grade levels, they'll be able to select their self-assessed score from the list during the open time period. If you don't, they'll be able to select that they did the work and earn full points.
+      %p
+        %i(ng-if="assignment.resubmissions_allowed")
+          Resubmitted assignments cannot be student logged
 
   .form-subsection
     %h3.form-subtitle Submissions
@@ -61,6 +64,9 @@
             %i.fa.fa-info-circle
             .display-on-hover.hover-style
               Can {{ termFor("students")}} resubmit this {{ termFor("assignment")}}?
+      %p
+        %i(ng-if="assignment.student_logged")
+          Student-logged assignments cannot accept resubmissions
 
   .form-subsection
     %h3.form-subtitle Basic Visibility Settings

--- a/app/assets/javascripts/angular/templates/assignments/edit_grading.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_grading.html.haml
@@ -1,5 +1,5 @@
 %section.form-section
-  .form-subsection(ng-if="rubricId")
+  .form-subsection(ng-if="rubricId" ng-if="!assignment.student_logged" )
     %h3.form-subtitle Rubrics
     %rubric-design.rubric-design(data-rubric-id="rubricId")
 

--- a/app/assets/javascripts/angular/templates/grades/rubric_edit.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/rubric_edit.html.haml
@@ -1,5 +1,4 @@
 %section#rubric-grader
-
   .grade-section-label.collapse-toggler
     Grade Assignment by Rubric
 

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -111,7 +111,8 @@ class Assignments::GradesController < ApplicationController
         instructor_modified: true,
         student_visible: true,
         complete: true,
-        graded_at: DateTime.now
+        graded_at: DateTime.now,
+        graded_by_id: current_student.id
       )
 
       if @grade.save

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -49,7 +49,9 @@ class AssignmentsController < ApplicationController
 
   def edit
     @assignment = current_course.assignments.find params[:id]
-    @rubric = @assignment.find_or_create_rubric
+    if !@assignment.student_logged
+      @rubric = @assignment.find_or_create_rubric
+    end
   end
 
   # Duplicate an assignment - important for super repetitive items like

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -140,7 +140,7 @@ class Assignment < ApplicationRecord
 
   def find_or_create_rubric
     return rubric if rubric
-    if !assignment.student_logged
+    if !self.student_logged
       Rubric.create assignment_id: self.id, course_id: self.course_id
     else
       nil

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -140,10 +140,9 @@ class Assignment < ApplicationRecord
 
   def find_or_create_rubric
     return rubric if rubric
-    if !self.student_logged
-      Rubric.create assignment_id: self.id, course_id: self.course_id
+    return nil if self.student_logged
+    Rubric.create assignment_id: self.id, course_id: self.course_id
     end
-  end
 
   # Checking to see if an assignment is individually graded
   def is_individual?

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -142,8 +142,6 @@ class Assignment < ApplicationRecord
     return rubric if rubric
     if !self.student_logged
       Rubric.create assignment_id: self.id, course_id: self.course_id
-    else
-      nil
     end
   end
 

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -140,7 +140,11 @@ class Assignment < ApplicationRecord
 
   def find_or_create_rubric
     return rubric if rubric
-    Rubric.create assignment_id: self.id, course_id: self.course_id
+    if !assignment.student_logged
+      Rubric.create assignment_id: self.id, course_id: self.course_id
+    else
+      nil
+    end
   end
 
   # Checking to see if an assignment is individually graded

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -38,12 +38,14 @@ class Submission < ApplicationRecord
   scope :ungraded, -> do
     includes(:assignment, :group, :student)
     .where.not(id: with_grade.where(grades: { instructor_modified: true }))
+    .where.not(assignment_id: Assignment.where(student_logged: true))
   end
 
   scope :resubmitted, -> {
     includes(:grade, :assignment)
     .where("grades.student_visible = true")
     .where("grades.graded_at < submitted_at")
+    .where.not(assignment_id: Assignment.where(student_logged: true))
     .references(:grade, :assignment)
   }
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -38,14 +38,14 @@ class Submission < ApplicationRecord
   scope :ungraded, -> do
     includes(:assignment, :group, :student)
     .where.not(id: with_grade.where(grades: { instructor_modified: true }))
-    .where.not(assignment_id: Assignment.where(student_logged: true))
+    .where.not(assignments: {student_logged: true})
   end
 
   scope :resubmitted, -> {
     includes(:grade, :assignment)
     .where("grades.student_visible = true")
     .where("grades.graded_at < submitted_at")
-    .where.not(assignment_id: Assignment.where(student_logged: true))
+    .where.not(assignments: {student_logged: true})
     .references(:grade, :assignment)
   }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -400,7 +400,6 @@ class User < ApplicationRecord
   end
 
   # Used to allow students to self-log a grade
-  #currently does not allow for students to regraded an assignment 
   def self_reported_done?(assignment)
     grade = grade_for_assignment(assignment)
     GradeProctor.new(grade).viewable?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -400,6 +400,7 @@ class User < ApplicationRecord
   end
 
   # Used to allow students to self-log a grade
+  #currently does not allow for students to regraded an assignment 
   def self_reported_done?(assignment)
     grade = grade_for_assignment(assignment)
     GradeProctor.new(grade).viewable?

--- a/app/presenters/assignments/presenter.rb
+++ b/app/presenters/assignments/presenter.rb
@@ -151,6 +151,10 @@ class Assignments::Presenter < Showtime::Presenter
     assignment.student_logged? && assignment.open? && user.is_student?(course)
   end
 
+  def check_student_logged?
+    assignment.student_logged?
+  end
+
   def submission_grade_history(student)
     grade = self.grade_for_student(student)
     submission = self.submission_for_assignment(student)

--- a/app/views/assignments/_buttons.html.haml
+++ b/app/views/assignments/_buttons.html.haml
@@ -13,7 +13,7 @@
             - if presenter.assignment.has_groups?
               %li= link_to decorative_glyph(:users) + "Create #{term_for :group}", new_group_path
 
-            - if !presenter.grade_with_rubric?
+            - if !presenter.grade_with_rubric? || presenter.check_student_logged?
               - if presenter.for_team?
                 = active_course_link_to decorative_glyph(:check) + "Quick Grade", mass_edit_assignment_grades_path(presenter.assignment, team: presenter.team)
               - else

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -33,7 +33,7 @@
   %h3.uppercase Downloads
   %p= link_to glyph(:download) + "Download Grades", export_assignment_grades_path(presenter.assignment, format: :csv)
 
-  - if presenter.grade_with_rubric? && presenter.grades.present?
+  - if presenter.grade_with_rubric? && presenter.grades.present? && ! presenter.check_student_logged?
     .clear= link_to glyph(:download) + "Download Rubric Grades", export_earned_levels_assignment_grades_path(presenter.assignment, format: :csv)
 
 - if current_student.present?

--- a/app/views/assignments/_show_staff.haml
+++ b/app/views/assignments/_show_staff.haml
@@ -12,7 +12,7 @@
         %a{"href" => "#tab2"}
           Description
           %span &amp; Downloads
-      - if presenter.grade_with_rubric?
+      - if presenter.grade_with_rubric? && !presenter.check_student_logged?
         %li
           %a{"href" => "#tab3"}
             %span Grading
@@ -36,7 +36,7 @@
           = render partial: "assignments/individual/individual_show", locals: { presenter: presenter }
       .ui-tabs-panel.assignment-details-container#tab2{role: "tabpanel", "aria-hidden" => false }
         = render partial: "assignments/description", locals: { presenter: presenter }
-      - if presenter.grade_with_rubric?
+      - if presenter.grade_with_rubric? && !presenter.check_student_logged?
         .ui-tabs-panel#tab3{ role: "tabpanel", "aria-hidden" => false }
           .tab-container
             = render partial: "rubrics/components/rubric_table", locals: { rubric: presenter.rubric, presenter: presenter, student: nil, include_grade_info: false }

--- a/app/views/assignments/_show_student.haml
+++ b/app/views/assignments/_show_student.haml
@@ -12,7 +12,7 @@
           %a.class-analytics-tab{"href" => "#tab2"} Class Analytics
       %li
         %a{"href" => "#tab3"} Description
-      - if presenter.show_rubric_preview?(current_student)
+      - if presenter.show_rubric_preview?(current_student) && !presenter.student_logged?(current_student)
         %li
           %a{"href" => "#tab4"} Rubric
       - if presenter.has_viewable_learning_objectives? current_student
@@ -48,7 +48,7 @@
         %section.assignment-details-container
           = render partial: "assignments/description", locals: { presenter: presenter }
 
-      - if presenter.show_rubric_preview?(current_student)
+      - if presenter.show_rubric_preview?(current_student) && !presenter.student_logged?(current_student)
         .ui-tabs-panel#tab4{role: "tabpanel", "aria-hidden" => false }
           %section.assignment-details-container
             %h2 Grading Rubric

--- a/app/views/assignments/edit.html.haml
+++ b/app/views/assignments/edit.html.haml
@@ -1,2 +1,2 @@
 .pageContent
-  %assignment-edit(data-assignment-id="#{@assignment.id}" data-rubric-id="#{@rubric.id}" data-course-uses-learning-objectives="#{current_course.uses_learning_objectives?}")
+  %assignment-edit(data-assignment-id="#{@assignment.id}" data-rubric-id="#{@assignment.rubric.try(:id)}" data-course-uses-learning-objectives="#{current_course.uses_learning_objectives?}")

--- a/app/views/assignments/grades_review.haml
+++ b/app/views/assignments/grades_review.haml
@@ -12,7 +12,7 @@
           = render partial: "grades/components/score", locals: { student: student, grade: grade, assignment_type: grade.assignment_type, assignment: grade.assignment }
         = render partial: "grades/components/edit_button", locals: { student: student, grade: grade }
 
-    - if presenter.grade_with_rubric?
+    - if presenter.grade_with_rubric? && !presenter.check_student_logged?
       = render partial: "assignments/rubric_grade_review", locals: { presenter: presenter, student: student, grade: grade }
 
     - if grade.graded_by.present? && grade.feedback.present?

--- a/app/views/grades/_grade_content.haml
+++ b/app/views/grades/_grade_content.haml
@@ -32,7 +32,7 @@
 - if grade.earned_badges.present?
   = render partial: "grades/components/badges", locals: { grade: grade }
 
-- if grade.assignment.grade_with_rubric?
+- if grade.assignment.grade_with_rubric? && !grade.assignment.student_logged?
   .rubric-container
     = render partial: "rubrics/components/rubric_table", locals: { presenter: Assignments::Presenter.new(assignment: grade.assignment, course: current_course), rubric: grade.assignment.rubric, student: grade.student, include_grade_info: true }
 

--- a/app/views/grades/show.html.haml
+++ b/app/views/grades/show.html.haml
@@ -24,7 +24,7 @@
     %section
       = render partial: "assignments/description", locals: { presenter: presenter }
 
-    - if presenter.grades_available_for?(@grade.student) && presenter.show_rubric_preview?(@grade.student)
+    - if presenter.grades_available_for?(@grade.student) && presenter.show_rubric_preview?(@grade.student) && !presenter.check_student_logged?
       %hr.dotted
       %section
         %h2 Grading Rubric

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -262,7 +262,7 @@ describe Assignment do
     end
   end
 
-  describe "#find_or_create_rubric", :focus => true do
+  describe "#find_or_create_rubric" do
     it "returns a rubric if one exists" do
       rubric = create(:rubric, assignment: subject)
       expect(subject.find_or_create_rubric).to eq(rubric)

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -262,7 +262,7 @@ describe Assignment do
     end
   end
 
-  describe "#find_or_create_rubric" do
+  describe "#find_or_create_rubric", :focus => true do
     it "returns a rubric if one exists" do
       rubric = create(:rubric, assignment: subject)
       expect(subject.find_or_create_rubric).to eq(rubric)
@@ -272,6 +272,12 @@ describe Assignment do
       assignment = create(:assignment)
       new_rubric = assignment.find_or_create_rubric
       expect(new_rubric).to eq assignment.reload.rubric
+    end
+    it "does not create a rubric if the assignment is student logged" do
+      assignment = create(:assignment)
+      assignment.student_logged = true
+      new_rubric = assignment.find_or_create_rubric
+      expect(new_rubric).to eq nil
     end
   end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This resolves a bug regarding self logged assignments and grading rubrics.

Before, if you created an assignment and marked it as student logged there was still an option to grade according to a rubric. This does not make sense because there should not be any rubrics associated with self-logged assignments. 

Now:
As a student, if you go to the description of a self-logged assignment you have the option to say you've completed the assignment (and reward full points), without having the option to use a rubric.

As a professor, when editing an assignment if you select student_logged in the 'details' of an assignment you will no longer be able to add / copy a rubric to the assignment. 

Restrictions have been applied to assignments that do not allow the instructor to make an assignment self graded and accept submissions. 

Assignments that are self-logged no longer appear in the grading status table for instructors 

### Todos
- [ ] Test in staging

### Migrations
NO

### Steps to Test or Reproduce
Create an assignment and make it self_logged, now there should be no associations with a rubric and this assignment.

### Impacted Areas in Application
* Assignments and rubrics 

======================
Closes #4179