### PR TITLE
Student logged grades should not be submitted without an outcome level selected

### DIFF
--- a/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
+++ b/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
@@ -1,0 +1,12 @@
+var SelfGradeOutcomesSelect = document.querySelector("select");
+var SelfGradeOutcomesButton = document.querySelector(".self_grade_outcomes_button");
+
+if(SelfGradeOutcomesSelect && SelfGradeOutcomesSelect){
+    SelfGradeOutcomesSelect.addEventListener("change", function(){
+        if(SelfGradeOutcomesSelect.selectedIndex == 0)
+            SelfGradeOutcomesButton.disabled = true;
+
+        else
+            SelfGradeOutcomesButton.disabled = false;
+    });
+}

--- a/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
+++ b/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
@@ -1,3 +1,6 @@
+//Selectively disables the "Submit" button for student logged assignments, if the
+//assignment has outcome levels and no outcome level is selected.
+
 var SelfGradeOutcomesSelect = document.querySelector("select");
 var SelfGradeOutcomesButton = document.querySelector(".self_grade_outcomes_button");
 

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -107,7 +107,7 @@ class Assignments::GradesController < ApplicationController
         redirect_back fallback_location: assignments_path,
           notice: "We're sorry, there was an error saving your grade."
 
-          return
+        return
       end
 
       @grade.assign_attributes(

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -104,7 +104,10 @@ class Assignments::GradesController < ApplicationController
       elsif params[:grade].present? && params[:grade][:pass_fail_status].present?
         @grade.pass_fail_status = params[:grade][:pass_fail_status]
       else
-        @grade.raw_points = @assignment.full_points
+        redirect_back fallback_location: assignments_path,
+          notice: "We're sorry, there was an error saving your grade."
+
+          return
       end
 
       @grade.assign_attributes(

--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -103,6 +103,8 @@ class Assignments::GradesController < ApplicationController
         @grade.raw_points = params[:grade][:raw_points]
       elsif params[:grade].present? && params[:grade][:pass_fail_status].present?
         @grade.pass_fail_status = params[:grade][:pass_fail_status]
+      elsif !@assignment.assignment_score_levels.exists?
+        @grade.raw_points = @assignment.full_points
       else
         redirect_back fallback_location: assignments_path,
           notice: "We're sorry, there was an error saving your grade."

--- a/app/views/assignments/_self_log_form.html.haml
+++ b/app/views/assignments/_self_log_form.html.haml
@@ -2,10 +2,10 @@
   - if ! student.self_reported_done?(assignment)
     %h3.uppercase Self Log your outcome:
     - if assignment.has_levels?
-      = f.select :raw_points, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.points] }, :prompt => "Select your outcome"
-      = f.submit "Submit", class: "button success"
+      = f.select :raw_points, assignment.assignment_score_levels.map { |l| [l.formatted_name,l.points] }, prompt: "Select your outcome"
+      = f.submit "Submit", class: "button success self_grade_outcomes_button", disabled: true
     - elsif assignment.pass_fail?
       = f.select :pass_fail_status, [[term_for(:pass), "Pass"], [term_for(:fail), "Fail"]], prompt: "Select your outcome"
-      = f.submit "Submit", class: "button success"
+      = f.submit "Submit", class: "button success self_grade_outcomes_button", disabled: true
     - else
       = f.submit "I have completed this #{term_for :assignment}", class: "button success"

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -198,14 +198,14 @@ describe Assignments::GradesController do
       context "with a student loggable grade" do
         before(:each) { assignment.update(student_logged: true) }
 
-        it "creates a maximum score by the student if present" do
-          post :self_log, params: { assignment_id: assignment.id }
+        it "creates a maximum score by the student if present only if raw_points are set" do
+          post :self_log, params: { assignment_id: assignment.id, grade: { raw_points: assignment.full_points } } 
           grade = student.grade_for_assignment(assignment)
           expect(grade.raw_points).to eq assignment.full_points
         end
 
         it "updates the attributes on the grade" do
-          post :self_log, params: { assignment_id: assignment.id }
+          post :self_log, params: { assignment_id: assignment.id, grade: { raw_points: assignment.full_points } }
           grade = student.grade_for_assignment(assignment)
           grade.reload
           expect(grade.instructor_modified).to eq true


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
* Submitting a student logged grade as a student should not be allowed if there are outcome levels to be selected or if the assignment is pass/fail. Currently, submitting a grade without selecting any outcome levels results in a student logged grade with all the points for the assignment, even if full points isn't specified in one of the outcome levels listed.
* Now, a grade with outcome levels cannot be submitted without selecting an outcome level and the submit button for the student logged grade is disabled until an outcome level is selected.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor create an assignment that is student-logged and has two outcome levels
2. As a student try to submit the assignment without any outcome levels selected. This should not be possible.

### Impacted Areas in Application
* Grades controller (i.e. /controllers/assignments/grades_controller.rb)
* Submitting a student logged grade

======================
Closes #4335 
