### PR TITLE
removed link from [ delete ] button under assignment type if there are submissions or grades

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -158,6 +158,14 @@ class Assignment < ApplicationRecord
     submissions.submitted.any?
   end
 
+  def has_submissions?
+    submissions.exists?
+  end
+
+  def has_grades?
+    grades.exists?
+  end
+
   # Custom point total if the class has weighted assignments
   def full_points_for_student(student)
     return 0 unless full_points

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -158,6 +158,14 @@ class AssignmentType < ApplicationRecord
     assignments.any? { |a| a.visible_for_student? student }
   end
 
+  def has_assignments_with_submissions?
+    assignments.any? { |assignment| assignment.has_submissions? }
+  end
+
+  def has_assignments_with_grades?
+    assignments.any? { |assignment| assignment.has_grades? }
+  end
+
   private
 
   def zero_max_points_if_unused

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -30,7 +30,7 @@
               %span.has-tooltip
                 %i.fa.fa-info-circle
                 .display-on-hover.hover-style
-                  You cannot delete an #{(term_for :assignment_type).downcase} that has #{(term_for :assignment).pluralize.downcase} with submissions or grades
+                  You cannot delete #{(term_for :assignment_type).pluralize.downcase} that have #{(term_for :assignment).pluralize.downcase} with submissions or grades
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -23,7 +23,14 @@
         .assignment-type-container{role: "tabpanel"}
           %ul.assignment-action-buttons
             = active_course_link_to "[ Edit ]", edit_assignment_type_path(assignment_type)
-            = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure you want to delete #{term_for :assignment_type} #{assignment_type.name}?", method: :delete }
+            - if !(assignment_type.has_assignments_with_submissions? || assignment_type.has_assignments_with_grades?)
+              = active_course_link_to "[ Delete ]", assignment_type_path(assignment_type), data: { confirm: "Are you sure you want to delete #{term_for :assignment_type} #{assignment_type.name}?", method: :delete }
+            - else
+              = "[ Delete ]"
+              %span.has-tooltip
+                %i.fa.fa-info-circle
+                .display-on-hover.hover-style
+                  You cannot delete an #{(term_for :assignment_type).downcase} that has #{(term_for :assignment).pluralize.downcase} with submissions or grades
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr

--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -30,7 +30,7 @@
               %span.has-tooltip
                 %i.fa.fa-info-circle
                 .display-on-hover.hover-style
-                  You cannot delete #{(term_for :assignment_type).pluralize.downcase} that have #{(term_for :assignment).pluralize.downcase} with submissions or grades
+                  This #{(term_for :assignment_type).downcase} currently has student submissions and/or grades and cannot be deleted
           %table.instructor-assignments.second-row-header{"aria-describedby" => "assignment-type-#{assignment_type.id}"}
             %thead
               %tr


### PR DESCRIPTION
### Status
**READY**

### Description
On the assignments page, you have the ability to delete an assignment type even if there are submissions and grades for an assignment associated with that assignment type.

Now if there is at least 1 submission or 1 grade for an assignment associated with an assignment type, the `[ Delete ]` button will not be click able.

Also added a little tooltip icon to say why the button is not clickable.

### Todos
- [x] Test in staging 

### Migrations
NO

### Steps to Test or Reproduce
As an instructor or GSI go to the assignments page and look at assignment types with grades or submissions and make sure you can't delete them. 

### Impacted Areas in Application
Assignments and assignment types  

======================
Closes #4220
