### PR TITLE
Users should not have to reselect the assignment type while creating a new assignment

### DIFF
--- a/app/assets/javascripts/angular/directives/assignments/assignment_new.coffee
+++ b/app/assets/javascripts/angular/directives/assignments/assignment_new.coffee
@@ -11,12 +11,16 @@
     vmAssignmentNew.assignmentTypes = AssignmentTypeService.assignmentTypes
     vmAssignmentNew.termFor = AssignmentTypeService.termFor
 
+    URLQueries = new URLSearchParams(window.location.search)
+
+    vmAssignmentNew.assignmentTypeID = parseInt(URLQueries.get("assignment_type_id"))
+
     services(@courseUsesLearningObjectives).then(() ->
       vmAssignmentNew.loading = false
     )
 
     vmAssignmentNew.newAssignment = {
-      assignment_type_id: null
+      assignment_type_id: vmAssignmentNew.assignmentTypeID
       name: null
     }
 


### PR DESCRIPTION
### Status
**READY**

### Description
* While creating a new assignment, if the user selects "Add a New Assignment" under an assignment type, they should not have to reselect the assignment type in the next page (i.e. /assignments/new?assignment_type_id=<assignment-type-id>). However, there is no value selected in the "Assignment Type" dropdown.
* Now, if a user selects "Add a New Assignment" under an assignment type, the assignment type will be selected in the dropdown on the next page.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, create a new assignment using the "Add a New Assignment" button from under an assignment type. In the following page, the assignment type will be selected in the dropdown.

### Impacted Areas in Application
* Creating a new assignment (directives/assignments/assignment_new.coffee)

======================
Closes #4305 