### PR TITLE
Always display "Resend Activation Email" button

### DIFF
--- a/app/assets/javascripts/angular/templates/courses/students/index.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/students/index.html.haml
@@ -173,10 +173,10 @@
             %li{"ng-if"=>"coursesStudentsIndexCtrl.showActivateAccount(student)"}
               %a{"ng-click"=>"coursesStudentsIndexCtrl.activateUser(student)"}
                 %i.fa.fa-check
-                Activate Account
+              Activate Accapp/controllers/course_memberships_controller.rbount
 
             -# Resend activation email
-            %li{"ng-if"=>"coursesStudentsIndexCtrl.showResendActivationEmail(student)"}
+            %li
               %a{"ng-href"=>"{{student.resend_activation_email_path}}"}
                 %i.fa.fa-envelope
                 Resend Activation Email

--- a/app/assets/javascripts/angular/templates/courses/students/index.html.haml
+++ b/app/assets/javascripts/angular/templates/courses/students/index.html.haml
@@ -173,7 +173,7 @@
             %li{"ng-if"=>"coursesStudentsIndexCtrl.showActivateAccount(student)"}
               %a{"ng-click"=>"coursesStudentsIndexCtrl.activateUser(student)"}
                 %i.fa.fa-check
-              Activate Accapp/controllers/course_memberships_controller.rbount
+                Activate Account
 
             -# Resend activation email
             %li

--- a/app/views/staff/index.html.haml
+++ b/app/views/staff/index.html.haml
@@ -33,6 +33,6 @@
                 %li= link_to decorative_glyph(:dashboard) + "Dashboard",  staff_path(user)
                 = active_course_link_to decorative_glyph(:edit) + "Edit",  edit_user_path(user)
                 = active_course_link_to decorative_glyph(:trash) + "Delete",  user.course_memberships.where(course: current_course).first, data: { confirm: "Are you sure you want to delete #{user.name}'s course membership in #{current_course.name}?"}, :method => :delete
+                = active_course_link_to glyph(:envelope) + "Resend Activation Email", resend_activation_email_user_path(user.id)
                 - if !user.activated?
                   = active_course_link_to decorative_glyph(:check) + "Activate", manually_activate_user_path(user.id), :method => :put
-                  = active_course_link_to glyph(:envelope) + "Resend Activation Email", resend_activation_email_user_path(user.id)


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
* Instructors should be able to resend activation emails whenever required. Currently, the activation email can be resent only until the user is activated. To allow instructors to resend the email, the check for activation has been removed, and the option to resend the email will always appear.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, visit /staff or /students and click on the options for a staff member or student. The option to resend the activation email should be displayed.

### Impacted Areas in Application
* Resending activation emails for instructors
* templates/courses/students/index.html.haml
* views/staff/index.html.haml

======================
