### PR TITLE
Send email notifications to instructors when a student submits or updates an assignment

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -222,7 +222,7 @@ class CoursesController < ApplicationController
       :team_score_average, :has_team_challenges, :team_leader_term,
       :max_assignment_types_weighted, :full_points, :has_in_team_leaderboards,
       :grade_scheme_elements_attributes, :add_team_score_to_student,
-      :assignments_attributes, :start_date, :end_date,
+      :assignments_attributes, :start_date, :end_date, :assignment_submitted_notification, :assignment_revised_notification,
       unlock_conditions_attributes: [:id, :unlockable_id, :unlockable_type, :condition_id,
         :condition_type, :condition_state, :condition_value, :condition_date, :_destroy],
       instructors_of_record_ids: [], course_memberships_attributes: [:id, :course_id, :user_id, :instructor_of_record]

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -127,8 +127,21 @@ class SubmissionsController < ApplicationController
   def send_notification(submission_id, submission_was_draft)
     if submission_was_draft
       NotificationMailer.successful_submission(submission_id).deliver_now
+
+      if @assignment.course.assignment_submitted_notification?
+        @assignment.course.staff.each do |professor|
+          NotificationMailer.new_submission(submission_id, professor).deliver_now
+        end
+      end
+
     else
       NotificationMailer.updated_submission(submission_id).deliver_now
+
+      if @assignment.course.assignment_revised_notification?
+        @assignment.course.staff.each do |professor|
+          NotificationMailer.revised_submission(submission_id, professor).deliver_now
+        end
+      end
     end
   end
 

--- a/app/views/courses/_custom_terms.haml
+++ b/app/views/courses/_custom_terms.haml
@@ -44,3 +44,16 @@
       - if current_course.allows_learning_objectives? && current_course.uses_learning_objectives?
         = f.input :learning_objective_term, label: "Learning Objective", hint: "What should learning objectives be called?", as: :select,
           collection: Course.learning_objective_terms.keys.to_a, include_blank: false
+
+%section.form-section
+  %h2.form-title Email Settings
+  .form-item
+    = f.check_box :assignment_submitted_notification
+    = f.label :assignment_submitted_notification, "Assignment Submitted Notification", {"aria-describedby" => "assignmentSubmittedNotification"}
+    .form-hint{id: "assignmentSubmittedNotification"} Send an email notification to instructors when an assignment is submitted by a student
+
+  .form-item
+    = f.check_box :assignment_revised_notification
+    = f.label :assignment_revised_notification, "Assignment Revised Notification", {"aria-describedby" => "assignmentRevisedNotification"}
+    .form-hint{id: "assignmentRevisedNotification"} Send an email notification to instructors when an assignment is revised by a student
+

--- a/db/migrate/20190628151658_add_assignment_revised_notification_to_course.rb
+++ b/db/migrate/20190628151658_add_assignment_revised_notification_to_course.rb
@@ -1,0 +1,5 @@
+class AddAssignmentRevisedNotificationToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses, :assignment_revised_notification, :boolean
+  end
+end

--- a/db/migrate/20190628173258_add_assignment_submitted_notification_to_course.rb
+++ b/db/migrate/20190628173258_add_assignment_submitted_notification_to_course.rb
@@ -1,0 +1,5 @@
+class AddAssignmentSubmittedNotificationToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses, :assignment_submitted_notification, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_04_204001) do
+ActiveRecord::Schema.define(version: 2019_06_28_151658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -366,7 +366,8 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.boolean "objectives_award_points", default: false, null: false
     t.boolean "always_show_objectives", default: false, null: false
     t.boolean "allows_learning_objectives", default: false, null: false
-    t.boolean "disable_grade_emails", default: false
+    t.boolean "assignment_submitted_notification", default: false, null: false
+    t.boolean "assignment_revised_notification", default: false, null: false
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_28_151658) do
+ActiveRecord::Schema.define(version: 2019_06_28_173258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -366,8 +366,9 @@ ActiveRecord::Schema.define(version: 2019_06_28_151658) do
     t.boolean "objectives_award_points", default: false, null: false
     t.boolean "always_show_objectives", default: false, null: false
     t.boolean "allows_learning_objectives", default: false, null: false
-    t.boolean "assignment_submitted_notification", default: false, null: false
-    t.boolean "assignment_revised_notification", default: false, null: false
+    t.boolean "disable_grade_emails", default: false
+    t.boolean "assignment_revised_notification"
+    t.boolean "assignment_submitted_notification"
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
 


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
* When a student submits or updates an assignment, the instructors of the course should receive an email notification.
* Now, a setting has been added in the "Advanced Settings" tab in course settings for enabling assignment submission / update emails.

### Related PRs
#4284 

### Deploy Notes
* Two migrations have been made (#20190628151658: Add assignment revised notification to course, #20190628173258: Add assignment submitted notification to course) for adding the boolean values for keeping track of the email notification preference for the instructors.

### Migrations
YES

### Steps to Test or Reproduce
1. As an instructor, go to course settings. Under the advanced tab check the "Assignment Submitted Notification" and "Assignment Revised Notification" in the Email Settings section.
2. As a student, submit and update an assignment. The instructors in the course should receive an email when the student submits and updates the assignment.

### Impacted Areas in Application
* Course model for adding boolean values for keeping track of the email notification preference as a course wide setting
* controllers/submissions_controller for sending the notification emails

======================
