### PR TITLE
Learning objectives should always have at least two levels

### DIFF
--- a/app/assets/javascripts/angular/services/LearningObjectivesService.coffee
+++ b/app/assets/javascripts/angular/services/LearningObjectivesService.coffee
@@ -279,10 +279,19 @@
     params[term] = article
     params
 
+  _hasLOLevels = (included_article_list) ->
+    included_article_list.some((article) -> 
+                                    if article.type == "levels"
+                                      return true)
+
   _resolve = (promise, article, type, redirectUrl) ->
     promise.then(
       (response) ->
         angular.copy(response.data.data.attributes, article)
+        console.log("in resolve")
+        console.log(response)
+        if response.data.included && _hasLOLevels(response.data.included)
+          GradeCraftAPI.loadFromIncluded(_levels, "levels", response.data)
         lastUpdated(article.updated_at || new Date())
         article.isCreating = false
         window.location.href = redirectUrl if redirectUrl?

--- a/app/assets/javascripts/angular/services/LearningObjectivesService.coffee
+++ b/app/assets/javascripts/angular/services/LearningObjectivesService.coffee
@@ -280,7 +280,7 @@
     params
 
   _hasLOLevels = (included_article_list) ->
-    included_article_list.some((article) -> 
+    included_article_list.some((article) ->
                                     if article.type == "levels"
                                       return true)
 
@@ -288,8 +288,6 @@
     promise.then(
       (response) ->
         angular.copy(response.data.data.attributes, article)
-        console.log("in resolve")
-        console.log(response)
         if response.data.included && _hasLOLevels(response.data.included)
           GradeCraftAPI.loadFromIncluded(_levels, "levels", response.data)
         lastUpdated(article.updated_at || new Date())

--- a/app/controllers/api/learning_objectives/levels_controller.rb
+++ b/app/controllers/api/learning_objectives/levels_controller.rb
@@ -49,6 +49,12 @@ class API::LearningObjectives::LevelsController < ApplicationController
       end
     end
 
+    if @objective.levels.length - 1 < 2
+      render json: { message: "Cannot delete levels as there should be at least two levels for a learning objective.", success: false },
+      status: 500
+      return
+    end
+
     @level = @objective.levels.find params[:id]
     @level.destroy
 

--- a/app/controllers/api/learning_objectives/levels_controller.rb
+++ b/app/controllers/api/learning_objectives/levels_controller.rb
@@ -49,7 +49,9 @@ class API::LearningObjectives::LevelsController < ApplicationController
       end
     end
 
-    if @objective.levels.length - 1 < 2
+    levels_count = @objective.levels.length - 1
+    
+    if levels_count < 2
       render json: { message: "Cannot delete levels as there should be at least two levels for a learning objective.", success: false },
       status: 500
       return

--- a/app/controllers/api/learning_objectives/objectives_controller.rb
+++ b/app/controllers/api/learning_objectives/objectives_controller.rb
@@ -27,6 +27,7 @@ class API::LearningObjectives::ObjectivesController < ApplicationController
     @objective = current_course.learning_objectives.new learning_objective_params
 
     if @objective.save
+      @objective.create_default_levels
       render "api/learning_objectives/objectives/show", status: 201
     else
       render json: {

--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -120,6 +120,24 @@ class LearningObjective < ApplicationRecord
     end
   end
 
+  def create_default_levels
+    minimum_proficiency = LearningObjectiveLevel.new
+    minimum_proficiency.flagged_value = LearningObjectiveLevel.flagged_values.key(3)
+    minimum_proficiency.name = "Minimum Proficiency Level"
+    minimum_proficiency.description = "Level with minimum proficiency"
+    minimum_proficiency.course_id = course_id
+    minimum_proficiency.objective_id = id
+
+    maximum_proficiency = LearningObjectiveLevel.new
+    maximum_proficiency.flagged_value = LearningObjectiveLevel.flagged_values.key(0)
+    maximum_proficiency.name = "Maximum Proficiency Level"
+    maximum_proficiency.description = "Level with maximum proficiency"
+    maximum_proficiency.course_id = course_id
+
+    levels.push(minimum_proficiency)
+    levels.push(maximum_proficiency)
+  end
+
   def copy(attributes={}, lookup_store=nil)
     ModelCopier.new(self, lookup_store).copy(
       attributes: attributes,

--- a/app/models/learning_objective.rb
+++ b/app/models/learning_objective.rb
@@ -124,14 +124,14 @@ class LearningObjective < ApplicationRecord
     minimum_proficiency = LearningObjectiveLevel.new
     minimum_proficiency.flagged_value = LearningObjectiveLevel.flagged_values.key(3)
     minimum_proficiency.name = "Minimum Proficiency Level"
-    minimum_proficiency.description = "Level with minimum proficiency"
+    minimum_proficiency.description = ""
     minimum_proficiency.course_id = course_id
     minimum_proficiency.objective_id = id
 
     maximum_proficiency = LearningObjectiveLevel.new
     maximum_proficiency.flagged_value = LearningObjectiveLevel.flagged_values.key(0)
     maximum_proficiency.name = "Maximum Proficiency Level"
-    maximum_proficiency.description = "Level with maximum proficiency"
+    maximum_proficiency.description = ""
     maximum_proficiency.course_id = course_id
 
     levels.push(minimum_proficiency)
@@ -143,7 +143,7 @@ class LearningObjective < ApplicationRecord
       attributes: attributes,
       associations: [:levels],
       options: { lookups: [:course, :category, :assignments],
-                 overrides: [-> (copy) { copy_category(copy, lookup_store) }, 
+                 overrides: [-> (copy) { copy_category(copy, lookup_store) },
                              -> (copy) { copy_assignment_links(copy, lookup_store) }] }
     )
   end
@@ -196,5 +196,5 @@ class LearningObjective < ApplicationRecord
     NotificationMailer.unlocked_condition(unlockable, student, course).deliver_now
   end
 
- 
+
 end

--- a/spec/controllers/api/learning_objectives/levels_controller_spec.rb
+++ b/spec/controllers/api/learning_objectives/levels_controller_spec.rb
@@ -30,10 +30,11 @@ describe API::LearningObjectives::LevelsController do
     end
 
     describe "DELETE destroy" do
-      it "deletes the level" do
+      it "does not delete the level if there are less than 2" do
         level
-        expect{ delete :destroy, params: { objective_id: objective.id, id: level.id }, format: :json }.to \
-          change(LearningObjectiveLevel, :count).by -1
+        delete :destroy, params: { objective_id: objective.id, id: level.id }, format: :json
+        expect(LearningObjectiveLevel.count).to eq(1)
+        expect(JSON.parse(response.body)).to eq("message"=>"Cannot delete levels as there should be at least two levels for a learning objective.", "success"=>false)
       end
     end
 


### PR DESCRIPTION
### Status
**READY*

### Description
* A learning objective should have at least two learning objective levels. Currently it is possible to have a learning objective with no learning objective levels or one learning objective level.
* Now, creating a learning objective creates two learning objective levels, one with the minimum proficiency level and one with the maximum proficiency level. Additional learning objective levels can be created and deleted as necessary however it is ensured that every learning objective will have at least two learning objective levels as deletion of learning objective levels is prevented once there are two learning objective levels remaining.

### Related PRs
branch | PR
------ | ------
`add-lo-assignment-overview` | #4108

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, create a learning objective.
2. The learning objective will have two levels one with the minimum proficiency level set and one with the maximum proficiency level set. It should not be possible to delete levels if there are only two levels (it should be possible to add and delete when there more than 2 levels, but there should always be at least 2 remaining). 

### Impacted Areas in Application
* Creating learning objective (i.e. models/learning_objective.rb,  controllers/api/learning_objectives/objectives_controller.rb)
* Learning objective edit page

======================
Closes #4114
