### PR TITLE
Ability for instructors to delete students even if they have a grade

### DIFF
--- a/app/assets/javascripts/angular/services/CourseMembershipService.coffee
+++ b/app/assets/javascripts/angular/services/CourseMembershipService.coffee
@@ -4,8 +4,10 @@
     $http.delete("/course_memberships/#{id}").then(
       (response) ->
         GradeCraftAPI.logResponse(response.data)
+        Promise.resolve(response)
       , (response) ->
         GradeCraftAPI.logResponse(response.data)
+        Promise.reject(response)
     )
 
   toggleActivation = (id, student, notify=true) ->

--- a/app/assets/javascripts/angular/services/StudentService.coffee
+++ b/app/assets/javascripts/angular/services/StudentService.coffee
@@ -119,7 +119,8 @@
         (success) ->
           students.splice(students.indexOf(student) , 1)
           alert("Successfully deleted #{student.name} from the course")
-        , (failure) -> alert("Failed to delete #{student.name} from course")
+        , (failure) -> 
+            alert("Failed to delete #{student.name} from course. #{failure.data.errors}")
       )
 
     recalculateRanks = (students) ->

--- a/app/assets/javascripts/angular/templates/courses/students/index.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/students/index.html.haml
@@ -165,7 +165,7 @@
                 %i.fa.fa-flash
                 Reactivate
 
-            %li{"ng-if"=>"student.deleteable"}
+            %li
               %a{"ng-click"=>"coursesStudentsIndexCtrl.deleteFromCourse(student)"}
                 %i.fa.fa-trash
                 Delete


### PR DESCRIPTION

### Status
**IN DEVELOPMENT**

### Description
* It should be possible to delete students as an instructor even if they have grades. Currently it is not possible for instructors to delete students if they have grades
* Now, instructors can delete students from their course even if they have grades. If the student belongs to a group which has been added to an assignment which requires a minimum group size, and deleting the student causes the group to fail to meet this minimum group size, a message is displayed to the instructors underlining the problem.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, visit the /students page and click the options button for the student to delete to bring up the options menu. Click the "Delete" option to remove the student from the course. The student should be deleted from the course if all the groups they belong to continue to satisfy the minimum group size requirement for all the assignments they are added after the student has been deleted. Otherwise a message is displayed showing which group and assignment prevents the student from being deleted.
2. Furthermore, add a student in a group, and add the group to an assignment which has a minimum group size that will not be satisfied if the student is removed from the group. Visit the /students page and delete the student. This should not be possible and a message should be displayed explaining the problem.

### Impacted Areas in Application
* Deleting a student from the course as an instructor (i.e. controllers/course_memberships.rb)

======================
Closes #4193 
