### PR TITLE
removes old spec tests for matching string in email templates

### DIFF
--- a/spec/mailers/exports_mailer/grade_export_spec.rb
+++ b/spec/mailers/exports_mailer/grade_export_spec.rb
@@ -59,10 +59,6 @@ describe ExportsMailer do
       it "includes the course name" do
         should include_in_mail_body course.name
       end
-
-      it "doesn't include a template" do
-        should_not include "Regents of The University of Michigan"
-      end
     end
 
     describe "html part body" do
@@ -74,10 +70,6 @@ describe ExportsMailer do
 
       it "includes the course name" do
         should include_in_mail_body course.name
-      end
-
-      it "doesn't include a template" do
-        should include "Regents of The University of Michigan"
       end
     end
   end

--- a/spec/mailers/exports_mailer/gradebook_export_spec.rb
+++ b/spec/mailers/exports_mailer/gradebook_export_spec.rb
@@ -59,10 +59,6 @@ describe ExportsMailer do
       it "includes the course name" do
         should include_in_mail_body course.name
       end
-
-      it "doesn't include a template" do
-        should_not include "Regents of The University of Michigan"
-      end
     end
 
     describe "html part body" do
@@ -73,10 +69,6 @@ describe ExportsMailer do
 
       it "includes the course name" do
         should include_in_mail_body course.name
-      end
-
-      it "does include a template" do
-        should include "Regents of The University of Michigan"
       end
     end
   end

--- a/spec/mailers/notification_mailer/earned_badge_awarded_spec.rb
+++ b/spec/mailers/notification_mailer/earned_badge_awarded_spec.rb
@@ -58,10 +58,6 @@ describe NotificationMailer do
 
       it_behaves_like "a complete earned badge email body"
 
-      it "doesn't include a template" do
-        should_not include "Regents of The University of Michigan"
-      end
-
       it "contains the badges url" do
         should include badges_url
       end
@@ -77,10 +73,6 @@ describe NotificationMailer do
         # this isn't included in the text part
         it "includes the badge icon" do
           should include earned_badge.badge.icon
-        end
-
-        it "should use include a template" do
-          should include "Regents of The University of Michigan"
         end
 
         it "declares a doctype" do

--- a/spec/mailers/notification_mailer/professor_submissions_spec.rb
+++ b/spec/mailers/notification_mailer/professor_submissions_spec.rb
@@ -24,7 +24,6 @@ RSpec.shared_examples "a submission email to a professor" do
   end
 
   it "doesn't include a template" do
-    should_not include "Regents of The University of Michigan"
     should_not include "DOCTYPE"
   end
 end

--- a/spec/mailers/notification_mailer/student_submissions_spec.rb
+++ b/spec/mailers/notification_mailer/student_submissions_spec.rb
@@ -45,20 +45,12 @@ describe NotificationMailer do
       subject { text_part.body }
 
       it_behaves_like "a complete submission email body"
-
-      it "doesn't include a template" do
-        should_not include "Regents of The University of Michigan"
-      end
     end
 
     describe "html part body" do
       subject { html_part.body }
 
       it_behaves_like "a complete submission email body"
-
-      it "should use include a template" do
-        should include "Regents of The University of Michigan"
-      end
 
       it "declares a doctype" do
         should include "DOCTYPE"
@@ -87,20 +79,12 @@ describe NotificationMailer do
       subject { text_part.body }
 
       it_behaves_like "a complete submission email body"
-
-      it "doesn't include a template" do
-        should_not include "Regents of The University of Michigan"
-      end
     end
 
     describe "html part body" do
       subject { html_part.body }
 
       it_behaves_like "a complete submission email body"
-
-      it "should use include a template" do
-        should include "Regents of The University of Michigan"
-      end
 
       it "declares a doctype" do
         should include "DOCTYPE"

--- a/spec/toolkits/mailers/email_toolkit.rb
+++ b/spec/toolkits/mailers/email_toolkit.rb
@@ -24,16 +24,9 @@ module Toolkits
 
       module SharedExamples
         RSpec.shared_examples "an email text part" do
-          it "doesn't include a template" do
-            should_not include "Regents of The University of Michigan"
-          end
         end
 
         RSpec.shared_examples "an email html part" do
-          it "should use include a template" do
-            should include "Regents of The University of Michigan"
-          end
-
           it "declares a doctype" do
             should include "DOCTYPE"
           end


### PR DESCRIPTION
### Status
**READY**

### Description
Working on the emails with Sophia and Ollie I found that there were a few tests looking specifically (and case sensitively) for "Regents of The University of Michigan".


### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

### Impacted Areas in Application
List general components of the application that this PR will affect:

* Spec test regarding emails and their templates 
