### PR TITLE
Value in number input changes while scrolling over it, when changing rubric criterion points while creating an assignment

### DIFF
--- a/app/assets/javascripts/behaviors/number_input_scroll_disable.js
+++ b/app/assets/javascripts/behaviors/number_input_scroll_disable.js
@@ -1,0 +1,5 @@
+$(function() {
+    $(document).on("wheel", "input[type=number]", function (e) {
+        $(this).blur();
+    });
+});


### PR DESCRIPTION

### Status
**READY**

### Description
* When a number input has focus, scrolling over it will cause the value in the input to change. Probably a feature that ends up being more of an annoyance. 
* Now scrolling over a number input will not change the value in the input.

### Migrations
NO

### Steps to Test or Reproduce
1. Create an assignment with a rubric as an instructor and create a criterion for the rubric
2. Enter a value for the criterion and then scroll with the input for the points selected. The value in the input will change

### Impacted Areas in Application
* Inputting numbers (i.e. input with type=number)

======================
Closes #4275 
