### PR TITLE
It should be possible to select a team for a new user during their creation

### DIFF
--- a/app/controllers/course_memberships_controller.rb
+++ b/app/controllers/course_memberships_controller.rb
@@ -57,10 +57,6 @@ class CourseMembershipsController < ApplicationController
   end
 
   def remove_leaders_from_teams(course_membership)
-    if !course_membership.user.is_staff?(course_membership.course)
-      return false
-    end
-
     staff_member = course_membership.user
 
     course = course_membership.course
@@ -70,14 +66,14 @@ class CourseMembershipsController < ApplicationController
       team.leaders = team.leaders.reject {|member| member["id"] == staff_member.id}
       team.save
     end
-
-    return true
   end
 
   def destroy
     course_membership = current_course.course_memberships.find(params[:id])
     
-    remove_leaders_from_teams(course_membership)
+    if course_membership.user.is_staff?(course_membership.course)
+      remove_leaders_from_teams(course_membership)
+    end
 
     Services::CancelsCourseMembership.call course_membership
    

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,15 +86,13 @@ class UsersController < ApplicationController
   end
 
   def add_to_team(course, team_name, role)
-    if !course.has_teams || team_name.nil? || team_name.length == 0
-      return false
-    end
+    return false if !course.has_teams
+    return false if team_name.nil?
+    return false if team_name.length == 0
 
     team = Team.find_by(name: team_name, course_id: course.id)
 
-    if team.nil?
-      return false
-    end
+    return false if team.nil?
 
     if role == "student"
       team.students.push(@user)
@@ -114,27 +112,24 @@ class UsersController < ApplicationController
       @user = result[:user]
       if result.success?
         team_name = user_params["course_memberships_attributes"]["0"]["team_in_course"]
+        added_to_team_message = ""
         
         if @user.is_student?(current_course)
-          student_added_to_team_message = ""
-
           if add_to_team(current_course, team_name, "student")
-            student_added_to_team_message = "The #{(term_for :student).downcase} #{@user.name} has also been added to the #{(term_for :team).downcase} #{team_name}"
+            added_to_team_message = "The #{(term_for :student).downcase} #{@user.name} has also been added to the #{(term_for :team).downcase} #{team_name}"
           end
 
           redirect_to students_path,
-            notice: "#{term_for :student} #{@user.name} was successfully created!" + " #{student_added_to_team_message}" and return
+            notice: "#{term_for :student} #{@user.name} was successfully created!" + " #{added_to_team_message}" and return
         elsif @user.is_staff?(current_course)
           Services::SendsResourceEmail.call @user
-          
-          staff_added_to_team_message = ""
-
+ 
           if add_to_team(current_course, team_name, "staff")
-            staff_added_to_team_message = "The staff member #{@user.name} has also been added to the #{(term_for :team).downcase} #{team_name}"
+            added_to_team_message = "The staff member #{@user.name} has also been added to the #{(term_for :team).downcase} #{team_name}"
           end
 
           redirect_to staff_index_path,
-            notice: "Staff Member #{@user.name} was successfully created!" + " #{staff_added_to_team_message}" and return
+            notice: "Staff Member #{@user.name} was successfully created!" + " #{added_to_team_message}" and return
         elsif @user.is_observer?(current_course)
           redirect_to observers_path,
             notice: "Observer #{@user.name} was successfully created!" and return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -86,7 +86,7 @@ class UsersController < ApplicationController
   end
 
   def add_to_team(course, team_name, role)
-    if !course.has_teams || team_name.nil?
+    if !course.has_teams || team_name.nil? || team_name.length == 0
       return false
     end
 

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -19,8 +19,7 @@ module CoursesHelper
   end
 
   def available_teams(course)
-    teams = course.teams.pluck("name")
-    return teams
+    course.teams.pluck("name")
   end
 
   def bust_course_list_cache(user)

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -18,6 +18,11 @@ module CoursesHelper
     roles
   end
 
+  def available_teams(course)
+      teams = course.teams.pluck("name")
+      return teams
+  end
+
   def bust_course_list_cache(user)
     expire_fragment current_courses_cache_key(user)
     expire_fragment archived_courses_cache_key(user)

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -19,8 +19,8 @@ module CoursesHelper
   end
 
   def available_teams(course)
-      teams = course.teams.pluck("name")
-      return teams
+    teams = course.teams.pluck("name")
+    return teams
   end
 
   def bust_course_list_cache(user)

--- a/app/models/course_membership.rb
+++ b/app/models/course_membership.rb
@@ -16,6 +16,8 @@ class CourseMembership < ApplicationRecord
     end
   end
 
+  attr_accessor :team_in_course
+
   scope :auditing, -> { where( role: "student", auditing: true, active: true ) }
   scope :being_graded, -> { where( role: "student", auditing: false, active: true) }
   scope :instructors_of_record, -> { where(instructor_of_record: true) }

--- a/app/services/cancels_course_membership/destroys_team_memberships.rb
+++ b/app/services/cancels_course_membership/destroys_team_memberships.rb
@@ -8,9 +8,23 @@ module Services
       executed do |context|
         membership = context[:membership]
 
-        TeamMembership.for_course(membership.course)
-          .for_student(membership.user)
-          .destroy_all
+        TeamMembership.for_course(membership.course).for_student(membership.user).destroy_all
+
+        if membership.user.team_leaderships_for_course(membership.course).length > 0
+          puts "Member is a leader for at least one team"
+        end
+
+        puts "Member: #{membership.user.first_name} #{membership.user.last_name}"
+        
+        membership.user.team_leaderships_for_course(membership.course).each do |team_leadership|
+          team = team_leadership.team 
+          puts "Team: #{team.name}"
+          puts "Team leaders: #{team.leaders.pluck("first_name")}"
+          team.leadership = team.leaders.reject {|member| member["id"] == membership.user.id}
+          puts "Team leaders: #{team.leaders.pluck("first_name")}"
+          team.save
+        end
+
       end
     end
   end

--- a/app/services/cancels_course_membership/destroys_team_memberships.rb
+++ b/app/services/cancels_course_membership/destroys_team_memberships.rb
@@ -8,23 +8,9 @@ module Services
       executed do |context|
         membership = context[:membership]
 
-        TeamMembership.for_course(membership.course).for_student(membership.user).destroy_all
-
-        if membership.user.team_leaderships_for_course(membership.course).length > 0
-          puts "Member is a leader for at least one team"
-        end
-
-        puts "Member: #{membership.user.first_name} #{membership.user.last_name}"
-        
-        membership.user.team_leaderships_for_course(membership.course).each do |team_leadership|
-          team = team_leadership.team 
-          puts "Team: #{team.name}"
-          puts "Team leaders: #{team.leaders.pluck("first_name")}"
-          team.leadership = team.leaders.reject {|member| member["id"] == membership.user.id}
-          puts "Team leaders: #{team.leaders.pluck("first_name")}"
-          team.save
-        end
-
+        TeamMembership.for_course(membership.course)
+          .for_student(membership.user)
+          .destroy_all
       end
     end
   end

--- a/app/views/users/_courses.html.haml
+++ b/app/views/users/_courses.html.haml
@@ -5,10 +5,17 @@
     .form-item
       = cm.label :role, "Select Role"
       = cm.select :role, available_roles(current_course)
+
     - if current_course.has_in_team_leaderboards?
       .form-item
         = cm.label :pseudonym, "Pseudonym"
         = cm.text_field :pseudonym
+
+    - if current_course.has_teams
+      .form-item
+        = cm.label @user.teams, "Select Team"
+        = cm.select @user.teams, available_teams(current_course)
+
     - if current_course.has_team_roles?
       .form-item
         = cm.label :team_role, "Team Role"

--- a/app/views/users/_courses.html.haml
+++ b/app/views/users/_courses.html.haml
@@ -14,7 +14,7 @@
     - if current_course.has_teams
       .form-item
         = cm.label :team_in_course, "Select Team"
-        = cm.select :team_in_course, available_teams(current_course)
+        = cm.select :team_in_course, available_teams(current_course), selected: 1, include_blank: true
 
     - if current_course.has_team_roles?
       .form-item

--- a/app/views/users/_courses.html.haml
+++ b/app/views/users/_courses.html.haml
@@ -11,9 +11,9 @@
         = cm.label :pseudonym, "Pseudonym"
         = cm.text_field :pseudonym
 
-    - if current_course.has_teams
+    - if !edit_user && current_course.has_teams
       .form-item
-        = cm.label :team_in_course, "Select Team"
+        = cm.label :team_in_course, "Select #{term_for(:teams).singularize}"
         = cm.select :team_in_course, available_teams(current_course), selected: 1, include_blank: true
 
     - if current_course.has_team_roles?

--- a/app/views/users/_courses.html.haml
+++ b/app/views/users/_courses.html.haml
@@ -13,8 +13,8 @@
 
     - if current_course.has_teams
       .form-item
-        = cm.label @user.teams, "Select Team"
-        = cm.select @user.teams, available_teams(current_course)
+        = cm.label :team_in_course, "Select Team"
+        = cm.select :team_in_course, available_teams(current_course)
 
     - if current_course.has_team_roles?
       .form-item

--- a/app/views/users/_gradecraft_user_form.html.haml
+++ b/app/views/users/_gradecraft_user_form.html.haml
@@ -17,5 +17,5 @@
       .form-item
         = f.label :password_confirmation
         = f.password_field :password_confirmation, as: :password
-  = render partial: "courses", locals: { form: f }
+  = render partial: "courses", locals: { form: f, edit_user: edit_user }
   = render partial: "users/submit_buttons"

--- a/app/views/users/_internal_user_form.html.haml
+++ b/app/views/users/_internal_user_form.html.haml
@@ -15,5 +15,5 @@
       .form-item
         = label_tag :send_welcome, "Send welcome email"
         = check_box_tag :send_welcome, "1", true
-  = render partial: "courses", locals: { form: f }
+  = render partial: "courses", locals: { form: f, edit_user: edit_user }
   = render partial: "users/submit_buttons"

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,6 @@
 .pageContent
-  = render partial: "layouts/alerts", locals: { model: @user, term: "user" }
+  = render partial: "layouts/alerts", locals: { model: @user, term: "user"}
   - if @user.internal?
-    = render partial: "internal_user_form"
+    = render partial: "internal_user_form", locals: { edit_user: true }
   - else
-    = render partial: "gradecraft_user_form"
+    = render partial: "gradecraft_user_form", locals: { edit_user: true }

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,5 +1,5 @@
 .pageContent
-  = render partial: "layouts/alerts", locals: { model: @user, term: "user" }
+  = render partial: "layouts/alerts", locals: { model: @user, term: "user"}
 
   - if Rails.env.production?
     %h3 Please note:
@@ -20,7 +20,7 @@
 
     #tabt1.ui-tabs-panel.ui-widget-content{role: "tabpanel"}
       #tab1{ class: ("active" unless @user.internal?) }
-        = render partial: "gradecraft_user_form"
+        = render partial: "gradecraft_user_form", locals: { edit_user: false }
 
       #tab2{ class: ("active" if @user.internal?) }
-        = render partial: "internal_user_form"
+        = render partial: "internal_user_form", locals: { edit_user: false }


### PR DESCRIPTION
### Status
**READY**

### Description
* When creating a new user as an admin, it should be possible to add the new user to a team if the course has teams.
* Now a dropdown has been added to the /users/new page under the course section that lists all the teams in the course if the course has teams. If the new user is a student, they are added to the list of the team's students. If the user is a GSI or professor they are added to the list of the team's leaders.
* Also, now deleting a staff member will also remove them from their team

### Migrations
NO

### Steps to Test or Reproduce
1. As an admin, create a new user by visiting /users/new in a course with teams
2. Select a team for the user by selecting a team from the dropdown. When the user is created they are a member of the team. If no options from the dropdown are selected, the new user is not added to any team.

### Impacted Areas in Application
* Adding a new user (/users/new)
* controllers/users_controller.rb
* The course view when creating a new user (/views/users/_courses.html.haml)
* The model course_membership.rb to add an attr_accessor called team_in_course to store the new user's team in the course
* courses_helper.rb now includes a helper function to list all the names of the teams

======================
Closes #4308, #4317 