### PR TITLE
Prevent internal server error when viewing analytics for a course with no assignment types

### DIFF
--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -341,9 +341,7 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
 
   def info_per_assign
     dashboard
-    if objects[:course].assignment_types.length > 0
-      breadcrumb(objects[:assignment_types].first.course.assignment_term + " Analytics")
-    end
+    breadcrumb(objects[:course].assignment_term + " Analytics")
   end
 
   def institutions_edit

--- a/app/models/breadcrumb_trail.rb
+++ b/app/models/breadcrumb_trail.rb
@@ -341,7 +341,9 @@ class BreadcrumbTrail < Croutons::BreadcrumbTrail
 
   def info_per_assign
     dashboard
-    breadcrumb(objects[:assignment_types].first.course.assignment_term + " Analytics")
+    if objects[:course].assignment_types.length > 0
+      breadcrumb(objects[:assignment_types].first.course.assignment_term + " Analytics")
+    end
   end
 
   def institutions_edit

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -3,6 +3,14 @@
 
   = render partial: "analytics/in_page_nav"
 
+  - if @assignment_types.length == 0
+    %p
+      There are currently no assignment types for this course, add an assignment type and then create assignments to see analytics.
+
+  - if @assignment_types.length > 0 && @course.assignments.length == 0
+    %p
+      There are currently no assignments for this course, add an assignment to see analytics.
+
   - @assignment_types.each do |assignment_type|
     - assignments_for_type = assignment_type.assignments
     - if assignments_for_type.select {|a| a.grades.student_visible.length > 1}.present?


### PR DESCRIPTION
### Status
**READY**

### Description
* When viewing the analytics page for a course with no assignment types an internal server error was caused due to an uninitialized object access in models/breadcrumb_trail.rb > info_per_assign
* Now a conditional check has been added to prevent the server error and a message is displayed if the course has no assignment types or if the course has no assignments

### Migrations
NO

### Steps to Test or Reproduce
1. As an admin create a new course
2. Click on the "Analytics" link on the navigation sidebar. There will be no internal server error when the /per_assign page is displayed and there will be a message that indicates that there are no assignment types in the course

### Impacted Areas in Application
* models/breadcrumb_trail.rb
* Viewing assignment analytics (/per_assign) (i.e. views/info/per_assign.html.haml)

======================
Closes #4289 
