### PR TITLE
Only show warning message about marking grades as invisible to students while grading group assignments if the grades are visible to at least one student in the group

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -49,8 +49,11 @@ module LinkHelper
   end
 
   def edit_group_grade_link_to(assignment, group, options={})
-    confirm_message = 'These grades are about to be marked as ungraded and unavailable to the students - they won\'t be visible again until you click "Submit" - are you sure?'
-    options.merge! data: { confirm:  confirm_message }
+    grades_visible_to_any_student = assignment.grades.where(student_id: group.students.ids).pluck("student_visible").include? true
+    if grades_visible_to_any_student
+      confirm_message = 'These grades are about to be marked as ungraded and unavailable to the students - they won\'t be visible again until you click "Submit" - are you sure?'
+      options.merge! data: { confirm:  confirm_message }
+    end
     link_to decorative_glyph(:edit) + "Edit Group Grades", grade_assignment_group_path(assignment, group), options
   end
 

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -49,7 +49,7 @@ module LinkHelper
   end
 
   def edit_group_grade_link_to(assignment, group, options={})
-    grades_visible_to_any_student = assignment.grades.where(student_id: group.students.ids).pluck("student_visible").include? true
+    grades_visible_to_any_student = assignment.grades.where(student_id: group.students.ids, student_visible: true).exists?
     if grades_visible_to_any_student
       confirm_message = 'These grades are about to be marked as ungraded and unavailable to the students - they won\'t be visible again until you click "Submit" - are you sure?'
       options.merge! data: { confirm:  confirm_message }


### PR DESCRIPTION
### Status
**READY**

### Description
* When regrading a group assignment as an instructor, the warning message about grades being marked as ungraded and being made unavailable to students should only be displayed if at least one student can see the grades. There was no check for this condition and the warning message was displayed regardless of whether the grades for any student in the group had been released.
* Now the warning message is displayed only if the grades for the group have been released to at least one student.

### Migrations
NO

### Steps to Test or Reproduce
1. On a assignment with groups, grade any group making sure that the "Student Visible" option is off
2. Press the "Edit Group Grades" button for the group that was just graded. There should be no warning message displayed.
3. Now on the assignment grading page, toggle the "Student Visible" option to make the grade student visible
4. Press the "Edit Group Grades" button for the group that was just graded. A warning message that says "These grades are about to be marked as ungraded and unavailable to the students - they won\'t be visible again until you click "Submit" - are you sure?" will be displayed

### Impacted Areas in Application
* helpers/link_helper.rb
* Grading a group assignment

======================
Closes #4274 
