### PR TITLE
Rubric criteria and level duplication 

### DIFF
--- a/app/assets/javascripts/angular/services/RubricService.coffee
+++ b/app/assets/javascripts/angular/services/RubricService.coffee
@@ -18,6 +18,9 @@
     $http.get("/api/rubrics/" + rubricId).then(
       (response) ->
         if response.data.data?  # if no rubric is found, data is null
+          rubric.length = 0
+          criteria.length = 0
+          levels.length = 0
           GradeCraftAPI.loadItem(rubric, "rubrics", response.data)
           GradeCraftAPI.loadFromIncluded(criteria, "criteria", response.data)
           GradeCraftAPI.loadFromIncluded(levels, "levels", response.data)


### PR DESCRIPTION
### Status
**READY**

### Description
When creating or editing an assignment with a rubric, changing the "Student Logged" option under Grading Style (in the Details Tab) would cause duplicates of the rubric criteria and levels to appear under the Grading tab of the assignment. 

The issue was that each time the button was toggled, the existing data was being appended instead of being repopulated on the UI side. 

### Migrations
NO

### Steps to Test or Reproduce
1. Create an assignment with a rubric
2. Add rubric criterion
3. Toggle the "Student Logged" option under Grading Style (in the Details Tab)
4. The rubric criterion and levels will appear to have been duplicated (several times according to the number of times the "Student Logged" option is toggled)

### Impacted Areas in Application
* Assignment creation and modification with rubrics enabled
======================
Closes #4216 
