### PR TITLE
removing tempory fix where condition that checks if student visible i…

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -171,7 +171,7 @@ class Assignment < ApplicationRecord
   end
 
   def has_grades?
-    grades.where(student_visible: true).exists?
+    grades.exists?
   end
 
   def has_unlock_condition?


### PR DESCRIPTION
…s true because grades are getting deleted from the assignment_type table

### Status
**HOLD**

### Description
removing tempory fix where condition that checks if student visible is true because grades are getting deleted from the assignment_type table.

On hold to for cleanup time happens where we check for old deleted grades and delete them from the assignment_type table.

Retroactive Fix

### Related PRs
Other Clean-up PRs: 



### Todos
- [ ] Remove deleted grades from assignment type table 

### Migrations
NO


### Impacted Areas in Application
List general components of the application that this PR will affect:

* Assignment type grades

======================
Closes #[ISSUE NUMBER]
