### PR TITLE
Deleting points threshold causes inability to update assignment

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -136,6 +136,13 @@
   # Handles incremental updates from the Assignment form
   _updateAssignment = (assignment)->
     if assignment && ValidateDates(assignment).valid
+      #Treats the symptom not the cause
+      #Checks whether threshold_points has a valid
+      #state, if not, set it to 0
+      if isNaN(assignment.threshold_points)
+        assignment.has_threshold = false
+        assignment.threshold_points = 0
+
       $http.put("/api/assignments/#{assignment.id}", assignment: assignment).then(
         (response) ->
           angular.copy(response.data.data.attributes, assignment)

--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -136,9 +136,6 @@
   # Handles incremental updates from the Assignment form
   _updateAssignment = (assignment)->
     if assignment && ValidateDates(assignment).valid
-      #Treats the symptom not the cause
-      #Checks whether threshold_points has a valid
-      #state, if not, set it to 0
       if isNaN(assignment.threshold_points)
         assignment.has_threshold = false
         assignment.threshold_points = 0


### PR DESCRIPTION
### Status
**READY**

### Description
Deleting the value in the Points Threshold field under Grading Styles in the Details tab while editing an assignment would cause an issue where updating the assignment was no longer possible

### Migrations
NO

### Steps to Test or Reproduce
* Create an assignment, assign Total Possible Points under Grading Styles in the Details tab, set a Points Threshold and then Update Assignment
* Edit the assignment and press backspace/delete in the Points Threshold field until the value becomes 0
* It was not possible to update the assignment anymore

### Impacted Areas in Application
* Changes assets/services/AssignmentService > _updateAssignment to handle the case of the threshold_points field being NaN and resets the state of threshold_points to 0 and sets the has_threshold field to false if this is the case.

======================
Closes #4219 
