### PR TITLE
allows_canvas default value change

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,6 +8,7 @@ class Course < ApplicationRecord
   # Callbacks
   before_validation :reset_weight_fields_if_unused
   before_create :mark_umich_as_paid
+  before_create :umich_allows_canvas
   after_create :create_admin_memberships
 
   # Note: we are setting the role scopes as instance methods,
@@ -277,6 +278,10 @@ class Course < ApplicationRecord
 
   def mark_umich_as_paid
     self.has_paid = true if Rails.env.production?
+  end
+
+  def umich_allows_canvas
+    self.allows_canvas = true if Rails.env.production?
   end
 
   def copy_with_associations(attributes, associations)

--- a/db/migrate/20200117163258_change_allows_canvas_default_to_false.rb
+++ b/db/migrate/20200117163258_change_allows_canvas_default_to_false.rb
@@ -1,0 +1,5 @@
+class ChangeAllowsCanvasDefaultToFalse < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :courses, :allows_canvas, from: true, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_12_154738) do
+ActiveRecord::Schema.define(version: 2020_01_17_163258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -354,7 +354,7 @@ ActiveRecord::Schema.define(version: 2019_11_12_154738) do
     t.string "time_zone", default: "Eastern Time (US & Canada)"
     t.boolean "has_multipliers", default: false, null: false
     t.boolean "has_paid", default: false, null: false
-    t.boolean "allows_canvas", default: true, null: false
+    t.boolean "allows_canvas", default: false, null: false
     t.boolean "published", default: false, null: false
     t.integer "institution_id"
     t.text "dashboard_message"


### PR DESCRIPTION
### Status
**READY**

### Description
Adds migration to change allows_canvas course variable default from false to true, adds a before_create method on the course model to change allows_canvas to true for umich

### Related PRs
https://github.com/UM-USElab/gradecraft-development/pull/4432

### Migrations
YES

Devs run `bundle exec rails db:migrate` 
* will also have to run migration for spec suit to run `bundle exec rspec` will show that command

### Impacted Areas in Application

* Courses created on app will no longer have allows_canvas set to true by default 
