### PR TITLE
Group email notifications

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -51,7 +51,7 @@ class GroupsController < ApplicationController
     respond_to do |format|
       if @group.update_attributes(group_params)
         @group.students.each do |group_member|
-            NotificationMailer.group_status_updated(group_member, @group).deliver_later
+          NotificationMailer.group_status_updated(group_member, @group).deliver_later
         end
 
         format.html { respond_with @group }
@@ -80,7 +80,7 @@ class GroupsController < ApplicationController
       group_membership_attributes: [:accepted, :group_id, :student_id, :id, :course_id],
       assignment_ids: [], student_ids: []
   end
-
+  
   def potential_team_members
     current_course.students.where.not(id: current_user.id).order_by_name
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -31,6 +31,10 @@ class GroupsController < ApplicationController
     end
     respond_to do |format|
       if @group.save
+        @group.students.each do |group_member|
+          NotificationMailer.group_notify(group_member, @group).deliver_later
+        end
+
         format.html { respond_with @group }
       else
         @other_students = potential_team_members
@@ -46,6 +50,10 @@ class GroupsController < ApplicationController
   def update
     respond_to do |format|
       if @group.update_attributes(group_params)
+        @group.students.each do |group_member|
+            NotificationMailer.group_status_updated(group_member, @group).deliver_later
+        end
+
         format.html { respond_with @group }
       else
         @other_students = potential_team_members

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -79,7 +79,6 @@ class NotificationMailer < ApplicationMailer
       format.text
       format.html
     end
-
   end
 
   def unlocked_condition(unlocked_item, student, course)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -55,29 +55,31 @@ class NotificationMailer < ApplicationMailer
     send_student_email "#{@course.course_number} - You've completed the #{@course.learning_objective_term}!"
   end
 
-  def group_status_updated(group_id)
-    @group = Group.find group_id
+  def group_status_updated(group_member, group)
+    @student = group_member
+
+    @group = group
+
     @course = @group.course
-    @group.students.each do |group_member|
-      mail(to: group_member.email, subject: "#{@course.course_number} - Group #{@group.approved}") do |format|
-        @student = group_member
-        format.text
-        format.html
-      end
+    
+    mail(to: @student.email, subject: "#{@course.course_number} - Group #{@group.approved}") do |format|
+      format.text
+      format.html
     end
   end
 
-  def group_notify(group_id)
-    @group = Group.find group_id
+  def group_notify(group_member, group)
+    @student = group_member
+
+    @group = group
+
     @course = @group.course
-    @group_members = @group.students
-    @group_members.each do |gm|
-      mail(to: gm.email, subject: "#{@course.course_number} - New Group") do |format|
-        @student = gm
-        format.text
-        format.html
-      end
+    
+    mail(to: @student.email, subject: "#{@course.course_number} - New Group") do |format|
+      format.text
+      format.html
     end
+
   end
 
   def unlocked_condition(unlocked_item, student, course)


### PR DESCRIPTION
### Status
**READY**

### Description
When a group is created, approved or rejected, a group notification should be sent to all members of the group. These notification emails were not being sent as controllers/groups_controller.rb did not call NotificationMailer when a new group was created (i.e. /groups/new) and when a group status was changed (i.e. /groups/update).

**Note**
* mailers/notification_mailer.rb had to be changed to accommodate sending multiple emails to many recipients. The previous version would only send out the last email whenever deliver_now or deliver_later was called. The method described in [this Stack Overflow post](https://stackoverflow.com/questions/7437270/send-to-multiple-recipients-in-rails-with-actionmailer) for sending emails to multiple recipients using ActionMailer caused weird issues where the contents of the email for each recipient was being appended to the email source, causing a mismatch between the email addresses and the names mentioned in the email. 
  
* The notification_mailer views for group_status_updated (views/notification_mailer/group_status_updated.html.haml, views/notification_mailer/group_status_updated.text.haml) are broken on staging as they use @group.approved as a boolean while it is a string. This caused emails for rejected group members to have the content "Good news, Name!" when the content should have been "Uh oh, Name!". 

### Migrations
NO

### Steps to Test or Reproduce
1.  Create a group for a group assignment as a student. A notification email should go out to every group member notifying them of the creation of the group
2. Approve/reject a group as an instructor. This should cause emails to go out to every group member notifying them of the change in status of the group.

### Impacted Areas in Application
* Groups controller (controllers/groups_controller.rb)
* Notification mailer (mailers/notification_mailer.rb)

======================
Closes #4251 
