### PR TITLE
Attachment directory fix

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -70,7 +70,6 @@ class CoursesController < ApplicationController
       change_current_course @course.id
       redirect_to action: :edit, id: @course.id and return
     end
-    @attachments = @course.has_attachments?
     authorize! :update, @course
   end
 

--- a/app/models/challenge_file.rb
+++ b/app/models/challenge_file.rb
@@ -5,4 +5,8 @@ class ChallengeFile < ApplicationRecord
   validates :filename, presence: true, length: { maximum: 50 }
 
   mount_uploader :file, AttachmentUploader
+
+  def course
+    challenge.course
+  end
 end

--- a/app/models/challenge_file.rb
+++ b/app/models/challenge_file.rb
@@ -5,8 +5,4 @@ class ChallengeFile < ApplicationRecord
   validates :filename, presence: true, length: { maximum: 50 }
 
   mount_uploader :file, AttachmentUploader
-
-  def course
-    challenge.course
-  end
 end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -46,9 +46,7 @@ class SubmissionFile < ApplicationRecord
   # returns nil if group or student has been deleted but file still exists
   def owner_name
     if submission.assignment.grade_scope == "Group"  && submission.group.present?
-      submission.group.name.gsub(/\s/, "-")
-    elsif submission.assignment.grade_scope == "Individual" && submission.student.present?
-      "#{submission.student.last_name}-#{submission.student.first_name}"
+      "#{submission.id}"
     end
   end
 

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -45,9 +45,7 @@ class SubmissionFile < ApplicationRecord
 
   # returns nil if group or student has been deleted but file still exists
   def owner_name
-    if submission.assignment.grade_scope == "Group"  && submission.group.present?
-      "#{submission.id}"
-    end
+    submission.id.to_s
   end
 
   def extension

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -45,7 +45,11 @@ class SubmissionFile < ApplicationRecord
 
   # returns nil if group or student has been deleted but file still exists
   def owner_name
-    submission.id.to_s
+    if submission.assignment.grade_scope == "Group"  && submission.group.present?
+      submission.group.name.gsub(/\s/, "-")
+    elsif submission.assignment.grade_scope == "Individual" && submission.student.present?
+      "#{submission.student.last_name}-#{submission.student.first_name}"
+    end
   end
 
   def extension

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -43,7 +43,8 @@ class SubmissionFile < ApplicationRecord
     "#{submission.base_filename} - Submission File#{file_number}#{extension}"
   end
 
-  # returns nil if group or student has been deleted but file still exists
+  # BEFORE EFS this would return this users name or group name
+  # Now just returning the ID of the submission 
   def owner_name
     submission.id.to_s
   end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -45,11 +45,7 @@ class SubmissionFile < ApplicationRecord
 
   # returns nil if group or student has been deleted but file still exists
   def owner_name
-    if submission.assignment.grade_scope == "Group"  && submission.group.present?
-      submission.group.name.gsub(/\s/, "-")
-    elsif submission.assignment.grade_scope == "Individual" && submission.student.present?
-      "#{submission.student.last_name}-#{submission.student.first_name}"
-    end
+    submission.id.to_s
   end
 
   def extension

--- a/app/performers/submissions_export_performer.rb
+++ b/app/performers/submissions_export_performer.rb
@@ -88,8 +88,9 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
   def write_submission_binary_file(submitter, submission_file, index)
     destination_file_path = submission_binary_file_path(submitter, submission_file, index)
-    source_file_path = "#{Rails.root}/#{submission_file.file.to_s}"
-    FileUtils.cp(source_file_path, destination_file_path)
+    source_file_path = "#{Rails.root}#{submission_file.file.to_s}"
+    source_path = URI.decode(source_file_path)
+    FileUtils.cp(source_path, destination_file_path)
   end
 
   def create_binary_files_for_submission(submission)

--- a/app/performers/submissions_export_performer.rb
+++ b/app/performers/submissions_export_performer.rb
@@ -89,12 +89,8 @@ class SubmissionsExportPerformer < ResqueJob::Performer
   def write_submission_binary_file(submitter, submission_file, index)
     destination_file_path = submission_binary_file_path(submitter, submission_file, index)
     source_file_path = "#{Rails.root}#{submission_file.file.to_s}"
-<<<<<<< HEAD
     source_path = URI.decode(source_file_path)
     FileUtils.cp(source_path, destination_file_path)
-=======
-    FileUtils.cp(source_file_path, destination_file_path)
->>>>>>> parent of 40bb10418... removing premature changes to directory paths
   end
 
   def create_binary_files_for_submission(submission)

--- a/app/performers/submissions_export_performer.rb
+++ b/app/performers/submissions_export_performer.rb
@@ -21,7 +21,7 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
         submissions_export.update_export_completed_time
       rescue StandardError => error
-        puts "Submission Export: #{error}"
+        puts "Submission Export error: #{error}"
       end
     else
       if logger
@@ -89,8 +89,12 @@ class SubmissionsExportPerformer < ResqueJob::Performer
   def write_submission_binary_file(submitter, submission_file, index)
     destination_file_path = submission_binary_file_path(submitter, submission_file, index)
     source_file_path = "#{Rails.root}#{submission_file.file.to_s}"
+<<<<<<< HEAD
     source_path = URI.decode(source_file_path)
     FileUtils.cp(source_path, destination_file_path)
+=======
+    FileUtils.cp(source_file_path, destination_file_path)
+>>>>>>> parent of 40bb10418... removing premature changes to directory paths
   end
 
   def create_binary_files_for_submission(submission)

--- a/app/performers/submissions_export_performer.rb
+++ b/app/performers/submissions_export_performer.rb
@@ -21,7 +21,7 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
         submissions_export.update_export_completed_time
       rescue StandardError => error
-        puts "Submission Export error: #{error}"
+        puts "Submission Export: #{error}"
       end
     else
       if logger
@@ -88,7 +88,7 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
   def write_submission_binary_file(submitter, submission_file, index)
     destination_file_path = submission_binary_file_path(submitter, submission_file, index)
-    source_file_path = "#{Rails.root}#{submission_file.file.to_s}"
+    source_file_path = "#{Rails.root}/#{submission_file.file.to_s}"
     FileUtils.cp(source_file_path, destination_file_path)
   end
 

--- a/app/performers/submissions_export_performer.rb
+++ b/app/performers/submissions_export_performer.rb
@@ -21,7 +21,7 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
         submissions_export.update_export_completed_time
       rescue StandardError => error
-        puts "Submission Export: #{error}"
+        puts "Submission Export error: #{error}"
       end
     else
       if logger
@@ -88,7 +88,7 @@ class SubmissionsExportPerformer < ResqueJob::Performer
 
   def write_submission_binary_file(submitter, submission_file, index)
     destination_file_path = submission_binary_file_path(submitter, submission_file, index)
-    source_file_path = "#{Rails.root}/#{submission_file.file.to_s}"
+    source_file_path = "#{Rails.root}#{submission_file.file.to_s}"
     FileUtils.cp(source_file_path, destination_file_path)
   end
 

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -2,10 +2,11 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   # NOTE: course, assignment and assignment_file_type, and student should be
   # defined on the model in order to use them as subdirectories, otherwise
   # they will be ommited: submission_file: files/uploads/<course-name_id>/assignments/<assignment-name_id>/submission_files/<student_name>/timestamp_file_name.ext
-  # assignment_file:  files/uploads/<course-name_id>/assignments/<assignment-name_id>/assignment_files/<timestamp_file-name.ext>
-  # attachment: files/uploads/<course-name_id>/assignments/<assignment-name_id>/attachments/<timestamp_file-name.ext>
-  # badge_file: files/uploads/<course-name_id>/badge_files/<timestamp_file-name.ext>
-  # challenge_file: files/uploads/<course-name_id>/challenge_files/<timestamp_file-name.ext>
+  # assignment_file:  files/uploads/<course_id>/assignments/<assignment_id>/assignment_files/<timestamp_file-name.ext>
+  # attachment/file_upload: files/uploads/<course_id>/assignments/<assignment_id>/attachments/<timestamp_file-name.ext>
+  # badge_file: files/uploads/<course_id>/badge_files/badge_id/<timestamp_file-name.ext>
+  # challenge_file: files/uploads/<course_id>/challenge_files/<timestamp_file-name.ext>
+  # submission_file: files/uploads/<course_id>/assignments/<assignment_id>/submission_files/<submission_id>/<timestamp_file-name.ext>
 
   attr_accessor :course, :assignment
 
@@ -45,21 +46,20 @@ class AttachmentUploader < CarrierWave::Uploader::Base
     "#{model.course.id}" if model and model.class.method_defined? :course and model.course
   end
 
-  # Assignment name is added into directory path, used for submission_file and submisison_attachments
+  # Before EFS Assignment name was added into directory path, used for submission_file and submisison_attachments
+  # now only the assignment ID is used
   def assignment
     "assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
   end
 
-  #in prod: adds "attachments" for FileUpload
-  #changing to add "grade_attachments" for FileUpload,
-  #else adds model name like assignment_files
+  # adds model name like assignment_files
   def file_klass
     return model.klass_name if model.class.method_defined? :klass_name
     klass_name = model.class.to_s.underscore.pluralize
   end
 
-  # User's name is put into directory path if it is a submission_file
-  #Changing to put in submission ID
+  # Before EFS, User's name or group name were put into directory path for a submission_file
+  # Changing to put in submission ID
   def owner_name
     model.owner_name if model.class.method_defined? :owner_name
   end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -42,14 +42,12 @@ class AttachmentUploader < CarrierWave::Uploader::Base
 
   def course
     # rubocop:disable AndOr
-    "#{model.course.course_number}-#{model.course.id}" if model and model.class.method_defined? :course and model.course
-    #"#{model.course.id}" if model and model.class.method_defined? :course and model.course
+    "#{model.course.id}" if model and model.class.method_defined? :course and model.course
   end
 
   # Assignment name is added into directory path, used for submission_file and submisison_attachments
   def assignment
-    "assignments/#{model.assignment.name.gsub(/\s/, "_").downcase[0..20]}-#{model.assignment.id}" if model.class.method_defined? :assignment
-    #"assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
+    "assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
   end
 
   #in prod: adds "attachments" for FileUpload

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -29,7 +29,6 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   def store_dir_pieces
     [
       store_dir_prefix,
-      "uploads",
       course,
       assignment,
       file_klass,
@@ -38,23 +37,29 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def store_dir_prefix
-    return "files"
+    return "files/uploads"
   end
 
   def course
     # rubocop:disable AndOr
-    "#{model.course.course_number}-#{model.course.id}" if model and model.class.method_defined? :course and model.course
+    "#{model.course.id}" if model and model.class.method_defined? :course and model.course
   end
 
+  # Assignment name is added into directory path, used for submission_file and submisison_attachments
   def assignment
-    "assignments/#{model.assignment.name.gsub(/\s/, "_").downcase[0..20]}-#{model.assignment.id}" if model.class.method_defined? :assignment
+    "assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
   end
 
+  #in prod: adds "attachments" for FileUpload
+  #changing to add "grade_attachments" for FileUpload,
+  #else adds model name like assignment_files
   def file_klass
     return model.klass_name if model.class.method_defined? :klass_name
     klass_name = model.class.to_s.underscore.pluralize
   end
 
+  # User's name is put into directory path if it is a submission_file
+  #Changing to put in submission ID
   def owner_name
     model.owner_name if model.class.method_defined? :owner_name
   end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -29,7 +29,6 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   def store_dir_pieces
     [
       store_dir_prefix,
-      "uploads",
       course,
       assignment,
       file_klass,
@@ -38,23 +37,31 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def store_dir_prefix
-    return "files"
+    return "files/uploads"
   end
 
   def course
     # rubocop:disable AndOr
     "#{model.course.course_number}-#{model.course.id}" if model and model.class.method_defined? :course and model.course
+    #"#{model.course.id}" if model and model.class.method_defined? :course and model.course
   end
 
+  # Assignment name is added into directory path, used for submission_file and submisison_attachments
   def assignment
     "assignments/#{model.assignment.name.gsub(/\s/, "_").downcase[0..20]}-#{model.assignment.id}" if model.class.method_defined? :assignment
+    #"assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
   end
 
+  #in prod: adds "attachments" for FileUpload
+  #changing to add "grade_attachments" for FileUpload,
+  #else adds model name like assignment_files
   def file_klass
     return model.klass_name if model.class.method_defined? :klass_name
     klass_name = model.class.to_s.underscore.pluralize
   end
 
+  # User's name is put into directory path if it is a submission_file
+  #Changing to put in submission ID
   def owner_name
     model.owner_name if model.class.method_defined? :owner_name
   end

--- a/app/uploaders/attachment_uploader.rb
+++ b/app/uploaders/attachment_uploader.rb
@@ -29,6 +29,7 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   def store_dir_pieces
     [
       store_dir_prefix,
+      "uploads",
       course,
       assignment,
       file_klass,
@@ -37,29 +38,23 @@ class AttachmentUploader < CarrierWave::Uploader::Base
   end
 
   def store_dir_prefix
-    return "files/uploads"
+    return "files"
   end
 
   def course
     # rubocop:disable AndOr
-    "#{model.course.id}" if model and model.class.method_defined? :course and model.course
+    "#{model.course.course_number}-#{model.course.id}" if model and model.class.method_defined? :course and model.course
   end
 
-  # Assignment name is added into directory path, used for submission_file and submisison_attachments
   def assignment
-    "assignments/#{model.assignment.id}" if model.class.method_defined? :assignment
+    "assignments/#{model.assignment.name.gsub(/\s/, "_").downcase[0..20]}-#{model.assignment.id}" if model.class.method_defined? :assignment
   end
 
-  #in prod: adds "attachments" for FileUpload
-  #changing to add "grade_attachments" for FileUpload,
-  #else adds model name like assignment_files
   def file_klass
     return model.klass_name if model.class.method_defined? :klass_name
     klass_name = model.class.to_s.underscore.pluralize
   end
 
-  # User's name is put into directory path if it is a submission_file
-  #Changing to put in submission ID
   def owner_name
     model.owner_name if model.class.method_defined? :owner_name
   end

--- a/app/views/courses/_basic_settings.haml
+++ b/app/views/courses/_basic_settings.haml
@@ -3,11 +3,7 @@
     %h2.form-title Basics
     .form-flex-row
       .form-item
-        - if @attachments
-          = f.input :course_number, label: "Course Number", disabled: true
-          = "You are unable to change your course number at this time, please contact us if you need this changed"
-        - else
-          = f.input :course_number, label: "Course Number"
+        = f.input :course_number, label: "Course Number"
 
       .form-item
         = f.input :name, label: "Course Name"

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -95,11 +95,14 @@ namespace :move_attachment_directories do
     all_course_directories = get_source_directories(upload_directory)
     taskAuditFile.puts("all_course_directories: #{all_course_directories}")
 
+    deleted_course_ids = []
+
     all_course_directories.each do |dir|
       course_id = dir.split('-').last
-      course = Course.find(course_id)
 
-      if course.has_attachments?
+      course = Course.find(course_id) if Course.find(course_id).exists? else deleted_course_ids << course_id
+
+      if course && course.has_attachments?
         taskAuditFile.puts("course #{course_id} has attachments")
 
         if course.has_assignment_attachments?
@@ -117,7 +120,7 @@ namespace :move_attachment_directories do
           end
         end
 
-        if course.has_badge_attachments?
+        if course && course.has_badge_attachments?
           course.badges.each do |badge|
             if badge.badge_files.present?
               badge.badge_files.each do |bf|
@@ -132,7 +135,7 @@ namespace :move_attachment_directories do
           end
         end
 
-        if course.has_grade_attachments?
+        if course && course.has_grade_attachments?
           course.grades.each do |grade|
             if grade.file_uploads.present?
               grade.file_uploads.each do |fu|
@@ -147,7 +150,7 @@ namespace :move_attachment_directories do
           end
         end
 
-        if course.has_submission_attachments?
+        if course && course.has_submission_attachments?
           course.submissions.each do |sub|
             if sub.submission_files.present?
               sub.submission_files.each do |sf|
@@ -185,6 +188,9 @@ namespace :move_attachment_directories do
         cf.file.file.move_to(new_path)
         taskAuditFile.puts("---------------------------")
       end
+
+      taskAuditFile.puts("Course ID's of courses that were deleted but still in files/uploads: #{deleted_course_ids}")
+
     end
   end
 

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -191,7 +191,7 @@ namespace :move_attachment_directories do
   desc "Go through the files/uploads and remove empty directorys"
   task :delete_empty_directories, [:run_it] => [:environment] do |t, args|
 
-    auditFile = "#{Rails.root}/files/AttachmentTask.txt"
+    auditFile = "#{Rails.root}/files/DeleteDirectories.txt"
     taskAuditFile = File.open(auditFile, 'w')
 
     upload_directory = "#{Rails.root}/files/uploads"
@@ -200,11 +200,15 @@ namespace :move_attachment_directories do
 
     all_course_directories.each do |dir|
       old_path = upload_directory + "/" + dir
-      puts("checking the old path: #{old_path}")
+      taskAuditFile.puts("checking the old path: #{old_path}")
 
-      if(Dir.empty?(old_path))
-        puts("old path is empty")
+      size = `du -s #{old_path}`
+      taskAuditFile.puts("size of old path: #{size}")
+
+      if(size.chars.first == "0")
+        taskAuditFile.puts("old path is empty")
         if args[:run_it] == "true"
+          taskAuditFile.puts("deleting directory #{old_path}")
           FileUtils.remove_dir old_dir
         end
       end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -42,11 +42,9 @@ namespace :move_attachment_directories do
     path = [
       base_dir,
       course_id.to_s,
-      "badge_files",
-      badge_id.to_s,
+      "badge_files/",
     ].compact
-    path = path.join "/"
-    path << "/"
+    path.join "/"
   end
 
   #/gradecraft-development/files/uploads/<course_id>/challenge_files/

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -165,9 +165,12 @@ namespace :move_attachment_directories do
       else
         old_dir = "#{upload_directory}/#{dir}"
         taskAuditFile.puts("course has no attachments")
-        taskAuditFile.puts("deleteing directory: #{old_dir}")
-        if args[:run_it] == "true"
-          FileUtils.remove_dir old_dir
+        if Dir.empty?(old_dir)
+          taskAuditFile.puts("directory is empty")
+          taskAuditFile.puts("deleteing directory: #{old_dir}")
+          if args[:run_it] == "true"
+            FileUtils.remove_dir old_dir
+          end
         end
       end
 
@@ -183,5 +186,29 @@ namespace :move_attachment_directories do
         taskAuditFile.puts("---------------------------")
       end
     end
+  end
+
+  desc "Go through the files/uploads and remove empty directorys"
+  task :delete_empty_directories, [:run_it] => [:environment] do |t, args|
+
+    auditFile = "#{Rails.root}/files/AttachmentTask.txt"
+    taskAuditFile = File.open(auditFile, 'w')
+
+    upload_directory = "#{Rails.root}/files/uploads"
+
+    all_course_directories = get_source_directories(upload_directory)
+
+    all_course_directories.each do |dir|
+      old_path = upload_directory + "/" + dir
+      puts("checking the old path: #{old_path}")
+
+      if(Dir.empty?(old_path))
+        puts("old path is empty")
+        if args[:run_it] == "true"
+          FileUtils.remove_dir old_dir
+        end
+      end
+    end
+
   end
 end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -21,77 +21,169 @@ namespace :move_attachment_directories do
     end
   end
 
-  desc "Recursively copy directories of attachments using the course number"
-  task :move_attachment_directories, [:run_it] => [:environment] do |t, args|
-
-    courses = Course.all
-    courses.each do |c|
-      if c.has_attachments?
-        puts(c.inspect)
-        old_file_path = "#{Rails.root}/files/uploads/#{c.course_number}-#{c.id}"
-        puts("old_file_path: ", old_file_path)
-
-        new_file_path = "#{Rails.root}/files/uploads/#{c.id}"
-        puts("new_file_path: ", new_file_path)
-
-        if old_directory_exists(c) && !new_directory_exists(c)
-          if args[:run_it] == "true"
-            puts("making a copy of directory: ", old_file_path)
-            puts("naming it: ", new_file_path)
-            FileUtils.cp_r old_file_path, new_file_path
-          end
-        end
-
-        if check_new_directory(c, old_file_path, new_file_path)
-          puts("Deleting directory: ", old_file_path)
-          if args[:run_it] == "true"
-            FileUtils.remove_dir old_file_path
-          end
-        end
-      end
-    end
+  def base_dir
+    "#{Rails.root}/files/uploads"
   end
 
-  desc "Get the extra attachment directories from courses that have changed numbers"
+  #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/assignment_files/
+  def build_assignment_path(course_id, assignment_id)
+    path = [
+      base_dir,
+      course_id.to_s,
+      "assignments",
+      assignment_id.to_s,
+      "assignment_files/"
+    ]
+    path.join "/"
+  end
+
+  #/gradecraft-development/files/uploads/<course_id>/badge_files/<badge_id>/
+  def build_badge_path(course_id, badge_id)
+    path = [
+      base_dir,
+      course_id.to_s,
+      "badge_files",
+      badge_id.to_s,
+    ].compact
+    path = path.join "/"
+    path << "/"
+  end
+
+  #/gradecraft-development/files/uploads/<course_id>/challenge_files/
+  def build_challange_path(course_id)
+    path = [
+      base_dir,
+      course_id.to_s,
+      "challenge_files/",
+    ].compact
+    path.join "/"
+  end
+
+  #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/grade_attachments/
+  def build_file_upload_path(course_id, assignment_id)
+    path = [
+      base_dir,
+      course_id.to_s,
+      "assignments",
+      assignment_id.to_s,
+      "attachments/"
+    ].compact
+    path.join "/"
+  end
+
+  #NEED to change `owner_name` to submission id
+  #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/submission_files/<submission_id>
+  def build_submission_path(course_id, assignment_id, submission_id)
+    path = [
+      base_dir,
+      course_id.to_s,
+      "assignments",
+      assignment_id.to_s,
+      "submission_files",
+      submission_id.to_s
+    ].compact
+    path = path.join "/"
+    path << "/"
+  end
+
+
+  desc "Go through the course numbers in the files directory and move them to a better directory"
   task :move_extra_attachments, [:run_it] => [:environment] do |t, args|
 
+    auditFile = "#{Rails.root}/files/AttachmentTask.txt"
+    taskAuditFile = File.open(auditFile, 'w')
+
     upload_directory = "#{Rails.root}/files/uploads"
-    all_directories = get_source_directories(upload_directory)
+    all_course_directories = get_source_directories(upload_directory)
+    taskAuditFile.puts("all_course_directories: #{all_course_directories}")
 
-    all_directories.each do |dir|
+    all_course_directories.each do |dir|
       course_id = dir.split('-').last
-      old_dir = "#{upload_directory}/#{dir}"
-      puts("old dir: ", old_dir)
-      new_dir = "#{upload_directory}/#{course_id}"
-      puts("new dir: ", new_dir)
+      course = Course.find(course_id)
 
-      if File.directory?(new_dir)
-        puts("course_id directory exists")
-        if args[:run_it] == "true"
-          puts("copying old_dir to new dir")
-          FileUtils.cp_r("#{old_dir}/.", "#{new_dir}/.")
-          puts("Deleting directory: ", old_dir)
-          FileUtils.remove_dir old_dir
+      if course.has_attachments?
+        taskAuditFile.puts("course #{course_id} has attachments")
+
+        if course.has_assignment_attachments?
+          course.assignments.each do |assignment|
+            if assignment.assignment_files.present?
+              assignment.assignment_files.each do |af|
+                taskAuditFile.puts("moving assignment file: #{af.inspect}")
+                new_path = build_assignment_path(course_id, assignment.id)
+                new_path << af.file.file.filename
+                taskAuditFile.puts("to this new path: #{new_path}")
+                af.file.file.move_to(new_path)
+                taskAuditFile.puts("---------------------------")
+              end
+            end
+          end
         end
-      elsif(Course.exists?(course_id))
-        if((Course.find(course_id)).has_attachments?)
-          puts("Course has attachments, but does not have 'new' directory")
-          puts("Course number was perviously changed")
-          if args[:run_it] == "true"
-            puts("making a copy of directory: ", old_dir)
-            puts("naming it: ", new_dir)
-            FileUtils.cp_r old_dir, new_dir
-            puts("Deleting directory: ", old_dir)
-            FileUtils.remove_dir old_dir
+
+        if course.has_badge_attachments?
+          course.badges.each do |badge|
+            if badge.badge_files.present?
+              badge.badge_files.each do |bf|
+                taskAuditFile.puts("moving badge file: #{bf.inspect}")
+                new_path = build_badge_path(course_id, badge.id)
+                new_path << bf.file.file.filename
+                taskAuditFile.puts("to this new path: #{new_path}")
+                bf.file.file.move_to(new_path)
+                taskAuditFile.puts("---------------------------")
+              end
+            end
+          end
+        end
+
+        if course.has_grade_attachments?
+          course.grades.each do |grade|
+            if grade.file_uploads.present?
+              grade.file_uploads.each do |fu|
+                taskAuditFile.puts("moving grade file upload: #{fu.inspect}")
+                new_path = build_file_upload_path(course_id, grade.assignment.id)
+                new_path << fu.file.file.filename
+                taskAuditFile.puts("to this new path: #{new_path}")
+                fu.file.file.move_to(new_path)
+                taskAuditFile.puts("---------------------------")
+              end
+            end
+          end
+        end
+
+        if course.has_submission_attachments?
+          course.submissions.each do |sub|
+            if sub.submission_files.present?
+              sub.submission_files.each do |sf|
+                taskAuditFile.puts("moving submission file: #{sf.inspect}")
+                new_path = build_submission_path(course_id, sub.assignment.id, sub.id)
+                new_path << sf.file.file.filename
+                taskAuditFile.puts("to this new path: #{new_path}")
+                sf.file.file.move_to(new_path)
+                taskAuditFile.puts("---------------------------")
+              end
+            end
           end
         end
 
       else
-        puts("Did not find directory with just an id")
-        puts("path: ", old_dir)
-        puts("No attachments were found for this course")
+        old_dir = "#{upload_directory}/#{dir}"
+        taskAuditFile.puts("course has no attachments")
+        taskAuditFile.puts("deleteing directory: #{old_dir}")
+        if args[:run_it] == "true"
+          FileUtils.remove_dir old_dir
+        end
       end
-      puts("===========================================")
+
+      challenge_files = ChallengeFile.all
+
+      challenge_files.each do |cf|
+        taskAuditFile.puts("moving challenge file: #{cf.inspect}")
+        course_id = cf.challenge.course.id
+        new_path = build_challange_path(course_id)
+        new_path << cf.file.file.filename
+        taskAuditFile.puts("to this new path: #{new_path}")
+        cf.file.file.move_to(new_path)
+        taskAuditFile.puts("---------------------------")
+      end
     end
   end
 end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -96,6 +96,7 @@ namespace :move_attachment_directories do
     taskAuditFile.puts("all_course_directories: #{all_course_directories}")
 
     deleted_course_ids = []
+    no_attachment_course_ids = []
 
     all_course_directories.each do |dir|
       course_id = dir.split('-').last
@@ -167,10 +168,10 @@ namespace :move_attachment_directories do
                 taskAuditFile.puts("moving submission file: #{sf.inspect}")
                 new_path = build_submission_path(course_id, sub.assignment.id, sub.id)
                 new_path << sf.file.file.filename
+                taskAuditFile.puts("to this new path: #{new_path}")
                 if args[:run_it] == "true"
-                  taskAuditFile.puts("to this new path: #{new_path}")
+                  sf.file.file.move_to(new_path)
                 end
-                sf.file.file.move_to(new_path)
                 taskAuditFile.puts("---------------------------")
               end
             end
@@ -179,7 +180,8 @@ namespace :move_attachment_directories do
 
       else
         old_dir = "#{upload_directory}/#{dir}"
-        taskAuditFile.puts("course has no attachments")
+        taskAuditFile.puts("course #{course_id} has no attachments")
+        no_attachment_course_ids << course_id
         if Dir.empty?(old_dir)
           taskAuditFile.puts("directory is empty")
           taskAuditFile.puts("deleteing directory: #{old_dir}")
@@ -204,6 +206,7 @@ namespace :move_attachment_directories do
     end
 
     taskAuditFile.puts("Course ID's of courses that were deleted but still in files/uploads: #{deleted_course_ids}")
+    taskAuditFile.puts("Course ID's of courses still have a folder in files/uploads but do not have attachments in the DB: #{no_attachment_course_ids}")
 
   end
 

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -215,21 +215,23 @@ namespace :move_attachment_directories do
 
     upload_directory = "#{Rails.root}/files/uploads"
 
-    Dir.foreach(upload_directory) do |folder_name|
-      path = upload_directory << "/" << folder_name
+    Dir.chdir(upload_directory) do
+      Dir.glob('*').select { |folder_name|
+        path = upload_directory + "/" + folder_name
 
-      taskAuditFile.puts("checking old path: #{path}")
+        taskAuditFile.puts("checking old path: #{path}")
 
-      size = `du -s #{path}`
-      taskAuditFile.puts("size of old path: #{size}")
+        size = `du -s #{path}`
+        taskAuditFile.puts("size of old path: #{size}")
 
-      if(size.chars.first == "0")
-        taskAuditFile.puts("path is empty")
-        taskAuditFile.puts("deleting directory #{path}")
-        if args[:run_it] == "true"
-          FileUtils.remove_dir path
+        if(size.chars.first == "0")
+          taskAuditFile.puts("path is empty")
+          taskAuditFile.puts("deleting directory #{path}")
+          if args[:run_it] == "true"
+            FileUtils.remove_dir path
+          end
         end
-      end
+      }
     end
   end
 end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -221,7 +221,7 @@ namespace :move_attachment_directories do
 
         taskAuditFile.puts("checking old path: #{path}")
 
-        size = `du -s #{path}`
+        size = `du -s #{path.shellescape}`
         taskAuditFile.puts("size of old path: #{size}")
 
         if(size.chars.first == "0")

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -57,7 +57,7 @@ namespace :move_attachment_directories do
     path.join "/"
   end
 
-  #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/grade_attachments/
+  #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/attachments/
   def build_file_upload_path(course_id, assignment_id)
     path = [
       base_dir,
@@ -69,7 +69,6 @@ namespace :move_attachment_directories do
     path.join "/"
   end
 
-  #NEED to change `owner_name` to submission id
   #/gradecraft-development/files/uploads/<course_id>/assignments/<assignment_id>/submission_files/<submission_id>
   def build_submission_path(course_id, assignment_id, submission_id)
     path = [

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -100,7 +100,11 @@ namespace :move_attachment_directories do
     all_course_directories.each do |dir|
       course_id = dir.split('-').last
 
-      course = Course.find(course_id) if Course.find(course_id).exists? else deleted_course_ids << course_id
+      if Course.exists?(course_id)
+        course = Course.find(course_id)
+      else
+        deleted_course_ids << course_id
+      end
 
       if course && course.has_attachments?
         taskAuditFile.puts("course #{course_id} has attachments")
@@ -113,14 +117,16 @@ namespace :move_attachment_directories do
                 new_path = build_assignment_path(course_id, assignment.id)
                 new_path << af.file.file.filename
                 taskAuditFile.puts("to this new path: #{new_path}")
-                af.file.file.move_to(new_path)
+                if args[:run_it] == "true"
+                  af.file.file.move_to(new_path)
+                end
                 taskAuditFile.puts("---------------------------")
               end
             end
           end
         end
 
-        if course && course.has_badge_attachments?
+        if course.has_badge_attachments?
           course.badges.each do |badge|
             if badge.badge_files.present?
               badge.badge_files.each do |bf|
@@ -128,14 +134,16 @@ namespace :move_attachment_directories do
                 new_path = build_badge_path(course_id, badge.id)
                 new_path << bf.file.file.filename
                 taskAuditFile.puts("to this new path: #{new_path}")
-                bf.file.file.move_to(new_path)
+                if args[:run_it] == "true"
+                  bf.file.file.move_to(new_path)
+                end
                 taskAuditFile.puts("---------------------------")
               end
             end
           end
         end
 
-        if course && course.has_grade_attachments?
+        if course.has_grade_attachments?
           course.grades.each do |grade|
             if grade.file_uploads.present?
               grade.file_uploads.each do |fu|
@@ -143,21 +151,25 @@ namespace :move_attachment_directories do
                 new_path = build_file_upload_path(course_id, grade.assignment.id)
                 new_path << fu.file.file.filename
                 taskAuditFile.puts("to this new path: #{new_path}")
-                fu.file.file.move_to(new_path)
+                if args[:run_it] == "true"
+                  fu.file.file.move_to(new_path)
+                end
                 taskAuditFile.puts("---------------------------")
               end
             end
           end
         end
 
-        if course && course.has_submission_attachments?
+        if course.has_submission_attachments?
           course.submissions.each do |sub|
             if sub.submission_files.present?
               sub.submission_files.each do |sf|
                 taskAuditFile.puts("moving submission file: #{sf.inspect}")
                 new_path = build_submission_path(course_id, sub.assignment.id, sub.id)
                 new_path << sf.file.file.filename
-                taskAuditFile.puts("to this new path: #{new_path}")
+                if args[:run_it] == "true"
+                  taskAuditFile.puts("to this new path: #{new_path}")
+                end
                 sf.file.file.move_to(new_path)
                 taskAuditFile.puts("---------------------------")
               end
@@ -215,7 +227,7 @@ namespace :move_attachment_directories do
         taskAuditFile.puts("old path is empty")
         if args[:run_it] == "true"
           taskAuditFile.puts("deleting directory #{old_path}")
-          FileUtils.remove_dir old_dir
+          FileUtils.remove_dir old_path
         end
       end
     end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -190,7 +190,7 @@ namespace :move_attachment_directories do
       end
 
     end
-    
+
     challenge_files = ChallengeFile.all
 
     challenge_files.each do |cf|
@@ -215,23 +215,21 @@ namespace :move_attachment_directories do
 
     upload_directory = "#{Rails.root}/files/uploads"
 
-    all_course_directories = get_source_directories(upload_directory)
+    Dir.foreach(upload_directory) do |folder_name|
+      path = upload_directory << "/" << folder_name
 
-    all_course_directories.each do |dir|
-      old_path = upload_directory + "/" + dir
-      taskAuditFile.puts("checking the old path: #{old_path}")
+      taskAuditFile.puts("checking old path: #{path}")
 
-      size = `du -s #{old_path}`
+      size = `du -s #{path}`
       taskAuditFile.puts("size of old path: #{size}")
 
       if(size.chars.first == "0")
-        taskAuditFile.puts("old path is empty")
+        taskAuditFile.puts("path is empty")
+        taskAuditFile.puts("deleting directory #{path}")
         if args[:run_it] == "true"
-          taskAuditFile.puts("deleting directory #{old_path}")
-          FileUtils.remove_dir old_path
+          FileUtils.remove_dir path
         end
       end
     end
-
   end
 end

--- a/lib/tasks/course_number.rake
+++ b/lib/tasks/course_number.rake
@@ -189,21 +189,22 @@ namespace :move_attachment_directories do
         end
       end
 
-      challenge_files = ChallengeFile.all
-
-      challenge_files.each do |cf|
-        taskAuditFile.puts("moving challenge file: #{cf.inspect}")
-        course_id = cf.challenge.course.id
-        new_path = build_challange_path(course_id)
-        new_path << cf.file.file.filename
-        taskAuditFile.puts("to this new path: #{new_path}")
-        cf.file.file.move_to(new_path)
-        taskAuditFile.puts("---------------------------")
-      end
-
-      taskAuditFile.puts("Course ID's of courses that were deleted but still in files/uploads: #{deleted_course_ids}")
-
     end
+    
+    challenge_files = ChallengeFile.all
+
+    challenge_files.each do |cf|
+      taskAuditFile.puts("moving challenge file: #{cf.inspect}")
+      course_id = cf.challenge.course.id
+      new_path = build_challange_path(course_id)
+      new_path << cf.file.file.filename
+      taskAuditFile.puts("to this new path: #{new_path}")
+      cf.file.file.move_to(new_path)
+      taskAuditFile.puts("---------------------------")
+    end
+
+    taskAuditFile.puts("Course ID's of courses that were deleted but still in files/uploads: #{deleted_course_ids}")
+
   end
 
   desc "Go through the files/uploads and remove empty directorys"

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -1,4 +1,4 @@
-describe SubmissionFile, :focus => true do
+describe SubmissionFile do
   subject { new_submission_file }
 
   let(:course) { build(:course) }

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -1,4 +1,4 @@
-describe SubmissionFile do
+describe SubmissionFile, :focus => true do
   subject { new_submission_file }
 
   let(:course) { build(:course) }
@@ -126,13 +126,9 @@ describe SubmissionFile do
   describe "#owner_name" do
 
     context "student submission" do
-      it "returns the formatted student name associated with the submission" do
-        expect(subject.owner_name).to eq("#{student.last_name}-#{student.first_name}")
-      end
-
       it "returns nil if the student has been deleted" do
         allow(submission).to receive(:student).and_return nil
-        expect(subject.owner_name).to be_nil
+        expect(subject.owner_name).to eq ""
       end
     end
 
@@ -141,15 +137,10 @@ describe SubmissionFile do
       let(:group_assignment) { build(:assignment, grade_scope: "Group") }
       let(:group_submission) { build(:submission, course: course, assignment: group_assignment, group: group) }
 
-      it "returns the group name associated with a group submission" do
-        group_file = group_submission.submission_files.new image_file_attrs
-        expect(group_file.owner_name).to eq(group.name)
-      end
-
       it "returns nil if the group has been deleted" do
         group_file = group_submission.submission_files.new image_file_attrs
         allow(group_submission).to receive(:group).and_return nil
-        expect(group_file.owner_name).to be_nil
+        expect(group_file.owner_name).to eq""
       end
     end
   end

--- a/spec/uploaders/attachment_uploader_spec.rb
+++ b/spec/uploaders/attachment_uploader_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe AttachmentUploader do
 
     before(:each) do
       allow(subject).to receive_messages(
-        store_dir_prefix: "some-prefix",
+        store_dir_prefix: "files/uploads",
         course: "some-course",
         assignment: "some-assignment",
         file_klass: "devious_files",
@@ -81,7 +81,7 @@ RSpec.describe AttachmentUploader do
     it "returns an array with those components" do
       expect(result).to eq(
         [
-          "some-prefix", "uploads", "some-course", "some-assignment",
+          "files/uploads", "some-course", "some-assignment",
           "devious_files", "dave-eversby"
         ]
       )
@@ -89,7 +89,7 @@ RSpec.describe AttachmentUploader do
 
     it "compacts nils from the array" do
       allow(subject).to receive_messages(course: nil, file_klass: nil)
-      expect(result).to eq([ "some-prefix", "uploads", "some-assignment", "dave-eversby" ])
+      expect(result).to eq([ "files/uploads", "some-assignment", "dave-eversby" ])
     end
   end
 
@@ -98,9 +98,9 @@ RSpec.describe AttachmentUploader do
     let(:course) { create(:course) }
 
     context "model has a course method" do
-      it "returns a string with the format of <course_number-course_id>" do
+      it "returns a string with the format of <course_id>" do
         allow(model).to receive(:course) { course }
-        expect(result).to eq("#{course.course_number}-#{course.id}")
+        expect(result).to eq("#{course.id}")
       end
     end
 
@@ -117,9 +117,9 @@ RSpec.describe AttachmentUploader do
     let(:assignment) { create(:assignment) }
 
     context "model has an assignment method" do
-      it "returns a string with the format of <assignment_name-assignment_id>" do
+      it "returns a string with the format of <assignment_id>" do
         allow(model).to receive(:assignment) { assignment }
-        expect(result).to eq("assignments/#{model.assignment.name.gsub(/\s/, "_").downcase[0..20]}-#{model.assignment.id}")
+        expect(result).to eq("assignments/#{model.assignment.id}")
       end
     end
 


### PR DESCRIPTION
### Status
**READY**

### Description
This holds the changes to find the locations of the attachments after they've been moved by the rake task.  Finishing the work in removing s3 and having a better system in place using the EFS

### Deploy Notes
Run the rake tasks first:

`rake move_attachment_directories:move_extra_attachments[true]`
`rake move_attachment_directories:delete_empty_directories[true]`

### Migrations
NO

======================
Closes #4363
