### PR TITLE
Allow students to delete student-logged grades for an assignment

### DIFF
--- a/app/controllers/api/assignments_controller.rb
+++ b/app/controllers/api/assignments_controller.rb
@@ -103,7 +103,9 @@ class API::AssignmentsController < ApplicationController
         course_id: @assignment.course_id
     end unless assignment_params[:linked_objective_ids].nil?
 
-    @assignment.learning_objective_links.where.not(id: links.pluck(:id)).destroy_all if @assignment.learning_objective_links.any?
+    if !links.nil?
+      @assignment.learning_objective_links.where.not(id: links.pluck(:id)).destroy_all if @assignment.learning_objective_links.any?
+    end
   end
 
   def assignment_params

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -140,7 +140,7 @@ class Assignments::GradesController < ApplicationController
 
     if !@assignment.open? || !@assignment.student_logged?
       redirect_to assignments_path,
-          notice: "You cannot edit the grade for this assignment as it is no longer open or is not student logged."
+          notice: "You cannot edit the grade for this assignment because it is not open or not student logged."
     end
 
     @grade = Grade.find_by(assignment_id: @assignment.id, student_id: current_student.id)

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -4,7 +4,7 @@ class Assignments::GradesController < ApplicationController
   before_action :ensure_staff?, except: [:self_log, :delete_self_logged]
   before_action :ensure_student?, only: [:self_log, :delete_self_logged]
   before_action :find_assignment, only: [:mass_edit, :mass_update, :self_log, :delete_self_logged, :delete_all]
-  before_action :use_current_course, only: [:mass_edit, :mass_update]
+  before_action :use_current_course, only: [:mass_edit, :mass_update, :delete_self_logged]
 
   # GET /assignments/:assignment_id/grades/export
   # Sends a CSV file to the user with the current grades for all students
@@ -133,6 +133,11 @@ class Assignments::GradesController < ApplicationController
   end
 
   def delete_self_logged
+    if !current_course.delete_student_logged_grade
+      redirect_to assignments_path,
+        notice: "Ask an instructor in this course to allow you to delete student logged grades."
+    end
+
     if !@assignment.open? || !@assignment.student_logged?
       redirect_to assignments_path,
           notice: "You cannot edit the grade for this assignment as it is no longer open / is not student logged."

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -140,7 +140,7 @@ class Assignments::GradesController < ApplicationController
 
     if !@assignment.open? || !@assignment.student_logged?
       redirect_to assignments_path,
-          notice: "You cannot edit the grade for this assignment as it is no longer open / is not student logged."
+          notice: "You cannot edit the grade for this assignment as it is no longer open or is not student logged."
     end
 
     @grade = Grade.find_by(assignment_id: @assignment.id, student_id: current_student.id)

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -210,7 +210,7 @@ class CoursesController < ApplicationController
       :course_number, :name, :semester, :year, :has_badges, :has_teams,
       :has_learning_objectives, :learning_objective_term, :objectives_award_points, :always_show_objectives,
       :team_term, :student_term, :section_leader_term, :group_term, :lti_uid,
-      :user_id, :course_id, :course_rules, :dashboard_message, :syllabus, :has_multipliers,
+      :user_id, :course_id, :course_rules, :dashboard_message, :delete_student_logged_grade, :syllabus, :has_multipliers,
       :has_character_names, :has_team_roles, :has_character_profiles, :show_analytics, :show_grade_predictor,
       :total_weights, :weights_close_at, :has_public_badges,
       :assignment_weight_type, :has_submissions, :teams_visible,

--- a/app/views/courses/_advanced_settings.haml
+++ b/app/views/courses/_advanced_settings.haml
@@ -1,3 +1,4 @@
 .form-wrapper
   = render partial: "courses/custom_terms", locals: { f: f }
   = render partial: "courses/player_settings", locals: { f: f }
+  = render partial: "courses/assignment_settings", locals: { f: f }

--- a/app/views/courses/_assignment_settings.html.haml
+++ b/app/views/courses/_assignment_settings.html.haml
@@ -1,0 +1,6 @@
+%section.form-section
+  %h2.form-title Assignment Settings
+  .form-item
+    = f.check_box :delete_student_logged_grade, {"aria-describedby" => "txtAssignmentDeleteStudentLoggedGrades"}
+    = f.label :delete_student_logged_grade, "Delete Student Logged Grades"
+    .form-hint{id: "txtAssignmentDeleteStudentLoggedGrades"} Are students allowed to delete grades that they log in a student-logged assignment?

--- a/app/views/grades/_grade_content.haml
+++ b/app/views/grades/_grade_content.haml
@@ -29,7 +29,7 @@
 - if grade.feedback.present?
   = render partial: "grades/components/feedback", locals: { grade: grade }
 
-- if grade.assignment.student_logged?
+- if current_course.delete_student_logged_grade && grade.assignment.student_logged?
   = render partial: "grades/components/delete_self_logged", locals: { grade: grade }
 
 - if grade.earned_badges.present?

--- a/app/views/grades/_grade_content.haml
+++ b/app/views/grades/_grade_content.haml
@@ -29,6 +29,9 @@
 - if grade.feedback.present?
   = render partial: "grades/components/feedback", locals: { grade: grade }
 
+- if grade.assignment.student_logged?
+  = render partial: "grades/components/delete_self_logged", locals: { grade: grade }
+
 - if grade.earned_badges.present?
   = render partial: "grades/components/badges", locals: { grade: grade }
 

--- a/app/views/grades/components/_delete_self_logged.haml
+++ b/app/views/grades/components/_delete_self_logged.haml
@@ -1,0 +1,3 @@
+%p
+  = simple_form_for grade.assignment, url: delete_self_logged_assignment_grades_path(grade.assignment.id), method: :delete do |f|
+    = f.submit "Delete self logged grade", class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
         get :mass_edit
         put :mass_update
         post :self_log
+        delete :delete_self_logged
         delete :delete_all
       end
     end

--- a/db/migrate/20190709192921_add_delete_student_logged_grade_to_course.rb
+++ b/db/migrate/20190709192921_add_delete_student_logged_grade_to_course.rb
@@ -1,0 +1,5 @@
+class AddDeleteStudentLoggedGradeToCourse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses, :delete_student_logged_grade, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -367,9 +367,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
     t.boolean "always_show_objectives", default: false, null: false
     t.boolean "allows_learning_objectives", default: false, null: false
     t.boolean "disable_grade_emails", default: false
-    t.boolean "assignment_revised_notification"
-    t.boolean "assignment_submitted_notification"
-    t.integer "license_id"
     t.boolean "delete_student_logged_grade", default: true
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
@@ -606,7 +603,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order"
-    t.boolean "default_level"
     t.index ["objective_id"], name: "index_learning_objective_levels_on_objective_id"
   end
 
@@ -673,26 +669,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
     t.index ["criterion_id"], name: "index_levels_on_criterion_id"
   end
 
-  create_table "license_types", force: :cascade do |t|
-    t.string "name", null: false
-    t.integer "default_max_courses"
-    t.integer "default_max_students"
-    t.integer "default_duration_months"
-    t.decimal "price_usd"
-    t.boolean "hide", default: false, null: false
-  end
-
-  create_table "licenses", force: :cascade do |t|
-    t.bigint "user_id"
-    t.integer "license_type_id", null: false
-    t.integer "max_courses"
-    t.integer "max_students"
-    t.datetime "expires", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_licenses_on_user_id"
-  end
-
   create_table "linked_courses", force: :cascade do |t|
     t.integer "course_id"
     t.string "provider"
@@ -711,26 +687,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
     t.string "launch_url"
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  create_table "payments", force: :cascade do |t|
-    t.bigint "license_id"
-    t.string "first_name", null: false
-    t.string "last_name", null: false
-    t.string "organization", null: false
-    t.string "phone", null: false
-    t.string "addr1", null: false
-    t.string "addr2"
-    t.string "city", null: false
-    t.string "state"
-    t.string "zip"
-    t.string "country", null: false
-    t.string "source", null: false
-    t.string "confirmation"
-    t.decimal "amount_usd", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["license_id"], name: "index_payments_on_license_id"
   end
 
   create_table "predicted_earned_badges", force: :cascade do |t|
@@ -976,7 +932,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
     t.boolean "admin", default: false
     t.string "time_zone", default: "Eastern Time (US & Canada)"
     t.boolean "received_resources", default: false, null: false
-    t.boolean "show_guide", default: true
     t.index ["activation_token"], name: "index_users_on_activation_token"
     t.index ["current_course_id"], name: "index_users_on_current_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -1016,7 +971,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
   add_foreign_key "announcements", "users", column: "author_id"
   add_foreign_key "announcements", "users", column: "recipient_id"
   add_foreign_key "courses", "institutions"
-  add_foreign_key "courses", "licenses"
   add_foreign_key "earned_badges", "users", column: "awarded_by_id"
   add_foreign_key "flagged_users", "courses"
   add_foreign_key "flagged_users", "users", column: "flagged_id"
@@ -1031,10 +985,7 @@ ActiveRecord::Schema.define(version: 2019_07_09_192921) do
   add_foreign_key "learning_objective_observed_outcomes", "learning_objective_cumulative_outcomes", column: "learning_objective_cumulative_outcomes_id"
   add_foreign_key "learning_objectives", "courses"
   add_foreign_key "learning_objectives", "learning_objective_categories", column: "category_id"
-  add_foreign_key "licenses", "license_types"
-  add_foreign_key "licenses", "users"
   add_foreign_key "linked_courses", "courses"
-  add_foreign_key "payments", "licenses"
   add_foreign_key "secure_tokens", "courses"
   add_foreign_key "secure_tokens", "users"
   add_foreign_key "user_authorizations", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_04_204001) do
+ActiveRecord::Schema.define(version: 2019_07_09_192921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -367,6 +367,10 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.boolean "always_show_objectives", default: false, null: false
     t.boolean "allows_learning_objectives", default: false, null: false
     t.boolean "disable_grade_emails", default: false
+    t.boolean "assignment_revised_notification"
+    t.boolean "assignment_submitted_notification"
+    t.integer "license_id"
+    t.boolean "delete_student_logged_grade", default: true
     t.index ["institution_id"], name: "index_courses_on_institution_id"
   end
 
@@ -602,6 +606,7 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order"
+    t.boolean "default_level"
     t.index ["objective_id"], name: "index_learning_objective_levels_on_objective_id"
   end
 
@@ -668,6 +673,26 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.index ["criterion_id"], name: "index_levels_on_criterion_id"
   end
 
+  create_table "license_types", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "default_max_courses"
+    t.integer "default_max_students"
+    t.integer "default_duration_months"
+    t.decimal "price_usd"
+    t.boolean "hide", default: false, null: false
+  end
+
+  create_table "licenses", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "license_type_id", null: false
+    t.integer "max_courses"
+    t.integer "max_students"
+    t.datetime "expires", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_licenses_on_user_id"
+  end
+
   create_table "linked_courses", force: :cascade do |t|
     t.integer "course_id"
     t.string "provider"
@@ -686,6 +711,26 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.string "launch_url"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.bigint "license_id"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "organization", null: false
+    t.string "phone", null: false
+    t.string "addr1", null: false
+    t.string "addr2"
+    t.string "city", null: false
+    t.string "state"
+    t.string "zip"
+    t.string "country", null: false
+    t.string "source", null: false
+    t.string "confirmation"
+    t.decimal "amount_usd", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["license_id"], name: "index_payments_on_license_id"
   end
 
   create_table "predicted_earned_badges", force: :cascade do |t|
@@ -931,6 +976,7 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
     t.boolean "admin", default: false
     t.string "time_zone", default: "Eastern Time (US & Canada)"
     t.boolean "received_resources", default: false, null: false
+    t.boolean "show_guide", default: true
     t.index ["activation_token"], name: "index_users_on_activation_token"
     t.index ["current_course_id"], name: "index_users_on_current_course_id"
     t.index ["email"], name: "index_users_on_email", unique: true
@@ -970,6 +1016,7 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
   add_foreign_key "announcements", "users", column: "author_id"
   add_foreign_key "announcements", "users", column: "recipient_id"
   add_foreign_key "courses", "institutions"
+  add_foreign_key "courses", "licenses"
   add_foreign_key "earned_badges", "users", column: "awarded_by_id"
   add_foreign_key "flagged_users", "courses"
   add_foreign_key "flagged_users", "users", column: "flagged_id"
@@ -984,7 +1031,10 @@ ActiveRecord::Schema.define(version: 2019_01_04_204001) do
   add_foreign_key "learning_objective_observed_outcomes", "learning_objective_cumulative_outcomes", column: "learning_objective_cumulative_outcomes_id"
   add_foreign_key "learning_objectives", "courses"
   add_foreign_key "learning_objectives", "learning_objective_categories", column: "category_id"
+  add_foreign_key "licenses", "license_types"
+  add_foreign_key "licenses", "users"
   add_foreign_key "linked_courses", "courses"
+  add_foreign_key "payments", "licenses"
   add_foreign_key "secure_tokens", "courses"
   add_foreign_key "secure_tokens", "users"
   add_foreign_key "user_authorizations", "users"


### PR DESCRIPTION
### Status
**READY**

### Description
* When a grade has been logged by a student for an assignment, it should be possible for them to delete the grade. Currently this is not possible and the instructor is required to delete the grade logged by the student if they want to resubmit the grade.
* Now a setting has been added under the "Advanced" tab in Course Settings that enables students to delete student logged grades for an assignment. A button that enables students to delete the grade they logged appears after they submit a grade. After they delete the grade they logged they can resubmit their grade as normal. They are allowed to repeat this as long as the assignment is open.

![image](https://user-images.githubusercontent.com/33792934/60919265-4e433480-a263-11e9-9686-65eeb8373ab3.png)

![image](https://user-images.githubusercontent.com/33792934/60919298-60bd6e00-a263-11e9-8c95-731324569047.png)

### Deploy Notes
* A boolean value called delete_student_logged_grade has been added to the Course model to track whether or not the instructors allow students to delete student logged grades.

### Migrations
YES

### Steps to Test or Reproduce
1. As an instructor, create an assignment and mark it as student logged. Ensure that the "Delete Student Logged Grades" setting  under the "Advanced" tab in Course Settings is checked.
2. As a student submit a grade for the assignment. Visit the submitted grade for the assignment (i.e. visit /assignments/\<id\>), you will see a button that says "Delete self-logged grade". Clicking the button will delete the grade that was submitted and will enable you to submit a grade for the assignment again.

### Impacted Areas in Application
* Course Model 
* Assignment Grades controller (i.e. controllers/assignments/grades_controller.rb)
* Course settings
* Viewing a grade as a student 

======================
Closes #4237 
