### PR TITLE
hide password field if lti id is present

### DIFF
--- a/app/views/users/edit_profile.html.haml
+++ b/app/views/users/edit_profile.html.haml
@@ -22,7 +22,7 @@
             = f.check_box :remove_avatar_file_name
             Remove Image
 
-      - if ! @user.kerberos_uid.present?
+      - if ! @user.kerberos_uid.present? && ! @user.lti_uid.present? 
         .update-password-wrapper
           %button.button-link.update-button#update-password Change Password
           .update-password-form{"aria-hidden": "true"}


### PR DESCRIPTION
### Status
**READY**

### Description
This PR fixes an issue where students would try to reset their passwords after coming in from the LTI link and it would not function properly for them. 

### Migrations
NO

### Steps to Test or Reproduce
Log in to staging via an LTI link. Navigate to your account. Confirm that you can't see the "Change Password" fields. 


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Account management

======================
Closes #3631 
