### PR TITLE
User page cleanup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
       @users = @team.students
       @users << @team.leaders
     else
-      @users = current_course.users.includes(:courses, :teams).order_by_name
+      @users = current_course.users.where(admin: false).includes(:courses, :teams).order_by_name
     end
   end
 

--- a/app/views/layouts/navigation/_staff_subnav_links.haml
+++ b/app/views/layouts/navigation/_staff_subnav_links.haml
@@ -57,6 +57,6 @@
     %li= link_to_unless_current decorative_glyph(:university) + "Manage Courses", overview_courses_path
     %li= link_to_unless_current decorative_glyph(:trash) + "Delete Course Memberships", course_memberships_path
     %li= link_to_unless_current decorative_glyph(:building) + "All Institutions", institutions_path
-    %li= link_to_unless_current decorative_glyph("user-times") + "All Users", users_path
+    %li= link_to_unless_current decorative_glyph("user-times") + "Current Course Users", users_path
     %li= link_to_unless_current decorative_glyph(:search) + "Search Users", search_users_path
     %li= link_to_unless_current decorative_glyph(:wrench) + "Tools", admin_tools_path

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -18,35 +18,36 @@
         %th.options{"data-dynatable-no-sort": "true"} Options
     %tbody
       - @users.each do |user|
-        %tr
-          - user_is_student = user.is_student?(current_course)
-          - user_is_staff = user.is_staff?(current_course)
-          - course_membership = user.course_memberships.where(course_id: current_course.id).first
-          %td
-            - if user.avatar_file_name.present?
-              %img.img-rounded{:src => user.avatar_file_name, :width => 30}
-            = link_to user.first_name, student_path(user) if user_is_student
-            = link_to user.first_name, staff_path(user) if !user_is_student
-          %td
-            = link_to user.last_name, student_path(user) if user_is_student
-            = link_to user.last_name, staff_path(user) if !user_is_student
-          %td= course_membership.role.capitalize
-          %td
-            - user.courses.each do |course|
-              %li= link_to course.name
-          %td
-            - user.teams.each do |team|
-              %li= link_to team.name, team
-          %td
-            - if user_is_student
-              = points user.score_for_course(current_course) if user.respond_to?(:grades)
-          %td
-            .button-container.dropdown
-              %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
-              %ul.options-menu.dropdown-content
-                - if user_is_student
-                  %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(user) if user_is_student
-                - elsif user_is_staff
-                  %li= link_to decorative_glyph(:dashboard) + "Dashboard", staff_path(user) if user_is_staff
-                %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user)
-                %li= link_to decorative_glyph(:trash) + "Delete", course_membership, data: { confirm: "This will delete the student from your course - Are you sure?" }, :method => :delete
+        - if !user.is_admin?(current_course)
+          %tr
+            - user_is_student = user.is_student?(current_course)
+            - user_is_staff = user.is_staff?(current_course)
+            - course_membership = user.course_memberships.where(course_id: current_course.id).first
+            %td
+              - if user.avatar_file_name.present?
+                %img.img-rounded{:src => user.avatar_file_name, :width => 30}
+              = link_to user.first_name, student_path(user) if user_is_student
+              = link_to user.first_name, staff_path(user) if !user_is_student
+            %td
+              = link_to user.last_name, student_path(user) if user_is_student
+              = link_to user.last_name, staff_path(user) if !user_is_student
+            %td= course_membership.role.capitalize
+            %td
+              - user.courses.each do |course|
+                %li= link_to course.name
+            %td
+              - user.teams.each do |team|
+                %li= link_to team.name, team
+            %td
+              - if user_is_student
+                = points user.score_for_course(current_course) if user.respond_to?(:grades)
+            %td
+              .button-container.dropdown
+                %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
+                %ul.options-menu.dropdown-content
+                  - if user_is_student
+                    %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(user) if user_is_student
+                  - elsif user_is_staff
+                    %li= link_to decorative_glyph(:dashboard) + "Dashboard", staff_path(user) if user_is_staff
+                  %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user)
+                  %li= link_to decorative_glyph(:trash) + "Delete", course_membership, data: { confirm: "This will delete the student from your course - Are you sure?" }, :method => :delete

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -18,36 +18,35 @@
         %th.options{"data-dynatable-no-sort": "true"} Options
     %tbody
       - @users.each do |user|
-        - if !user.is_admin?(current_course)
-          %tr
-            - user_is_student = user.is_student?(current_course)
-            - user_is_staff = user.is_staff?(current_course)
-            - course_membership = user.course_memberships.where(course_id: current_course.id).first
-            %td
-              - if user.avatar_file_name.present?
-                %img.img-rounded{:src => user.avatar_file_name, :width => 30}
-              = link_to user.first_name, student_path(user) if user_is_student
-              = link_to user.first_name, staff_path(user) if !user_is_student
-            %td
-              = link_to user.last_name, student_path(user) if user_is_student
-              = link_to user.last_name, staff_path(user) if !user_is_student
-            %td= course_membership.role.capitalize
-            %td
-              - user.courses.each do |course|
-                %li= link_to course.name
-            %td
-              - user.teams.each do |team|
-                %li= link_to team.name, team
-            %td
-              - if user_is_student
-                = points user.score_for_course(current_course) if user.respond_to?(:grades)
-            %td
-              .button-container.dropdown
-                %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
-                %ul.options-menu.dropdown-content
-                  - if user_is_student
-                    %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(user) if user_is_student
-                  - elsif user_is_staff
-                    %li= link_to decorative_glyph(:dashboard) + "Dashboard", staff_path(user) if user_is_staff
-                  %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user)
-                  %li= link_to decorative_glyph(:trash) + "Delete", course_membership, data: { confirm: "This will delete the student from your course - Are you sure?" }, :method => :delete
+        %tr
+          - user_is_student = user.is_student?(current_course)
+          - user_is_staff = user.is_staff?(current_course)
+          - course_membership = user.course_memberships.where(course_id: current_course.id).first
+          %td
+            - if user.avatar_file_name.present?
+              %img.img-rounded{:src => user.avatar_file_name, :width => 30}
+            = link_to user.first_name, student_path(user) if user_is_student
+            = link_to user.first_name, staff_path(user) if !user_is_student
+          %td
+            = link_to user.last_name, student_path(user) if user_is_student
+            = link_to user.last_name, staff_path(user) if !user_is_student
+          %td= course_membership.role.capitalize
+          %td
+            - user.courses.each do |course|
+              %li= link_to course.name
+          %td
+            - user.teams.each do |team|
+              %li= link_to team.name, team
+          %td
+            - if user_is_student
+              = points user.score_for_course(current_course) if user.respond_to?(:grades)
+          %td
+            .button-container.dropdown
+              %button.button-edit.button-options{role: "button", type: "button", "aria-label": "Additional Options"}= decorative_glyph(:cog) + decorative_glyph("caret-down")
+              %ul.options-menu.dropdown-content
+                - if user_is_student
+                  %li= link_to decorative_glyph(:dashboard) + "Dashboard", student_path(user) if user_is_student
+                - elsif user_is_staff
+                  %li= link_to decorative_glyph(:dashboard) + "Dashboard", staff_path(user) if user_is_staff
+                %li= link_to decorative_glyph(:edit) + "Edit", edit_user_path(user)
+                %li= link_to decorative_glyph(:trash) + "Delete", course_membership, data: { confirm: "This will delete the student from your course - Are you sure?" }, :method => :delete


### PR DESCRIPTION
### Status
**READY**

### Description
Noticed that admin's were being included in the `All users` tab.  

2 things misleading about this section: 
* "All users" are actually just the users for the current course and shows the other GC courses they're in
* Admins are included in this, making this page virtually useless because an admin is in every course

### Todos
- [x] Observe changes in staging 

### Migrations
NO

### Steps to Test or Reproduce
As an admin go to the `all users` page, now called `Current course users` and observe that there are no admins included in this page

### Impacted Areas in Application
Admin view of `all users`'
