### PR TITLE
Assignment analytics empty state

### DIFF
--- a/app/helpers/info_helper.rb
+++ b/app/helpers/info_helper.rb
@@ -1,0 +1,10 @@
+module InfoHelper
+    def any_one_assignment_has_two_submissions?(assignment_types)
+        assignment_types.each do |assignment_type|
+            if assignment_type.assignments.select {|a| a.grades.student_visible.length > 1}.present?
+                return true
+            end
+        end
+        return false
+    end
+end

--- a/app/helpers/info_helper.rb
+++ b/app/helpers/info_helper.rb
@@ -1,10 +1,10 @@
 module InfoHelper
-    def any_one_assignment_has_two_submissions?(assignment_types)
-        assignment_types.each do |assignment_type|
-            if assignment_type.assignments.select {|a| a.grades.student_visible.length > 1}.present?
-                return true
-            end
-        end
-        return false
-    end
+  def any_one_assignment_has_two_submissions?(assignment_types)
+    assignment_types.each do |assignment_type|
+      if assignment_type.assignments.select {|a| a.grades.student_visible.length > 1}.present?
+        return true
+      end
+    end    
+    return false
+  end
 end

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -7,7 +7,7 @@
     %p
       There are currently no assignments in this course; add an assignment to see analytics.
 
-  - if !any_one_assignment_has_two_submissions?(@assignment_types)
+  - if @course.assignments.length > 0 && !any_one_assignment_has_two_submissions?(@assignment_types)
     %p
       No assignment currently has more than one graded assignment visible to students; grade and release more assignments to see analytics.
   

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -6,11 +6,7 @@
   - if @assignment_types.length == 0 || @course.assignments.length == 0
     %p
       There are currently no assignments in this course; add an assignment to see analytics.
-  
-  - if Grade.find_by(course_id: @course.id).nil?
-    %p
-      There are currently no assignments with grades in this course; grade an assignment to see analytics.
-  
+
   - if !any_one_assignment_has_two_submissions?(@assignment_types)
     %p
       No assignment currently has more than one graded assignment visible to students; grade and release more assignments to see analytics.

--- a/app/views/info/per_assign.html.haml
+++ b/app/views/info/per_assign.html.haml
@@ -3,14 +3,18 @@
 
   = render partial: "analytics/in_page_nav"
 
-  - if @assignment_types.length == 0
+  - if @assignment_types.length == 0 || @course.assignments.length == 0
     %p
-      There are currently no assignment types for this course, add an assignment type and then create assignments to see analytics.
-
-  - if @assignment_types.length > 0 && @course.assignments.length == 0
+      There are currently no assignments in this course; add an assignment to see analytics.
+  
+  - if Grade.find_by(course_id: @course.id).nil?
     %p
-      There are currently no assignments for this course, add an assignment to see analytics.
-
+      There are currently no assignments with grades in this course; grade an assignment to see analytics.
+  
+  - if !any_one_assignment_has_two_submissions?(@assignment_types)
+    %p
+      No assignment currently has more than one graded assignment visible to students; grade and release more assignments to see analytics.
+  
   - @assignment_types.each do |assignment_type|
     - assignments_for_type = assignment_type.assignments
     - if assignments_for_type.select {|a| a.grades.student_visible.length > 1}.present?


### PR DESCRIPTION
### Status
**READY**

### Description
* When viewing the assignment analytics page as an instructor for a course in which assignment analytics cannot be displayed, the view remained blank.
* Now, messages are displayed to the instructor, indicating why assignment analytics cannot be shown.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, visit the assignment analytics page (i.e. /per_assign) in a course with no assignment types and/or a course with no assignments. A message that reads "There are currently no assignments in this course; add an assignment to see analytics." is displayed.
2. As an instructor, visit the assignment analytics page (i.e. /per_assign) in a course which has no more than one graded submission per assignment (in any assignment type). A message that reads "No assignment currently has more than one graded assignment visible to students; grade and release more assignments to see analytics." is displayed.

### Impacted Areas in Application
* Assignment analytics view (i.e. /per_assign) (views/info/per_assign.html.haml)
* Added a helper helpers/info_helper.rb for checking an empty condition for the assignment analytics page
======================
Closes #4291 
