### PR TITLE
Adds method call to update users current_course_id during login

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -55,6 +55,7 @@ class CoursesController < ApplicationController
       auto_login @user
       @user.update_login_at
       @user.update_course_login_at(@course.id)
+      @user.update_current_course_id(@course.id)
       redirect_to dashboard_path, flash: {
         notice: "Course #{@course.name} successfully created"
       }
@@ -84,6 +85,7 @@ class CoursesController < ApplicationController
       bust_course_list_cache current_user
       current_user.update_login_at
       current_user.update_course_login_at(@course.id)
+      current_user.update_current_course_id(@course.id)
       redirect_to edit_course_path(@course), flash: {
         notice: "Course #{@course.name} successfully created"
       }

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -20,6 +20,7 @@ class SamlController < ApplicationController
         auto_login @user
         @user.update_login_at
         @user.update_course_login_at(current_course.id)
+        @user.update_current_course_id(@course.id)
         session[:course_id] = current_course
         redirect_back_or_to dashboard_path
       else

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -47,6 +47,7 @@ class UserSessionsController < ApplicationController
       auto_login @user
       record_course_login_event user: @user
       @user.update_login_at
+      @user.update_current_course_id(@course.id)
       respond_with @user, location: dashboard_path
     else
       redirect_to root_path, alert: "An unknown error occurred."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,6 +237,10 @@ class User < ApplicationRecord
     membership.update_attribute(:last_login_at, DateTime.current) if membership
   end
 
+  def update_current_course_id(course_id)
+    self.current_course_id = course_id
+  end
+
   ### TEAMS
   # Finding a student's team for a course
   def team_for_course(course)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
user.current_course_id was only being set when the user switched courses.

This PR aims to add functionality to other aspects of the login time to set `user.current_course_id` to the id of the course they are entering.

Needs testing to see the scope of course in some of the login methods, as well as testing to make sure this field actually gets updated 

### Related PRs
#4229 

### Todos
- [ ] Needs Testing 

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

### Impacted Areas in Application
* User login and user.current_course_id 

======================
Closes #4257 
