### PR TITLE
Ability to add badge feedback for awarding badges, during assignment grading

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -2,6 +2,9 @@
   AwardedBadgesCtrl = [()->
     vm = this
     vm.BadgeService = BadgeService
+    
+    vm.badgeFeedback = null
+
     BadgeService.getBadges(vm.studentId)
 
     # Has the student currently earned this badge on this grade?
@@ -30,7 +33,10 @@
         BadgeService.deleteEarnedBadge(earnedBadge)
         badge.available_for_student = true
       else
-        BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id)
+        BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id, vm.badgeFeedback)
+
+    vm.setBadgeFeedback = (feedback)->
+      console.log(vm.badgeFeedback)
   ]
 
   {
@@ -38,7 +44,8 @@
     controller: AwardedBadgesCtrl,
     controllerAs: 'vm',
     scope: {
-      studentId: '@'
+      studentId: '@',
+      badgeFeedbackInput: '@'
     },
     templateUrl: 'grades/earned_badges_select.html'
   }

--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -3,9 +3,21 @@
     vm = this
     vm.BadgeService = BadgeService
     
-    vm.badgeFeedback = null
+    #for earned_badge in BadgeService.earnedBadges
+    #  console.log(earnedBadge)
+    #  vm.badgeFeedbackData[earned_badge.badge_id] = earned_badge.feedback
+
+    vm.badgeFeedbackData = BadgeService.earnedBadges
 
     BadgeService.getBadges(vm.studentId)
+
+    vm.setBadgeFeedback = ()->
+      for earned_badge in BadgeService.earnedBadges
+        vm.badgeFeedbackData[earned_badge.badge_id] = earned_badge.feedback
+
+      console.log(vm.badgeFeedbackData)
+
+      return true
 
     # Has the student currently earned this badge on this grade?
     vm.badgeIsEarnedForGrade = (badge)->
@@ -35,8 +47,11 @@
       else
         BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id, vm.badgeFeedback)
 
-    vm.setBadgeFeedback = (feedback)->
-      console.log(vm.badgeFeedback)
+    vm.setBadgeFeedback = (badge)->
+      #console.log(vm.BadgeService.earnedBadgesFeedback[badge.id], badge)
+      return if !vm.badgeIsActionable(badge)
+      if earnedBadge = vm.badgeIsEarnedForGrade(badge)
+        BadgeService.updateEarnedBadge(badge.id, earnedBadge, vm.BadgeService.earnedBadgesFeedback[badge.id])
   ]
 
   {

--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -2,22 +2,8 @@
   AwardedBadgesCtrl = [()->
     vm = this
     vm.BadgeService = BadgeService
-    
-    #for earned_badge in BadgeService.earnedBadges
-    #  console.log(earnedBadge)
-    #  vm.badgeFeedbackData[earned_badge.badge_id] = earned_badge.feedback
-
-    vm.badgeFeedbackData = BadgeService.earnedBadges
 
     BadgeService.getBadges(vm.studentId)
-
-    vm.setBadgeFeedback = ()->
-      for earned_badge in BadgeService.earnedBadges
-        vm.badgeFeedbackData[earned_badge.badge_id] = earned_badge.feedback
-
-      console.log(vm.badgeFeedbackData)
-
-      return true
 
     # Has the student currently earned this badge on this grade?
     vm.badgeIsEarnedForGrade = (badge)->
@@ -48,7 +34,6 @@
         BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id, vm.badgeFeedback)
 
     vm.setBadgeFeedback = (badge)->
-      #console.log(vm.BadgeService.earnedBadgesFeedback[badge.id], badge)
       return if !vm.badgeIsActionable(badge)
       if earnedBadge = vm.badgeIsEarnedForGrade(badge)
         BadgeService.updateEarnedBadge(badge.id, earnedBadge, vm.BadgeService.earnedBadgesFeedback[badge.id])

--- a/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
+++ b/app/assets/javascripts/angular/directives/grades/earned_badges_select.coffee
@@ -2,7 +2,6 @@
   AwardedBadgesCtrl = [()->
     vm = this
     vm.BadgeService = BadgeService
-
     BadgeService.getBadges(vm.studentId)
 
     # Has the student currently earned this badge on this grade?
@@ -31,7 +30,7 @@
         BadgeService.deleteEarnedBadge(earnedBadge)
         badge.available_for_student = true
       else
-        BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id, vm.badgeFeedback)
+        BadgeService.createEarnedBadge(badge.id, vm.studentId, GradeService.grades[0].id)
 
     vm.setBadgeFeedback = (badge)->
       return if !vm.badgeIsActionable(badge)

--- a/app/assets/javascripts/angular/services/BadgeService.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.coffee
@@ -49,8 +49,6 @@
       for earned_badge in earnedBadges
         earnedBadgesFeedback[earned_badge.badge_id] = earned_badge.feedback
 
-      console.log("earned badges", earnedBadgesFeedback)
-
       GradeCraftAPI.setTermFor("badges", response.meta.term_for_badges)
       GradeCraftAPI.setTermFor("badge", response.meta.term_for_badge)
       update.predictions = response.meta.allow_updates
@@ -181,13 +179,12 @@
   #------ Earned Badge Methods ------------------------------------------------#
 
   # currently creates explictly for a student and a grade
-  createEarnedBadge = (badgeId, studentId, gradeId, badgeFeedback)->
+  createEarnedBadge = (badgeId, studentId, gradeId)->
     setBadgeIsUpdating(badgeId)
     requestParams = {
       "student_id": studentId,
       "badge_id": badgeId,
       "grade_id": gradeId,
-      "feedback": badgeFeedback
     }
 
     $http.post('/api/earned_badges/', requestParams).then(

--- a/app/assets/javascripts/angular/services/BadgeService.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.coffee
@@ -180,12 +180,8 @@
 
   #------ Earned Badge Methods ------------------------------------------------#
 
-  EarnedBadges = []
-
   # currently creates explictly for a student and a grade
   createEarnedBadge = (badgeId, studentId, gradeId, badgeFeedback)->
-    console.log(badgeFeedback)
-    
     setBadgeIsUpdating(badgeId)
     requestParams = {
       "student_id": studentId,
@@ -198,7 +194,6 @@
       (response)-> # success
         if response.status == 201
           GradeCraftAPI.addItem(earnedBadges, "earned_badges", response.data)
-          EarnedBadges.push(response.data)
         GradeCraftAPI.logResponse(response)
         setBadgeIsUpdating(badgeId, false)
       ,(response)-> # error
@@ -244,7 +239,7 @@
       badges: badges
       earnedBadges: earnedBadges
       earnedBadgesFeedback: earnedBadgesFeedback
-      
+
       createBadge: createBadge
       queueUpdateBadge: queueUpdateBadge
       submitBadge: submitBadge

--- a/app/assets/javascripts/angular/services/BadgeService.coffee
+++ b/app/assets/javascripts/angular/services/BadgeService.coffee
@@ -174,12 +174,15 @@
   #------ Earned Badge Methods ------------------------------------------------#
 
   # currently creates explictly for a student and a grade
-  createEarnedBadge = (badgeId, studentId, gradeId)->
+  createEarnedBadge = (badgeId, studentId, gradeId, badgeFeedback)->
+    console.log(badgeFeedback)
+    
     setBadgeIsUpdating(badgeId)
     requestParams = {
       "student_id": studentId,
       "badge_id": badgeId,
-      "grade_id": gradeId
+      "grade_id": gradeId,
+      "feedback": badgeFeedback
     }
 
     $http.post('/api/earned_badges/', requestParams).then(

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -23,7 +23,7 @@
       %p.badge-award-name {{badge.name}}
 
   %div(ng-repeat="badge in vm.BadgeService.badges" ng-if="vm.badgeIsEarnedForGrade(badge)"){:style => "margin-top: 40px;"}
-    %p(ng-if="vm.badgeIsEarnedForGrade(badge)")
-      Feedback for {{badge.name}}       
+    %h3(ng-if="vm.badgeIsEarnedForGrade(badge)")
+      Provide feedback for badge {{badge.name}}       
     %textarea(ng-model="vm.BadgeService.earnedBadgesFeedback[badge.id]" ng-model-options="{debounce: 1000}" ng-change="vm.setBadgeFeedback(badge)" ng-if="vm.badgeIsEarnedForGrade(badge)" froala)
 

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -4,21 +4,23 @@
     %span Award {{vm.BadgeService.termFor("badges")}}
 
 %section.badge-index-section.collapse.collapsed
-  %label.badge-award-container(for="{{vm.inputId(badge)}}"
-    ng-repeat="badge in vm.BadgeService.badges"
-    ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
-    )
-    .badge-award-checkmark
-      %input(id="{{vm.inputId(badge)}}"
-      ng-if="vm.badgeIsActionable(badge)"
-      type="checkbox"
-      ng-checked="vm.badgeIsEarnedForGrade(badge)"
-      ng-click="vm.awardBadge(badge)")
+  %div.badge-list
+    %label.badge-award-container(for="{{vm.inputId(badge)}}"
+      ng-repeat="badge in vm.BadgeService.badges"
+      ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
+      )
+      
+      .badge-award-checkmark
+        %input(id="{{vm.inputId(badge)}}"
+        ng-if="vm.badgeIsActionable(badge)"
+        type="checkbox"
+        ng-checked="vm.badgeIsEarnedForGrade(badge)"
+        ng-click="vm.awardBadge(badge)")
 
-    .img-cropper.small-crop
-      %img(ng-src="{{badge.icon}}" alt="")
+      .img-cropper.small-crop
+        %img(ng-src="{{badge.icon}}" alt="")
 
-    %p.badge-award-name {{badge.name}}
+      %p.badge-award-name {{badge.name}}
 
   %div(ng-repeat="badge in vm.BadgeService.badges" ng-if="vm.badgeIsEarnedForGrade(badge)"){:style => "margin-top: 40px;"}
     %p(ng-if="vm.badgeIsEarnedForGrade(badge)")

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -4,23 +4,24 @@
     %span Award {{vm.BadgeService.termFor("badges")}}
 
 %section.badge-index-section.collapse.collapsed
-  %textarea(ng-model="vm.badgeFeedback" froala)
-
   %label.badge-award-container(for="{{vm.inputId(badge)}}"
-  ng-repeat="badge in vm.BadgeService.badges"
-  ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
-  )
+    ng-repeat="badge in vm.BadgeService.badges"
+    ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
+    )
     .badge-award-checkmark
       %input(id="{{vm.inputId(badge)}}"
       ng-if="vm.badgeIsActionable(badge)"
       type="checkbox"
       ng-checked="vm.badgeIsEarnedForGrade(badge)"
-      ng-click="vm.awardBadge(badge)"
-    )
-    .badge-award-image
-      .img-cropper.small-crop
-        %img(ng-src="{{badge.icon}}" alt="")
+      ng-click="vm.awardBadge(badge)")
 
-    .badge-award-name {{badge.name}}
+    .img-cropper.small-crop
+      %img(ng-src="{{badge.icon}}" alt="")
 
-.clear
+    %p.badge-award-name {{badge.name}}
+
+  %div(ng-repeat="badge in vm.BadgeService.badges" ng-if="vm.badgeIsEarnedForGrade(badge)"){:style => "margin-top: 40px;"}
+    %p(ng-if="vm.badgeIsEarnedForGrade(badge)")
+      Feedback for {{badge.name}}       
+    %textarea(ng-model="vm.BadgeService.earnedBadgesFeedback[badge.id]" ng-model-options="{debounce: 1000}" ng-change="vm.setBadgeFeedback(badge)" ng-if="vm.badgeIsEarnedForGrade(badge)" froala)
+

--- a/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
+++ b/app/assets/javascripts/angular/templates/grades/earned_badges_select.html.haml
@@ -4,6 +4,8 @@
     %span Award {{vm.BadgeService.termFor("badges")}}
 
 %section.badge-index-section.collapse.collapsed
+  %textarea(ng-model="vm.badgeFeedback" froala)
+
   %label.badge-award-container(for="{{vm.inputId(badge)}}"
   ng-repeat="badge in vm.BadgeService.badges"
   ng-class='{"unavailable":!vm.badgeIsActionable(badge), "awardable":vm.badgeIsAwardable(badge), "awarded":vm.badgeIsEarnedForGrade(badge)}'
@@ -20,4 +22,5 @@
         %img(ng-src="{{badge.icon}}" alt="")
 
     .badge-award-name {{badge.name}}
+
 .clear

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -156,8 +156,9 @@ ul.earned-badge-list
     padding: 0
 
 .badge-list
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  display: grid
+  grid-template-columns: repeat(4, 1fr)
+  
 .badge-award-checkmark
   input
     cursor: pointer

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -139,8 +139,6 @@ ul.earned-badge-list
 
 // Award Earned Badges on Grading Page
 .badge-award-container
-  //float: left
-  //width: 30%
   vertical-align: top
   cursor: pointer
   display: flex

--- a/app/assets/stylesheets/pages/_badges.sass
+++ b/app/assets/stylesheets/pages/_badges.sass
@@ -139,8 +139,8 @@ ul.earned-badge-list
 
 // Award Earned Badges on Grading Page
 .badge-award-container
-  float: left
-  width: 30%
+  //float: left
+  //width: 30%
   vertical-align: top
   cursor: pointer
   display: flex
@@ -157,6 +157,9 @@ ul.earned-badge-list
     width: 48%
     padding: 0
 
+.badge-list
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
 .badge-award-checkmark
   input
     cursor: pointer

--- a/app/controllers/api/earned_badges_controller.rb
+++ b/app/controllers/api/earned_badges_controller.rb
@@ -29,6 +29,22 @@ class API::EarnedBadgesController < ApplicationController
     end
   end
 
+  def update    
+    @earned_badge = EarnedBadge.find(params[:id])
+
+    if @earned_badge.nil?
+      render json: { message: "Earned badge could not be updated", success: false },
+        status: 400
+    end
+
+    @earned_badge.feedback = params[:feedback]
+    
+    @earned_badge.save
+
+    render json: { message: "Earned badge feedback updated", success: true },
+        status: 200
+  end
+
   # DELETE /api/earned_badges/:id
   def destroy
     earned_badge = EarnedBadge.where(id: params[:id]).first

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -496,7 +496,8 @@ Rails.application.routes.draw do
       get :due_this_week, on: :collection
     end
 
-    resources :earned_badges, only: [:create, :destroy]
+    resources :earned_badges, only: [:create, :update, :destroy]
+
     get "courses/:course_id/badges/:badge_id/earned_badges/:id/confirm_earned", to: "earned_badges#confirm_earned",
       as: :earned_badge_confirm
 


### PR DESCRIPTION
### Status
**READY**

### Description
* When grading an assignment as an instructor it should be possible to leave feedback for awarding a badge without leaving the assignment grading view
* Now awarding a badge for a student while grading an assignment displays a text input for providing feedback for the badge. Any existing feedback for a badge can also be edited in this view.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, grade an assignment and award a badge to a student. Once the checkbox for a badge has been selected, a text box will appear below the list of badges for entering feedback about the badge that was awarded.

### Impacted Areas in Application
* "Award Badges" section wile grading an assignment (i.e.directives/grades/earned_badges_select.coffee, /services/BadgeService.coffee, app/controllers/api/earned_badges_controller.rb)
* config/routes.rb for updating feedback for EarnedBadges using PUT api/earned_badges/<id>
======================
Closes #4314 