### PR TITLE
Creating users even though they share the same local part ("pre-@" portion) of their emails

### DIFF
--- a/app/services/creates_new_user/generates_usernames.rb
+++ b/app/services/creates_new_user/generates_usernames.rb
@@ -9,16 +9,7 @@ module Services
         user = context[:user]
 
         if user.username.blank?
-          new_username = username_from_email(user.email) 
-        
-          username_duplicates = User.where(username: new_username).length
-      
-          if username_duplicates > 0
-            changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
-            new_username += "_#{username_duplicates + changed_username_duplicates}"
-          end
-
-          user.username = new_username
+          user.username = generate_username_from_email(user.email)
         end
         
         if user.internal?
@@ -33,8 +24,17 @@ module Services
         "#{username}@umich.edu"
       end
 
-      def self.username_from_email(email)
-        email.split(/@/).first
+      def self.generate_username_from_email(user_email)
+        new_username = user_email.split(/@/).first
+        
+        username_duplicates = User.where(username: new_username).length
+      
+        if username_duplicates > 0
+          changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
+          new_username += "_#{username_duplicates + changed_username_duplicates}"
+        end
+
+        return new_username
       end
     end
   end

--- a/app/services/creates_new_user/generates_usernames.rb
+++ b/app/services/creates_new_user/generates_usernames.rb
@@ -8,16 +8,18 @@ module Services
       executed do |context|
         user = context[:user]
 
-        new_username = username_from_email(user.email)
+        if user.username.blank?
+          new_username = username_from_email(user.email) 
         
-        username_duplicates = User.where(username: new_username).length
+          username_duplicates = User.where(username: new_username).length
       
-        if username_duplicates > 0
-          changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
-          new_username += "_#{username_duplicates + changed_username_duplicates}"
-        end
+          if username_duplicates > 0
+            changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
+            new_username += "_#{username_duplicates + changed_username_duplicates}"
+          end
 
-        user.username = new_username
+          user.username = new_username
+        end
         
         if user.internal?
           user.email = email_from_username(user.username) if user.email.blank?

--- a/app/services/creates_new_user/generates_usernames.rb
+++ b/app/services/creates_new_user/generates_usernames.rb
@@ -8,7 +8,17 @@ module Services
       executed do |context|
         user = context[:user]
 
-        user.username = username_from_email(user.email) if user.username.blank?
+        new_username = username_from_email(user.email)
+        
+        username_duplicates = User.where(username: new_username).length
+      
+        if username_duplicates > 0
+          changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
+          new_username += "_#{username_duplicates + changed_username_duplicates}"
+        end
+
+        user.username = new_username
+        
         if user.internal?
           user.email = email_from_username(user.username) if user.email.blank?
           user.kerberos_uid = user.username

--- a/app/services/creates_new_user/generates_usernames.rb
+++ b/app/services/creates_new_user/generates_usernames.rb
@@ -30,7 +30,7 @@ module Services
         username_duplicates = User.where(username: new_username).length
       
         if username_duplicates > 0
-          changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '_\d+').length
+          changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '\d+').length
           new_username += "_#{username_duplicates + changed_username_duplicates}"
         end
 

--- a/app/services/creates_new_user/generates_usernames.rb
+++ b/app/services/creates_new_user/generates_usernames.rb
@@ -31,7 +31,7 @@ module Services
       
         if username_duplicates > 0
           changed_username_duplicates = User.where("username ~* ?", new_username.to_s + '\d+').length
-          new_username += "_#{username_duplicates + changed_username_duplicates}"
+          new_username += "#{username_duplicates + changed_username_duplicates}"
         end
 
         return new_username

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -36,7 +36,6 @@ module Services
 
       def self.find_and_set_user_context(context, email, username)
         user = User.find_by_insensitive_email email
-        user ||= User.find_by_insensitive_username username
         context[:user] = user unless user.nil?
       end
     end

--- a/app/services/creates_or_updates_user/creates_or_updates_user.rb
+++ b/app/services/creates_or_updates_user/creates_or_updates_user.rb
@@ -36,6 +36,7 @@ module Services
 
       def self.find_and_set_user_context(context, email, username)
         user = User.find_by_insensitive_email email
+        user ||= User.find_by_insensitive_username username
         context[:user] = user unless user.nil?
       end
     end


### PR DESCRIPTION
### Status
**READY**

### Description
* When a new user is created, as long as their email is unique, the user should be created. However, this was not occurring as the username for the user was being created using the username for their email (the "pre-@" portion), which is not necessarily unique across different email providers. 
* Now, a user can be created as long as they have a unique email address, regardless of whether they have the same "pre-@" portion in their email as another person in the course. When each user is created, if they share the "pre-@" portion of their email with another person in the course, the username is modified as <duplicate-username>_<number-of-duplicates> in the database to preserve the uniqueness of the username

### Migrations
NO

### Steps to Test or Reproduce
1. As an admin, create a new user (i.e. /users/new) with an email, say "test.learner@schoola.edu"
2. Create another user with the email "test.learner@schoolb.edu". Both users should be created even though their emails share the same "pre-@" portion.

### Impacted Areas in Application
* Creating a new user

======================
Closes #4172 
