### PR TITLE
hide view tour on medium screens

### DIFF
--- a/app/views/layouts/navigation/_account_info.haml
+++ b/app/views/layouts/navigation/_account_info.haml
@@ -1,3 +1,3 @@
 %li= link_to glyph(:rocket) + "My Account", edit_profile_users_path
-%li.hide-for-small= link_to glyph("question-circle") + "View Tour", '#', {class: 'modal-open'}
+%li.hide-for-small.hide-for-medium= link_to glyph("question-circle") + "View Tour", '#', {class: 'modal-open'}
 %li= link_to glyph("sign-out") + "Logout", :logout


### PR DESCRIPTION
### Status
**READY**

### Description
The View Tour feature doesn't actually work on medium sized screens, and so should be hidden as a button. 

### Migrations
NO

### Steps to Test or Reproduce
Log in as an instructor. Set your screen to a medium sized width (the moment when the sidebar first disappears on the left and gets tucked under the hamburger menu). Confirm that the "View Tour" button no longer shows. 


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Instructor perspective of mobile/tablet experience

======================
Closes #4182 
