### PR TITLE
Change checks for select dropdown on student logged grade page to prevent errors

### DIFF
--- a/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
+++ b/app/assets/javascripts/behaviors/self_grade_outcomes_select.js
@@ -1,10 +1,13 @@
 //Selectively disables the "Submit" button for student logged assignments, if the
 //assignment has outcome levels and no outcome level is selected.
 
-var SelfGradeOutcomesSelect = document.querySelector("select");
+var SelfGradeOutcomesSelect = document.querySelector("#grade_raw_points");
+
+if(!SelfGradeOutcomesSelect) SelfGradeOutcomesSelect = document.querySelector("#grade_pass_fail_status");
+
 var SelfGradeOutcomesButton = document.querySelector(".self_grade_outcomes_button");
 
-if(SelfGradeOutcomesSelect && SelfGradeOutcomesSelect){
+if(SelfGradeOutcomesSelect && SelfGradeOutcomesButton){
     SelfGradeOutcomesSelect.addEventListener("change", function(){
         if(SelfGradeOutcomesSelect.selectedIndex == 0)
             SelfGradeOutcomesButton.disabled = true;


### PR DESCRIPTION
### Status
**READY**

### Description
* Changes checks in behaviors/self_grade_outcomes_select.js to prevent errors. Currently, the checks caused errors when checking for the dropdown menus as they would return null. 
* Now, the dropdowns are checked with ids and the "Submit" self-logged grade button is disabled only if the raw points dropdown or the pass fail dropdown and the "Submit" self-logged grade button is present on the page.

### Related PRs
students-delete-self-logged-grade (#4330)

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, create a student logged assignment and create outcome levels for the assignment.
2. As a student, submit the assignment and view the assignment page under the "My Submission" tab. It should not be possible to submit the student logged grade without selecting an outcome level

### Impacted Areas in Application
* behaviors/self_grade_outcomes_select.js

======================
