### PR TITLE
Show submission dates for grades when submissions are not accepted in an assignment

### DIFF
--- a/app/assets/javascripts/angular/templates/assignments/show/individual/table_body.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/show/individual/table_body.html.haml
@@ -68,7 +68,7 @@
         This feedback has been viewed by the {{individualTableBodyCtrl.termFor("student")}}
 
   -# Formatted submit date
-  %td{"ng-if"=>"individualTableBodyCtrl.assignment().accepts_submissions"}
+  %td
     {{student.formatted_submission_submitted_at}}
 
   -# Assignment options

--- a/app/assets/javascripts/angular/templates/assignments/show/individual/table_header.html.haml
+++ b/app/assets/javascripts/angular/templates/assignments/show/individual/table_header.html.haml
@@ -24,7 +24,7 @@
   %th.sortable-header{"scope"=>"col", "data-sortable-header-text"=>"Visible to Student", "data-sortable-predicate"=>"grade_student_visible"}
   %th.sortable-header{"scope"=>"col", "data-sortable-header-text"=>"Read?", "data-sortable-predicate"=>"grade_feedback_read"}
 
-  %th.sortable-header{"scope"=>"col", "ng-if"=>"individualTableHeaderCtrl.assignment().accepts_submissions",
+  %th.sortable-header{"scope"=>"col",
                       "data-sortable-header-text"=>"Submitted", "data-sortable-predicate"=>"submission_submitted_at"}
 
   %th{"scope"=>"col", "style"=>"min-width: 180px"}


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
* Instructors should always see the submitted date for a grade for an assignment. Currently, the date is hidden when submissions are not accepted in an assignment. Now, the check for the assignment accepting submissions has been removed and the submission dates are always displayed for instructors.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, set an assignment that has grades to not accept submissions and visit the grades tab (i.e. /assignments/\<id\>). There should be a column with called "Submitted" that displays the submission date for the grade.

### Impacted Areas in Application
* Viewing assignments as an instructor
* templates/assignments/show/individual/table_body.html.haml
* templates/assignments/show/individual/table_header.html.haml
======================
Closes #4364 