### PR TITLE
When viewing an assignment, valid links to unlock conditions should be shown

### DIFF
--- a/app/views/assignments/_description.haml
+++ b/app/views/assignments/_description.haml
@@ -71,7 +71,7 @@
       %p.italic You have not unlocked this #{term_for :assignment}. To achieve this you must:
       %ul
         - presenter.assignment.unlock_conditions.each do |uc|
-          - if !uc.condition_type == "Learning Objective"
+          - if !(uc.condition_type == "Learning Objective")
             %li= link_to uc.requirements_description_sentence(current_user.time_zone), uc.condition
           - else
             %li= link_to uc.requirements_description_sentence(current_user.time_zone), learning_objectives_objective_path(uc.condition_id)
@@ -80,7 +80,7 @@
   %p.italic To unlock it, #{ term_for :students } must:
   %ul
     - presenter.assignment.unlock_conditions.each do |condition|
-      - if !condition.unlockable_type == GradeSchemeElement
+      - if !(condition.unlockable_type == GradeSchemeElement)
         %li= link_to condition.requirements_description_sentence(current_user.time_zone), condition.unlockable
       - else
         %li= condition.requirements_description_sentence(current_user.time_zone)
@@ -89,7 +89,7 @@
   %h3.uppercase #{glyph(:key)} This #{term_for :assignment} is a Key:
   %ul
     - presenter.assignment.unlock_keys.each do |key|
-      - if !key.unlockable_type == GradeSchemeElement
+      - if !(key.unlockable_type == GradeSchemeElement)
         %li= link_to key.key_description_sentence(current_user.time_zone), key.unlockable
       - else
         %li= key.key_description_sentence(current_user.time_zone)


### PR DESCRIPTION

### Status
**READY**

### Description
* When viewing an assignment as a student, the links to the unlock conditions should lead to the appropriate page for the unlock condition. However, as the unlock condition type was not being checked properly the wrong link was provided
* Now, the links to the proper unlock conditions are displayed

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor create an assignment and set a badge as an unlock condition
2. As a student who has not earned the badge, view the assignment and click on the link for the unlock condition. The link will now lead to page for the unlock condition, in this case, the page for the badge.

### Impacted Areas in Application
* Viewing an assignment (views/assignments/_description.html.haml)

======================
Closes #4290 
