### PR TITLE
Fixed Lock Icon Bug

### DIFF
--- a/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
+++ b/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
@@ -21,7 +21,7 @@
             %ul.no-style
               %li{"ng-repeat"=>"assignment in loShowCtrl.linkedAssignments"}
                 %a{"ng-href"=>"/assignments/{{assignment.id}}"} {{assignment.name}}
-                %descriptor-icon{"data-icon"=>"lock"}
+                %descriptor-icon{"ng-if" => "assignment.unlock_conditions", "data-icon"=>"lock"}
                   %ul.icon-list
                     %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
                       {{condition}}
@@ -102,6 +102,10 @@
             "ng-repeat"=>"assignment in loShowCtrl.linkedAssignments | orderBy : loShowCtrl.sortable.predicate : loShowCtrl.sortable.reverse"}
           %td
             %a{"ng-href"=>"/assignments/{{assignment.id}}"} {{assignment.name}}
+            %descriptor-icon{"ng-if" => "assignment.unlock_conditions", "data-icon"=>"lock"}
+              %ul.icon-list
+                %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
+                  {{condition}}
             %assignment-descriptor-icons{"data-assignment"=>"assignment"}
           %td.center
             %span.has-tooltip{"ng-show"=>"loShowCtrl.submittedAt(assignment.id)"}


### PR DESCRIPTION
### Status
Ready

### Description
Previously, lock icons did not display on the admin view of a learner's LO progress. This pull request aims to solve that.

### Migrations
No Migrations

### Steps to Test or Reproduce
Create an assignment with locks, and set a learning objective for that assignment.
Look at a learner's progress page for that LO. 

### Impacted Areas in Application
Learning Objectives' Angular template.

======================
Closes #4117 
