### PR TITLE
Server-side checks for rubric criteria points exceeding total points for assignment

### DIFF
--- a/app/assets/javascripts/angular/services/AssignmentService.coffee
+++ b/app/assets/javascripts/angular/services/AssignmentService.coffee
@@ -166,6 +166,9 @@
           window.location = "/assignments"
         ,(response) ->
           GradeCraftAPI.logResponse(response)
+          console.log("Assignment save:", response)
+          if(response.data.errors == "invalid rubric criterion")
+            alert(response.data.message)
       )
 
   _updateScoreLevel = (assignmentId, scoreLevel)->


### PR DESCRIPTION

### Status
**N DEVELOPMENT**

### Description
* When a new assignment with a rubric is created, and criteria for the rubric are being assigned it should not be possible to provide values such that the total value of the rubric criteria points are greater than the total points for the assignment. However, this was possible.
* Now, incremental updates to the criterion points do not occur if the sum of all the rubric criteria are more than the total points for the assignments. Also, if the total value of the rubric criteria points is less than the total points for the assignment, a message is displayed that indicates this.

### Related PRs
 #4270 

### Migrations
NO

### Steps to Test or Reproduce
1.  Create an assignment with a rubric as an instructor and create a rubric criterion
2. Entering a value for the points of the rubric criterion created that is greater than the total points of the assignment will invalidate the new value on the server side (i.e. the new value will not be saved)
3. If the total points of all the rubric criteria for the assignment is less than the total points for the assignment, the user is shown a message indicating the issue and also instructions on how to correct it.

### Impacted Areas in Application
* Creating an assignment, creating rubric criteria
* controllers/api/assignments_controller.rb and controllers/api/criteria_controller.rb to check for invalid rubric criteria points
* services/AssigmentService.coffee to display a message if the user provides invalid rubric criteria points
======================
