### PR TITLE
Always show "Import Assignments" button in assignment options

### DIFF
--- a/app/views/assignments/_index_staff.haml
+++ b/app/views/assignments/_index_staff.haml
@@ -6,8 +6,7 @@
       %li.dropdown
         %button.button-edit.button-options{role: "button", type: "button"}= decorative_glyph(:cog) + "Options" + decorative_glyph("caret-down")
         %ul.options-menu.dropdown-content
-          - if current_course.allows_canvas?
-            = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path
+          = active_course_link_to decorative_glyph(:download) + "Import #{term_for :assignments}", assignments_importers_path
           - if current_course.assignments.present? && current_course.institution.try(:has_google_access)
             = active_course_link_to decorative_glyph(:calendar) + "Add All to Google Calendar", add_assignments_google_calendars_assignments_path, :target => "_parent", method: :post
 .pageContent


### PR DESCRIPTION
### Status
**READY**

### Description
* Currently, unchecking the "Allow canvas" option within course settings causes the "Import Assignments" button under assignment options to be hidden.
* This PR removes the conditional that checks the "allow_canvas" boolean of the course, in the assignments (staff) view

### Migrations
NO

### Steps to Test or Reproduce
* Checking/unchecking the "Allow Canvas" course setting should not affect the "Import Assignment" button under Assignment options 

### Impacted Areas in Application
* Assignments staff view (views/assignments/_index_staff.haml

======================
Closes #4431 