### PR TITLE
Changed submission file links to use external links

### DIFF
--- a/app/views/submissions/_autosave_form.html.haml
+++ b/app/views/submissions/_autosave_form.html.haml
@@ -22,10 +22,10 @@
           - if presenter.submission.submission_files.exists?
             %h3.bold Uploaded files
             %ul.file-attachments-list
-              - presenter.submission.submission_files.each do |sf|
+              - presenter.present_submission_files.each_with_index do |sf, index|
                 - if sf.persisted?
                   %li.file-attachment-list-item
-                    = link_to "#{sf.filename}", sf.file.to_s, target: "_blank"
+                    = external_link_to "#{sf.filename}", submission_file_download_path(sf, index: index)
                     = link_to "(Remove)", remove_uploads_path(:model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id)
 
       - if presenter.assignment.accepts_links

--- a/app/views/submissions/_form.html.haml
+++ b/app/views/submissions/_form.html.haml
@@ -21,10 +21,10 @@
       - if presenter.submission.submission_files.exists?
         %h5.bold Uploaded files
         %ul.uploaded-files
-          - presenter.submission.submission_files.each do |sf|
+          - presenter.present_submission_files.each_with_index do |sf, index|
             - if sf.id != nil
               %li
-                = link_to sf.filename, sf.file.to_s, :target => "_blank"
+                = external_link_to "#{sf.filename}", submission_file_download_path(sf, index: index)
                 = link_to "(Remove)", remove_uploads_path({ :model => "SubmissionFile", assignment_id: presenter.assignment.id, :upload_id => sf.id } )
 
     - if presenter.assignment.accepts_links


### PR DESCRIPTION
### Status
**READY**

### Description
* The links to attachments for submissions should be accessible when editing the submission, both as a student and an instructor. Currently, the links for the submission files are complete file paths, which causes the files to not be downloadable as the redocuments_controller prevents submissions from being downloaded directly.
* Now, the edit submissions page for students and instructors have been updated to use external_links when showing links for submission files

### Related PRs
branch | PR
------ | ------
master-efs| (#4352)
carrierwave-settings2 |(#4351)

### Migrations
NO

### Steps to Test or Reproduce
1. As a student, submit an assignment with attachments and edit the submission (/assignments/\<id\>/submissions/\<id\>). The attachment files should be downloadable through the links shown.
2. As a student, view a student's submission with attachments and edit the submission (/assignments/\<id\>/submissions/\<id\>). The attachment files should be downloadable through the links shown.

### Impacted Areas in Application
* Editing a submission as a student and an instructor
* views/submissions/_autosave_form.html.haml
* views/submissions/_form.html.haml

======================
Closes #4354 