### PR TITLE
Unlock visibility

### DIFF
--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -45,9 +45,9 @@ class UnlockCondition < ApplicationRecord
         description = "#{ condition_state_do } in the #{ condition.name } #{unlockable.course.assignment_term} Type"
       end
     elsif condition_type == "LearningObjective"
-        description = "#{ condition_state_do } the #{ condition.name } #{unlockable.course.learning_objective_term.singularize}"
+      description = "#{ condition_state_do } the #{ condition.name } #{unlockable.course.learning_objective_term.singularize}"
     else
-        description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }" 
+      description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }" 
     end
     description += condition_date_sentence(condition_date_timezone) if condition_date.present?
     description

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -29,6 +29,11 @@ class UnlockCondition < ApplicationRecord
     check_condition_for_each_student(group)
   end
 
+  def check_assignment_condition_visible
+    assignment = Assignment.find(self.condition_id)
+    return assignment.visible
+  end
+
   # Human readable sentence to describe what students need to do to unlock this
   def requirements_description_sentence(condition_date_timezone=nil)
     if condition_type == "Course"
@@ -40,17 +45,9 @@ class UnlockCondition < ApplicationRecord
         description = "#{ condition_state_do } in the #{ condition.name } #{unlockable.course.assignment_term} Type"
       end
     elsif condition_type == "LearningObjective"
-      description = "#{ condition_state_do } the #{ condition.name } #{unlockable.course.learning_objective_term.singularize}"
+        description = "#{ condition_state_do } the #{ condition.name } #{unlockable.course.learning_objective_term.singularize}"
     else
-      assignment = Assignment.find(self.unlockable_id) 
-      # Currenty, this is giving us the assignment that will be unlocked
-      # -- not the assignmet that the UC correponds to
-      if !assignment.visible
-        description = "This unlock condition is hidden"
-        return description
-      else 
         description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }" 
-      end
     end
     description += condition_date_sentence(condition_date_timezone) if condition_date.present?
     description

--- a/app/models/unlock_condition.rb
+++ b/app/models/unlock_condition.rb
@@ -42,7 +42,15 @@ class UnlockCondition < ApplicationRecord
     elsif condition_type == "LearningObjective"
       description = "#{ condition_state_do } the #{ condition.name } #{unlockable.course.learning_objective_term.singularize}"
     else
-      description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }"
+      assignment = Assignment.find(self.unlockable_id) 
+      # Currenty, this is giving us the assignment that will be unlocked
+      # -- not the assignmet that the UC correponds to
+      if !assignment.visible
+        description = "This unlock condition is hidden"
+        return description
+      else 
+        description = "#{ condition_state_do } the #{ condition.name } #{ condition_type }" 
+      end
     end
     description += condition_date_sentence(condition_date_timezone) if condition_date.present?
     description

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -76,8 +76,8 @@
           - elsif uc.condition_type == "Assignment"
             - if !uc.check_assignment_condition_visible
               %li= "You have not unlocked this assignment."
-            - else
-              %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
+          - else
+            %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
 - elsif presenter.assignment.is_unlockable?
   %h3.uppercase #{glyph(:lock)} This #{term_for :assignment} is Locked
   %p.italic To unlock it, #{ term_for :students } must:

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -73,7 +73,8 @@
         - presenter.assignment.unlock_conditions.each do |uc|
           - if !uc.condition_type == "Learning Objective"
             %li= link_to uc.requirements_description_sentence(current_user.time_zone), uc.condition
-          - else
+          - elsif uc.condition_type == "Assignment"
+            
             %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
 - elsif presenter.assignment.is_unlockable?
   %h3.uppercase #{glyph(:lock)} This #{term_for :assignment} is Locked

--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -74,8 +74,10 @@
           - if !uc.condition_type == "Learning Objective"
             %li= link_to uc.requirements_description_sentence(current_user.time_zone), uc.condition
           - elsif uc.condition_type == "Assignment"
-            
-            %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
+            - if !uc.check_assignment_condition_visible
+              %li= "You have not unlocked this assignment."
+            - else
+              %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
 - elsif presenter.assignment.is_unlockable?
   %h3.uppercase #{glyph(:lock)} This #{term_for :assignment} is Locked
   %p.italic To unlock it, #{ term_for :students } must:

--- a/app/views/assignments/index_student/components/_assignment_icons.haml
+++ b/app/views/assignments/index_student/components/_assignment_icons.haml
@@ -13,8 +13,8 @@
             -if condition.condition_type == "Assignment"
               - if !condition.check_assignment_condition_visible
                 %li= "You have not unlocked this assignment."
-              - else
-                %li= condition.requirements_description_sentence(current_user.time_zone)
+            - else
+              %li= condition.requirements_description_sentence(current_user.time_zone)
     - else
       = tooltip("unlocked-assignment-tip_#{assignment.id}", :unlock) do
         %p You have unlocked this #{term_for :assignment}

--- a/app/views/assignments/index_student/components/_assignment_icons.haml
+++ b/app/views/assignments/index_student/components/_assignment_icons.haml
@@ -10,8 +10,11 @@
         .small.italic In order to unlock it you must:
         %ol
           - assignment.unlock_conditions.each do |condition|
-            %li= condition.requirements_description_sentence(current_user.time_zone)
-
+            -if condition.condition_type == "Assignment"
+              - if !condition.check_assignment_condition_visible
+                %li= "You have not unlocked this assignment."
+              - else
+                %li= condition.requirements_description_sentence(current_user.time_zone)
     - else
       = tooltip("unlocked-assignment-tip_#{assignment.id}", :unlock) do
         %p You have unlocked this #{term_for :assignment}


### PR DESCRIPTION
### Status
**Ready**

### Description
It is expect that if an assignment is set to be invisible, then it will not appear in the list of unlock requirements/keys. This pull request fixes this, as a link-less statement saying "You have not unlocked this assignment" will appear in place of the link.

### Migrations
NO

### Steps to Test or Reproduce
Create an assignment that is set to invisible. Make it a key for another assignment. Go look at the requirements for that assignment - the 'hidden' assignment will no longer appear, and is instead replaced by the link-less statement. Furthermore, hovering over the lock icon in the assignments list will also display this message.

### Impacted Areas in Application
List general components of the application that this PR will affect:
Assignments
- Description view
- Icon view

Closes #4171 
