### PR TITLE
Student Dashboard progress bar customization in course settings

### DIFF
--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -35,6 +35,5 @@ class API::StudentsController < ApplicationController
     else 
       @course_potential_points_for_student = current_course.full_points
     end
-
   end
 end

--- a/app/controllers/api/students_controller.rb
+++ b/app/controllers/api/students_controller.rb
@@ -29,6 +29,12 @@ class API::StudentsController < ApplicationController
     @student = student
     @assignment_types = current_course.assignment_types
     @earned_badge_points = @student.earned_badge_score_for_course current_course
-    @course_potential_points_for_student = current_course.total_points + @earned_badge_points
+  
+    if current_course.full_points.nil? || current_course.full_points == 0
+      @course_potential_points_for_student = current_course.total_points + @earned_badge_points
+    else 
+      @course_potential_points_for_student = current_course.full_points
+    end
+
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -97,7 +97,7 @@ class Course < ApplicationRecord
   validates_presence_of :name, :course_number, :student_term, :team_term, :group_term,
     :team_leader_term, :group_term, :weight_term, :badge_term, :assignment_term, :challenge_term, :grade_predictor_term
 
-  validates_numericality_of :total_weights, :max_weights_per_assignment_type, :ful_points,
+  validates_numericality_of :total_weights, :max_weights_per_assignment_type, :full_points,
     :max_assignment_types_weighted, less_than_or_equal_to: 999999999, greater_than: 0, if: lambda { self.has_multipliers? }, message: "must be set to greater than 0 for the Multipliers feature to work properly."
 
   validates_format_of :twitter_hashtag, with: /\A[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)*\z/, allow_blank: true, length: { within: 3..20 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -97,7 +97,7 @@ class Course < ApplicationRecord
   validates_presence_of :name, :course_number, :student_term, :team_term, :group_term,
     :team_leader_term, :group_term, :weight_term, :badge_term, :assignment_term, :challenge_term, :grade_predictor_term
 
-  validates_numericality_of :total_weights, :max_weights_per_assignment_type,
+  validates_numericality_of :total_weights, :max_weights_per_assignment_type, :ful_points,
     :max_assignment_types_weighted, less_than_or_equal_to: 999999999, greater_than: 0, if: lambda { self.has_multipliers? }, message: "must be set to greater than 0 for the Multipliers feature to work properly."
 
   validates_format_of :twitter_hashtag, with: /\A[A-Za-z][A-Za-z0-9]*(?:_[A-Za-z0-9]+)*\z/, allow_blank: true, length: { within: 3..20 }

--- a/app/views/courses/_player_settings.haml
+++ b/app/views/courses/_player_settings.haml
@@ -14,3 +14,7 @@
     = f.check_box :has_character_profiles, {"aria-describedby" => "has_character_profiles"}
     = f.label :has_character_profiles, "Character Profiles"
     .form-hint{id: "has_character_profiles"} Do students create a profile for their character in the class?
+
+  .form-flex-row
+    .form-item.col-50
+      = f.input :full_points, label: "Student Dashboard Progress Bar Points Limit", hint: "Change the upper limit of the number of points used while displaying the progress bar on the student dashboard. (Useful if the course has many optional assignments) \n (Set value to 0 for default progress bar)"

--- a/app/views/courses/_player_settings.haml
+++ b/app/views/courses/_player_settings.haml
@@ -17,4 +17,4 @@
 
   .form-flex-row
     .form-item.col-50
-      = f.input :full_points, label: "Student Dashboard Progress Bar Points Limit", hint: "Change the upper limit of the number of points used while displaying the progress bar on the student dashboard. (Useful if the course has many optional assignments) \n (Set value to 0 for default progress bar)"
+      = f.input :full_points, label: "Customize Student Dashboard Progress Bar Points Limit", hint: "Change the upper limit of the number of points used while displaying the progress bar on the student dashboard. (Useful if the course has many optional assignments) \n (Set value to 0 for default progress bar)"

--- a/spec/controllers/multipliers_controller_spec.rb
+++ b/spec/controllers/multipliers_controller_spec.rb
@@ -1,6 +1,6 @@
 describe MultipliersController do
   let(:course_1) { create :course }
-  let(:course_2) { create :course_with_weighting }
+  let(:course_2) { create :course_with_weighting, full_points: 1 }
 
   before(:each) do
     login_user current_user

--- a/spec/exporters/multiplier_exporter_spec.rb
+++ b/spec/exporters/multiplier_exporter_spec.rb
@@ -1,5 +1,5 @@
 describe MultipliersExporter do
-  let(:course) {create :course_with_weighting}
+  let(:course) {create :course_with_weighting, full_points: 1}
   let!(:student_1) {create :user, courses: [course], role: :student, first_name: "Yirmiyahu", last_name: "Valentin", email: "yirmiyahu.valentin@gmail.com"}
   let!(:student_2) {create :user, courses: [course], role: :student, first_name: "Loretta", last_name: "Nhung", email: "loretta.nhung@gmail.com"}
   let!(:assignment_type_1) {create :assignment_type, course: course, name: "Charms", student_weightable: true, position: 1}

--- a/spec/features/downloading_the_multiplied_gradebook_spec.rb
+++ b/spec/features/downloading_the_multiplied_gradebook_spec.rb
@@ -1,6 +1,6 @@
 feature "downloading multiplied gradebook file" do
   context "as a professor" do
-    let(:course) { build :course, name: "Course Name", has_multipliers: true, total_weights: 1, max_weights_per_assignment_type: 2, max_assignment_types_weighted: 2, weight_term: "Multiplier" }
+    let(:course) { build :course, name: "Course Name", has_multipliers: true, total_weights: 1, max_weights_per_assignment_type: 2, max_assignment_types_weighted: 2, weight_term: "Multiplier", full_points: 1 }
     let!(:course_membership) { create :course_membership, :professor, user: professor, course: course }
     let(:professor) { create :user }
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -588,7 +588,7 @@ describe Course do
   end
 
   describe "#assignment_weight_spent_for_student(student)" do
-    subject { create :course_with_weighting, total_weights: 4 }
+    subject { create :course_with_weighting, total_weights: 4, full_points: 1 }
 
     it "returns false if the student has not yet spent enough weights" do
       student = create(:user, courses: [subject], role: :student)

--- a/spec/views/api/assignment_types/index_spec.rb
+++ b/spec/views/api/assignment_types/index_spec.rb
@@ -6,7 +6,8 @@ describe "api/assignment_types/index" do
       total_weights: 6,
       weights_close_at: Time.now,
       max_weights_per_assignment_type: 4,
-      max_assignment_types_weighted: 2
+      max_assignment_types_weighted: 2,
+      full_points: 1
     )
     assignment_type = create(:assignment_type, course: @course, student_weightable: true, has_max_points: true, max_points: 1234)
     @assignment_types = [assignment_type]


### PR DESCRIPTION
### Status
**READY**

### Description
* The upper limit of the progress bar displayed on the student dashboard can be too large, causing a student's progress to appear very small in comparison to the course total while it might be the case that many points in the course are optional. Now a new course setting has been added which can be used to set the student dashboard progress bar's upper limit to a custom value, and can be set back to 0 for the default upper limit.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor go to the "Advanced Settings" tab in the course settings page (i.e. /courses/<id>/edit). Under the "Student Settings" list, you can now enter a custom value for the upper limit and save the course settings.
2. As a student, log in and select the course, you will now see that the progress bar's upper limit has changed to the value that was set in the course settings page.

### Impacted Areas in Application
* Student dashboard (directives/analytics/points_breakdown.coffee)
* Students controller (controllers/api/students_controller.rb)
* Course model (for adding validation for the full_points field used to store the custom value for the progress bar's upper limit) (models/course.rb)

======================
Closes #4306 
