### PR TITLE
Numeric date sort

### DIFF
--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -2,6 +2,7 @@
 $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
       dynatable.sorts.functions["numeric"] = numeric;
       dynatable.sorts.functions["alphanum"] = alphanum;
+      dynatable.sorts.functions["dateSort"] = dateSort;
     }).dynatable({
   features: {
       paginate: false,
@@ -30,9 +31,8 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
         calendarDate: 'numeric',
         openDateSort: 'numeric',
         closeDateSort: 'numeric',
-        calendarDate: 'numeric',
-        lastUpdated: 'numeric',
-        createdAt: 'numeric'
+        lastUpdated: 'dateSort',
+        createdAt: 'dateSort'
       }
     }
 });
@@ -40,6 +40,12 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
 function numeric(a, b, attr, direction) {
   var aa = a[attr].replace(/[^0-9]/g, "");
   var bb = b[attr].replace(/[^0-9]/g, "");
+  return aa === bb ? 0 : (direction > 0 ? aa - bb : bb - aa);
+}
+
+function dateSort(a, b, attr, direction) {
+  var aa = Date.parse(a[attr]);
+  var bb = Date.parse(b[attr]);
   return aa === bb ? 0 : (direction > 0 ? aa - bb : bb - aa);
 }
 

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -31,7 +31,8 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
         openDateSort: 'numeric',
         closeDateSort: 'numeric',
         calendarDate: 'numeric',
-        lastUpdated: 'numeric'
+        lastUpdated: 'numeric',
+        createdAt: 'numeric'
       }
     }
 });

--- a/app/assets/javascripts/dynatable.js
+++ b/app/assets/javascripts/dynatable.js
@@ -30,7 +30,8 @@ $('table.dynatable').bind('dynatable:init', function(e, dynatable) {
         calendarDate: 'numeric',
         openDateSort: 'numeric',
         closeDateSort: 'numeric',
-        calendarDate: 'numeric'
+        calendarDate: 'numeric',
+        lastUpdated: 'numeric'
       }
     }
 });

--- a/app/controllers/staff_controller.rb
+++ b/app/controllers/staff_controller.rb
@@ -13,7 +13,7 @@ class StaffController < ApplicationController
 
   def show
     @staff_member = current_course.users.find(params[:id])
-    @grades = current_course.grades.where(graded_by: @staff_member)
+    @grades = current_course.grades.where(graded_by: @staff_member).order_by_updated_at_date
   end
 
 end

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -20,8 +20,8 @@
         %th Student
         %th Score
         %th Feedback
-        %th Created At
-        %th Last Updated
+        %th{"data-dynatable-sorts" => "createdAt"} Created At
+        %th{"data-dynatable-sorts" => "lastUpdated"} Last Updated
         %th.options Options
     %tbody
       - @grades.each do |grade|

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -21,7 +21,7 @@
         %th Score
         %th Feedback
         %th Created at
-        %th Last Updated
+        %th{"data-dynatable-sorts" => "lastUpdated"} Last Updated
         %th.options Options
     %tbody
       - @grades.each do |grade|

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -20,7 +20,7 @@
         %th Student
         %th Score
         %th Feedback
-        %th Created at
+        %th Created At
         %th Last Updated
         %th.options Options
     %tbody
@@ -31,7 +31,7 @@
           %td= points grade.score
           %td= raw grade.feedback
           %td= l grade.created_at.in_time_zone(current_user.time_zone)
-          %td= l grade.graded_at.in_time_zone(current_user.time_zone)
+          %td= l grade.updated_at.in_time_zone(current_user.time_zone)
           %td
             .button-container.dropdown
               %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")

--- a/app/views/staff/show.html.haml
+++ b/app/views/staff/show.html.haml
@@ -21,7 +21,7 @@
         %th Score
         %th Feedback
         %th Created at
-        %th{"data-dynatable-sorts" => "lastUpdated"} Last Updated
+        %th Last Updated
         %th.options Options
     %tbody
       - @grades.each do |grade|


### PR DESCRIPTION
### Status
**READY**

### Description
Dynatable columns were sorting alphabetically instead of numerically by date.

### Todos
- [x] Change date sort from numeric to date/time
- [x] Test in Staging

### Migrations
NO

### Steps to Test or Reproduce

As a staff member in a course, view the 'Staff' page, then click a member of the staff that has graded students assignments. 

On this staff table, the grades should be coming in ordered by the last updated at. 
Now the table will be able to sort based on 'Created At' and 'Last Updated' 

======================
Closes #4211 
