### PR TITLE
checks to see if grade for assignment is student visible or not

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -163,7 +163,7 @@ class Assignment < ApplicationRecord
   end
 
   def has_grades?
-    grades.exists?
+    grades.where(student_visible: true).exists?
   end
 
   # Custom point total if the class has weighted assignments

--- a/app/models/assignment_type.rb
+++ b/app/models/assignment_type.rb
@@ -9,7 +9,7 @@ class AssignmentType < ApplicationRecord
   belongs_to :course
   has_many :assignments, -> { order("position ASC") }, dependent: :destroy
   has_many :submissions, through: :assignments
-  has_many :grades
+  has_many :grades, through: :assignments
 
   has_many :learning_objective_links, as: :learning_objective_linkable
 


### PR DESCRIPTION
### Status
**READY**

### Description
An assignment type should be deletable if there are no submissions or grades associated with the assignments for the assignment type. 

There was a problem with this because grades being "deleted" aren't actually being deleted from the associated assignment_type.  This caused a problem because the assignment_type still thinks the grade "exists" but has actually been deleted.

This is fixed by adding a relationship between the assignment_type `has_many :grades through: :assignments`

### Related PRs
#4220 

### Migrations
NO

### Steps to Test or Reproduce
Have an assignment type with submissions and grades, delete all the associated submissions and grades in order to delete the assignment type.

### Impacted Areas in Application
Assignments page & assignment types being deleted

======================
Closes #4227 
