### PR TITLE
fixing grade button styling, issue 4309

### DIFF
--- a/app/assets/javascripts/angular/templates/grading_status/submissions.html.haml
+++ b/app/assets/javascripts/angular/templates/grading_status/submissions.html.haml
@@ -78,6 +78,6 @@
 
               -# Grade group assignment
               %li{"ng-if"=>"gsSubmissionsCtrl.showGroupGradeBtn(submission)"}
-                %a{"ng-href"=>"{{submission.group_grade_path}}"}
+                %a.button{"ng-href"=>"{{submission.group_grade_path}}"}
                   %i.fa.fa-check
                   Grade


### PR DESCRIPTION
### Status
**READY**

### Description
The "grade" link was not styled as an in-table button, like all the other assignment/submission types. A button class was added to fix this.

### Migrations
NO

======================
Closes #4309
