### PR TITLE
Grading an assignment causes multiple announcements for students on staging

### DIFF
--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -1,3 +1,25 @@
-%gee
-  %whiz
-    Wow this is cool!
+%td.hero_img
+  = image_tag "email-hero_Neutral.png", alt: "a yeti illustration is here!", width: "1200", height: "435"
+
+%td
+  %h1
+    You’ve got a new grade!
+  %p
+    Hi #{ @student.first_name }, you can now view your grade for
+    #{ @course.assignment_term.downcase }
+    %strong
+      #{ @assignment.name }
+    in #{ @course.name }.
+
+  =link_to "View your results!", assignment_url(@assignment)
+  
+  - if @course.show_grade_predictor?
+    %p
+      Don’t forget to update your plan for the semester by checking your
+      = succeed "." do
+        = link_to "#{ @course.grade_predictor_term }", predictor_url
+
+  %p
+    Play on!
+    %br
+    GradeCraft

--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -1,26 +1,3 @@
-%td.hero_img
-  = image_tag "email-hero_Neutral.png", alt: "a yeti illustration is here!", width: "1200", height: "435"
-
-%td
-  %h1
-    You’ve got a new grade!
-  %p
-    Hi #{ @student.first_name }, you can now view your grade for
-    #{ @course.assignment_term.downcase }
-    %strong
-      #{ @assignment.name }
-    in #{ @course.name }.
-
-  =link_to assignment_url(@assignment)
-    %button View your results!
-
-  - if @course.show_grade_predictor?
-    %p
-      Don’t forget to update your plan for the semester by checking your
-      = succeed "." do
-        = link_to "#{ @course.grade_predictor_term }", predictor_url
-
-  %p
-    Play on!
-    %br
-    GradeCraft
+%gee
+  %whiz
+    Wow this is cool!

--- a/app/views/notification_mailer/grade_released.html.haml
+++ b/app/views/notification_mailer/grade_released.html.haml
@@ -11,7 +11,8 @@
       #{ @assignment.name }
     in #{ @course.name }.
 
-  =link_to "View your results!", assignment_url(@assignment)
+  %center
+    =link_to "View your results!", assignment_url(@assignment)
   
   - if @course.show_grade_predictor?
     %p


### PR DESCRIPTION
### Status
**READY**

### Description
Grading an assignment should release a single announcement for the student mentioning that the assignment has been graded, however, multiple announcements are released for the student, for the same graded assignment.

The issue was due to an error in views/notification_mailer/grade_released.html.haml which caused delayed jobs in the grade_updater Resque queue, had to remove the "View your results!" button and replace with a link instead. (More details on issue page #4252)

(Issue only on staging)

### Migrations
NO

### Steps to Test or Reproduce
1. Create an assignment as an instructor and grade a student on it
2. Log in as a student and view the /announcements page. There will be multiple notifications for the same assignment being graded

### Impacted Areas in Application
* Viewing /announcements for students
* View for "Grade released" notification email

======================
Closes #4252 
