### PR TITLE
make the interfaces consistent in order and language

### DIFF
--- a/app/views/courses/_student_onboarding_setup.haml
+++ b/app/views/courses/_student_onboarding_setup.haml
@@ -3,13 +3,13 @@
 %section.form-section
   %h2.form-title Grading Philosophy
   .form-item
+    %p.form-hint What would you like to tell students about how they should expect to be graded? If you add content here, it will appear on the "Syllabus" page for students.
     .textarea
-      .form-hint What would you like to tell students about how they should expect to be graded? If you add content here, it will appear on the "Syllabus" page for students.
       = f.text_area :gameful_philosophy, class: "froala"
 
 %section.form-section
   %h2.form-title Course Rules
   .form-item
+    %p.form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and available accommodations for student disabilities. If you add content here, it will appear on the "Syllabus" page for students.
     .textarea
-      .form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and available accommodations for student disabilities. If you add content here, it will appear on the "Syllabus" page for students.
       = f.text_area :course_rules, class: "froala"

--- a/app/views/courses/_student_onboarding_setup.haml
+++ b/app/views/courses/_student_onboarding_setup.haml
@@ -1,15 +1,15 @@
 = render partial: "layouts/alerts", locals: { model: @course }
 
 %section.form-section
-  %h2.form-title Gameful Philosophy
+  %h2.form-title Grading Philosophy
   .form-item
     .textarea
-      .form-hint What would you like to tell students about how they should expect to be graded?
+      .form-hint What would you like to tell students about how they should expect to be graded? If you add content here, it will appear on the "Syllabus" page for students.
       = f.text_area :gameful_philosophy, class: "froala"
 
 %section.form-section
   %h2.form-title Course Rules
   .form-item
     .textarea
-      .form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and available accomodations for student disabilities.
+      .form-hint Are there specific rules for this course that students should know? We recommend including details like minimum thresholds that must be met, your policy regarding late work, and available accommodations for student disabilities. If you add content here, it will appear on the "Syllabus" page for students.
       = f.text_area :course_rules, class: "froala"

--- a/app/views/info/syllabus.html.haml
+++ b/app/views/info/syllabus.html.haml
@@ -3,10 +3,16 @@
     %h3.bold Course Details
     = glyph(:bank) + current_course.meeting_times + ' ' + current_course.location
     %p
+
   - if current_course.gameful_philosophy.present?
     %h3.bold Grading Philosophy
     = render partial: "courses/grading_philosophy", locals: {course: current_course}
     %p
+
+  - if current_course.course_rules.present?
+    %h3.bold Course Rules
+    %p= raw current_course.course_rules
+
   - if current_course.syllabus.present?
     %h3.bold Course Syllabus
     = external_link_to "Download the Current Syllabus", current_course.syllabus_url
@@ -20,7 +26,3 @@
       = render partial: "grade_scheme_elements/index_observer", locals: { "@grade_scheme_elements": current_course.grade_scheme_elements.order_by_points_desc }
     - elsif current_user_is_staff?
       = render partial: "grade_scheme_elements/index_staff", locals: {  "@grade_scheme_elements": current_course.grade_scheme_elements.order_by_points_desc }
-
-  - if current_course.course_rules.present?
-    %h3.bold Course Rules
-    %p= raw current_course.course_rules


### PR DESCRIPTION
### Status
**READY**

### Description
The grading philosophy and course rules section were unclear to instructors about where the content would be shared with students. The language and order of the content was also inconsistent. 

### Migrations
NO

### Steps to Test or Reproduce
As an instructor navigate to the Course Settings page and then click "Student Onboarding." Confirm that the content language now matches that of the Syllabus page for students (Grading Philosophy should show in both places, and it should be above Course Rules. There's also a note letting them know where to find this on the student side.)

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Course setup for instructors
* Syllabus page for students

======================
Closes #4173 
