### PR TITLE
Deleting student logged grades from the grades display page as an instructor

### DIFF
--- a/app/controllers/assignments/grades_controller.rb
+++ b/app/controllers/assignments/grades_controller.rb
@@ -2,7 +2,6 @@ require_relative "../../services/creates_many_grades"
 
 class Assignments::GradesController < ApplicationController
   before_action :ensure_staff?, except: [:self_log, :delete_self_logged]
-  before_action :ensure_student?, only: [:self_log, :delete_self_logged]
   before_action :find_assignment, only: [:mass_edit, :mass_update, :self_log, :delete_self_logged, :delete_all]
   before_action :use_current_course, only: [:mass_edit, :mass_update, :delete_self_logged]
 
@@ -160,8 +159,13 @@ class Assignments::GradesController < ApplicationController
     ScoreRecalculatorJob.new(user_id: current_student.id,
                              course_id: current_course.id).enqueue
 
+
+    message = "#{current_student.first_name} #{current_student.last_name}'s' self logged grade for this assignment has been deleted."
+
+    message = "Your grade for this assignment has been deleted." if current_user.is_student?(current_course)
+
     redirect_to assignments_path,
-          notice: "Your grade for this assignment has been deleted."
+          notice: message
   end
 
   private

--- a/app/views/grades/components/_delete_self_logged.haml
+++ b/app/views/grades/components/_delete_self_logged.haml
@@ -1,3 +1,3 @@
 %p
-  = simple_form_for grade.assignment, url: delete_self_logged_assignment_grades_path(grade.assignment.id), method: :delete do |f|
+  = simple_form_for grade.assignment, url: delete_self_logged_assignment_grades_path(assignment_id: grade.assignment.id, student_id: grade.student.id), method: :delete do |f|
     = f.submit "Delete self logged grade", class: "button"

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Assignments::GradesController do
+describe Assignments::GradesController, :focus => true do
   let(:course) { build(:course) }
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let!(:student) { create(:course_membership, :student, course: course).user }
@@ -157,7 +157,7 @@ describe Assignments::GradesController do
     describe "POST self_log" do
       it "redirects back to the root" do
         expect(post :self_log, params: { assignment_id: assignment.id }).to \
-          redirect_to(:root)
+          redirect_to(:dashboard)
       end
     end
 
@@ -199,7 +199,7 @@ describe Assignments::GradesController do
         before(:each) { assignment.update(student_logged: true) }
 
         it "creates a maximum score by the student if present only if raw_points are set" do
-          post :self_log, params: { assignment_id: assignment.id, grade: { raw_points: assignment.full_points } } 
+          post :self_log, params: { assignment_id: assignment.id, grade: { raw_points: assignment.full_points } }
           grade = student.grade_for_assignment(assignment)
           expect(grade.raw_points).to eq assignment.full_points
         end

--- a/spec/controllers/assignments/grades_controller_spec.rb
+++ b/spec/controllers/assignments/grades_controller_spec.rb
@@ -1,4 +1,4 @@
-describe Assignments::GradesController, :focus => true do
+describe Assignments::GradesController do
   let(:course) { build(:course) }
   let(:professor) { create(:course_membership, :professor, course: course).user }
   let!(:student) { create(:course_membership, :student, course: course).user }


### PR DESCRIPTION
### Status
**READY**

### Description
* It should be possible for instructors to delete student logged grades. Currently this is not possible as there is a `before_action` filter in the controllers/assignments/grades_controller.rb controller that prevented instructors from deleting student logged grades. Now, this `before_action` filter has been removed and instructors can delete student logged grades.

### Migrations
NO

### Steps to Test or Reproduce
1. As an instructor, create an assignment and mark it as student logged.
2. As a student, create a submission for the assignment and self-log the grade for the assignment
3. As an instructor, it should be possible to delete the student logged grade from the grades display page (i.e. /grades/\<id\>)

### Impacted Areas in Application
* Deleting student logged grades as an instructor
* controllers/assignments/grades_controller.rb
* views/grades/components/_delete_self_logged.haml

======================
Closes #4390 
