### PR TITLE
Updates mini_magick gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem 'jquery-rails'
 gem 'light-service'
 
 gem 'multi_json'
-gem 'mini_magick'
+gem 'mini_magick', '~> 4.9.4'
 gem 'mongoid', '~> 6.0.0'
 gem 'namae'
 gem 'ng-rails-csrf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
-    mini_magick (4.9.2)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -678,7 +678,7 @@ DEPENDENCIES
   launchy
   light-service
   lol_dba
-  mini_magick
+  mini_magick (~> 4.9.4)
   mongoid (~> 6.0.0)
   multi_json
   namae


### PR DESCRIPTION
### Status
**READY**

### Description
Addresses a security issue github found for the mini_magick gem

### Todos
- [x] Devs run `bundle` 

### Gem dependencies
upgraded the patch version from 4.9.2 to 4.9.5 (makes sure that you are above the 4.9.4 version)

### Migrations
NO

* Gemfile and Gemfile.lock

