### PR TITLE
Do not show "Learning Objectives" tab for assignments that have no linked Learning Objectives on staging

### DIFF
--- a/app/views/assignments/_show_staff.haml
+++ b/app/views/assignments/_show_staff.haml
@@ -22,7 +22,7 @@
           %a.class-analytics-tab{"href" => "#tab4"}
             %span Class
             Analytics
-      - if presenter.course_uses_learning_objectives?
+      - if presenter.course_uses_learning_objectives? && presenter.assignment.learning_objectives.length > 0
         %li
           %a{"href" => "#tab5"}= term_for :learning_objectives
 
@@ -47,6 +47,6 @@
           - else
             .tab-container
               = render partial: "grades/analytics", locals: { presenter: presenter, analytics_class: "analytics-tab-panel" }
-      - if presenter.course_uses_learning_objectives?
+      - if presenter.course_uses_learning_objectives? && presenter.assignment.learning_objectives.length > 0
         .ui-tabs-panel#tab5{ role: "tabpanel", "aria-hidden" => false }
           %learning-objective-instructor-overview{"data-course-id"=>"#{current_course.id}", "data-assignment-id"=>"#{presenter.assignment.id}"}


### PR DESCRIPTION


### Status
**READY**

### Description
When an assignment in a course with Learning Objectives has no linked Learning Objectives, there should be no "Learning Objectives" tab when viewing the assignment. (i.e. when /assignments/<assignment-id> is visited), however the "Learning Objectives" tab is show when viewing assignments without any linked Learning Objectives on staging.
Now, the "Learning Objectives" tab is only displayed if the assignment has linked Learning Objectives.

### Migrations
NO

### Steps to Test or Reproduce
1. Create an assignment as an instructor in a course with Learning Objectives
2. When viewing the assignment at /assignments/<assignment-id> there should be no "Learning Objectives" tab diplayed

### Impacted Areas in Application
* Assignments staff view (/views/assignments/_show_staff.haml)

======================
