### PR TITLE
Rubric points overview  while creating new assignment checks whether total possible points are 0

### DIFF
--- a/app/assets/javascripts/angular/directives/rubrics/points_overview.coffee
+++ b/app/assets/javascripts/angular/directives/rubrics/points_overview.coffee
@@ -6,6 +6,9 @@
     templateUrl: 'rubrics/points_overview.html'
     link: (scope, el, attr) ->
 
+      scope.noPoints = () ->
+        AssignmentService.assignment().full_points == 0
+
       scope.fullPoints = () ->
         AssignmentService.assignment().full_points || RubricService.fullPoints()
 
@@ -13,15 +16,15 @@
         RubricService.pointsAssigned()
 
       scope.pointsRemaining = () ->
-        RubricService.fullPoints() - RubricService.pointsAssigned()
+        AssignmentService.assignment().full_points && AssignmentService.assignment().full_points - RubricService.pointsAssigned()
 
       scope.pointsAreSatisfied = () ->
-        RubricService.fullPoints() == RubricService.pointsAssigned()
+        AssignmentService.assignment().full_points && AssignmentService.assignment().full_points == RubricService.pointsAssigned()
 
       scope.pointsAreMissing = () ->
-        RubricService.fullPoints() > RubricService.pointsAssigned()
+        AssignmentService.assignment().full_points && AssignmentService.assignment().full_points > RubricService.pointsAssigned()
 
       scope.pointsAreOver = () ->
-        RubricService.fullPoints() < RubricService.pointsAssigned()
+        AssignmentService.assignment().full_points && AssignmentService.assignment().full_points < RubricService.pointsAssigned()
   }
 ]

--- a/app/assets/javascripts/angular/templates/rubrics/points_overview.html.haml
+++ b/app/assets/javascripts/angular/templates/rubrics/points_overview.html.haml
@@ -1,8 +1,9 @@
 .points-overview-container
   #points-overview-floating
     %h4#points-legend
-      %span.points-assigned(ng-class="{'points-missing': pointsAreMissing(), 'points-satisfied': pointsAreSatisfied(), 'points-overage': pointsAreOver()}") {{pointsAssigned() | number:0}}
+      %span.points-assigned(ng-class="{'no-points': noPoints(), 'points-missing': pointsAreMissing(), 'points-satisfied': pointsAreSatisfied(), 'points-overage': pointsAreOver()}") {{pointsAssigned() | number:0}}
       \/ {{fullPoints() | number:0}} Points Allocated
+    %h4.notice(ng-show="noPoints()") You have not allocated any points yet
     %h4.notice(ng-show="pointsAreMissing()") You have {{pointsRemaining() | number:0}} point{{pointsRemaining() > 1 ? "s" : ""}} left to assign
     %h4.notice(ng-show="pointsAreSatisfied()") You have allocated all possible points
     %h4.notice(ng-show="pointsAreOver()") You have allocated {{- pointsRemaining() | number:0}} more point{{pointsRemaining() < -1 ? "s" : ""}} than the assignment total


### PR DESCRIPTION

### Status
**READY**

### Description
When creating an assignment with a rubric as an instructor, and the total possible points for the assignment is 0 in the "Details" tab, the points overview in the "Grading" tab should display a message indicating that the assignment has 0 points that are possible, however a message using the unhelpful calculation (Criterion points) - (0) was displayed.
The points overview now displays "You have not allocated any points yet"  in the "Grading" tab when the total possible points in the "Details" tab is 0 and displays the message even when there are criterion points added while keeping the total possible points 0.

### Migrations
NO

### Steps to Test or Reproduce
1.  Create a new assignment with a rubric
2. In the "Grading" tab add a criterion, provide a criterion name and the maximum points for that criterion
3. As the total possible points for the new assignment under the "Details" tab is 0, the points overview in the "Grading" tab will continue to display the message "You have not allocated any points yet". When the total possible points are changed, the message also changes to display the updated value.

### Impacted Areas in Application
* Points overview in the "Grading" tab while creating a new assignment with a rubric as an instructor, the AgnularJS points_overview.html.haml template (angular/templates/rubrics/points_overview.html.haml)  and directives/rubrics/points_overview.coffee 

======================
Closes #4268 
