### PR TITLE
Show a message in the "Grading" tab when Pass/Fail and Student Logged options are selected, when creating an assignment

### DIFF
--- a/app/assets/javascripts/angular/templates/assignments/edit_grading.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/edit_grading.html.haml
@@ -5,3 +5,6 @@
 
   .form-subsection(ng-if="!assignment.pass_fail")
     %assignment-score-levels(data-assignment="assignment")
+
+  .form-subsection(ng-if="assignment.student_logged && assignment.pass_fail")
+    %p Uncheck student logged or pass/fail to see more grading options

--- a/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
+++ b/app/assets/javascripts/angular/templates/learning_objectives/objectives/show.html.haml
@@ -21,11 +21,10 @@
             %ul.no-style
               %li{"ng-repeat"=>"assignment in loShowCtrl.linkedAssignments"}
                 %a{"ng-href"=>"/assignments/{{assignment.id}}"} {{assignment.name}}
-                %span{"ng-if"=>"assignment.unlock_conditions"}
-                  %descriptor-icon{"data-icon"=>"lock"}
-                    %ul.icon-list
-                      %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
-                        {{condition}}
+                %descriptor-icon{"data-icon"=>"lock"}
+                  %ul.icon-list
+                    %li{"ng-repeat"=>"condition in assignment.unlock_conditions"}
+                      {{condition}}
       %tr{"ng-if"=>"loShowCtrl.studentId"}
         %th Progress:
         %td


### PR DESCRIPTION
### Status
**READY**

### Description
When creating a new assignment, if both the "Pass/Fail" and "Student Graded" options are checked under the "Details" tab, there was no content displayed under the "Grading" tab. 
Now a message that says "Uncheck student logged or pass/fail to see more grading options" is displayed when the  "Pass/Fail" and "Student Graded" options are checked

### Migrations
NO

### Steps to Test or Reproduce
1. Create an assignment as an instructor
2. Check both the  "Pass/Fail" and "Student Graded" options under the "Details" tab
3. When viewing the "Grading" tab, it shows a message instructing the user to uncheck one of the options

### Impacted Areas in Application
* The assignment editing grading template (/templates/assignments/edit_grading.html.haml)
* Editing assignments (/assignments/<assignment-id>/edit)

======================
