### PR TITLE
Show user time zone for auto awarded message for earned badges

### DIFF
--- a/app/helpers/badges_helper.rb
+++ b/app/helpers/badges_helper.rb
@@ -1,0 +1,27 @@
+module BadgesHelper
+    def is_formatted_date_time(badge_feedback_value)
+        begin
+            badge_feedback_date_time = DateTime.strptime(badge_feedback_value, "%A, %B %d, %Y, %l:%M%p %:z")
+            return badge_feedback_value.length == "#{badge_feedback_date_time}".length
+        rescue => exception
+            return false
+        end
+
+        return false
+    end
+
+    def is_auto_awarded(badge_feedback)
+        puts "Time zone: #{current_user.time_zone}"
+        badge_feedback = badge_feedback.split("Auto-awarded on ")
+
+        if badge_feedback.length == 2 && badge_feedback[0].length == 0 && is_formatted_date_time(badge_feedback[1])
+            return true
+        end
+
+        return false
+    end
+
+    def get_auto_awarded_in_user_timezone
+        "Auto-awarded on #{DateTime.now.in_time_zone(current_user.time_zone)}"
+    end
+end

--- a/app/views/badges/_all_students_earned_badges_table.haml
+++ b/app/views/badges/_all_students_earned_badges_table.haml
@@ -24,7 +24,10 @@
         %td= link_to student.last_name, student_path(student)
         %td{ :width => 80}
           - presenter.badge.earned_badges.where(student_id: student.id).each do |badge|
-            %div{ :width => 80}= raw badge.feedback
+            - if is_auto_awarded(badge.feedback)
+              %div{ :width => 80}= get_auto_awarded_in_user_timezone
+            - else
+              %div{ :width => 80}= raw badge.feedback
         - if presenter.badge.can_earn_multiple_times
           %td= presenter.badge.earned_badge_count_for_student(student)
         - if presenter.badge.is_unlockable?


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
* When displaying the auto-awarded message for earned badges for instructors and students the date and time displayed was not in the timezone of the user. This was as the auto-awarded feedback was stored in the database and not dynamically changed in the view. Now, the time zone in the message is changed to that of the user when it is displayed on the page by changing the time zone to that of the current user dynamically within the view.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, create a badge that will be auto awarded on submission of a specified assignment. As a student within the same course, submit the assignment. The badge should be auto-awarded when the assignment is submitted. The earned badge should have the feedback "Auto-awarded on \<date and time when the badge was awarded in the current user time zone\>". This feedback is visible for instructors and students on the display page for a badge (i.e. /badges/\<id\>).
2. Change the time zone of the instructor or the student in the account display page (i.e. /edit_profile)
3. When viewing the auto-awarded feedback for the earned badge again the the badge display page (i.e. /badges/\<id\>), the new time zone for the user should be displayed in the feedback message for the earned badge.

### Impacted Areas in Application
* Auto-awarded feedback for earned badges
* Viewing badges as an instructor (i.e. views/badges/_all_students_earned_badges_table.haml)
* helpers/badges_helper.rb

======================
Closes #4384 
