### PR TITLE
Fixed Assigment copying to enable Unlock Conditions to copy over

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -58,6 +58,7 @@ class AssignmentsController < ApplicationController
     begin
       assignment = current_course.assignments.find(params[:id])
       duplicated = assignment.copy_with_prepended_name
+      copy_unlock_conditions(assignment, duplicated)
       redirect_to edit_assignment_path(duplicated), notice: "#{(term_for :assignment).titleize} #{duplicated.name} successfully created"
     rescue CopyValidationError => e
       render json: { message: e.message, details: e.details }, status: :internal_server_error
@@ -89,5 +90,13 @@ class AssignmentsController < ApplicationController
       team_id: params[:team_id],
       view_context: view_context
       })
+  end
+end
+
+def copy_unlock_conditions(assignment, duplicated)
+  UnlockCondition.where(unlockable_id: assignment.id, course: assignment.course, unlockable_type: "Assignment").each do |condition|
+    copied_unlock_condition = condition.copy
+    copied_unlock_condition.unlockable_id = duplicated.id
+    copied_unlock_condition.save
   end
 end


### PR DESCRIPTION
### Status
READY

### Description
An Assignment may have several Unlock Conditions, of which students must successfully complete in order to unlock the Assignment. Previously, when an instructor attempted to copy an Assignment with Unlock Conditions, those conditions would now copy over. This behavior is now fixed.

### Future Steps
- Add RSpec Tests

### Steps to Test or Reproduce
1) Create an assignment
2) Set any unlock condition you want. 
3) Copy that assignment
4) Check to see if the unlock conditions are there in the copied assignment.

### Impacted Areas in Application
List general components of the application that this PR will affect:
AssignmentController

### Migrations
None

### Gem Dependencies
None

======================
Closes #4121 
