### PR TITLE
Conditionally displaying a "lock" icon for linked assignments under a learning objective

### DIFF
--- a/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
+++ b/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
@@ -21,10 +21,11 @@
             %ul.no-style
               %li{"ng-repeat"=>"assignment in loShowCtrl.linkedAssignments"}
                 %a{"ng-href"=>"/assignments/{{assignment.id}}"} {{assignment.name}}
-                %descriptor-icon{"data-icon"=>"lock"}
-                  %ul.icon-list
-                    %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
-                      {{condition}}
+                %span{"ng-if"=>"assignment.unlock_conditions"}
+                  %descriptor-icon{"data-icon"=>"lock"}
+                    %ul.icon-list
+                      %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
+                        {{condition}}
       %tr{"ng-if"=>"loShowCtrl.studentId"}
         %th Progress:
         %td


### PR DESCRIPTION
### Status
**READY**

### Description
Only assignments with an unlock condition should cause the lock icon to show under the "Linked Assignments" list when showing a learning objective (learning_objectives/objectives/<objective-id>)
This was as there was no check for conditionally displaying the lock icon (i.e. there was no check for whether or not there were unlock conditions for a given assignment) in the angular/templates/learning_objectives/objectives/show.html.haml view

### Migrations
NO

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
1. Create a learning objective and link an assignment without an unlock condition
2. The lock icon displaying an empty unlock conditions pop-up will appear in the learning_objectives/objectives/<objective-id> page

### Impacted Areas in Application
* Linked Assignments list under the learning objectives display view

======================
Closes #4263 
