### PR TITLE
Fixed style for badges sidebar in student view

### DIFF
--- a/app/assets/stylesheets/layout/_student_sidebar.sass
+++ b/app/assets/stylesheets/layout/_student_sidebar.sass
@@ -41,7 +41,7 @@
 
   .student-panel-article
     z-index: 50
-    position: fixed
+    position: relative
     width: 400px
     height: 100vh
     overflow-y: scroll


### PR DESCRIPTION
### Status
**READY**

### Description
* Changed positioning for badges sidebar from fixed to relative to prevent it from overlapping with the page footer when viewing badges as a student.

### Migrations
NO

### Steps to Test or Reproduce
1. As a student, visiting the badges page and click on a badge. The sidebar should appear with the footer below it.

![image](https://user-images.githubusercontent.com/33792934/60343026-0a0d8580-9981-11e9-9d21-18ff9890a69f.png)

### Impacted Areas in Application
* Viewing badges as a student

======================
Closes #4325
