### PR TITLE
Do not disable grading buttons if the user returns to add rubric criteria

### DIFF
--- a/app/assets/javascripts/angular/directives/grades/submit_buttons.coffee
+++ b/app/assets/javascripts/angular/directives/grades/submit_buttons.coffee
@@ -13,8 +13,9 @@
       scope.isSubmitted = false
       
       scope.submitGrade = (returnURL)->
-        scope.isSubmitted = true
-        GradeService.submitGrade(returnURL)
+        status = GradeService.submitGrade(returnURL)
+
+        if status != false then scope.isSubmitted = true
 
       scope.textForButton = ()->
         if GradeService.isSetToComplete() then "Submit Grade" else "Save as Draft"


### PR DESCRIPTION
### Status
**READY**

### Description
* When grading an assignment with a rubric, if a rubric criterion level was not assigned and the Submit Grade button was clicked, a confirmation dialog appears that alerts the user to the unselected rubric criterion level. Currently, if the user chose to return to add a rubric level (i.e. click cancel on the confirmation dialog), the grading buttons would be disabled. This was as the "isSubmitted" boolean in the scope would get erroneously set to true, even if the user chose to return to add the level.
* This PR fixes this problem and checks for the status the grade submission to not be false before setting the isSubmitted boolean.

### Migrations
NO

### Steps to Test or Reproduce
1. In an assignment with a rubric, click the "Submit Grade" without selecting any rubric criteria levels.
2. In the confirmation dialog that appears, click "Cancel"
3. The grading buttons should not appear disabled

### Impacted Areas in Application
* grading/submit_buttons.coffee directive

======================
Closes #4422 
